### PR TITLE
Fix: filter button and unappropriate roles and aria on filters and nav_links

### DIFF
--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -6,7 +6,7 @@
   </button>
   <ul id="dropdown-menu-participatory-space" class="participatory-space__nav">
     <% model.each do |item| %>
-      <li role="menuitem">
+      <li>
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>
           <%= item[:name] %>
           <%= icon "arrow-right-line" %>
@@ -15,3 +15,16 @@
     <% end %>
   </ul>
 </div>
+<script>
+  document.addEventListener("DOMContentLoaded", function(event) {
+    const dropdownUl = document.querySelector('#dropdown-menu-participatory-space')
+    setTimeout(() => {
+      dropdownUl.removeAttribute("role")
+      dropdownUl.removeAttribute("aria-hidden")
+    }, 500)
+    // remove the aria-hidden attribute added when clicking anywhere on window
+    window.addEventListener("click", function(){
+      dropdownUl.removeAttribute("aria-hidden")
+    })
+  });
+</script>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -14,12 +14,12 @@
 
     <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
-        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem" %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip" %>
       <% end %>
-      <p class="filter-help" role="menuitem" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
+      <p class="filter-help" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
 
       <% if local_assigns.has_key?(:search_variable) %>
-        <div class="filter-search filter-container" role="menuitem">
+        <div class="filter-search filter-container">
           <%= form.search_field search_variable,
                                 label: false,
                                 placeholder: search_label,
@@ -40,3 +40,58 @@
 
   <% end %>
 <% end %>
+<script type="text/javascript">
+  // fix button to display/hide filters
+  const button = document.querySelector('#dropdown-trigger-filters');
+  const arrowDown = button.querySelector('svg:first-of-type');
+  const arrowUp = button.querySelector('svg:last-of-type');
+  const list = document.querySelector('#dropdown-menu-filters');
+  // the arrow is up when user arrives on the page, with the list displayed
+  arrowUp.addEventListener('click', function(){
+    setTimeout(() => {
+      button.setAttribute('aria-expanded', 'false');
+      list.style.display = "none";
+      list.setAttribute("aria-hidden", "true");
+    }, 300)
+  })
+  arrowDown.addEventListener('click', function(){
+    setTimeout(() => {
+      button.setAttribute('aria-expanded', 'true');
+      list.style.display = "block";
+      list.setAttribute("aria-hidden", "false");
+    }, 300)
+  })
+  // 32 is code for space bar and 13 is code for enter
+  button.addEventListener('keydown', function(e){
+    if ((e.keyCode === 13 || e.keyCode === 32) && button.getAttribute('aria-expanded') === 'true') {
+      setTimeout(() => {
+        button.setAttribute('aria-expanded', 'false');
+        list.style.display = "none";
+        list.setAttribute("aria-hidden", "true");
+      }, 300)
+    } else if ((e.keyCode === 13 || e.keyCode === 32) && button.getAttribute('aria-expanded') === 'false'){
+      setTimeout(() => {
+        button.setAttribute('aria-expanded', 'true');
+        list.style.display = "block";
+        list.setAttribute("aria-hidden", "false");
+      }, 300)
+    }
+  })
+  // fix inappropriate roles
+  document.addEventListener("DOMContentLoaded", function(event) {
+    const panelDropdownDivs = document.querySelectorAll('div[id^="panel-dropdown-menu"]')
+    setTimeout(() => {
+      list.removeAttribute("role")
+      panelDropdownDivs.forEach((elem) => elem.setAttribute("role", "group"))
+    }, 500)
+  })
+  // when first clicking outside button
+  // keep aria-expanded to true on button, and aria-hidden to false on list
+  function handleAria(event){
+    if(event.currentTarget.id !== "dropdown-trigger-filters") {
+      button.setAttribute('aria-expanded', 'true');
+      list.setAttribute("aria-hidden", 'false')
+    }
+  }
+  window.addEventListener("click", handleAria)
+</script>

--- a/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the filter button that doesn't hide/show the filters.

It also handle accessibility on filters and nav_links:
- remove `role="menu"`, `role="menuitem"` and `aria-hidden="true"` , which are inappropriate on nav_links
- remove `role="menu"`and `role="menuitem"`, which are inappropriate on filters
- changes inappropriate `role="region"` for `role="group"` on filters

This PR is issued from the audit of Angers city (pages 61, 62, 67 and 76), related to criterias 1.31, 1.3.2, 3.3.2, 2.5.3, 4.1.2 from WCAG.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112583524&issue=OpenSourcePolitics%7Cintern-tasks%7C45
- Related to https://github.com/orgs/OpenSourcePolitics/projects/26/views/1?pane=issue&itemId=112541802&issue=OpenSourcePolitics%7Cintern-tasks%7C39

#### Testing
As a user, go to the index of processes
Click anywhere on the window and see that the filter arrow is still up, and in devTools that `div id="dropdown-menu-filters"` aria-hidden is still false
In the filters, click on "Filter" button and see that the filters are hidden. Click again and see that the filters are displayed
Open the devTools and check that divs with `id="panel-dropdown-menu-(...)"` have a `role="group"`
As a user, go to a process show page, and open the devTools to check the menu on the right. 
See that `ul` have no attributes role and aria-hidden,  and that `li` have no attribute role
Click anywhere on the page and see that `ul` still have no aria-hidden attribute

### :camera: Screenshots
FILTERS
<img width="912" alt="dropdown_filters" src="https://github.com/user-attachments/assets/f52f5e5c-cae5-4424-8148-2e5a37264e38" />
<img width="942" alt="panel_dropdown" src="https://github.com/user-attachments/assets/912d09eb-ce4b-4e54-8fc0-d8c37fa3ceb5" />
NAV_LINKS
<img width="1277" alt="nav_links" src="https://github.com/user-attachments/assets/062b5df9-6d6f-4dbb-a325-d7c50c4eb7f6" />


:hearts: Thank you!
