### PR TITLE
Implement dropdown menu for taxonomies

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_taxonomies.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_taxonomies.scss
@@ -23,10 +23,10 @@
 }
 
 ul.taxonomy {
-  @apply flex;
+  @apply md:flex;
 
   li {
-    @apply flex-none text-center w-20 mt-2 mb-2;
+    @apply flex-none md:w-20 mt-2 mb-2 md:text-center;
 
     &:first-child {
       @apply flex-initial text-left flex-grow;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_taxonomies.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_taxonomies.scss
@@ -50,6 +50,10 @@ ul.taxonomy {
     .action-space {
       @apply w-5 h-5;
     }
+
+    .dropdown__item {
+      @apply text-left m-0 w-full;
+    }
   }
 }
 

--- a/decidim-admin/app/views/decidim/admin/taxonomies/_row.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomies/_row.html.erb
@@ -3,15 +3,33 @@
   <td role="cell">
     <ul class="taxonomy">
       <% if taxonomy.root? %>
-        <li><%= link_to translated_attribute(taxonomy.name), edit_taxonomy_path(taxonomy), class: "js-drawer-editor" %></li>
-        <li><%= taxonomy.all_children.count %></li>
-        <li><%= taxonomy.filters_count %></li>
+        <li>
+          <span class="md:hidden"><%= t("decidim.admin.taxonomies.name") %>: </span>
+          <%= link_to translated_attribute(taxonomy.name), edit_taxonomy_path(taxonomy), class: "js-drawer-editor" %>
+        </li>
+        <li>
+          <span class="md:hidden"><%= t("decidim.admin.taxonomies.total_items") %>: </span>
+          <%= taxonomy.all_children.count %>
+        </li>
+        <li>
+          <span class="md:hidden"><%= t("decidim.admin.taxonomies.total_filters") %>: </span>
+          <%= taxonomy.filters_count %>
+        </li>
       <% else %>
-        <li><%= link_to translated_attribute(taxonomy.name), edit_taxonomy_item_path(taxonomy_id: taxonomy.root_taxonomy.id, id: taxonomy.id), class: "js-drawer-editor" %></li>
-        <li><%= taxonomy.taxonomizations_count %></li>
+        <li>
+          <span class="md:hidden"><%= t("decidim.admin.taxonomies.name") %>: </span>
+          <%= link_to translated_attribute(taxonomy.name), edit_taxonomy_item_path(taxonomy_id: taxonomy.root_taxonomy.id, id: taxonomy.id), class: "js-drawer-editor" %>
+        </li>
+        <li>
+          <span class="md:hidden"><%= t("decidim.admin.taxonomies.count") %>: </span>
+          <%= taxonomy.taxonomizations_count %>
+        </li>
       <% end %>
 
-      <li class="taxonomy-list__actions"><%= render "taxonomy_actions", taxonomy: %></li>
+      <li class="taxonomy-list__actions">
+        <span class="md:hidden !ml-0"><%= t("decidim.admin.taxonomies.actions.actions") %>: </span>
+        <%= render "taxonomy_actions", taxonomy: %>
+      </li>
     </ul>
     <% if with_children && taxonomy.children.any? %>
       <div class="js-sortable js-draggable-<%= taxonomy.id %>"

--- a/decidim-admin/app/views/decidim/admin/taxonomies/_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomies/_table.html.erb
@@ -1,4 +1,4 @@
-<div class="table-scroll mt-8" role="table" aria-labelledby="taxonomies-title">
+<div class="table-stacked mt-8" role="table" aria-labelledby="taxonomies-title">
   <table class="table-list">
     <thead>
     <tr role="row">

--- a/decidim-admin/app/views/decidim/admin/taxonomies/_taxonomy_actions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomies/_taxonomy_actions.html.erb
@@ -1,15 +1,48 @@
-<% if allowed_to? :update, :taxonomy, taxonomy: taxonomy %>
-  <% if taxonomy.root? %>
-    <%= icon_link_to "pencil-line", edit_taxonomy_path(taxonomy), t("actions.edit", scope: "decidim.admin.taxonomies"), class: "action-icon--edit js-drawer-editor" %>
-    <%= icon_link_to "filter-line", taxonomy_filters_path(taxonomy), t("actions.filters", scope: "decidim.admin.taxonomies"), class: "-action-icon--edit" %>
-  <% else %>
-    <%= icon_link_to "pencil-line", edit_taxonomy_item_path(taxonomy_id: taxonomy.root_taxonomy.id, id: taxonomy.id), t("actions.edit", scope: "decidim.admin.taxonomies"), class: "action-icon--edit js-drawer-editor" %>
-  <% end %>
-<% else %>
-  <span class="action-space icon"></span>
-<% end %>
-<% if allowed_to? :destroy, :taxonomy, taxonomy: taxonomy %>
-  <%= icon_link_to "delete-bin-line", taxonomy, t("actions.destroy", scope: "decidim.admin.taxonomies"), class: "action-icon--remove", method: :delete, data: { confirm: t(".confirm_destroy", name: strip_tags(translated_attribute(taxonomy.name))) } %>
-<% else %>
-  <span class="action-space icon"></span>
-<% end %>
+<button type="button" data-component="dropdown" data-target="actions-taxonomy-<%= taxonomy.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: taxonomy.name) %>">
+  <%= icon "more-fill", class: "text-secondary" %>
+</button>
+
+<div class="inline-block relative">
+  <ul id="actions-taxonomy-<%= taxonomy.id %>" class="dropdown dropdown__action" aria-hidden="true">
+    <% if allowed_to? :update, :taxonomy, taxonomy: taxonomy %>
+      <li class="dropdown__item">
+        <% if taxonomy.root? %>
+          <%= link_to edit_taxonomy_path(taxonomy), class: "dropdown__button js-drawer-editor" do %>
+            <%= icon "pencil-line" %>
+            <%= t("actions.edit", scope: "decidim.admin.taxonomies") %>
+          <% end %>
+        <% else %>
+          <%= link_to edit_taxonomy_item_path(taxonomy_id: taxonomy.root_taxonomy.id, id: taxonomy.id), class: "dropdown__button js-drawer-editor" do %>
+            <%= icon "pencil-line" %>
+            <%= t("actions.edit", scope: "decidim.admin.taxonomies") %>
+          <% end %>
+        <% end %>
+      </li>
+
+      <% if taxonomy.root? %>
+        <hr>
+
+        <li class="dropdown__item">
+          <%= link_to taxonomy_filters_path(taxonomy), class: "dropdown__button" do %>
+            <%= icon "filter-line" %>
+            <%= t("actions.filters", scope: "decidim.admin.taxonomies") %>
+          <% end %>
+        </li>
+      <% end %>
+    <% end %>
+
+    <% if allowed_to? :destroy, :taxonomy, taxonomy: taxonomy %>
+      <hr>
+
+      <li class="dropdown__item">
+        <%= link_to taxonomy,
+                    method: :delete,
+                    data: { confirm: t(".confirm_destroy", name: strip_tags(translated_attribute(taxonomy.name))) },
+                    class: "dropdown__button dropdown__button--danger" do %>
+          <%= icon "delete-bin-line" %>
+          <%= t("actions.destroy", scope: "decidim.admin.taxonomies") %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
@@ -1,4 +1,4 @@
-<div class="table-scroll mt-8" role="table" aria-labelledby="taxonomies-title">
+<div class="table-stacked mt-8" role="table" aria-labelledby="taxonomies-title">
   <table class="table-list">
     <thead>
       <tr role="row">
@@ -11,20 +11,57 @@
     <tbody role="rowgroup">
       <% collection.each do |taxonomy_filter| %>
         <tr>
-          <td><%= translated_attribute(taxonomy_filter.internal_name) %></td>
-          <td><%= translated_attribute(taxonomy_filter.name) %></td>
-          <td><%= taxonomy_filter.components_count %></td>
-          <td>
-            <% if allowed_to? :update, :taxonomy_filter, taxonomy_filter: %>
-              <%= icon_link_to "pencil-line", edit_taxonomy_filter_path(root_taxonomy, taxonomy_filter), t(".edit"), class: "action-icon--edit" %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
-            <% if allowed_to? :destroy, :taxonomy_filter, taxonomy_filter: %>
-              <%= icon_link_to "delete-bin-line", taxonomy_filter_path(root_taxonomy, taxonomy_filter), t(".destroy"), class: "action-icon--remove", method: :delete, data: { confirm: t(".confirm_destroy", name: strip_tags(translated_attribute(taxonomy_filter.name))) } %>
-            <% else %>
-              <span class="action-space icon"></span>
-            <% end %>
+          <td data-label="<%= t('.internal_name') %>">
+            <%= translated_attribute(taxonomy_filter.internal_name) %>
+          </td>
+          <td data-label="<%= t('.name') %>">
+            <%= translated_attribute(taxonomy_filter.name) %>
+          </td>
+          <td data-label="<%= t('.components_count') %>">
+            <%= taxonomy_filter.components_count %>
+          </td>
+          <td data-label="<%= t('.actions') %>" class="table-list__actions">
+            <button type="button" data-component="dropdown" data-target="actions-taxonomy-filter-<%= taxonomy_filter.id %>" aria-label="<%= t(".actions") %>">
+              <%= icon "more-fill", class: "text-secondary" %>
+            </button>
+
+            <div class="inline-block relative">
+              <ul id="actions-taxonomy-filter-<%= taxonomy_filter.id %>" class="dropdown dropdown__action" aria-hidden="true">
+                <% if allowed_to? :update, :taxonomy_filter, taxonomy_filter: taxonomy_filter %>
+                  <li class="dropdown__item">
+                    <%= link_to edit_taxonomy_filter_path(root_taxonomy, taxonomy_filter), class: "dropdown__button" do %>
+                      <%= icon "pencil-line" %>
+                      <%= t(".edit") %>
+                    <% end %>
+                  </li>
+                <% else %>
+                  <div class="dropdown__button-disabled">
+                    <%= with_tooltip t("tooltips.cannot_edit_taxonomy_filter", scope: "decidim.admin") do %>
+                      <%= icon "pencil-line", class: "text-gray" %>
+                      <%= t(".edit") %>
+                    <% end %>
+                  </div>
+                <% end %>
+
+                <% if allowed_to? :destroy, :taxonomy_filter, taxonomy_filter: taxonomy_filter %>
+                  <hr>
+
+                  <li class="dropdown__item">
+                    <%= link_to taxonomy_filter_path(root_taxonomy, taxonomy_filter), method: :delete, data: { confirm: t(".confirm_destroy", name: strip_tags(translated_attribute(taxonomy_filter.name))) }, class: "dropdown__button" do %>
+                      <%= icon "delete-bin-line" %>
+                      <%= t(".destroy") %>
+                    <% end %>
+                  </li>
+                <% else %>
+                  <div class="dropdown__button-disabled">
+                    <%= with_tooltip t("tooltips.cannot_destroy_taxonomy_filter", scope: "decidim.admin") do %>
+                      <%= icon "delete-bin-line", class: "text-gray" %>
+                      <%= t(".destroy") %>
+                    <% end %>
+                  </div>
+                <% end %>
+              </ul>
+            </div>
           </td>
         </tr>
       <% end %>

--- a/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
@@ -11,16 +11,16 @@
     <tbody role="rowgroup">
       <% collection.each do |taxonomy_filter| %>
         <tr>
-          <td data-label="<%= t('.internal_name') %>">
+          <td data-label="<%= t(".internal_name") %>">
             <%= translated_attribute(taxonomy_filter.internal_name) %>
           </td>
-          <td data-label="<%= t('.name') %>">
+          <td data-label="<%= t(".name") %>">
             <%= translated_attribute(taxonomy_filter.name) %>
           </td>
-          <td data-label="<%= t('.components_count') %>">
+          <td data-label="<%= t(".components_count") %>">
             <%= taxonomy_filter.components_count %>
           </td>
-          <td data-label="<%= t('.actions') %>" class="table-list__actions">
+          <td data-label="<%= t(".actions") %>" class="table-list__actions">
             <button type="button" data-component="dropdown" data-target="actions-taxonomy-filter-<%= taxonomy_filter.id %>" aria-label="<%= t(".actions") %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1234,10 +1234,10 @@ en:
         taxonomy_filters: Taxonomy filters for "%{taxonomy}"
         users: Administrators
       tooltips:
+        cannot_destroy_taxonomy_filter: Cannot destroy this taxonomy filter
         cannot_edit_taxonomy_filter: Cannot edit this taxonomy filter
         deleted_attachment_collections_info: Cannot delete this folder because it has attachments.
         deleted_component_info: This component can only be deleted if status is 'Unpublished'.
-        cannot_destroy_taxonomy_filter: Cannot destroy this taxonomy filter
       trash_management:
         restore:
           invalid: There was a problem restoring %{resource_name}.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1234,7 +1234,10 @@ en:
         taxonomy_filters: Taxonomy filters for "%{taxonomy}"
         users: Administrators
       tooltips:
+        cannot_edit_taxonomy_filter: Cannot edit this taxonomy filter
+        deleted_attachment_collections_info: Cannot delete this attachment collection as it has attachments on it.
         deleted_component_info: This component can only be deleted if status is 'Unpublished'.
+        cannot_destroy_taxonomy_filter: Cannot destroy this taxonomy filter
       trash_management:
         restore:
           invalid: There was a problem restoring %{resource_name}.

--- a/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
@@ -16,8 +16,14 @@ shared_examples "manage taxonomy filters in settings" do
     let!(:another_taxonomy_filter) do
       create(:taxonomy_filter, internal_name: { en: "Another filter" }, participatory_space_manifests: [participatory_space.manifest.name], root_taxonomy:)
     end
+
     before do
-      click_on "Configure"
+      puts translated_attribute(component.name)
+      within "tr", text: translated_attribute(component.name) do
+        find("button[data-component='dropdown']").click
+        take_screenshot
+        click_on "Configure"
+      end
     end
 
     it "can be added to settings" do
@@ -57,6 +63,7 @@ shared_examples "manage taxonomy filters in settings" do
       expect(component.reload.settings.taxonomy_filters).to contain_exactly(taxonomy_filter.id.to_s, another_taxonomy_filter.id.to_s)
 
       click_on "Update"
+      find("button[data-component='dropdown']").click if page.has_css?("button[data-component='dropdown']")
       click_on "Configure"
       within ".js-current-filters" do
         expect(page).to have_css("td", text: "Internal taxonomy filter name")
@@ -69,6 +76,7 @@ shared_examples "manage taxonomy filters in settings" do
     let(:taxonomy_filter_item) { nil }
     let(:taxonomy_filter) { nil }
     before do
+      find("button[data-component='dropdown']").click if page.has_css?("button[data-component='dropdown']")
       click_on "Configure"
     end
 
@@ -83,12 +91,14 @@ shared_examples "manage taxonomy filters in settings" do
 
     before do
       component.update!(settings: { taxonomy_filters: [another_taxonomy_filter.id.to_s, taxonomy_filter.id.to_s] })
+      find("button[data-component='dropdown']").click if page.has_css?("button[data-component='dropdown']")
       click_on "Configure"
     end
 
     it "can be removed from settings" do
       within ".js-current-filters" do
         within "tr", text: "Internal taxonomy filter name" do
+          find("button[data-component='dropdown']").click if page.has_css?("button[data-component='dropdown']")
           click_on "Edit"
         end
       end
@@ -117,6 +127,7 @@ shared_examples "manage taxonomy filters in settings" do
       end
 
       click_on "Update"
+      find("button[data-component='dropdown']").click if page.has_css?("button[data-component='dropdown']")
       click_on "Configure"
       within ".js-current-filters" do
         expect(page).to have_css("td", text: "Internal taxonomy filter name")

--- a/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
@@ -231,12 +231,14 @@ describe "Admin manages taxonomies" do
 
   def click_delete_taxonomy
     within "tr", text: translated(taxonomy.name) do
+      find("button[data-component='dropdown']").click
       accept_confirm { click_on "Delete" }
     end
   end
 
   def click_edit_taxonomy
     within "tr", text: translated(taxonomy.name) do
+      find("button[data-component='dropdown']").click
       click_on "Edit"
     end
   end

--- a/decidim-admin/spec/system/admin_manages_taxonomy_filters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_taxonomy_filters_spec.rb
@@ -69,6 +69,7 @@ describe "Admin manages taxonomy filters" do
     before do
       visit decidim_admin.taxonomy_filters_path(taxonomy_id: another_root_taxonomy.id)
       within "tr", text: translated(another_taxonomy_filter.name) do
+        find("button[data-component='dropdown']").click
         click_on "Edit"
       end
     end
@@ -83,6 +84,7 @@ describe "Admin manages taxonomy filters" do
   context "when editing a taxonomy with items" do
     before do
       within "tr", text: translated(taxonomy_filter.name) do
+        find("button[data-component='dropdown']").click
         click_on "Edit"
       end
     end
@@ -112,6 +114,7 @@ describe "Admin manages taxonomy filters" do
   context "when destroying a taxonomy filter" do
     before do
       within "tr", text: translated(taxonomy_filter.name) do
+        find("button[data-component='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR moves the actions for the admin tables to a meatball menu, so it is easier to understand what each actions does. It's a follow-up from #14805, this time doing the other tables from the admin module sections in the admin panel. 

Only implements this change in some of the resources, to make the review easier. These resources are:

- Taxonomies
- Taxonomies filters

Note that as Taxonomies is a weird table and doesn't follow the same patterns of the other tables (i.e. it can has children rows in it), I couldn't implement the `table-stacked`/`data-label` pattern here. I think the responsiveness is a pending task for now, but to be honest I don't think there would be hundreds of admins trying to configure the general Taxonomies using the mobile devices.

#### :pushpin: Related Issues
 
- Related to #14713
- Related to #14805
- Related to #14651

#### Testing

1. Sign in as admin
2. Navigate in the dashboard and see the actions for the resources

:hearts: Thank you!
