### PR TITLE
Fix specs running on local development environments

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -127,8 +127,8 @@ FactoryBot.define do
     sequence(:host) { |n| "#{n}.lvh.me" }
     description { generate_localized_description(:organization_description, skip_injection:) }
     favicon { Decidim::Dev.test_file("icon.png", "image/png") }
-    default_locale { Decidim.default_locale }
-    available_locales { Decidim.available_locales }
+    default_locale { "en" }
+    available_locales { %w(en ca es) }
     users_registration_mode { :enabled }
     official_img_footer { Decidim::Dev.test_file("avatar.jpg", "image/jpeg") }
     official_url { Faker::Internet.url }


### PR DESCRIPTION
#### :tophat: What? Why?

A couple of days ago, @greenwoodt detected an issue on his local environment:

> Im noticing some strange behaviour with the CI. I am massively perlexed as to why certain actions fail locally but are undetected by the CI

I could also reproduce it locally.

The culprit was the change in the default locales in #14832. This PR fixes that by changing the factories to not depend in the environment, and to make it always with the same configuration.

I'm not sure why this wasn't happening in CI (I could not find where we're setting `DECIDIM_AVAILABLE_LOCALES`)

#### :pushpin: Related Issues
 
- Related to #14832 

#### Testing

Run a spec that depends on having only 2/3 locales (i.e. without the dropdown when you have more than 4 locales). For instance: 

```ruby
$ bin/rspec decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb --fail-fast

Randomized with seed 42192

Admin copies meetings
  when online
    creates a new Online meeting (FAILED - 1)

Failures:

  1) Admin copies meetings when online creates a new Online meeting
     Failure/Error:
       fill_in_i18n(
         :meeting_title,
         "#meeting-title-tabs",
         en: "My duplicate meeting",
         es: "Mi meeting duplicado",
         ca: "El meu meeting duplicat"
       )

     Capybara::ElementNotFound:
       Unable to find link or button "English" within #<Capybara::Node::Element tag="select" path="/HTML/BODY[1]/MAIN[1]/DIV[1]/DIV[2]/DIV[2]/DIV[4]/DIV[1]/DIV[2]/DIV[2]/DIV[1]/FORM[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/DIV[1]/SELECT[1]">

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_copies_meetings_when_online_creates_a_new_online_meeting_240.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_copies_meetings_when_online_creates_a_new_online_meeting_240.html




     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:301:in `synced_resolve'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:60:in `find'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/actions.rb:26:in `click_link_or_button'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:774:in `click_on'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `call'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `click_on'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:117:in `block (2 levels) in fill_in_i18n_fields'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:366:in `within'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `call'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `within_element'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/rspec/matcher_proxies.rb:15:in `within'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:116:in `block in fill_in_i18n_fields'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:115:in `each'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:115:in `fill_in_i18n_fields'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/translation_helpers.rb:50:in `fill_in_i18n'
     # ./spec/system/admin/admin_manages_meetings_copy_spec.rb:34:in `block (3 levels) in <top (required)>'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in `block (3 levels) in <main>'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:305:in `using_wait_time'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:810:in `using_wait_time'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/dsl.rb:28:in `using_wait_time'
     # /home/apereira/Work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in `block (2 levels) in <main>'

Finished in 37.57 seconds (files took 3.62 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_meetings_copy_spec.rb:28 # Admin copies meetings when online creates a new Online meeting

Randomized with seed 42192
``` 

It's important that you **do not have the `DECIDIM_AVAILABLE_LOCALES` env var set-up locally. 
 

:hearts: Thank you!
