### PR TITLE
Change default seeding strategy to have fast seeds

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -15,7 +15,6 @@ on:
       - "decidim-generators/**"
 
 env:
-  FAST_SEEDS: "true"
   CI: "true"
   RUBY_VERSION: 3.3.4
   NODE_VERSION: 22.14.0

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -16,7 +16,6 @@ on:
       - "decidim-dev/**"
 
 env:
-  FAST_SEEDS: "true"
   CI: "true"
   SIMPLECOV: "true"
   RUBY_VERSION: 3.3.4

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -128,7 +128,6 @@ jobs:
           DECIDIM_MACHINE_TRANSLATION_SERVICE: Decidim::Dev::DummyTranslator
           DISPLAY: ":99"
           CI: "true"
-          FAST_SEEDS: "true"
           SIMPLECOV: "true"
           SHAKAPACKER_RUNTIME_COMPILE: "false"
           NODE_ENV: "test"

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -9,12 +9,12 @@ module Decidim
   class Seeds
     protected
 
-    def fast_seeds?
-      Decidim::Env.new("FAST_SEEDS").present?
+    def slow_seeds?
+      Decidim::Env.new("SLOW_SEEDS").present?
     end
 
     def number_of_records
-      fast_seeds? ? 1 : rand(3..5)
+      slow_seeds? ? rand(3..5) : 1
     end
 
     def organization

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -17,7 +17,7 @@ module Decidim
 
         Decidim::Proposals.create_default_states!(component, admin_user)
 
-        number_of_records = fast_seeds? ? 10 : rand(25..50)
+        number_of_records = slow_seeds? ? 10 : rand(25..50)
 
         (5..number_of_records).to_a.sample.times do |n|
           proposal = create_proposal!(component:)

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -972,8 +972,8 @@ Note that this only applies to production environments.
 |5
 |No
 
-|FAST_SEEDS
-|If seeding various environment that needs to be fast (like gitpod). Please use `FAST_SEEDS` environment variable to reduce the seeding time.
+|SLOW_SEEDS
+|If seeding various environment that needs to have more data. Please use `SLOW_SEEDS` environment variable to add additional seed data.
 |false
 |No
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in https://github.com/decidim/decidim/pull/14528 we have added an environment variable named `FAST_SEEDS` . 

@ahukkanen mentioned in #14945 the seeding process is too slow, so during the conversation, it was suggested to change the default behavior to faster seeds. This PR does exactly that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14528
- Fixes #14945

#### Testing
Green pipeline

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
