### PR TITLE
Backport 'Fix importing attachments collections for processes and assemblies' to v0.29

### DIFF
--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -125,9 +125,11 @@ module Decidim
           end
         end
 
-        attachments["attachment_collections"].map do |collection|
-          Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
-            create_attachment_collection(collection)
+        unless attachments["attachment_collections"].empty?
+          attachments["attachment_collections"].map do |collection|
+            Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
+              create_attachment_collection(collection)
+            end
           end
         end
       end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -149,6 +149,16 @@ module Decidim::ParticipatoryProcesses
           expect { subject }.not_to change(Decidim::ParticipatoryProcessType, :count)
         end
       end
+
+      context "when the process group is nil" do
+        let(:group_data) do
+          nil
+        end
+
+        it "imports the process correctly" do
+          expect { subject }.to change(Decidim::ParticipatoryProcess, :count).by(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14880 to v0.29

:hearts: Thank you!