### PR TITLE
Update Releases Notes after v0.29.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ the instructions for all the patch releases in GitHub:
 - https://github.com/decidim/decidim/releases/tag/v0.29.1
 - https://github.com/decidim/decidim/releases/tag/v0.29.2
 - https://github.com/decidim/decidim/releases/tag/v0.29.3
+- https://github.com/decidim/decidim/releases/tag/v0.29.4
 
 ## 1. Upgrade notes
 
@@ -56,27 +57,7 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 ## 5. Changes in APIs
 
-### 5.1. Require organization in nicknamize method
-
-In order to avoid potential performance issues, we have changed the `nicknamize` method by requiring the organization as a parameter.
-
-If you have used code as such:
-
-```ruby
-# We were including the organization in an optional scope
-Decidim::UserBaseEntity.nicknamize(nickname, decidim_organization_id: user.decidim_organization_id)
-```
-
-You need to change it, to something like:
-
-```ruby
-# Now the organization is the required second parameter of the method
-Decidim::UserBaseEntity.nicknamize(nickname, user.decidim_organization_id)
-```
-
-You can read more about this change on PR [#14669](https://github.com/decidim/decidim/pull/14669).
-
-### 5.2. [[TITLE OF THE CHANGE]]
+### 5.1. [[TITLE OF THE CHANGE]]
 
 In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 


### PR DESCRIPTION
#### :tophat: What? Why? 

This PR cleans-up the Releases Notes after the publication of https://github.com/decidim/decidim/releases/tag/v0.29.4 

:hearts: Thank you!
