### PR TITLE
Fix hidden content in "More information"

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -23,7 +23,7 @@
         <% end %>
       </div>
 
-      <button class="button button__sm button__text-secondary mt-2" data-controls="panel-view-more-<%= seed %>" aria-expanded="false">
+      <button class="button button__sm button__text-secondary mt-2" data-controls="panel-view-more-<%= seed %>" aria-expanded="false" onclick="document.querySelector('div[id^=panel-view-more]').toggleAttribute('inert')">
         <span>
           <%= t("view_more", scope: "layouts.decidim.announcements") %>
         </span>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -15,7 +15,7 @@
   <div class="content-block__description editor-content" <%= "data-component='accordion'" if should_truncate %>>
     <% if should_truncate %>
       <% seed = SecureRandom.hex(4) %>
-      <div id="panel-view-more-<%= seed %>" aria-hidden="true" class="editor-content">
+      <div id="panel-view-more-<%= seed %>" class="editor-content" inert>
         <% if rich_text_processors? %>
           <%= render_rich_text(resource, :description) %>
         <% else %>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -42,3 +42,12 @@
     <% end %>
   </div>
 <% end %>
+<script>
+  const button = document.querySelector('button[data-controls^="panel-view-more"]')
+  button.addEventListener('keydown', function(e){
+    // press space or enter
+    if (e.keyCode === 32 || e.keyCode === 13){
+      document.querySelector('div[id^=panel-view-more]').toggleAttribute('inert')
+    }
+  })
+</script>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds an `inert` attribute on hidden content, and adds the toggle of the attribute when the content is displayed.
This PR is issued from the audit of Angers city (page 68) and corresponds to criterias 1.3.2 and 4.1.2 from WCAG.


#### Testing

1. As an admin, go in the BO to the edit page of the process
2. In the description of the process, add 10 lines, and one or two links in it
3. In the FO, go to the process show page
4. Navigate with the keyboard, and see that the links in the hidden description are not accessible
5. Click on "More information"
6. Navigate with the keyboard, and see that the links are accessible

### :camera: Screenshots
<img width="1016" alt="457043853-8a63e30b-d7a1-4b50-a1d7-cd1c014c3a5c" src="https://github.com/user-attachments/assets/d8d544de-7478-4690-be91-86282a6d75bf" />

<img width="980" alt="457043918-8dcde273-de92-4794-b8b9-bc511ac4e579" src="https://github.com/user-attachments/assets/fc04dd78-74a6-4ebb-bc7e-edb601773ed5" />


:hearts: Thank you!
