### PR TITLE
Breadcrumb mobile responsiveness nitpicks

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -416,7 +416,7 @@ header {
         @apply w-full px-4;
 
         &-menu {
-          @apply w-full md:w-1/2 mt-0 grid md:grid-cols-2 gap-x-6 text-secondary;
+          @apply w-full md:w-[105%] mt-0 grid md:grid-cols-2 gap-x-6 text-secondary;
 
           > * {
             @apply py-3 md:py-3.5 border-b last:border-0 border-gray-3;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -416,7 +416,7 @@ header {
         @apply w-full px-4;
 
         &-menu {
-          @apply w-full md:w-[105%] mt-0 grid md:grid-cols-2 gap-x-6 text-secondary;
+          @apply w-full md:w-[100%] mt-0 grid md:grid-cols-2 gap-x-6 text-secondary;
 
           > * {
             @apply py-3 md:py-3.5 border-b last:border-0 border-gray-3;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -443,6 +443,14 @@ header {
 
       &__bottom {
         @apply hidden md:flex;
+
+        &-right {
+          @apply mr-2 mb-2;
+        }
+
+        &-left {
+          @apply mr-2 mt-1;
+        }
       }
 
       &__title {

--- a/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
@@ -1,7 +1,7 @@
 <% if available_locales.length > 1 %>
     <div>
         <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10 border border-gray outline outline-1 outline-transparent">
-            <span><%= t("name", scope: "locale" ) %></span>
+            <span class="ml-2"><%= t("name", scope: "locale" ) %></span>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-up-s-line" %>
             <span class="sr-only">


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes some nitpicks of the header responsiveness using the breadcrumb on mobile on certain dimensions. 

#### :pushpin: Related Issues
- Fixes #14907

#### Testing
1. Head over to the Decidim app
2. Use the breadcrumb feature in homepage (the burger top right hand corner next to profile avatar)
3. Adjust to dimensions 1033 or below < 
4. See the improvement with alignment

### :camera: Screenshots
BEFORE CHANGES: 

![image](https://github.com/user-attachments/assets/fd77ca4a-fe9c-4941-acb7-4943c7702913)


AFTER CHANGES

- Visible pages to go to (Processes, Assemblies etc etc)
- Lang option dropdown alignment
- Column left and right alignment

![image](https://github.com/user-attachments/assets/5ad02136-4331-49da-ad68-da4f8225f49b)


:hearts: Thank you!
