### PR TITLE
Fix admin visibility menu of insights

### DIFF
--- a/decidim-admin/lib/decidim/admin/menu.rb
+++ b/decidim-admin/lib/decidim/admin/menu.rb
@@ -296,7 +296,8 @@ module Decidim
                         I18n.t("menu.insights", scope: "decidim.admin"),
                         decidim_admin.statistics_path,
                         icon_name: "line-chart",
-                        position: 11
+                        position: 11,
+                        if: allowed_to?(:read, :statistics)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #14783, i logged in as an evaluator, and i have noticed that insight menu entry is available for non admin users. This PR fixes this

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Login as `participatory_process_1_evaluator@example.org`
2. Visit the admin menu 
3. Accept TOS 
4. See menu entry 
5. Apply patch & restart app 
6. Refresh admin page
7. See menu entry is not displayed

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
