### PR TITLE
Update Releases Notes after v0.30.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 NOTE: This is the draft for the releases notes. If you are an implementer or someone that is upgrading a Decidim installation, you need to follow
 the instructions for all the patch releases in GitHub:
 
+- https://github.com/decidim/decidim/releases/tag/v0.30.1
 - https://github.com/decidim/decidim/releases/tag/v0.30.0
 
 ## 1. Upgrade notes
@@ -34,21 +35,7 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 ## 3. One time actions
 
-### 3.1. Removal of invalid user exports
-
-We have noticed an edge case when using private export functionality, in which the page becomes inaccessible if the user in question is using export single survey answer functionality.
-
-You can run the following rake task to ensure your system is not corrupted.
-
-```bash
-./bin/rails decidim:upgrade:clean:invalid_private_exports
-```
-
-For ease of in operations, we also added the above command to the main `decidim:upgrade:clean:invalid_records` rake task.
-
-You can read more about this change on PR [#14638](https://github.com/decidim/decidim/pull/14638).
-
-### 3.2. [[TITLE OF THE ACTION]]
+### 3.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 
@@ -67,27 +54,7 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 ## 5. Changes in APIs
 
-### 5.1. Require organization in nicknamize method
-
-In order to avoid potential performance issues, we have changed the `nicknamize` method by requiring the organization as a parameter.
-
-If you have used code as such:
-
-```ruby
-# We were including the organization in an optional scope
-Decidim::UserBaseEntity.nicknamize(nickname, decidim_organization_id: user.decidim_organization_id)
-```
-
-You need to change it, to something like:
-
-```ruby
-# Now the organization is the required second parameter of the method
-Decidim::UserBaseEntity.nicknamize(nickname, user.decidim_organization_id)
-```
-
-You can read more about this change on PR [#14669](https://github.com/decidim/decidim/pull/14669).
-
-### 5.2. [[TITLE OF THE CHANGE]]
+### 5.1. [[TITLE OF THE CHANGE]]
 
 In order to [[REASONING (e.g. improve the maintenance of the code base)]] we have changed...
 


### PR DESCRIPTION
#### :tophat: What? Why? 

This PR cleans-up the Releases Notes after the publication of https://github.com/decidim/decidim/releases/tag/v0.30.1 

:hearts: Thank you!
