### PR TITLE
Add missing component actions translations

### DIFF
--- a/decidim-collaborative_texts/config/locales/en.yml
+++ b/decidim-collaborative_texts/config/locales/en.yml
@@ -137,6 +137,10 @@ en:
           invalid_nodes: Invalid selected nodes.
     components:
       collaborative_texts:
+        actions:
+          create: Create
+          update: Update
+          destroy: Destroy
         name: Collaborative Texts
         settings:
           global:

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -18,6 +18,10 @@ en:
         edit_elections_info: Cannot edit this election
     components:
       elections:
+        actions:
+          create: Create
+          update: Update
+          destroy: Destroy
         name: Elections
         settings:
           global:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -28,7 +28,8 @@ en:
     components:
       surveys:
         actions:
-          response: Response
+          respond: Respond
+          response: Respond
         name: Surveys
         settings:
           announcement: Announcement


### PR DESCRIPTION
#### :tophat: What? Why?
Some component permission pages are currently unreachable because there are missing translations for the component actions:
- Collaborative texts
- Elections
- Surveys

This fixes the issue by adding these missing translations to the system.

#### Testing
- Go to the "Permissions" page on each of these components
- Expect the page to work normally without missing translations