### PR TITLE
Fix accessibility on tabbed partial

### DIFF
--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -18,10 +18,10 @@
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>
       </button>
-      <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
+      <ul id="dropdown-menu-pages" class="vertical-tabs__list">
         <% pages.each do |sibling| %>
-          <li class="<%= "is-active" if page == sibling %>" role="menuitem">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria-current": (page == sibling).to_s %>
+          <li class="<%= "is-active" if page == sibling %>">
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria-current": page == sibling ? "page" : "false" %>
           </li>
         <% end %>
       </ul>
@@ -43,3 +43,16 @@
     </section>
   </div>
 <% end %>
+<script>
+  // remove not necessary attribute on ul added on js
+  const ul = document.querySelector("#dropdown-menu-pages")
+  document.addEventListener("DOMContentLoaded", function(){
+    setTimeout(() => {
+      ul.removeAttribute("role")
+    }, 300)
+  })
+  // avoid change value of aria-hidden when clicking anywhere on window
+  window.addEventListener("click", function(){
+    ul.setAttribute("aria-hidden", "false")
+  })
+</script>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR improves accessibility on tabbed partial :
- it removes the `role="menu"` on `ul id="dropdown-menu-pages"` and `role="menuitem"` on` li`
- it prevents the changing of `aria-hidden` value on `ul id="dropdown-menu-pages"` when clicking on window
- it changes the value of `aria-current` on active `a` by for "page"

Those issues come from the audit of Angers city (page 56), and they refer to criterias 2.5.3, 4.1.2, 1.3.2, 4.1.2, 1.3.3 and 4.1.1 from WCAG

#### Testing
1. As a user, go to the footer of decidim page and in "Help" column, click on "General"
2. Open you devTools, check that the `ul id="dropdown-menu-pages"` and its `li `children have no attribute role
3. Check inside active `li` that the `a` link has a `aria-current="page"`, and check that inside non active `li` the `aria-current` on `a` has a false value
4. Click anywhere on window and check that `ul aria-hidden` attribute value is still false

### :camera: Screenshots
<img width="878" alt="464630040-bbbf7c41-d43c-4c0b-91be-e5bf07650d64" src="https://github.com/user-attachments/assets/80b0733a-0069-4742-bee4-5d5497f9aa7b" />


:hearts: Thank you!
