### PR TITLE
Implement dropdown menu for resources (part 2)

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/resource_permissions_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/resource_permissions_helper.rb
@@ -6,6 +6,23 @@ module Decidim
       # Public: Render a link to the permissions page for the resource.
       #
       # resource - The resource which permissions are going to be modified
+      def dropdown_resource_permissions_link(resource)
+        return unless resource.allow_resource_permissions? && allowed_to?(:update, :component, component: resource.component)
+
+        current_participatory_space_admin_proxy = ::Decidim::EngineRouter.admin_proxy(current_participatory_space)
+        link_to current_participatory_space_admin_proxy.edit_component_permissions_path(
+          current_component.id,
+          resource_name: resource.resource_manifest.name,
+          resource_id: resource.id
+        ), class: "dropdown__button" do
+          concat icon "key-2-line"
+          concat t("actions.permissions", scope: "decidim.admin")
+        end
+      end
+
+      # Public: Render a link to the permissions page for the resource.
+      #
+      # resource - The resource which permissions are going to be modified
       def resource_permissions_link(resource)
         return unless resource.allow_resource_permissions? && allowed_to?(:update, :component, component: resource.component)
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
@@ -1,38 +1,41 @@
 <% is_linked = meeting.decidim_component_id != current_component.id %>
 
 <tr data-id="<%= meeting.id %>">
-  <td>
+  <td data-label="<%= t('models.meeting.fields.id', scope: 'decidim.meetings') %>">
     <%= meeting.id %><br>
   </td>
-  <td class="!text-left">
+  <td class="!text-left" data-label="<%= t('models.meeting.fields.title', scope: 'decidim.meetings') %>">
     <% if allowed_to? :update, :meeting, meeting: meeting %>
       <%= link_to present(meeting).title(html_escape: true), edit_meeting_path(meeting) %>
     <% else %>
       <%= present(meeting).title(html_escape: true) %><br>
     <% end %>
   </td>
-  <td>
+  <td data-label="<%= t('models.meeting.fields.start_time', scope: 'decidim.meetings') %>">
     <% if meeting.start_time %>
       <%= l meeting.start_time, format: :long %>
     <% end %>
   </td>
-  <td>
+  <td data-label="<%= t('models.meeting.fields.end_time', scope: 'decidim.meetings') %>">
     <% if meeting.end_time %>
       <%= l meeting.end_time, format: :long %>
     <% end %>
   </td>
-  <td>
+  <td data-label="<%= t('models.meeting.fields.closed', scope: 'decidim.meetings') %>">
     <%= humanize_boolean meeting.closed? %>
   </td>
+
   <% if maps_enabled? && Decidim::Map.available?(:static, :geocoding) %>
-    <td>
+    <td data-label="<%= t('models.meeting.fields.map', scope: 'decidim.meetings') %>">
       <%= static_map_link(meeting, {}, { class: "static-map__admin" }) unless meeting.online? %>
     </td>
   <% end %>
-  <td>
+
+  <td data-label="<%= t('models.meeting.fields.taxonomies', scope: 'decidim.meetings') %>">
     <%= present(meeting).taxonomy_names.join(", ") %>
   </td>
-  <td class="table-list__actions">
+
+  <td class="table-list__actions" data-label="<%= t('actions.title', scope: 'decidim.meetings') %>">
     <% if is_linked %>
       <%= t("index.linked_meeting_warning_html", href: edit_meeting_path(meeting), name: present(meeting).space_title, scope: "decidim.meetings.admin.meetings") %>
     <% else %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
@@ -1,70 +1,197 @@
-<% if view == :deleted %>
-  <% if allowed_to? :restore, :meeting, trashable_deleted_resource: meeting %>
-    <%= icon_link_to "refresh-line", url_for(action: :restore, id: meeting, controller: "meetings"), t("decidim.admin.actions.restore"), method: :patch, class: "action-icon--restore" %>
-  <% end %>
-<% else %>
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <%= icon_link_to "pencil-line", edit_meeting_path(meeting), t("actions.edit", scope: "decidim.meetings"), class: "action-icon--edit" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
-
-  <% if allowed_to? :copy, :meeting, meeting: meeting %>
-    <%= icon_link_to "file-copy-line", new_meeting_copy_path(meeting), t("actions.duplicate", scope: "decidim.admin"), class: "action-icon--copy" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
-
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <%= icon_link_to "folder-line", meeting_attachment_collections_path(meeting), t("actions.attachment_collections", scope: "decidim.meetings"), class: "action-icon--attachment_collections" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
-
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <%= icon_link_to "attachment-line", meeting_attachments_path(meeting), t("actions.attachments", scope: "decidim.meetings"), class: "action-icon--attachments" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
-
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <% if meeting.registration_disabled? %>
-      <%= icon "group-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.registrations", scope: "decidim.meetings") %>
-    <% else %>
-      <%= icon_link_to "group-line", meeting.on_this_platform? ? edit_meeting_registrations_path(meeting) : meeting.registration_url, t("actions.registrations", scope: "decidim.meetings"), class: "action-icon--registrations" %>
+<% if view == :deleted && allowed_to?(:restore, :meeting, trashable_deleted_resource: meeting) %>
+  <li class="dropdown__item">
+    <%= link_to url_for(action: :restore, id: meeting, controller: "meetings"), method: :patch, class: "dropdown__button" do %>
+      <%= icon "refresh-line" %>
+      <%= t("decidim.admin.actions.restore") %>
     <% end %>
-  <% end %>
+  </li>
+<% elsif view != :deleted %>
+  <button type="button" data-component="dropdown" data-target="actions-meeting-<%= meeting.id %>" aria-label="<%= t('actions.actions_label', scope: 'decidim.admin') %>">
+    <%= icon "more-fill", class: "text-secondary" %>
+  </button>
 
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <%= icon_link_to "calendar-line", meeting.agenda.present? ? edit_meeting_agenda_path(meeting, meeting.agenda) : new_meeting_agenda_path(meeting), t("actions.agenda", scope: "decidim.meetings"), class: "action-icon--agenda" %>
-    <%= icon_link_to "list-check", edit_meeting_poll_path(meeting), t("actions.manage_poll", scope: "decidim.meetings"), class: "action-icon--manage-poll-questionnaire" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
+  <div class="inline-block relative">
+    <ul id="actions-meeting-<%= meeting.id %>" class="dropdown dropdown__action" aria-hidden="true">
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <%= link_to edit_meeting_path(meeting), class: "dropdown__button" do %>
+            <%= icon "pencil-line" %>
+            <%= t("actions.edit", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_edit_meetings", scope: "decidim.admin") do %>
+              <%= icon "pencil-line", class: "text-gray" %>
+              <span><%= t("actions.edit", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
 
-  <% if allowed_to? :close, :meeting, meeting: meeting %>
-    <%= icon_link_to "lock-line", edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), t("actions.close", scope: "decidim.meetings"), class: "action-icon--close" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
+      <li class="dropdown__item">
+        <% if allowed_to?(:copy, :meeting, meeting: meeting) %>
+          <%= link_to new_meeting_copy_path(meeting), class: "dropdown__button" do %>
+            <%= icon "file-copy-line" %>
+            <%= t("actions.duplicate", scope: "decidim.admin") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_duplicate_meetings", scope: "decidim.admin") do %>
+              <%= icon "file-copy-line", class: "text-gray" %>
+              <span><%= t("actions.duplicate", scope: "decidim.admin") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
 
-  <% if allowed_to? :update, :meeting, meeting: meeting %>
-    <% if meeting.published? %>
-      <%= icon_link_to "close-circle-line", unpublish_meeting_path(meeting), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish", data: { confirm: t("actions.unpublish", scope: "decidim.admin") } %>
-    <% else %>
-      <%= icon_link_to "check-line", publish_meeting_path(meeting), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
-    <% end %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
+      <hr>
 
-  <%= icon_link_to "eye-line", resource_locator(meeting).path, t("actions.preview", scope: "decidim.meetings"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <%= link_to meeting_attachment_collections_path(meeting), class: "dropdown__button" do %>
+            <%= icon "folder-line" %>
+            <%= t("actions.attachment_collections", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_manage_attachments_meetings", scope: "decidim.admin") do %>
+              <%= icon "folder-line", class: "text-gray" %>
+              <span><%= t("actions.attachment_collections", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
 
-  <%= resource_permissions_link(meeting) %>
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <%= link_to meeting_attachments_path(meeting), class: "dropdown__button" do %>
+            <%= icon "attachment-line" %>
+            <%= t("actions.attachments", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_manage_attachments_meetings", scope: "decidim.admin") do %>
+              <%= icon "attachment-line", class: "text-gray" %>
+              <span><%= t("actions.attachments", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
 
-  <% if allowed_to? :soft_delete, :meeting, trashable_deleted_resource: meeting %>
-    <%= icon_link_to "delete-bin-line", soft_delete_meeting_path(meeting), t("actions.soft_delete", scope: "decidim.admin"), method: :patch, class: "action-icon--delete", data: { confirm: t("actions.confirm_delete_meeting", scope: "decidim.meetings") } %>
-  <% else %>
-    <%= icon "delete-bin-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.soft_delete", scope: "decidim.admin") %>
-  <% end %>
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) && !meeting.registration_disabled? %>
+          <%= link_to(meeting.on_this_platform? ? edit_meeting_registrations_path(meeting) : meeting.registration_url, class: "dropdown__button") do %>
+            <%= icon "group-line" %>
+            <%= t("actions.registrations", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_manage_registrations_meetings", scope: "decidim.admin") do %>
+              <%= icon "group-line", class: "text-gray" %>
+              <span><%= t("actions.registrations", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <%= link_to(meeting.agenda.present? ? edit_meeting_agenda_path(meeting, meeting.agenda) : new_meeting_agenda_path(meeting), class: "dropdown__button") do %>
+            <%= icon "calendar-line" %>
+            <%= t("actions.agenda", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_manage_agenda_meetings", scope: "decidim.admin") do %>
+              <%= icon "calendar-line", class: "text-gray" %>
+              <span><%= t("actions.agenda", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <%= link_to edit_meeting_poll_path(meeting), class: "dropdown__button" do %>
+            <%= icon "list-check" %>
+            <%= t("actions.manage_poll", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_manage_poll_meetings", scope: "decidim.admin") do %>
+              <%= icon "list-check", class: "text-gray" %>
+              <span><%= t("actions.manage_poll", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:close, :meeting, meeting: meeting) %>
+          <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "dropdown__button" do %>
+            <%= icon "lock-line" %>
+            <%= t("actions.close", scope: "decidim.meetings") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_close_meetings", scope: "decidim.admin") do %>
+              <%= icon "lock-line", class: "text-gray" %>
+              <span><%= t("actions.close", scope: "decidim.meetings") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:update, :meeting, meeting: meeting) %>
+          <% if meeting.published? %>
+            <%= link_to unpublish_meeting_path(meeting), method: :put, data: { confirm: t("actions.unpublish", scope: "decidim.admin") }, class: "dropdown__button" do %>
+              <%= icon "close-circle-line" %>
+              <%= t("actions.unpublish", scope: "decidim.admin") %>
+            <% end %>
+          <% else %>
+            <%= link_to publish_meeting_path(meeting), method: :put, class: "dropdown__button" do %>
+              <%= icon "check-line" %>
+              <%= t("actions.publish", scope: "decidim.admin") %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <%= link_to resource_locator(meeting).path, class: "dropdown__button", target: :blank, data: { "external-link": false } do %>
+          <%= icon "eye-line" %>
+          <%= t("actions.preview", scope: "decidim.meetings") %>
+        <% end %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <%= dropdown_resource_permissions_link(meeting) %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:soft_delete, :meeting, trashable_deleted_resource: meeting) %>
+          <%= link_to soft_delete_meeting_path(meeting), method: :patch, data: { confirm: t("actions.confirm_delete_meeting", scope: "decidim.meetings") }, class: "dropdown__button" do %>
+            <%= icon "delete-bin-line" %>
+            <%= t("actions.soft_delete", scope: "decidim.admin") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.deleted_meetings_info", scope: "decidim.admin") do %>
+              <%= icon "delete-bin-line", class: "text-gray" %>
+              <span><%= t("actions.soft_delete", scope: "decidim.admin") %></span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+    </ul>
+  </div>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/index.html.erb
@@ -12,7 +12,7 @@
   </div>
 
   <%= admin_filter_selector(:meetings) %>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <%= render partial: "meetings-thead" %>
       <tbody>

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations_attendees/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations_attendees/index.html.erb
@@ -61,7 +61,7 @@
     <% end %>
 
     <div class="card" id="meeting-invites">
-      <div class="table-scroll">
+      <div class="table-stacked">
         <table class="table-list">
           <thead>
             <tr>
@@ -74,36 +74,46 @@
           <tbody>
             <% registrations.each do |registration| %>
               <% presenter = registration.presenter %>
+
               <tr data-id="<%= registration.id %>">
-                <td>
+                <td data-label="<%= t('models.registration.fields.name', scope: 'decidim.meetings') %>">
                   <%= presenter.name %>
                 </td>
-                <td>
+                <td data-label="<%= t('models.registration.fields.email', scope: 'decidim.meetings') %>">
                   <%= presenter.email %>
                 </td>
-                <td class="<%= presenter.status_html_class %>">
+                <td class="<%= presenter.status_html_class %>" data-label="<%= t('models.registration.fields.status', scope: 'decidim.meetings') %>">
                   <strong class="label <%= presenter.status_html_class %>">
                     <%= presenter.status %>
                   </strong>
                 </td>
-                <td class="table-list__actions">
+                <td class="table-list__actions" data-label="<%= t('models.registration.actions', scope: 'decidim.meetings') %>">
                   <% if allowed_to? :update, :meeting, meeting: meeting %>
-                    <% if presenter.validated? %>
-                      <%= icon(
-                            "user-follow-line",
-                            class: "action-icon action-icon--disabled",
-                            role: "img",
-                            aria_label: t("actions.mark_as_attendee", scope: "decidim.meetings")
-                          ) %>
-                    <% else %>
-                      <%= icon_link_to(
-                            "user-follow-line",
-                            mark_as_attendee_meeting_registrations_attendee_path(id: registration),
-                            t("actions.mark_as_attendee", scope: "decidim.meetings"),
-                            method: :put,
-                            class: "action-icon--mark-attendee"
-                          ) %>
-                    <% end %>
+                    <button type="button" data-component="dropdown" data-target="actions-meeting-registration-<%= registration.id %>" aria-label="<%= t('actions.actions_label', scope: 'decidim.admin', resource: translated_attribute(meeting.title)) %>">
+                      <%= icon "more-fill", class: "text-secondary" %>
+                    </button>
+
+                    <div class="inline-block relative">
+                      <ul id="actions-meeting-registration-<%= registration.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                        <li class="dropdown__item">
+                          <% if presenter.validated? %>
+                            <div class="dropdown__button-disabled">
+                              <%= with_tooltip t("tooltips.cannot_mark_attendee", scope: "decidim.admin") do %>
+                                <%= icon "user-follow-line", class: "text-gray" %>
+                                <span>
+                                  <%= t("actions.mark_as_attendee", scope: "decidim.meetings") %>
+                                </span>
+                              <% end %>
+                            </div>
+                          <% else %>
+                            <%= link_to mark_as_attendee_meeting_registrations_attendee_path(id: registration), method: :put, class: "dropdown__button" do %>
+                              <%= icon "user-follow-line" %>
+                              <%= t("actions.mark_as_attendee", scope: "decidim.meetings") %>
+                            <% end %>
+                          <% end %>
+                        </li>
+                      </ul>
+                    </div>
                   <% end %>
                 </td>
               </tr>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -147,6 +147,15 @@ en:
         new:
           copy: Copy
           title: Duplicate meeting
+      tooltips:
+        cannot_close_meetings: Cannot close this meeting as it is created by a participant
+        cannot_duplicate_meetings: Cannot duplicate this meeting as it is created by a participant
+        cannot_edit_meetings: Cannt edit this meeting as it is created by a participant
+        cannot_manage_agenda_meetings: Cannot manage agenda in this meeting as it is created by a participant
+        cannot_manage_attachments_meetings: Cannot manage attachments in this meeting as it is created by a participant
+        cannot_manage_poll_meetings: Cannot manage poll in this meeting as it is created by a participant
+        cannot_manage_registrations_meetings: Cannt manage registrations on this meeting as it is created by a participant, it has registrations disabled or these registrations are externals
+        cannot_mark_attendee: Cannot mark as atteendee as it was already marked
     components:
       meetings:
         actions:

--- a/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/admin/proposals_helper.rb
@@ -46,21 +46,6 @@ module Decidim
 
           translated_attribute(proposal&.proposal_state&.title)
         end
-
-        def icon_with_link_to_proposal(proposal)
-          icon, tooltip = if allowed_to?(:create, :proposal_answer, proposal:) && !proposal.emendation?
-                            [
-                              "question-answer-line",
-                              t(:answer_proposal, scope: "decidim.proposals.actions")
-                            ]
-                          else
-                            [
-                              "information-line",
-                              t(:show, scope: "decidim.proposals.actions")
-                            ]
-                          end
-          icon_link_to(icon, proposal_path(proposal), tooltip, class: "icon--small action-icon--show-proposal")
-        end
       end
     end
   end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
@@ -6,7 +6,7 @@
       <%= link_to t("actions.new_proposal_state", scope: "decidim.proposals"), new_proposal_state_path, class: "button button__sm button__secondary" if allowed_to? :create, :proposal_state %>
     </h1>
   </div>
-  <div class="table-scroll mt-16">
+  <div class="table-stacked mt-16">
     <table class="table-list">
       <thead>
         <tr>
@@ -22,23 +22,53 @@
       <tbody>
         <% proposal_states.each do |state| %>
           <tr>
-            <td>
+            <td data-label="<%= t("models.proposal_state.title", scope: "decidim.proposals") %>">
               <%= translated_attribute(state.title) %>
             </td>
-            <td>
+            <td data-label="<%= t("models.proposal_state.css_class", scope: "decidim.proposals") %>">
               <strong class="label" style="<%= state.css_style %>">
                 <%= decidim_sanitize_translated(state.token) %>
               </strong>
             </td>
-            <td>
-              <% if allowed_to? :update, :proposal_state, proposal_state: state %>
-                <%= icon_link_to "pencil-line", edit_proposal_state_path(state), t("actions.edit_proposal_state", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
-              <% else %>
-                <span class="action-space icon"></span>
-              <% end %>
-              <% if allowed_to?(:destroy, :proposal_state, proposal_state: state) %>
-                <%= icon_link_to "delete-bin-line", proposal_state_path(state), t("actions.destroy", scope: "decidim.proposals"), method: :delete, data: { confirm: t("actions.delete_proposal_state_confirm", scope: "decidim.proposals") }, class: "action-icon--delete-proposal" %>
-              <% end %>
+            <td data-label="<%= t("actions.title", scope: "decidim.proposals") %>" class="table-list__actions">
+              <button type="button" data-component="dropdown" data-target="actions-proposal-state-<%= state.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(state.title)) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
+
+              <div class="inline-block relative">
+                <ul id="actions-proposal-state-<%= state.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :update, :proposal_state, proposal_state: state %>
+                    <li class="dropdown__item">
+                      <%= link_to edit_proposal_state_path(state), class: "dropdown__button" do %>
+                        <%= icon "pencil-line" %>
+                        <%= t("actions.edit_proposal_state", scope: "decidim.proposals") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <hr>
+
+                  <% if allowed_to? :destroy, :proposal_state, proposal_state: state %>
+                    <li class="dropdown__item">
+                      <%= link_to proposal_state_path(state), method: :delete, data: { confirm: t("actions.delete_proposal_state_confirm", scope: "decidim.proposals") }, class: "dropdown__button" do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("actions.destroy", scope: "decidim.proposals") %>
+                      <% end %>
+                    </li>
+                  <% else %>
+                    <li class="dropdown__item">
+                      <div class="dropdown__button-disabled">
+                        <%= with_tooltip t("tooltips.deleted_proposal_states_info", scope: "decidim.admin") do %>
+                          <%= icon "pencil-line", class: "text-gray" %>
+                          <span>
+                            <%= t("actions.edit_proposal", scope: "decidim.proposals") %>
+                          </span>
+                        <% end %>
+                      </div>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_actions.html.erb
@@ -1,21 +1,87 @@
-<% if view == :deleted %>
-  <%= icon_link_to "refresh-line", restore_proposal_path(proposal), t("actions.restore", scope: "decidim.admin"), method: :patch, class: "action-icon--restore" %>
-  <% else %>
-  <% if allowed_to? :edit, :proposal, proposal: proposal %>
-    <%= icon_link_to "pencil-line", edit_proposal_path(proposal), t("actions.edit_proposal", scope: "decidim.proposals"), class: "action-icon--edit-proposal" %>
-  <% else %>
-    <span class="action-space icon"></span>
-  <% end %>
+<button type="button" data-component="dropdown" data-target="actions-proposal-<%= proposal.id %>" aria-label="<%= t('decidim.admin.actions.actions_label', resource: proposal.title) %>">
+  <%= icon "more-fill", class: "text-secondary" %>
+</button>
 
-  <%= icon_with_link_to_proposal(proposal) %>
+<div class="inline-block relative">
+  <ul id="actions-proposal-<%= proposal.id %>" class="dropdown dropdown__action" aria-hidden="true">
+    <% if view == :deleted %>
+      <li class="dropdown__item">
+        <%= link_to restore_proposal_path(proposal), method: :patch, class: "dropdown__button" do %>
+          <%= icon "refresh-line" %>
+          <%= t("actions.restore", scope: "decidim.admin") %>
+        <% end %>
+      </li>
+    <% else %>
+      <% if allowed_to? :edit, :proposal, proposal: proposal %>
+        <li class="dropdown__item">
+          <%= link_to edit_proposal_path(proposal), class: "dropdown__button" do %>
+            <%= icon "pencil-line" %>
+            <%= t("actions.edit_proposal", scope: "decidim.proposals") %>
+          <% end %>
+        </li>
+      <% else %>
+        <li class="dropdown__item">
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.cannot_edit_proposal_info", scope: "decidim.admin") do %>
+              <%= icon "pencil-line", class: "text-gray" %>
+              <span>
+                <%= t("actions.edit_proposal", scope: "decidim.proposals") %>
+              </span>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
 
-  <%= icon_link_to "eye-line", resource_locator(proposal).path, t("actions.preview", scope: "decidim.proposals.admin"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
+      <hr>
 
-  <%= resource_permissions_link(proposal) %>
+      <li class="dropdown__item">
+        <%= link_to resource_locator(proposal).path, target: :blank, data: { "external-link": false }, class: "dropdown__button" do %>
+          <%= icon "eye-line" %>
+          <%= t("actions.preview", scope: "decidim.proposals.admin") %>
+        <% end %>
+      </li>
 
-  <% if allowed_to?(:soft_delete, :proposal, trashable_deleted_resource: proposal) %>
-    <%= icon_link_to "delete-bin-line", soft_delete_proposal_path(proposal), t("actions.soft_delete", scope: "decidim.admin"), method: :patch, class: "action-icon--delete", data: { confirm: t("actions.confirm_delete_proposal", scope: "decidim.proposals.admin") } %>
-  <% else %>
-    <%= icon "delete-bin-line", class: "action-icon action-icon--disabled", role: "img", aria_label: t("actions.soft_delete", scope: "decidim.admin") %>
-  <% end %>
-<% end %>
+      <hr>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:create, :proposal_answer, proposal:) && !proposal.emendation? %>
+          <%= link_to proposal_path(proposal), class: "dropdown__button" do %>
+            <%= icon "question-answer-line" %>
+            <%= t("actions.answer_proposal", scope: "decidim.proposals") %>
+          <% end %>
+        <% else %>
+          <%= link_to proposal_path(proposal), class: "dropdown__button" do %>
+            <%= icon "information-line" %>
+            <%= t("actions.show", scope: "decidim.proposals") %>
+          <% end %>
+        <% end %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <%= dropdown_resource_permissions_link(proposal) %>
+      </li>
+
+      <hr>
+
+      <li class="dropdown__item">
+        <% if allowed_to?(:soft_delete, :proposal, trashable_deleted_resource: proposal) %>
+          <%= link_to soft_delete_proposal_path(proposal), method: :patch, data: { confirm: t("actions.confirm_delete_proposal", scope: "decidim.proposals.admin") }, class: "dropdown__button" do %>
+            <%= icon "delete-bin-line" %>
+            <%= t("actions.soft_delete", scope: "decidim.admin") %>
+          <% end %>
+        <% else %>
+          <div class="dropdown__button-disabled">
+            <%= with_tooltip t("tooltips.deleted_proposals_info", scope: "decidim.admin") do %>
+              <%= icon "pencil-line", class: "text-gray" %>
+              <span>
+                <%= t("actions.edit_proposal", scope: "decidim.proposals") %>
+              </span>
+            <% end %>
+          </div>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_proposal-tr.html.erb
@@ -1,10 +1,11 @@
+
 <tr data-id="<%= proposal.id %>"
     data-allow-answer="<%= allowed_to?(:create, :proposal_answer, proposal:) && !proposal.emendation? %>"
     <%= "data-published-state=false" if proposal.answered? && !proposal.published_state? %>>
-  <td>
-    <%= check_box_tag "proposal_ids_s[]", proposal.id, false, class: "js-check-all-proposal js-proposal-list-check  js-proposal-id-#{proposal.id}" %><br>
+  <td data-label="">
+    <%= check_box_tag "proposal_ids_s[]", proposal.id, false, class: "js-check-all-proposal js-proposal-list-check js-proposal-id-#{proposal.id}" %><br>
   </td>
-  <td class="!text-left">
+  <td class="!text-left" data-label="<%= t('models.proposal.fields.title', scope: 'decidim.proposals') %>">
     <% if allowed_to? :edit, :proposal, proposal: proposal %>
       <%= link_to present(proposal).title(html_escape: true), proposal_path(proposal) %><br>
     <% else %>
@@ -19,12 +20,12 @@
       </div>
     <% end %>
   </td>
-  <td class="table-list__date">
+  <td class="table-list__date" data-label="<%= t('models.proposal.fields.published_at', scope: 'decidim.proposals') %>">
     <%= l proposal.published_at, format: :decidim_short %>
   </td>
 
   <% unless current_settings.publish_answers_immediately? %>
-    <td>
+    <td data-label="<%= t('models.proposal.fields.published_answer', scope: 'decidim.proposals') %>">
       <% if proposal.answered? && !proposal.emendation? %>
         <%= humanize_boolean proposal.published_state? %>
       <% else %>
@@ -34,33 +35,33 @@
   <% end %>
 
   <% if current_settings.votes_enabled? %>
-    <td>
+    <td data-label="<%= t('models.proposal.fields.votes', scope: 'decidim.proposals') %>">
       <%= proposal.proposal_votes_count %>
     </td>
   <% end %>
 
   <% if current_component.settings.comments_enabled? and !current_settings.comments_blocked? %>
-    <td>
+    <td data-label="<%= t('models.proposal.fields.comments', scope: 'decidim.proposals') %>">
       <%= proposal.comments_count %>
     </td>
   <% end %>
 
-  <td>
+  <td data-label="<%= t('models.proposal.fields.notes', scope: 'decidim.proposals') %>">
     <%= proposal.proposal_notes_count %>
   </td>
 
-  <td class="evaluators-count">
+  <td class="evaluators-count" data-label="<%= t('models.proposal.fields.evaluators', scope: 'decidim.proposals') %>">
     <%= proposal.evaluation_assignments_count %>
   </td>
 
-  <td>
+  <td data-label="<%= t('models.proposal.fields.state', scope: 'decidim.proposals') %>">
     <strong class="label <%= proposal_state_css_class proposal %>" style="<%= proposal_state_css_style proposal %>">
       <%= t("decidim/amendment", scope: "activerecord.models", count: 1) if proposal.emendation? %>
       <%= proposal_complete_state proposal %>
     </strong>
   </td>
 
-  <td class="table-list__actions">
+  <td class="table-list__actions" data-label="<%= t('actions.title', scope: 'decidim.proposals') %>">
     <%= render partial: "decidim/proposals/admin/proposals/actions", locals: { proposal:, view: } %>
   </td>
 </tr>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -22,7 +22,7 @@
     <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/unassign_from_evaluator" %>
   </div>
   <%= admin_filter_selector(filter_prefix_key) %>
-  <div class="table-scroll mt-8">
+  <div class="table-stacked mt-8">
     <table class="table-list">
       <%= render partial: "proposals-thead" %>
       <tbody>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -148,6 +148,10 @@ en:
               state_published: Answered
         search_placeholder:
           id_string_or_title_cont: Search %{collection} by ID or title
+      tooltips:
+        cannot_edit_proposal_info: Cannot edit this proposal as it is created by a participant
+        deleted_proposal_states_info: Cannot delete this proposal state because there are proposals assigned to it
+        deleted_proposals_info: Cannot delete this proposal
     application:
       geocoding:
         not_configured: Geocoding is not configured!

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -9,7 +9,7 @@
       <%= render partial: "decidim/admin/components/resource_action" %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
@@ -22,31 +22,62 @@
       <tbody>
         <% sortitions.each do |sortition| %>
         <tr>
-          <td><%= sortition.reference %></td>
-          <td>
+          <td data-label="<%= t("models.sortition.fields.reference", scope: "decidim.sortitions.admin") %>">
+            <%= sortition.reference %>
+          </td>
+          <td data-label="<%= t("models.sortition.fields.title", scope: "decidim.sortitions.admin") %>">
             <% if allowed_to? :update, :sortition, sortition: sortition %>
               <%= link_to decidim_escape_translated(sortition.title), edit_sortition_path(sortition) %>
             <% else %>
               <%= decidim_escape_translated(sortition.title) %>
             <% end %>
           </td>
-          <td><%= l sortition.created_at, format: :short %></td>
-          <td class="table-list__actions">
-            <% if allowed_to? :update, :sortition, sortition: sortition %>
-              <%= icon_link_to "pencil-line", edit_sortition_path(sortition), t("actions.edit", scope: "decidim.sortitions.admin"), class: "action-icon--edit" %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
+          <td data-label="<%= t("models.sortition.fields.created_at", scope: "decidim.sortitions.admin") %>">
+            <%= l sortition.created_at, format: :short %>
+          </td>
+          <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.sortitions.admin") %>">
+            <button type="button" data-component="dropdown" data-target="actions-sortition-<%= sortition.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: sortition.title) %>">
+              <%= icon "more-fill", class: "text-secondary" %>
+            </button>
 
-            <%= icon_link_to "fullscreen-line", sortition_path(sortition), t("actions.show", scope: "decidim.sortitions.admin"), class: "action-icon--preview", target: "_blank", data: { "external-link": false } %>
+            <div class="inline-block relative">
+              <ul id="actions-sortition-<%= sortition.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                <% if allowed_to? :update, :sortition, sortition: sortition %>
+                  <li class="dropdown__item">
+                    <%= link_to edit_sortition_path(sortition), class: "dropdown__button" do %>
+                      <%= icon "pencil-line" %>
+                      <%= t("actions.edit", scope: "decidim.sortitions.admin") %>
+                    <% end %>
+                  </li>
 
-            <%= resource_permissions_link(sortition) %>
+                  <hr>
+                <% end %>
 
-            <% if allowed_to? :destroy, :sortition, sortition: sortition %>
-              <%= icon_link_to "delete-bin-line", confirm_destroy_sortition_path(sortition), t("actions.destroy", scope: "decidim.sortitions.admin"), class: "action-icon--remove" %>
-            <% else %>
-               <span class="action-space icon"></span>
-            <% end %>
+                <li class="dropdown__item">
+                  <%= link_to sortition_path(sortition), target: "_blank", data: { "external-link": false }, class: "dropdown__button" do %>
+                    <%= icon "fullscreen-line" %>
+                    <%= t("actions.show", scope: "decidim.sortitions.admin") %>
+                  <% end %>
+                </li>
+
+                <hr>
+
+                <li class="dropdown__item">
+                  <%= dropdown_resource_permissions_link(sortition) %>
+                </li>
+
+                <hr>
+
+                <% if allowed_to? :destroy, :sortition, sortition: sortition %>
+                  <li class="dropdown__item">
+                    <%= link_to confirm_destroy_sortition_path(sortition), class: "dropdown__button" do %>
+                      <%= icon "delete-bin-line" %>
+                      <%= t("actions.destroy", scope: "decidim.sortitions.admin") %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </ul>
+            </div>
           </td>
         </tr>
         <% end %>

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -45,6 +45,7 @@ en:
           edit: Edit
           new_sortition: New sortition
           show: Sortition details
+          title: Actions
         models:
           sortition:
             fields:

--- a/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
@@ -24,7 +24,7 @@
       <% end %>
     </h1>
   </div>
-  <div class="table-scroll">
+  <div class="table-stacked">
     <table class="table-list">
       <thead>
         <tr>
@@ -40,24 +40,54 @@
       <tbody>
         <% @participants.each_with_index do |participant, idx| %>
           <tr>
-            <td><%= idx + 1 + page_offset %></td>
-            <td class="!text-left">
+            <td data-label="#"> <%= idx + 1 + page_offset %> </td>
+            <td class="!text-left" data-label="<%= first_table_th(@participants.first) %>">
               <% if allowed_to? :show, :questionnaire_responses %>
                 <%= link_to first_table_td(participant), questionnaire_participant_responses_url(participant.session_token) %>
               <% else %>
-                <%= first_table_td(participant) %></td>
+                <%= first_table_td(participant) %>
               <% end %>
-            <td><%= participant.status %></td>
-            <td><%= participant.ip_hash %></td>
-            <td><%= display_percentage(participant.completion) %></td>
-            <td><%= l participant.responded_at, format: :short %></td>
-            <td class="table-list__actions">
-              <% if allowed_to? :show, :questionnaire_responses %>
-                <%= icon_link_to "eye-line", questionnaire_participant_responses_url(participant.session_token), t("actions.show", scope: "decidim.forms.admin.questionnaires.responses"), class: "action-icon--eye", target: "_blank", data: { "external-link": false } %>
-              <% end %>
-              <% if allowed_to? :export_response, :questionnaire_responses %>
-                <%= icon_link_to "download-line", questionnaire_export_response_url(participant.session_token), t("actions.export", scope: "decidim.forms.admin.questionnaires.responses"), class: "action-icon--data-transfer-download" %>
-              <% end %>
+            </td>
+            <td data-label="<%= t("user_status", scope: "decidim.forms.user_responses_serializer") %>">
+              <%= participant.status %>
+            </td>
+            <td data-label="<%= t("ip_hash", scope: "decidim.forms.user_responses_serializer") %>">
+              <%= participant.ip_hash %>
+            </td>
+            <td data-label="<%= t("completion", scope: "decidim.forms.user_responses_serializer") %>">
+              <%= display_percentage(participant.completion) %>
+            </td>
+            <td data-label="<%= t("created_at", scope: "decidim.forms.user_responses_serializer") %>">
+              <%= l participant.responded_at, format: :short %>
+            </td>
+            <td data-label="<%= t("actions.title", scope: "decidim.surveys") %>" class="table-list__actions">
+              <button type="button" data-component="dropdown" data-target="actions-participant-<%= idx %>" aria-label="<%= t("decidim.admin.actions.actions_label") %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
+
+              <div class="inline-block relative">
+                <ul id="actions-participant-<%= idx %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <% if allowed_to? :show, :questionnaire_responses %>
+                    <li class="dropdown__item">
+                      <%= link_to questionnaire_participant_responses_url(participant.session_token), target: "_blank", data: { "external-link": false }, class: "dropdown__button" do %>
+                        <%= icon "eye-line" %>
+                        <%= t("actions.show", scope: "decidim.forms.admin.questionnaires.responses") %>
+                      <% end %>
+                    </li>
+
+                    <hr>
+                  <% end %>
+
+                  <% if allowed_to? :export_response, :questionnaire_responses %>
+                    <li class="dropdown__item">
+                      <%= link_to questionnaire_export_response_url(participant.session_token), class: "dropdown__button" do %>
+                        <%= icon "download-line" %>
+                        <%= t("actions.export", scope: "decidim.forms.admin.questionnaires.responses") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -7,7 +7,7 @@
       <%= render partial: "decidim/admin/components/resource_action" %>
     </h1>
   </div>
-  <div class="table-scroll mt-8">
+  <div class="table-stacked mt-8">
     <table class="table-list">
       <thead>
         <tr>
@@ -21,27 +21,94 @@
       <tbody>
         <% surveys.each do |survey| %>
           <tr>
-            <td><%= decidim_sanitize_translated(survey.title) %></td>
-            <td><%= survey.questionnaire.questions.size %></td>
-            <td><%= survey.questionnaire.count_participants %></td>
-            <td><%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %></td>
-            <td class="table-list__actions">
-                <%= icon_link_to "pencil-line", edit_survey_path(survey), t("actions.edit", scope: "decidim.surveys"), class: "action-icon--edit" %>
-                <%= icon_link_to "survey-line", edit_questions_questions_survey_path(survey), t("actions.manage_questions", scope: "decidim.surveys"), class: "action-icon--copy" %>
-                <% if allowed_to? :preview, :questionnaire %>
-                <%= icon_link_to "eye-line", resource_locator(survey).path, t("actions.preview", scope: "decidim.surveys"), class: "action-icon--preview", target: :blank, data: { "external-link": false } %>
-                <% end %>
-                <% if allowed_to?(:update, :questionnaire) %>
-                  <% if survey.published? %>
-                    <%= icon_link_to "close-circle-line", unpublish_survey_path(survey), t("actions.unpublish", scope: "decidim.admin"), method: :put, class: "action-icon--unpublish" %>
-                  <% elsif survey.clean_after_publish? %>
-                    <%= icon_link_to "check-line", publish_survey_path(survey), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish", data: { confirm: t("actions.responses_alert", scope: "decidim.surveys", responses_count: survey.questionnaire.responses.size) } %>
-                  <% else %>
-                    <%= icon_link_to "check-line", publish_survey_path(survey), t("actions.publish", scope: "decidim.admin"), method: :put, class: "action-icon--publish" %>
+            <td data-label="<%= t("models.survey.fields.title", scope: "decidim.surveys") %>">
+              <%= decidim_sanitize_translated(survey.title) %>
+            </td>
+            <td data-label="<%= t("models.survey.fields.questions", scope: "decidim.surveys") %>">
+              <%= survey.questionnaire.questions.size %>
+            </td>
+            <td data-label="<%= t("models.survey.fields.responses", scope: "decidim.surveys") %>">
+              <%= survey.questionnaire.count_participants %>
+            </td>
+            <td data-label="<%= t("models.survey.fields.status", scope: "decidim.surveys") %>">
+              <%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %>
+            </td>
+            <td data-label="<%= t("actions.title", scope: "decidim.surveys") %>" class="table-list__actions">
+              <button type="button" data-component="dropdown" data-target="actions-survey-<%= survey.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: survey.title) %>">
+                <%= icon "more-fill", class: "text-secondary" %>
+              </button>
+
+              <div class="inline-block relative">
+                <ul id="actions-survey-<%= survey.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                  <li class="dropdown__item">
+                    <%= link_to edit_survey_path(survey), class: "dropdown__button" do %>
+                      <%= icon "pencil-line" %>
+                      <%= t("actions.edit", scope: "decidim.surveys") %>
+                    <% end %>
+                  </li>
+
+                  <li class="dropdown__item">
+                    <%= link_to edit_questions_questions_survey_path(survey), class: "dropdown__button" do %>
+                      <%= icon "survey-line" %>
+                      <%= t("actions.manage_questions", scope: "decidim.surveys") %>
+                    <% end %>
+                  </li>
+
+                  <hr>
+
+                  <% if allowed_to?(:update, :questionnaire) %>
+                    <% if survey.published? %>
+                      <li class="dropdown__item">
+                        <%= link_to unpublish_survey_path(survey), method: :put, class: "dropdown__button" do %>
+                          <%= icon "close-circle-line" %>
+                          <%= t("actions.unpublish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% elsif survey.clean_after_publish? %>
+                      <li class="dropdown__item">
+                        <%= link_to publish_survey_path(survey), method: :put, data: { confirm: t("actions.responses_alert", scope: "decidim.surveys", responses_count: survey.questionnaire.responses.size) }, class: "dropdown__button" do %>
+                          <%= icon "check-line" %>
+                          <%= t("actions.publish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% else %>
+                      <li class="dropdown__item">
+                        <%= link_to publish_survey_path(survey), method: :put, class: "dropdown__button" do %>
+                          <%= icon "check-line" %>
+                          <%= t("actions.publish", scope: "decidim.admin") %>
+                        <% end %>
+                      </li>
+                    <% end %>
+
+                    <hr>
                   <% end %>
-                <% end %>
-                <%= resource_permissions_link(survey) %>
-                <%= icon_link_to "delete-bin-line", survey_path(survey), t("actions.destroy", scope: "decidim.surveys"), method: :delete, class: "action-icon--remove", data: { confirm: t("actions.confirm_destroy", scope: "decidim.surveys") } %>
+
+                  <% if allowed_to? :preview, :questionnaire %>
+                    <li class="dropdown__item">
+                      <%= link_to resource_locator(survey).path, target: :blank, data: { "external-link": false }, class: "dropdown__button" do %>
+                        <%= icon "eye-line" %>
+                        <%= t("actions.preview", scope: "decidim.surveys") %>
+                      <% end %>
+                    </li>
+
+                    <hr>
+                  <% end %>
+
+
+                  <li class="dropdown__item">
+                    <%= dropdown_resource_permissions_link(survey) %>
+                  </li>
+
+                  <hr>
+
+                  <li class="dropdown__item">
+                    <%= link_to survey_path(survey), method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.surveys") }, class: "dropdown__button" do %>
+                      <%= icon "delete-bin-line" %>
+                      <%= t("actions.destroy", scope: "decidim.surveys") %>
+                    <% end %>
+                  </li>
+                </ul>
+              </div>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR moves the actions for the admin tables to a meatball menu, so it is easier to understand what each actions does. It's a follow-up from #14805, this time doing the other tables from the spaces sections in the admin panel. 

Only implements this change in half of the resources, to make the review easier. These modules are:

- Meetings
- Proposals
- Sortitions
- Surveys

#### :pushpin: Related Issues
 
- Related to #14713
- Related to #14805
- Related to #14651

#### Testing

1. Sign in as admin
2. Navigate in the dashboard and see the actions for the resources
 
:hearts: Thank you!
