### PR TITLE
Fix filters for impersonatable users admin table

### DIFF
--- a/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
@@ -15,18 +15,22 @@
 </div>
 
 <div class="filters__section">
-  <div class="fcell">
-    <ul class="dropdown menu" data-dropdown-menu data-close-on-click-inside="false">
-      <li class="is-dropdown-submenu-parent">
-        <a href="#" class="dropdown button">
-          <%= t("filter_label", scope: "decidim.admin.filters") %>
-          <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
-        </a>
-        <ul class="menu is-dropdown-submenu">
-          <li><%= link_to t(".filter.managed"), url_for(state: "managed", q: @query) %></li>
-          <li><%= link_to t(".filter.not_managed"), url_for(state: "not_managed", q: @query) %></li>
-          <li><%= link_to t(".filter.all"), url_for(q: @query) %></li>
-        </ul>
+  <div class="relative">
+    <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="dropdown-filters">
+      <%= t("filter_label", scope: "decidim.admin.filters") %>
+      <%= icon "arrow-down-s-line", class: "!fill-secondary" %>
+      <%= icon "arrow-down-s-line", class: "!fill-secondary" %>
+    </button>
+
+    <ul class="dropdown" id="dropdown-filters" aria-hidden="true">
+      <li class="dropdown__item">
+        <%= link_to t(".filter.managed"), url_for(state: "managed", q: @query), class: "dropdown__button" %>
+      </li>
+      <li class="dropdown__item">
+        <%= link_to t(".filter.not_managed"), url_for(state: "not_managed", q: @query), class: "dropdown__button" %>
+      </li>
+      <li class="dropdown__item">
+        <%= link_to t(".filter.all"), url_for(q: @query), class: "dropdown__button" %>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?

After the migration of dropdowns in  #14713, I missed one filter in http://localhost:3000/admin/impersonatable_users 

This PR fixes that

#### :pushpin: Related Issues
 
- Related to #14713 
 

#### Testing

1. Sign in as admin 
2. Go to 
3. (Before the patch) See the filters broken
4. (After the patch) See the filters well

### :camera: Screenshots

#### Before

![image](https://github.com/user-attachments/assets/90bcdd26-3208-4877-b10e-67a88d603e85)

#### After

![2025-07-02-110149_hyprshot](https://github.com/user-attachments/assets/3a232c02-7fa8-41a1-a0e1-ddcdb558b1dd)
![2025-07-02-110144_hyprshot](https://github.com/user-attachments/assets/46248c4b-de8e-4bdd-bdef-20548592d3e2)

:hearts: Thank you!
