### PR TITLE
Fixes proposal cards rendering alt-text when attachment is PDF #14962

### DIFF
--- a/decidim-proposals/app/cells/decidim/proposals/proposal_g_cell.rb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_g_cell.rb
@@ -41,7 +41,11 @@ module Decidim
       end
 
       def resource_image_path
-        model.attachments.first&.url
+        return has_image?
+      end
+
+      def has_image?
+        model.attachments.presence&.find_by("content_type LIKE ?", "image/%")&.url
       end
 
       private

--- a/decidim-proposals/spec/cells/decidim/proposals/proposal_g_cell_spec.rb
+++ b/decidim-proposals/spec/cells/decidim/proposals/proposal_g_cell_spec.rb
@@ -43,6 +43,23 @@ module Decidim::Proposals
         end
       end
 
+      context "when the proposal has a pdf" do
+        let!(:attachment) { create(:attachment, :with_pdf, attached_to: proposal) }
+
+        it "renders the proposal with the placeholder image" do
+          expect(subject).to have_css(".card__grid-img svg#ri-proposal-placeholder-card-g")
+        end
+      end
+
+      context "when the proposal has multiple attachments and the first is a pdf" do
+        let!(:pdf_attachment) { create(:attachment, :with_pdf, attached_to: proposal) }
+        let!(:image_attachment) { create(:attachment, :with_image, attached_to: proposal) }
+
+        it "renders the proposal with the attached image" do
+          expect(subject).to have_css("img[src*='city']")
+        end
+      end
+
       context "when the proposal has a custom state" do
         let!(:state) { create(:proposal_state, component:, token: :finished, title: { en: "Finished" }) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Methods for getting the image of the proposal for its card assumed either the resource is always an image like in has_image? being called in the view: 

https://github.com/decidim/decidim/blob/407c9ee4ffb33a544c2e3d504a51f54da4d08aeb/decidim-core/app/cells/decidim/card_g_cell.rb#L62-L64 

https://github.com/decidim/decidim/blob/407c9ee4ffb33a544c2e3d504a51f54da4d08aeb/decidim-core/app/cells/decidim/card_l_cell.rb#L76-L78

or in this line where it assumes the first attachment will always be an image:

https://github.com/decidim/decidim/blob/407c9ee4ffb33a544c2e3d504a51f54da4d08aeb/decidim-proposals/app/cells/decidim/proposals/proposal_g_cell.rb#L43-L45

This lead to 2 types of cases:
- When only posting a PDF as an attachment for a proposal, the alt-image would be displayed in the card, instead of the placeholder image 
- When posting both a PDF and an image as attachments for a proposal, but the PDF being attached first,  the alt-image would be displayed in the card, instead of the attached image

This PR corrects for both cases.

Attempting to correct this in v0.30 but appears to be an issue in development as well. LMK if I should merge to develop instead.

#### :pushpin: Related Issues

- Fixes #14962

#### Testing
- Upload a PDF in a proposal
- Upload an image in the same proposal
- Check the index proposals page in grid mode


### :camera: Screenshots

Before the change:
<img width="1020" height="405" alt="image" src="https://github.com/user-attachments/assets/aa834b73-95ad-41c7-9d41-c5d6e6af2a5b" />

After the change:
<img width="936" height="558" alt="image" src="https://github.com/user-attachments/assets/4dfb9880-b176-4441-954e-75fe42a06910" />


:hearts: Thank you!
