### PR TITLE
Fix grammar in conference admin registration count info

### DIFF
--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -394,7 +394,7 @@ en:
             no_taxonomy_filters_found: No taxonomy filters found.
             registrations_count:
               one: There has been 1 registration.
-              other: There has been %{count} registrations.
+              other: There have been %{count} registrations.
             slug_help_html: 'URL slugs are used to generate the URLs that point to this conference. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
             taxonomies: Taxonomies
         content_blocks:


### PR DESCRIPTION
#### :tophat: What? Why?
There's a small grammar error when displaying the number of registrations to a conference in English. (screenshot below).

- "There have been 0 registrations."
- "There has been 1 registration."
- "There have been 2 registrations."
- ...
#### Testing
Seed a local environment and check the admin panel of a conference registration:

- Sample url: localhost:3000/admin/conferences/Fried/components/1/manage/meetings/1/registrations/edit

### :camera: Screenshots
<img width="148" alt="image" src="https://github.com/user-attachments/assets/3b6f948c-89ff-4a93-9a95-7e4628f404cc" />

<img width="287" alt="image" src="https://github.com/user-attachments/assets/e5929742-5282-490c-8e6a-6d8dcee792a9" />

:hearts: Thank you!
