### PR TITLE
Remove some of the hashtag params

### DIFF
--- a/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
@@ -17,10 +17,13 @@ module Decidim
       # Render the result title
       #
       # Returns a String.
-      def title(links: false, extras: true, html_escape: false, all_locales: false)
+      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
         return unless result
 
-        super(result.title, links, html_escape, all_locales, extras:)
+        raise "Extras have been set" unless extras.nil?
+        raise "Links have been set" unless links.nil?
+
+        super(result.title, nil, html_escape, all_locales)
       end
     end
   end

--- a/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
@@ -23,7 +23,7 @@ module Decidim
         raise "Extras have been set" unless extras.nil?
         raise "Links have been set" unless links.nil?
 
-        super(result.title, nil, html_escape, all_locales)
+        super(result.title, html_escape, all_locales)
       end
     end
   end

--- a/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
@@ -17,11 +17,8 @@ module Decidim
       # Render the result title
       #
       # Returns a String.
-      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless result
-
-        raise "Extras have been set" unless extras.nil?
-        raise "Links have been set" unless links.nil?
 
         super(result.title, html_escape, all_locales)
       end

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -26,10 +26,8 @@ module Decidim
         Decidim::ResourceLocatorPresenter.new(post).path
       end
 
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless post
-
-        raise "Links have been set" unless links.nil?
 
         super(post.title, html_escape, all_locales)
       end
@@ -42,7 +40,7 @@ module Decidim
 
       def taxonomy_names(html_escape: false, all_locales: false)
         post.taxonomies.map do |taxonomy|
-          taxonomy.presenter.title(links: false, html_escape:, all_locales:)
+          taxonomy.presenter.title(html_escape:, all_locales:)
         end
       end
     end

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -26,10 +26,12 @@ module Decidim
         Decidim::ResourceLocatorPresenter.new(post).path
       end
 
-      def title(links: false, html_escape: false, all_locales: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless post
 
-        super(post.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(post.title, nil, html_escape, all_locales)
       end
 
       def body(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -32,10 +32,8 @@ module Decidim
         super(post.title, html_escape, all_locales)
       end
 
-      def body(links: nil, strip_tags: false, all_locales: false)
+      def body(links: false, strip_tags: false, all_locales: false)
         return unless post
-
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(post.body, all_locales, links, strip_tags)
       end

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -31,7 +31,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(post.title, nil, html_escape, all_locales)
+        super(post.title, html_escape, all_locales)
       end
 
       def body(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -32,8 +32,10 @@ module Decidim
         super(post.title, html_escape, all_locales)
       end
 
-      def body(links: false, extras: true, strip_tags: false, all_locales: false)
+      def body(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless post
+
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(post.body, all_locales, extras, links, strip_tags)
       end

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -32,12 +32,10 @@ module Decidim
         super(post.title, html_escape, all_locales)
       end
 
-      def body(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def body(links: false, strip_tags: false, all_locales: false)
         return unless post
 
-        raise "Extras being set" unless extras.nil?
-
-        content_handle_locale(post.body, all_locales, extras, links, strip_tags)
+        content_handle_locale(post.body, all_locales, links, strip_tags)
       end
 
       def taxonomy_names(html_escape: false, all_locales: false)

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -32,8 +32,10 @@ module Decidim
         super(post.title, html_escape, all_locales)
       end
 
-      def body(links: false, strip_tags: false, all_locales: false)
+      def body(links: nil, strip_tags: false, all_locales: false)
         return unless post
+
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(post.body, all_locales, links, strip_tags)
       end

--- a/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
@@ -14,7 +14,7 @@ module Decidim
         raise "Extras has been set" unless extras.nil?
         raise "Links have been set" unless links.nil?
 
-        super(project.title, nil, html_escape, all_locales)
+        super(project.title, html_escape, all_locales)
       end
 
       delegate_missing_to :project

--- a/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
@@ -8,10 +8,13 @@ module Decidim
       # @param html_escape [Boolean] Should HTML entities within the title be escaped? Default is +false+.
       # @param all_locales [Boolean] Should the title be returned for all locales? Default is +false+.
       # @return [String] The title of the project.
-      def title(links: false, extras: true, html_escape: false, all_locales: false)
+      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
         return unless project
 
-        super(project.title, links, html_escape, all_locales, extras:)
+        raise "Extras has been set" unless extras.nil?
+        raise "Links have been set" unless links.nil?
+
+        super(project.title, nil, html_escape, all_locales)
       end
 
       delegate_missing_to :project

--- a/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
+++ b/decidim-budgets/app/presenters/decidim/budgets/project_presenter.rb
@@ -8,11 +8,8 @@ module Decidim
       # @param html_escape [Boolean] Should HTML entities within the title be escaped? Default is +false+.
       # @param all_locales [Boolean] Should the title be returned for all locales? Default is +false+.
       # @return [String] The title of the project.
-      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless project
-
-        raise "Extras has been set" unless extras.nil?
-        raise "Links have been set" unless links.nil?
 
         super(project.title, html_escape, all_locales)
       end

--- a/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
+++ b/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
@@ -31,8 +31,11 @@ module Decidim
       # Render the suggestion title
       #
       # Returns a String.
-      def title(links: false, extras: true, html_escape: false, all_locales: false)
-        super(suggestion.document.title, links, html_escape, all_locales, extras:)
+      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
+        raise "Links have been set" unless links.nil?
+        raise "Extras have been set" unless extras.nil?
+
+        super(suggestion.document.title, nil, html_escape, all_locales)
       end
 
       def type

--- a/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
+++ b/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
@@ -35,7 +35,7 @@ module Decidim
         raise "Links have been set" unless links.nil?
         raise "Extras have been set" unless extras.nil?
 
-        super(suggestion.document.title, nil, html_escape, all_locales)
+        super(suggestion.document.title, html_escape, all_locales)
       end
 
       def type

--- a/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
+++ b/decidim-collaborative_texts/app/presenters/decidim/collaborative_texts/suggestion_presenter.rb
@@ -31,10 +31,7 @@ module Decidim
       # Render the suggestion title
       #
       # Returns a String.
-      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
-        raise "Links have been set" unless links.nil?
-        raise "Extras have been set" unless extras.nil?
-
+      def title(html_escape: false, all_locales: false)
         super(suggestion.document.title, html_escape, all_locales)
       end
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -112,9 +112,7 @@ module Decidim
       add_line_feeds_to_paragraphs(add_line_feeds_to_list_items(text))
     end
 
-    def content_handle_locale(body, all_locales, extras, links, strip_tags)
-      raise "Extras being set" unless extras.nil?
-
+    def content_handle_locale(body, all_locales, links, strip_tags)
       handle_locales(body, all_locales) do |content|
         content = strip_tags(sanitize_text(content)) if strip_tags
 

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -113,11 +113,13 @@ module Decidim
     end
 
     def content_handle_locale(body, all_locales, extras, links, strip_tags)
+      raise "Extras being set" unless extras.nil?
+
       handle_locales(body, all_locales) do |content|
         content = strip_tags(sanitize_text(content)) if strip_tags
 
         renderer = Decidim::ContentRenderers::BlobRenderer.new(content)
-        content = renderer.render(links:, extras:).html_safe
+        content = renderer.render.html_safe
 
         content = Decidim::ContentRenderers::LinkRenderer.new(content).render if links
         content

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -31,7 +31,9 @@ module Decidim
 
     # Prepares the HTML content for the editors with the correct tags included
     # to identify the mentions.
-    def editor_locales(data, all_locales, extras: true)
+    def editor_locales(data, all_locales, extras: nil)
+      raise "Extras are set" unless extras.nil?
+
       handle_locales(data, all_locales) do |content|
         [
           Decidim::ContentRenderers::BlobRenderer,

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -6,12 +6,12 @@ module Decidim
     include Decidim::TranslatableAttributes
     include Decidim::SanitizeHelper
 
-    def title(resource_title, links, html_escape, all_locales, extras: true)
+    def title(resource_title, links, html_escape, all_locales)
       handle_locales(resource_title, all_locales) do |content|
         content = decidim_html_escape(content) if html_escape
 
         renderer = Decidim::ContentRenderers::BlobRenderer.new(content)
-        renderer.render(links:, extras:).html_safe
+        renderer.render(links:).html_safe
       end
     end
 

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -39,7 +39,7 @@ module Decidim
           Decidim::ContentRenderers::MentionResourceRenderer
         ].each do |renderer_class|
           renderer = renderer_class.new(content)
-          content = renderer.render(links: false, editor: true, extras:).html_safe
+          content = renderer.render(links: false, editor: true).html_safe
         end
 
         content

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -13,7 +13,7 @@ module Decidim
         content = decidim_html_escape(content) if html_escape
 
         renderer = Decidim::ContentRenderers::BlobRenderer.new(content)
-        renderer.render(extras: true).html_safe
+        renderer.render.html_safe
       end
     end
 

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -6,9 +6,7 @@ module Decidim
     include Decidim::TranslatableAttributes
     include Decidim::SanitizeHelper
 
-    def title(resource_title, links, html_escape, all_locales)
-      raise "Links have been set" unless links.nil?
-
+    def title(resource_title, html_escape, all_locales)
       handle_locales(resource_title, all_locales) do |content|
         content = decidim_html_escape(content) if html_escape
 

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -7,11 +7,13 @@ module Decidim
     include Decidim::SanitizeHelper
 
     def title(resource_title, links, html_escape, all_locales)
+      raise "Links have been set" unless links.nil?
+
       handle_locales(resource_title, all_locales) do |content|
         content = decidim_html_escape(content) if html_escape
 
         renderer = Decidim::ContentRenderers::BlobRenderer.new(content)
-        renderer.render(links:).html_safe
+        renderer.render(extras: true).html_safe
       end
     end
 

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -31,9 +31,7 @@ module Decidim
 
     # Prepares the HTML content for the editors with the correct tags included
     # to identify the mentions.
-    def editor_locales(data, all_locales, extras: nil)
-      raise "Extras are set" unless extras.nil?
-
+    def editor_locales(data, all_locales)
       handle_locales(data, all_locales) do |content|
         [
           Decidim::ContentRenderers::BlobRenderer,

--- a/decidim-core/app/presenters/decidim/resource_presenter.rb
+++ b/decidim-core/app/presenters/decidim/resource_presenter.rb
@@ -39,7 +39,7 @@ module Decidim
           Decidim::ContentRenderers::MentionResourceRenderer
         ].each do |renderer_class|
           renderer = renderer_class.new(content)
-          content = renderer.render(links: false, editor: true).html_safe
+          content = renderer.render(editor: true).html_safe
         end
 
         content

--- a/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
+++ b/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
@@ -11,9 +11,7 @@ module Decidim
       @translated_name ||= translated_attribute name
     end
 
-    def title(links: nil, html_escape: false, all_locales: false)
-      raise "Links have been set" unless links.nil?
-
+    def title(html_escape: false, all_locales: false)
       super(name, html_escape, all_locales)
     end
   end

--- a/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
+++ b/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
@@ -11,8 +11,10 @@ module Decidim
       @translated_name ||= translated_attribute name
     end
 
-    def title(links: false, html_escape: false, all_locales: false)
-      super(name, links, html_escape, all_locales)
+    def title(links: nil, html_escape: false, all_locales: false)
+      raise "Links have been set" unless links.nil?
+
+      super(name, nil, html_escape, all_locales)
     end
   end
 end

--- a/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
+++ b/decidim-core/app/presenters/decidim/taxonomy_presenter.rb
@@ -14,7 +14,7 @@ module Decidim
     def title(links: nil, html_escape: false, all_locales: false)
       raise "Links have been set" unless links.nil?
 
-      super(name, nil, html_escape, all_locales)
+      super(name, html_escape, all_locales)
     end
   end
 end

--- a/decidim-core/app/views/decidim/amendments/preview_draft.html.erb
+++ b/decidim-core/app/views/decidim/amendments/preview_draft.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: "wizard_header" %>
 
   <div class="space-y-8 my-10">
-    <h2 class="h3 text-secondary"><%= present(emendation).title(links: true, html_escape: true) %></h2>
+    <h2 class="h3 text-secondary"><%= present(emendation).title(html_escape: true) %></h2>
 
     <%= cell "decidim/coauthorships", emendation %>
 

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -23,10 +23,8 @@ module Decidim
                     end
       end
 
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless debate
-
-        raise "Links have been set" unless links.nil?
 
         super(debate.title, html_escape, all_locales)
       end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -23,7 +23,7 @@ module Decidim
                     end
       end
 
-      def title(links: nil, all_locales: false, html_escape: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless debate
 
         raise "Links have been set" unless links.nil?

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -29,12 +29,10 @@ module Decidim
         super(debate.title, html_escape, all_locales)
       end
 
-      def description(strip_tags: false, extras: nil, links: false, all_locales: false)
+      def description(strip_tags: false, links: false, all_locales: false)
         return unless debate
 
-        raise "Extras being set" unless extras.nil?
-
-        content_handle_locale(debate.description, all_locales, extras, links, strip_tags)
+        content_handle_locale(debate.description, all_locales, links, strip_tags)
       end
 
       def last_comment_at

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -29,8 +29,10 @@ module Decidim
         super(debate.title, html_escape, all_locales)
       end
 
-      def description(strip_tags: false, extras: true, links: false, all_locales: false)
+      def description(strip_tags: false, extras: nil, links: false, all_locales: false)
         return unless debate
+
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(debate.description, all_locales, extras, links, strip_tags)
       end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -29,8 +29,10 @@ module Decidim
         super(debate.title, html_escape, all_locales)
       end
 
-      def description(strip_tags: false, links: false, all_locales: false)
+      def description(strip_tags: false, links: nil, all_locales: false)
         return unless debate
+
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(debate.description, all_locales, links, strip_tags)
       end

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -23,10 +23,12 @@ module Decidim
                     end
       end
 
-      def title(links: false, all_locales: false, html_escape: false)
+      def title(links: nil, all_locales: false, html_escape: false)
         return unless debate
 
-        super(debate.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(debate.title, nil, html_escape, all_locales)
       end
 
       def description(strip_tags: false, extras: true, links: false, all_locales: false)

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -28,7 +28,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(debate.title, nil, html_escape, all_locales)
+        super(debate.title, html_escape, all_locales)
       end
 
       def description(strip_tags: false, extras: true, links: false, all_locales: false)

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -29,10 +29,8 @@ module Decidim
         super(debate.title, html_escape, all_locales)
       end
 
-      def description(strip_tags: false, links: nil, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless debate
-
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(debate.description, all_locales, links, strip_tags)
       end

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -23,7 +23,7 @@ edit_link(
 <%= render layout: "layouts/decidim/shared/layout_item", locals: { back_path: debates_path, commentable: debate } do %>
   <section class="layout-main__section layout-main__heading">
     <h1 class="h2 decorator">
-      <%== present(debate).title(links: true, html_escape: true) %>
+      <%== present(debate).title(html_escape: true) %>
     </h1>
 
     <% debate_presenter = debate.presenter %>

--- a/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
+++ b/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
@@ -8,7 +8,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(__getobj__.title, nil, html_escape, all_locales)
+        super(__getobj__.title, html_escape, all_locales)
       end
     end
   end

--- a/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
+++ b/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
@@ -3,10 +3,12 @@
 module Decidim
   module Dev
     class DummyResourcePresenter < Decidim::ResourcePresenter
-      def title(links: false, html_escape: false, all_locales: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless __getobj__
 
-        super(__getobj__.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(__getobj__.title, nil, html_escape, all_locales)
       end
     end
   end

--- a/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
+++ b/decidim-dev/app/presenters/decidim/dev/dummy_resource_presenter.rb
@@ -3,10 +3,8 @@
 module Decidim
   module Dev
     class DummyResourcePresenter < Decidim::ResourcePresenter
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless __getobj__
-
-        raise "Links have been set" unless links.nil?
 
         super(__getobj__.title, html_escape, all_locales)
       end

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -17,10 +17,8 @@ module Decidim
         Decidim::ResourceLocatorPresenter.new(election).path
       end
 
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless election
-
-        raise "Links have been set" unless links.nil?
 
         super(election.title, html_escape, all_locales)
       end

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -22,7 +22,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(election.title, nil, html_escape, all_locales)
+        super(election.title, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -23,8 +23,10 @@ module Decidim
         super(election.title, html_escape, all_locales)
       end
 
-      def description(links: false, strip_tags: false, all_locales: false)
+      def description(links: nil, strip_tags: false, all_locales: false)
         return unless election
+
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(election.description, all_locales, links, strip_tags)
       end

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -23,12 +23,10 @@ module Decidim
         super(election.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless election
 
-        raise "Extras being set" unless extras.nil?
-
-        content_handle_locale(election.description, all_locales, extras, links, strip_tags)
+        content_handle_locale(election.description, all_locales, links, strip_tags)
       end
     end
   end

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -17,10 +17,12 @@ module Decidim
         Decidim::ResourceLocatorPresenter.new(election).path
       end
 
-      def title(links: false, html_escape: false, all_locales: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless election
 
-        super(election.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(election.title, nil, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -23,10 +23,8 @@ module Decidim
         super(election.title, html_escape, all_locales)
       end
 
-      def description(links: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless election
-
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(election.description, all_locales, links, strip_tags)
       end

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -23,8 +23,10 @@ module Decidim
         super(election.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: true, strip_tags: false, all_locales: false)
+      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless election
+
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(election.description, all_locales, extras, links, strip_tags)
       end

--- a/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
@@ -13,10 +13,12 @@ module Decidim
       __getobj__
     end
 
-    def title(links: false, html_escape: false, all_locales: false)
+    def title(links: nil, html_escape: false, all_locales: false)
       return unless initiative
 
-      super(initiative.title, links, html_escape, all_locales)
+      raise "Links have been set" unless links.nil?
+
+      super(initiative.title, nil, html_escape, all_locales)
     end
   end
 end

--- a/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
@@ -13,10 +13,8 @@ module Decidim
       __getobj__
     end
 
-    def title(links: nil, html_escape: false, all_locales: false)
+    def title(html_escape: false, all_locales: false)
       return unless initiative
-
-      raise "Links have been set" unless links.nil?
 
       super(initiative.title, html_escape, all_locales)
     end

--- a/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiative_presenter.rb
@@ -18,7 +18,7 @@ module Decidim
 
       raise "Links have been set" unless links.nil?
 
-      super(initiative.title, nil, html_escape, all_locales)
+      super(initiative.title, html_escape, all_locales)
     end
   end
 end

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -13,11 +13,10 @@ module Decidim
         __getobj__
       end
 
-      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless agenda_item
-        raise "Extras being set" unless extras.nil?
 
-        content_handle_locale(agenda_item.description, all_locales, extras, links, strip_tags)
+        content_handle_locale(agenda_item.description, all_locales, links, strip_tags)
       end
 
       def editor_description(all_locales: false, extras: true)

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -13,8 +13,9 @@ module Decidim
         __getobj__
       end
 
-      def description(links: false, strip_tags: false, all_locales: false)
+      def description(links: nil, strip_tags: false, all_locales: false)
         return unless agenda_item
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(agenda_item.description, all_locales, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -13,8 +13,9 @@ module Decidim
         __getobj__
       end
 
-      def description(links: false, extras: true, strip_tags: false, all_locales: false)
+      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless agenda_item
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(agenda_item.description, all_locales, extras, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -13,9 +13,8 @@ module Decidim
         __getobj__
       end
 
-      def description(links: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless agenda_item
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(agenda_item.description, all_locales, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -19,9 +19,8 @@ module Decidim
         content_handle_locale(agenda_item.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(all_locales: false, extras: nil)
+      def editor_description(all_locales: false)
         return unless agenda_item
-        raise "Extras are set" unless extras.nil?
 
         editor_locales(agenda_item.description, all_locales)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -19,10 +19,11 @@ module Decidim
         content_handle_locale(agenda_item.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(all_locales: false, extras: true)
+      def editor_description(all_locales: false, extras: nil)
         return unless agenda_item
+        raise "Extras are set" unless extras.nil?
 
-        editor_locales(agenda_item.description, all_locales, extras:)
+        editor_locales(agenda_item.description, all_locales)
       end
     end
   end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -42,10 +42,8 @@ module Decidim
         content_handle_locale(meeting.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(all_locales: false, extras: nil)
+      def editor_description(all_locales: false)
         return unless meeting
-
-        raise "Extras are set" unless extras.nil?
 
         editor_locales(meeting.description, all_locales)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -35,7 +35,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(meeting.title, nil, html_escape, all_locales)
+        super(meeting.title, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -36,8 +36,10 @@ module Decidim
         super(meeting.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: true, strip_tags: false, all_locales: false)
+      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless meeting
+
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(meeting.description, all_locales, extras, links, strip_tags)
       end
@@ -72,8 +74,9 @@ module Decidim
         end
       end
 
-      def closing_report(links: false, extras: false, strip_tags: false, all_locales: false)
+      def closing_report(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless meeting
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(meeting.closing_report, all_locales, extras, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -30,10 +30,12 @@ module Decidim
         link_to title, meeting_path
       end
 
-      def title(links: false, html_escape: false, all_locales: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless meeting
 
-        super(meeting.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(meeting.title, nil, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -36,12 +36,10 @@ module Decidim
         super(meeting.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless meeting
 
-        raise "Extras being set" unless extras.nil?
-
-        content_handle_locale(meeting.description, all_locales, extras, links, strip_tags)
+        content_handle_locale(meeting.description, all_locales, links, strip_tags)
       end
 
       def editor_description(all_locales: false, extras: true)
@@ -74,11 +72,10 @@ module Decidim
         end
       end
 
-      def closing_report(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def closing_report(links: false, strip_tags: false, all_locales: false)
         return unless meeting
-        raise "Extras being set" unless extras.nil?
 
-        content_handle_locale(meeting.closing_report, all_locales, extras, links, strip_tags)
+        content_handle_locale(meeting.closing_report, all_locales, links, strip_tags)
       end
 
       def registration_email_custom_content(links: false, all_locales: false)

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -30,10 +30,8 @@ module Decidim
         link_to title, meeting_path
       end
 
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless meeting
-
-        raise "Links have been set" unless links.nil?
 
         super(meeting.title, html_escape, all_locales)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -36,10 +36,8 @@ module Decidim
         super(meeting.title, html_escape, all_locales)
       end
 
-      def description(links: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless meeting
-
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(meeting.description, all_locales, links, strip_tags)
       end
@@ -74,10 +72,8 @@ module Decidim
         end
       end
 
-      def closing_report(links: nil, strip_tags: false, all_locales: false)
+      def closing_report(links: false, strip_tags: false, all_locales: false)
         return unless meeting
-
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(meeting.closing_report, all_locales, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -36,8 +36,10 @@ module Decidim
         super(meeting.title, html_escape, all_locales)
       end
 
-      def description(links: false, strip_tags: false, all_locales: false)
+      def description(links: nil, strip_tags: false, all_locales: false)
         return unless meeting
+
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(meeting.description, all_locales, links, strip_tags)
       end
@@ -72,8 +74,10 @@ module Decidim
         end
       end
 
-      def closing_report(links: false, strip_tags: false, all_locales: false)
+      def closing_report(links: nil, strip_tags: false, all_locales: false)
         return unless meeting
+
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(meeting.closing_report, all_locales, links, strip_tags)
       end

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -22,7 +22,7 @@ module Decidim
 
       def taxonomy_names(html_escape: false, all_locales: false)
         meeting.taxonomies.map do |taxonomy|
-          super_title(taxonomy.name, false, html_escape, all_locales)
+          super_title(taxonomy.name, html_escape, all_locales)
         end
       end
 

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -42,10 +42,12 @@ module Decidim
         content_handle_locale(meeting.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(all_locales: false, extras: true)
+      def editor_description(all_locales: false, extras: nil)
         return unless meeting
 
-        editor_locales(meeting.description, all_locales, extras:)
+        raise "Extras are set" unless extras.nil?
+
+        editor_locales(meeting.description, all_locales)
       end
 
       def location(all_locales: false)

--- a/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/layouts/live_event.html.erb
@@ -15,7 +15,7 @@
 
     <header class="meeting-polls__header">
       <div>
-        <strong class="text-secondary"><%= current_organization_name %></strong> / <strong><%= present(meeting).title(links: true, html_escape: true ) %></strong>
+        <strong class="text-secondary"><%= current_organization_name %></strong> / <strong><%= present(meeting).title(html_escape: true) %></strong>
       </div>
 
       <div class="flex gap-10">

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: "schema_org_event_meeting" %>
 
   <section class="layout-main__section layout-main__heading">
-      <h1 class="h2 decorator"><%= present(meeting).title(links: true, html_escape: true ) %></h1>
+      <h1 class="h2 decorator"><%= present(meeting).title(html_escape: true ) %></h1>
       <%= cell "decidim/meetings/dates_and_map", meeting %>
       <div class="block md:hidden">
         <%= render partial: "meeting_aside", locals: { hide_modal: true } %>

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -29,11 +29,10 @@ module Decidim
         content_handle_locale(process.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(extras: nil, all_locales: false)
+      def editor_description(all_locales: false)
         return unless process
-        raise "Extras are set" unless extras.nil?
 
-        editor_locales(process.description, all_locales, extras:)
+        editor_locales(process.description, all_locales)
       end
 
       def short_description(links: false, strip_tags: false, all_locales: false)
@@ -42,9 +41,8 @@ module Decidim
         content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end
 
-      def editor_short_description(extras: nil, all_locales: false)
+      def editor_short_description(all_locales: false)
         return unless process
-        raise "Extras are set" unless extras.nil?
 
         editor_locales(process.short_description, all_locales)
       end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -23,7 +23,7 @@ module Decidim
         raise "Extras has been set" unless extras.nil?
         raise "Links have been set" unless links.nil?
 
-        super(process.title, nil, html_escape, all_locales)
+        super(process.title, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -42,7 +42,7 @@ module Decidim
         content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end
 
-      def editor_short_description(extras: true, all_locales: nil)
+      def editor_short_description(extras: nil, all_locales: false)
         return unless process
         raise "Extras are set" unless extras.nil?
 

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -29,8 +29,9 @@ module Decidim
         content_handle_locale(process.description, all_locales, links, strip_tags)
       end
 
-      def editor_description(extras: true, all_locales: false)
+      def editor_description(extras: nil, all_locales: false)
         return unless process
+        raise "Extras are set" unless extras.nil?
 
         editor_locales(process.description, all_locales, extras:)
       end
@@ -41,10 +42,11 @@ module Decidim
         content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end
 
-      def editor_short_description(extras: true, all_locales: false)
+      def editor_short_description(extras: true, all_locales: nil)
         return unless process
+        raise "Extras are set" unless extras.nil?
 
-        editor_locales(process.short_description, all_locales, extras:)
+        editor_locales(process.short_description, all_locales)
       end
 
       def process

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -23,8 +23,9 @@ module Decidim
         super(process.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: true, strip_tags: false, all_locales: false)
+      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless process
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(process.description, all_locales, extras, links, strip_tags)
       end
@@ -35,8 +36,9 @@ module Decidim
         editor_locales(process.description, all_locales, extras:)
       end
 
-      def short_description(links: false, extras: true, strip_tags: false, all_locales: false)
+      def short_description(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless process
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(process.short_description, all_locales, extras, links, strip_tags)
       end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -23,9 +23,8 @@ module Decidim
         super(process.title, html_escape, all_locales)
       end
 
-      def description(links: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless process
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(process.description, all_locales, links, strip_tags)
       end
@@ -36,9 +35,8 @@ module Decidim
         editor_locales(process.description, all_locales)
       end
 
-      def short_description(links: nil, strip_tags: false, all_locales: false)
+      def short_description(links: false, strip_tags: false, all_locales: false)
         return unless process
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -17,10 +17,12 @@ module Decidim
         Decidim::AreaPresenter.new(process.area).translated_name_with_type
       end
 
-      def title(links: false, extras: true, html_escape: false, all_locales: false)
+      def title(links: false, extras: nil, html_escape: false, all_locales: false)
         return unless process
 
-        super(process.title, links, html_escape, all_locales, extras:)
+        raise "Extras has been set" unless extras.nil?
+
+        super(process.title, links, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -17,11 +17,8 @@ module Decidim
         Decidim::AreaPresenter.new(process.area).translated_name_with_type
       end
 
-      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless process
-
-        raise "Extras has been set" unless extras.nil?
-        raise "Links have been set" unless links.nil?
 
         super(process.title, html_escape, all_locales)
       end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -23,8 +23,9 @@ module Decidim
         super(process.title, html_escape, all_locales)
       end
 
-      def description(links: false, strip_tags: false, all_locales: false)
+      def description(links: nil, strip_tags: false, all_locales: false)
         return unless process
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(process.description, all_locales, links, strip_tags)
       end
@@ -35,8 +36,9 @@ module Decidim
         editor_locales(process.description, all_locales)
       end
 
-      def short_description(links: false, strip_tags: false, all_locales: false)
+      def short_description(links: nil, strip_tags: false, all_locales: false)
         return unless process
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -23,11 +23,10 @@ module Decidim
         super(process.title, html_escape, all_locales)
       end
 
-      def description(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def description(links: false, strip_tags: false, all_locales: false)
         return unless process
-        raise "Extras being set" unless extras.nil?
 
-        content_handle_locale(process.description, all_locales, extras, links, strip_tags)
+        content_handle_locale(process.description, all_locales, links, strip_tags)
       end
 
       def editor_description(extras: true, all_locales: false)
@@ -36,11 +35,10 @@ module Decidim
         editor_locales(process.description, all_locales, extras:)
       end
 
-      def short_description(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def short_description(links: false, strip_tags: false, all_locales: false)
         return unless process
-        raise "Extras being set" unless extras.nil?
 
-        content_handle_locale(process.short_description, all_locales, extras, links, strip_tags)
+        content_handle_locale(process.short_description, all_locales, links, strip_tags)
       end
 
       def editor_short_description(extras: true, all_locales: false)

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -17,12 +17,13 @@ module Decidim
         Decidim::AreaPresenter.new(process.area).translated_name_with_type
       end
 
-      def title(links: false, extras: nil, html_escape: false, all_locales: false)
+      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
         return unless process
 
         raise "Extras has been set" unless extras.nil?
+        raise "Links have been set" unless links.nil?
 
-        super(process.title, links, html_escape, all_locales)
+        super(process.title, nil, html_escape, all_locales)
       end
 
       def description(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -118,7 +118,7 @@ module Decidim
       # Returns :text_area or :editor based on the organization' settings.
       def text_editor_for_proposal_body(form)
         options = {
-          value: form_presenter.body(extras: false, strip_tags: !current_organization.rich_text_editor_in_public_views).strip
+          value: form_presenter.body(strip_tags: !current_organization.rich_text_editor_in_public_views).strip
         }
 
         text_editor_for(form, :body, options)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -33,11 +33,8 @@ module Decidim
       # Render the proposal title
       #
       # Returns a String.
-      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless proposal
-
-        raise "Extras has been set" unless extras.nil?
-        raise "Links have been set" unless links.nil?
 
         super(proposal.title, html_escape, all_locales)
       end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -39,7 +39,7 @@ module Decidim
         raise "Extras has been set" unless extras.nil?
         raise "Links have been set" unless links.nil?
 
-        super(proposal.title, nil, html_escape, all_locales)
+        super(proposal.title, html_escape, all_locales)
       end
 
       def id_and_title(links: false, html_escape: false)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -43,8 +43,10 @@ module Decidim
         "##{proposal.id} - #{title(html_escape:)}"
       end
 
-      def body(links: false, extras: true, strip_tags: false, all_locales: false)
+      def body(links: false, extras: nil, strip_tags: false, all_locales: false)
         return unless proposal
+
+        raise "Extras being set" unless extras.nil?
 
         content_handle_locale(proposal.body, all_locales, extras, links, strip_tags)
       end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -43,9 +43,8 @@ module Decidim
         "##{proposal.id} - #{title(html_escape:)}"
       end
 
-      def body(links: nil, strip_tags: false, all_locales: false)
+      def body(links: false, strip_tags: false, all_locales: false)
         return unless proposal
-        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(proposal.body, all_locales, links, strip_tags)
       end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -42,8 +42,8 @@ module Decidim
         super(proposal.title, html_escape, all_locales)
       end
 
-      def id_and_title(links: false, html_escape: false)
-        "##{proposal.id} - #{title(links:, html_escape:)}"
+      def id_and_title(html_escape: false)
+        "##{proposal.id} - #{title(html_escape:)}"
       end
 
       def body(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -49,9 +49,7 @@ module Decidim
         content_handle_locale(proposal.body, all_locales, links, strip_tags)
       end
 
-      def editor_body(all_locales: false, extras: nil)
-        raise "Extras are set" unless extras.nil?
-
+      def editor_body(all_locales: false)
         editor_locales(proposal.body, all_locales)
       end
 

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -49,8 +49,10 @@ module Decidim
         content_handle_locale(proposal.body, all_locales, links, strip_tags)
       end
 
-      def editor_body(all_locales: false, extras: true)
-        editor_locales(proposal.body, all_locales, extras:)
+      def editor_body(all_locales: false, extras: nil)
+        raise "Extras are set" unless extras.nil?
+
+        editor_locales(proposal.body, all_locales)
       end
 
       # Returns the proposal versions, hiding not published answers

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -43,12 +43,10 @@ module Decidim
         "##{proposal.id} - #{title(html_escape:)}"
       end
 
-      def body(links: false, extras: nil, strip_tags: false, all_locales: false)
+      def body(links: false, strip_tags: false, all_locales: false)
         return unless proposal
 
-        raise "Extras being set" unless extras.nil?
-
-        content_handle_locale(proposal.body, all_locales, extras, links, strip_tags)
+        content_handle_locale(proposal.body, all_locales, links, strip_tags)
       end
 
       def editor_body(all_locales: false, extras: true)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -43,8 +43,9 @@ module Decidim
         "##{proposal.id} - #{title(html_escape:)}"
       end
 
-      def body(links: false, strip_tags: false, all_locales: false)
+      def body(links: nil, strip_tags: false, all_locales: false)
         return unless proposal
+        raise "Links are being defined" unless links.nil?
 
         content_handle_locale(proposal.body, all_locales, links, strip_tags)
       end

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -33,12 +33,13 @@ module Decidim
       # Render the proposal title
       #
       # Returns a String.
-      def title(links: false, extras: nil, html_escape: false, all_locales: false)
+      def title(links: nil, extras: nil, html_escape: false, all_locales: false)
         return unless proposal
 
         raise "Extras has been set" unless extras.nil?
+        raise "Links have been set" unless links.nil?
 
-        super(proposal.title, links, html_escape, all_locales)
+        super(proposal.title, nil, html_escape, all_locales)
       end
 
       def id_and_title(links: false, html_escape: false)

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -33,14 +33,16 @@ module Decidim
       # Render the proposal title
       #
       # Returns a String.
-      def title(links: false, extras: true, html_escape: false, all_locales: false)
+      def title(links: false, extras: nil, html_escape: false, all_locales: false)
         return unless proposal
 
-        super(proposal.title, links, html_escape, all_locales, extras:)
+        raise "Extras has been set" unless extras.nil?
+
+        super(proposal.title, links, html_escape, all_locales)
       end
 
-      def id_and_title(links: false, extras: true, html_escape: false)
-        "##{proposal.id} - #{title(links:, extras:, html_escape:)}"
+      def id_and_title(links: false, html_escape: false)
+        "##{proposal.id} - #{title(links:, html_escape:)}"
       end
 
       def body(links: false, extras: true, strip_tags: false, all_locales: false)

--- a/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/collaborative_drafts/show.html.erb
@@ -17,7 +17,7 @@
   <section class="layout-main__section layout-main__heading">
     <%= cell("decidim/announcement", t("info-message", scope: "decidim.proposals.collaborative_drafts.show").html_safe) if current_user.nil? || allowed_to?(:request_access, :collaborative_draft, collaborative_draft: @collaborative_draft) %>
 
-    <h1 class="h2 decorator"><%= present(@collaborative_draft).title(links: true, html_escape: true) %></h1>
+    <h1 class="h2 decorator"><%= present(@collaborative_draft).title(html_escape: true) %></h1>
 
     <% if component_settings.geocoding_enabled? %>
       <div class="static-map__container">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -8,7 +8,7 @@
   <%= render partial: "wizard_header", locals: { callout_help_text_class: "warning" } %>
 
   <div class="proposal__container my-10 flex flex-col gap-4">
-    <h2 class="h3 text-secondary"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
+    <h2 class="h3 text-secondary"><%= present(@proposal).title(html_escape: true) %></h2>
 
     <% unless component_settings.participatory_texts_enabled? %>
       <%= cell "decidim/coauthorships", @proposal, context_actions: [] %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -50,7 +50,7 @@ extra_admin_link(
     <%= emendation_announcement_for @proposal %>
 
     <% if @proposal.emendation? %>
-      <h1 class="h2 decorator"><%= t("changes_at_title", scope: "decidim.proposals.proposals.show", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h1>
+      <h1 class="h2 decorator"><%= t("changes_at_title", scope: "decidim.proposals.proposals.show", title: present(@proposal.amendable).title(html_escape: true)) %></h1>
     <% else %>
       <h1 class="h2 decorator"><%= present(@proposal).title(html_escape: true) %></h1>
     <% end %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/show.html.erb
@@ -52,7 +52,7 @@ extra_admin_link(
     <% if @proposal.emendation? %>
       <h1 class="h2 decorator"><%= t("changes_at_title", scope: "decidim.proposals.proposals.show", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h1>
     <% else %>
-      <h1 class="h2 decorator"><%= present(@proposal).title(links: true, html_escape: true) %></h1>
+      <h1 class="h2 decorator"><%= present(@proposal).title(html_escape: true) %></h1>
     <% end %>
 
     <% unless component_settings.participatory_texts_enabled? %>

--- a/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
+++ b/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
@@ -7,10 +7,8 @@ module Decidim
         __getobj__
       end
 
-      def title(links: nil, html_escape: false, all_locales: false)
+      def title(html_escape: false, all_locales: false)
         return unless sortition
-
-        raise "Links have been set" unless links.nil?
 
         super(sortition.title, html_escape, all_locales)
       end

--- a/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
+++ b/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
@@ -12,7 +12,7 @@ module Decidim
 
         raise "Links have been set" unless links.nil?
 
-        super(sortition.title, nil, html_escape, all_locales)
+        super(sortition.title, html_escape, all_locales)
       end
     end
   end

--- a/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
+++ b/decidim-sortitions/app/presenters/decidim/sortitions/sortition_presenter.rb
@@ -7,10 +7,12 @@ module Decidim
         __getobj__
       end
 
-      def title(links: false, html_escape: false, all_locales: false)
+      def title(links: nil, html_escape: false, all_locales: false)
         return unless sortition
 
-        super(sortition.title, links, html_escape, all_locales)
+        raise "Links have been set" unless links.nil?
+
+        super(sortition.title, nil, html_escape, all_locales)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Back into #14868 @andreslucena requested that some of the unused parameters should be removed. https://github.com/decidim/decidim/pull/14868#discussion_r2149246314  @greenwoodt tried, and deemed that some of the parameters cannot be removed, and abandoned. 

I have taken a swing to it, and managed to remove some of the paramters. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14868

#### Testing
1. Green pipeline 

:hearts: Thank you!
