### PR TITLE
Remove SCSS `@import` statements

### DIFF
--- a/decidim-admin/app/packs/entrypoints/decidim_admin.scss
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/admin/application.scss";
+@use "stylesheets/decidim/admin/application";

--- a/decidim-admin/app/packs/entrypoints/decidim_admin_overrides.scss
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin_overrides.scss
@@ -1,2 +1,2 @@
 // Application specific styles: https://docs.decidim.org/en/customize/styles/
-@import "stylesheets/decidim/admin/decidim_application";
+@use "stylesheets/decidim/admin/decidim_application";

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_main-nav.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_main-nav.scss
@@ -1,4 +1,4 @@
-@import "stylesheets/decidim/_buttons.scss";
+@use "stylesheets/decidim/buttons";
 
 .layout-wrapper {
   &.is-nav-open {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_select_picker.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_select_picker.scss
@@ -1,4 +1,4 @@
-@import "tom-select/dist/scss/tom-select";
+@use "tom-select/dist/scss/tom-select";
 
 /* overwrite tom-select defaults */
 .ts {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
@@ -24,7 +24,7 @@
 @use "stylesheets/decidim/admin/datepicker";
 @use "stylesheets/decidim/admin/minimap";
 @use "stylesheets/decidim/admin/proposal_status";
-@use "stylesheets/decidim/_tribute";
+@use "stylesheets/decidim/tribute";
 
 :root {
   --primary: #e02d2d;

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
@@ -1,3 +1,31 @@
+@use "stylesheets/decidim/admin/forms";
+@use "stylesheets/decidim/admin/color_picker";
+@use "stylesheets/decidim/admin/main-nav";
+@use "stylesheets/decidim/admin/layout";
+@use "stylesheets/decidim/admin/secondary-nav";
+@use "stylesheets/decidim/admin/title-bar";
+@use "stylesheets/decidim/admin/user-login";
+@use "stylesheets/decidim/admin/cards";
+@use "stylesheets/decidim/admin/logs";
+@use "stylesheets/decidim/admin/filters";
+@use "stylesheets/decidim/admin/table-list";
+@use "stylesheets/decidim/admin/taxonomies";
+@use "stylesheets/decidim/admin/dropdown";
+@use "stylesheets/decidim/admin/item_show";
+@use "stylesheets/decidim/admin/item_edit";
+@use "stylesheets/decidim/admin/tabs";
+@use "stylesheets/decidim/admin/component-show";
+@use "stylesheets/decidim/admin/moderations";
+@use "stylesheets/decidim/admin/select_picker";
+@use "stylesheets/decidim/admin/show_email";
+@use "stylesheets/decidim/admin/data_picker";
+@use "stylesheets/decidim/admin/legacy_foundation";
+@use "stylesheets/decidim/admin/sidebar-menu";
+@use "stylesheets/decidim/admin/datepicker";
+@use "stylesheets/decidim/admin/minimap";
+@use "stylesheets/decidim/admin/proposal_status";
+@use "stylesheets/decidim/_tribute";
+
 :root {
   --primary: #e02d2d;
   --primary-rgb: 224 45 45;
@@ -12,31 +40,3 @@
   --alert: #e7131a;
   --alert-rgb: 231 19 26;
 }
-
-@import "stylesheets/decidim/admin/_forms.scss";
-@import "stylesheets/decidim/admin/_color_picker.scss";
-@import "stylesheets/decidim/admin/_main-nav.scss";
-@import "stylesheets/decidim/admin/_layout.scss";
-@import "stylesheets/decidim/admin/_secondary-nav.scss";
-@import "stylesheets/decidim/admin/_title-bar.scss";
-@import "stylesheets/decidim/admin/_user-login.scss";
-@import "stylesheets/decidim/admin/_cards.scss";
-@import "stylesheets/decidim/admin/_logs.scss";
-@import "stylesheets/decidim/admin/_filters.scss";
-@import "stylesheets/decidim/admin/_table-list.scss";
-@import "stylesheets/decidim/admin/_taxonomies.scss";
-@import "stylesheets/decidim/admin/_dropdown.scss";
-@import "stylesheets/decidim/admin/_item_show.scss";
-@import "stylesheets/decidim/admin/_item_edit.scss";
-@import "stylesheets/decidim/admin/_tabs.scss";
-@import "stylesheets/decidim/admin/_component-show.scss";
-@import "stylesheets/decidim/admin/_moderations.scss";
-@import "stylesheets/decidim/admin/_select_picker.scss";
-@import "stylesheets/decidim/admin/_show_email.scss";
-@import "stylesheets/decidim/admin/_data_picker.scss";
-@import "stylesheets/decidim/admin/_legacy_foundation.scss";
-@import "stylesheets/decidim/admin/_sidebar-menu.scss";
-@import "stylesheets/decidim/admin/_datepicker.scss";
-@import "stylesheets/decidim/admin/_minimap.scss";
-@import "stylesheets/decidim/admin/_proposal_status.scss";
-@import "stylesheets/decidim/_tribute.scss";

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -1,4 +1,4 @@
-@import "stylesheets/decidim/_tribute.scss";
+@use "stylesheets/decidim/tribute";
 
 .comments {
   &__container {

--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/conferences.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/conferences.scss
@@ -1,5 +1,5 @@
-@import "stylesheets/decidim/conferences/conference.scss";
-@import "stylesheets/decidim/conferences/speaker.scss";
-@import "stylesheets/decidim/conferences/registration.scss";
-@import "stylesheets/decidim/conferences/program.scss";
-@import "stylesheets/decidim/conferences/media.scss";
+@use "stylesheets/decidim/conferences/conference";
+@use "stylesheets/decidim/conferences/speaker";
+@use "stylesheets/decidim/conferences/registration";
+@use "stylesheets/decidim/conferences/program";
+@use "stylesheets/decidim/conferences/media";

--- a/decidim-core/app/packs/entrypoints/decidim_conference_diploma.scss
+++ b/decidim-core/app/packs/entrypoints/decidim_conference_diploma.scss
@@ -1,3 +1,3 @@
 // Since the following resource contains url() stuff, webpacker does not resolve as it should the inner paths
 // (it misses "file-loader" webpack plugin). Therefore, we need to keep this file separate from the JS entrypoint
-@import "stylesheets/decidim/legacy/conference-diploma.scss";
+@use "stylesheets/decidim/legacy/conference-diploma";

--- a/decidim-core/app/packs/entrypoints/decidim_core.scss
+++ b/decidim-core/app/packs/entrypoints/decidim_core.scss
@@ -1,3 +1,3 @@
 // Since the following resource contains url() stuff, webpacker does not resolve as it should the inner paths
 // (it misses "file-loader" webpack plugin). Therefore, we need to keep this file separate from the JS entrypoint
-@import "stylesheets/decidim/application.scss";
+@use "stylesheets/decidim/application";

--- a/decidim-core/app/packs/entrypoints/decidim_map.scss
+++ b/decidim-core/app/packs/entrypoints/decidim_map.scss
@@ -1,3 +1,3 @@
 // Since the following resource contains url() stuff, webpacker does not resolve as it should the inner paths
 // (it misses "file-loader" webpack plugin). Therefore, we need to keep this file separate from the JS entrypoint
-@import "stylesheets/decidim/map.scss";
+@use "stylesheets/decidim/map";

--- a/decidim-core/app/packs/entrypoints/decidim_overrides.scss
+++ b/decidim-core/app/packs/entrypoints/decidim_overrides.scss
@@ -1,2 +1,2 @@
 // Application specific styles: https://docs.decidim.org/en/customize/styles/
-@import "stylesheets/decidim/decidim_application";
+@use "stylesheets/decidim/decidim_application";

--- a/decidim-core/app/packs/stylesheets/decidim/application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/application.scss
@@ -1,83 +1,86 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@use "sass:meta";
+@use "tailwindcss/base";
+@use "tailwindcss/components";
+@use "tailwindcss/utilities";
+
+// Datepicker
+@use "stylesheets/decidim/vendor/datepicker_light";
+@use "stylesheets/decidim/datepicker";
+// On the other hand, the following styles match with specific routes
+@use "stylesheets/decidim/header";
+@use "stylesheets/decidim/footer";
+@use "stylesheets/decidim/login";
+@use "stylesheets/decidim/pages";
+@use "stylesheets/decidim/notifications";
+@use "stylesheets/decidim/profile";
+@use "stylesheets/decidim/conversations";
+@use "stylesheets/decidim/versions";
+@use "stylesheets/decidim/home";
+@use "stylesheets/decidim/search";
+@use "stylesheets/decidim/cookies";
+// participatory spaces are quite similar between processes and assemblies (different modules), so their stylesheets are placed in the core
+@use "stylesheets/decidim/participatory_spaces";
+@use "stylesheets/decidim/omnipresent_banner";
+// This imports all the Decidim module stylesheet imports registered at
+// `config/assets.rb` of the module for the "app" group. The import contains
+// a mixing named `styles` which is included at the bottom of this file.
+@use "decidim:style-imports[app]" as extra;
 
 @layer base {
-  @import "stylesheets/decidim/_fonts.scss";
-  @import "stylesheets/decidim/_typography.scss";
+  @include meta.load-css("stylesheets/decidim/fonts");
+  @include meta.load-css("stylesheets/decidim/typography");
   // Keep this in separate file as long as we are maintaining Foundation compatibility
-  @import "stylesheets/decidim/_rich_text.scss";
+  @include meta.load-css("stylesheets/decidim/rich_text");
 }
 
 // The CSS components must work identically all along the application,
 // no matter which view are being displayed in.
 @layer components {
-  @import "stylesheets/decidim/_layout.scss";
-  @import "stylesheets/decidim/_buttons.scss";
-  @import "stylesheets/decidim/_labels.scss";
-  @import "stylesheets/decidim/_forms.scss";
-  @import "stylesheets/decidim/_dropdown.scss";
-  @import "stylesheets/decidim/_login_box.scss";
-  @import "stylesheets/decidim/_callout.scss";
-  @import "stylesheets/decidim/_accordion.scss";
-  @import "stylesheets/decidim/_tos.scss";
-  @import "stylesheets/decidim/_vertical_tabs.scss";
-  @import "stylesheets/decidim/_flash.scss";
-  @import "stylesheets/decidim/_static-map.scss";
-  @import "stylesheets/decidim/_filters.scss";
-  @import "stylesheets/decidim/_tags.scss";
-  @import "stylesheets/decidim/_tabs_x.scss";
-  @import "stylesheets/decidim/_metadata.scss";
-  @import "stylesheets/decidim/_modal.scss";
-  @import "stylesheets/decidim/_modal_share.scss";
-  @import "stylesheets/decidim/_modal_flag.scss";
-  @import "stylesheets/decidim/_modal_authorization.scss";
-  @import "stylesheets/decidim/_modal_update.scss";
-  @import "stylesheets/decidim/_modal_tos_refuse.scss";
-  @import "stylesheets/decidim/_modal_fingerprint.scss";
-  @import "stylesheets/decidim/_address.scss";
-  @import "stylesheets/decidim/_statistics.scss";
-  @import "stylesheets/decidim/_content_blocks.scss";
-  @import "stylesheets/decidim/_documents.scss";
-  @import "stylesheets/decidim/_floating_help.scss";
-  @import "stylesheets/decidim/_cards.scss";
-  @import "stylesheets/decidim/_floating_help.scss";
-  @import "stylesheets/decidim/_order-by.scss";
-  @import "stylesheets/decidim/_photos.scss";
-  @import "stylesheets/decidim/_likes_list.scss";
-  @import "stylesheets/decidim/_activity.scss";
-  @import "stylesheets/decidim/_tooltip.scss";
-  @import "stylesheets/decidim/_author.scss";
-  @import "stylesheets/decidim/_order-by.scss";
-  @import "stylesheets/decidim/_wizard_steps.scss";
-  @import "stylesheets/decidim/_progress-bar.scss";
-  @import "stylesheets/decidim/_spinner.scss";
-  @import "stylesheets/decidim/_toggle_switch.scss";
-  @import "stylesheets/decidim/_hero.scss";
-  @import "stylesheets/decidim/_actions.scss";
-  @import "stylesheets/decidim/_emoji.scss";
-  @import "stylesheets/decidim/_success_image.scss";
+  @include meta.load-css("stylesheets/decidim/layout");
+  @include meta.load-css("stylesheets/decidim/buttons");
+  @include meta.load-css("stylesheets/decidim/labels");
+  @include meta.load-css("stylesheets/decidim/forms");
+  @include meta.load-css("stylesheets/decidim/dropdown");
+  @include meta.load-css("stylesheets/decidim/login_box");
+  @include meta.load-css("stylesheets/decidim/callout");
+  @include meta.load-css("stylesheets/decidim/accordion");
+  @include meta.load-css("stylesheets/decidim/tos");
+  @include meta.load-css("stylesheets/decidim/vertical_tabs");
+  @include meta.load-css("stylesheets/decidim/flash");
+  @include meta.load-css("stylesheets/decidim/static-map");
+  @include meta.load-css("stylesheets/decidim/filters");
+  @include meta.load-css("stylesheets/decidim/tags");
+  @include meta.load-css("stylesheets/decidim/tabs_x");
+  @include meta.load-css("stylesheets/decidim/metadata");
+  @include meta.load-css("stylesheets/decidim/modal");
+  @include meta.load-css("stylesheets/decidim/modal_share");
+  @include meta.load-css("stylesheets/decidim/modal_flag");
+  @include meta.load-css("stylesheets/decidim/modal_authorization");
+  @include meta.load-css("stylesheets/decidim/modal_update");
+  @include meta.load-css("stylesheets/decidim/modal_tos_refuse");
+  @include meta.load-css("stylesheets/decidim/modal_fingerprint");
+  @include meta.load-css("stylesheets/decidim/address");
+  @include meta.load-css("stylesheets/decidim/statistics");
+  @include meta.load-css("stylesheets/decidim/content_blocks");
+  @include meta.load-css("stylesheets/decidim/documents");
+  @include meta.load-css("stylesheets/decidim/floating_help");
+  @include meta.load-css("stylesheets/decidim/cards");
+  @include meta.load-css("stylesheets/decidim/order-by");
+  @include meta.load-css("stylesheets/decidim/photos");
+  @include meta.load-css("stylesheets/decidim/likes_list");
+  @include meta.load-css("stylesheets/decidim/activity");
+  @include meta.load-css("stylesheets/decidim/tooltip");
+  @include meta.load-css("stylesheets/decidim/author");
+  @include meta.load-css("stylesheets/decidim/address");
+  @include meta.load-css("stylesheets/decidim/wizard_steps");
+  @include meta.load-css("stylesheets/decidim/progress-bar");
+  @include meta.load-css("stylesheets/decidim/spinner");
+  @include meta.load-css("stylesheets/decidim/toggle_switch");
+  @include meta.load-css("stylesheets/decidim/hero");
+  @include meta.load-css("stylesheets/decidim/actions");
+  @include meta.load-css("stylesheets/decidim/emoji");
+  @include meta.load-css("stylesheets/decidim/success_image");
 }
 
-@import "stylesheets/decidim/vendor/datepicker_light.scss";
-@import "stylesheets/decidim/datepicker.scss";
-
-// On the other hand, the following styles match with specific routes
-@import "stylesheets/decidim/_header.scss";
-@import "stylesheets/decidim/_footer.scss";
-@import "stylesheets/decidim/_login.scss";
-@import "stylesheets/decidim/_pages.scss";
-@import "stylesheets/decidim/_notifications.scss";
-@import "stylesheets/decidim/_profile.scss";
-@import "stylesheets/decidim/_conversations.scss";
-@import "stylesheets/decidim/_versions.scss";
-@import "stylesheets/decidim/_home.scss";
-@import "stylesheets/decidim/_search.scss";
-@import "stylesheets/decidim/_cookies.scss";
-// participatory spaces are quite similar between processes and assemblies (different modules), so their stylesheets are placed in the core
-@import "stylesheets/decidim/_participatory_spaces.scss";
-@import "stylesheets/decidim/_omnipresent_banner.scss";
-
-// This imports all the Decidim module stylesheet imports registered at
-// `config/assets.rb` of the module for the "app" group.
-@import "!decidim-style-imports[app]";
+// This applies the custom style imports registered at the application.
+@include extra.styles;

--- a/decidim-core/app/packs/stylesheets/decidim/legacy/email.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/legacy/email.scss
@@ -1,4 +1,5 @@
-@import "stylesheets/decidim/legacy/variables";
+@use "sass:meta";
+@use "stylesheets/decidim/legacy/variables";
 
 /* Index:
   1 - Foundation settings
@@ -1190,8 +1191,8 @@ table.button {
 table.button table td {
   text-align: left;
   color: #fefefe;
-  background: $primary;
-  border: 2px solid $primary;
+  background: variables.$primary;
+  border: 2px solid variables.$primary;
 }
 
 table.button table td a {
@@ -1201,7 +1202,7 @@ table.button table td a {
   text-decoration: none;
   display: inline-block;
   padding: 8px 16px;
-  border: 0 solid $primary;
+  border: 0 solid variables.$primary;
   border-radius: 3px;
 }
 
@@ -1290,7 +1291,7 @@ table.button.expanded center {
 table.button:hover table td,
 table.button:visited table td,
 table.button:active table td {
-  background: $primary;
+  background: variables.$primary;
   color: #fefefe;
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/map.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/map.scss
@@ -1,6 +1,8 @@
-@import "leaflet/dist/leaflet";
-@import "leaflet.markercluster/dist/MarkerCluster";
-@import "leaflet.markercluster/dist/MarkerCluster.Default";
+@use "sass:meta";
+
+@include meta.load-css("leaflet/dist/leaflet");
+@include meta.load-css("leaflet.markercluster/dist/MarkerCluster");
+@include meta.load-css("leaflet.markercluster/dist/MarkerCluster.Default");
 
 /* overwrite leaflet and card styles */
 .leaflet-popup-content-wrapper {

--- a/decidim-core/app/packs/stylesheets/decidim/qr.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/qr.scss
@@ -1,12 +1,13 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@use "sass:meta";
+@use "tailwindcss/base";
+@use "tailwindcss/components";
+@use "tailwindcss/utilities";
 
 @layer base {
-  @import "stylesheets/decidim/_fonts.scss";
-  @import "stylesheets/decidim/_typography.scss";
+  @include meta.load-css("stylesheets/decidim/fonts");
+  @include meta.load-css("stylesheets/decidim/typography");
   // Keep this in separate file as long as we are maintaining Foundation compatibility
-  @import "stylesheets/decidim/_rich_text.scss";
+  @include meta.load-css("stylesheets/decidim/rich_text");
 }
 
 body {

--- a/decidim-design/app/packs/stylesheets/design.scss
+++ b/decidim-design/app/packs/stylesheets/design.scss
@@ -1,4 +1,4 @@
-@import "tom-select/dist/scss/tom-select";
+@use "tom-select/dist/scss/tom-select";
 
 .design__layout {
   @apply grid md:grid-cols-12 container min-h-screen before:content-[''] before:absolute before:-z-10 before:w-1/2 before:h-full before:inset-0 before:bg-background;

--- a/decidim-dev/app/packs/entrypoints/decidim_dev.scss
+++ b/decidim-dev/app/packs/entrypoints/decidim_dev.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/dev";
+@use "stylesheets/decidim/dev";

--- a/decidim-dev/app/packs/stylesheets/decidim/dev.scss
+++ b/decidim-dev/app/packs/stylesheets/decidim/dev.scss
@@ -1,4 +1,4 @@
-@import "stylesheets/decidim/dev/accessibility";
-@import "stylesheets/decidim/dev/bullet";
-@import "stylesheets/decidim/dev/rack_profiler";
-@import "stylesheets/decidim/dev/map";
+@use "stylesheets/decidim/dev/accessibility";
+@use "stylesheets/decidim/dev/bullet";
+@use "stylesheets/decidim/dev/rack_profiler";
+@use "stylesheets/decidim/dev/map";

--- a/decidim-elections/app/packs/entrypoints/decidim_elections_admin.scss
+++ b/decidim-elections/app/packs/entrypoints/decidim_elections_admin.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/elections/admin/elections.scss";
+@use "stylesheets/decidim/elections/admin/elections";

--- a/decidim-initiatives/app/packs/entrypoints/decidim_initiatives_admin.scss
+++ b/decidim-initiatives/app/packs/entrypoints/decidim_initiatives_admin.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/initiatives/admin/initiatives.scss";
+@use "stylesheets/decidim/initiatives/admin/initiatives";

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/meetings.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/meetings.scss
@@ -1,4 +1,4 @@
-@import "stylesheets/decidim/meetings/list.scss";
-@import "stylesheets/decidim/meetings/item.scss";
-@import "stylesheets/decidim/meetings/calendar.scss";
-@import "stylesheets/decidim/meetings/live_event.scss";
+@use "stylesheets/decidim/meetings/list";
+@use "stylesheets/decidim/meetings/item";
+@use "stylesheets/decidim/meetings/calendar";
+@use "stylesheets/decidim/meetings/live_event";

--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -1,4 +1,4 @@
-@import "tom-select/dist/scss/tom-select";
+@use "tom-select/dist/scss/tom-select";
 
 .proposal-list {
   &__aside {

--- a/decidim-system/app/packs/entrypoints/decidim_system_overrides.scss
+++ b/decidim-system/app/packs/entrypoints/decidim_system_overrides.scss
@@ -1,2 +1,2 @@
 // Application specific styles: https://docs.decidim.org/en/customize/styles/
-@import "stylesheets/decidim/system/decidim_application";
+@use "stylesheets/decidim/system/decidim_application";

--- a/decidim-system/app/packs/stylesheets/decidim/system/application.scss
+++ b/decidim-system/app/packs/stylesheets/decidim/system/application.scss
@@ -1,4 +1,4 @@
-@import "tom-select/dist/scss/tom-select";
+@use "tom-select/dist/scss/tom-select";
 
 :root {
   --primary: #e02d2d;

--- a/decidim-templates/app/packs/entrypoints/decidim_templates.scss
+++ b/decidim-templates/app/packs/entrypoints/decidim_templates.scss
@@ -1,1 +1,1 @@
-@import "stylesheets/decidim/templates/templates";
+@use "stylesheets/decidim/templates/templates";

--- a/packages/webpacker/src/loaders/decidim-sass-loader.js
+++ b/packages/webpacker/src/loaders/decidim-sass-loader.js
@@ -4,17 +4,17 @@ const path = require("path");
 const { config: { additional_paths: loadPaths, stylesheet_imports: stylesheetImports  } } = require("shakapacker");
 
 const decidimImporter = {
-  canonicalize(importUrl, options) {
-    if (!options.fromImport) {
+  canonicalize(importerUrl, options) {
+    if (options.fromImport) {
       return null;
     }
-    if (!importUrl.startsWith("!decidim-style-")) {
+    if (!importerUrl.startsWith("decidim:")) {
       return null;
     }
-    return new URL(`decidim:${importUrl}`);
+    return new URL(importerUrl);
   },
   load(canonicalUrl) {
-    const matches = decodeURI(canonicalUrl.toString()).match(/^decidim:!decidim-style-([^[]+)\[([^\]]+)\]$/);
+    const matches = decodeURI(canonicalUrl.toString()).match(/^decidim:style-([^[]+)\[([^\]]+)\]$/);
     if (!matches) {
       return { contents: "", syntax: "scss" };
     }
@@ -32,9 +32,16 @@ const decidimImporter = {
       return { contents: "", syntax: "scss" };
     }
 
-    const statements = stylesheetImports[type][group].map((style) => `@import "${style}";`);
+    const statements = stylesheetImports[type][group].map((style) => `@include meta.load-css("${style}");`);
+    const contents = `
+      @use "sass:meta";
 
-    return { contents: statements.join("\n"), syntax: "scss" };
+      @mixin styles {
+        ${statements.join("\n")}
+      }
+    `;
+
+    return { contents, syntax: "scss" };
   }
 };
 
@@ -58,7 +65,7 @@ module.exports = function(content) { // eslint-disable-line no-undef
         sourceMap: true,
         sourceMapIncludeSources: true,
         style: "expanded"
-      },
+      }
     );
   } catch (error) {
     if (error.span && typeof error.span.url !== "undefined") {

--- a/packages/webpacker/src/loaders/decidim-sass-loader.js
+++ b/packages/webpacker/src/loaders/decidim-sass-loader.js
@@ -16,11 +16,11 @@ const decidimImporter = {
   load(canonicalUrl) {
     const matches = decodeURI(canonicalUrl.toString()).match(/^decidim:style-([^[]+)\[([^\]]+)\]$/);
     if (!matches) {
-      return { contents: "", syntax: "scss" };
+      return { contents: "@mixin styles {}", syntax: "scss" };
     }
 
     if (!stylesheetImports) {
-      return { contents: "", syntax: "scss" };
+      return { contents: "@mixin styles {}", syntax: "scss" };
     }
 
     const type = matches[1];
@@ -29,7 +29,7 @@ const decidimImporter = {
       // If the group is not defined, return an empty configuration because
       // otherwise the importer would continue finding the asset through
       // paths which obviously fails.
-      return { contents: "", syntax: "scss" };
+      return { contents: "@mixin styles {}", syntax: "scss" };
     }
 
     const statements = stylesheetImports[type][group].map((style) => `@include meta.load-css("${style}");`);


### PR DESCRIPTION
#### :tophat: What? Why?
While working on a feature, noticed that there are currently a lot of SCSS deprecation warnings and a lot of these originate from the usage of `@import` statements.

This fixes the issue for Decidim SCSS files but there are still some deprecation messages coming from `tom-select` which are not fixed even in the latest version: orchidjs/tom-select#911

Therefore, this mitigates the problem but does not fully fix it

#### :pushpin: Related Issues
- Related to
  * #14949
  * orchidjs/tom-select#911

#### Testing
- Compile the assets
- See less SCSS deprecation warnings (but still some from `tom-select`)