### PR TITLE
Implement cards in the Conferences form and improve UX

### DIFF
--- a/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
+++ b/decidim-conferences/app/forms/decidim/conferences/admin/conference_form.rb
@@ -50,9 +50,6 @@ module Decidim
         validates :banner_image, passthru: { to: Decidim::Conference }
         validate :available_slots_greater_than_or_equal_to_registrations_count, if: ->(form) { form.registrations_enabled? && form.available_slots.try(:positive?) }
 
-        validates :start_date, presence: true, date: { before_or_equal_to: :end_date }
-        validates :end_date, presence: true, date: { after_or_equal_to: :start_date }
-
         alias organization current_organization
 
         def participatory_space_manifest

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -10,6 +10,7 @@ module Decidim
       # Renders the dates of a conference
       #
       def render_date(conference)
+        return if conference.start_date.nil? || conference.end_date.nil?
         return l(conference.start_date, format: :decidim_with_month_name_short) if conference.start_date == conference.end_date
 
         "#{l(conference.start_date, format: :decidim_with_month_name_short)} - #{l(conference.end_date, format: :decidim_with_month_name_short)}"

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -35,7 +35,20 @@
       <div class="row column">
         <%= form.translated :editor, :description, aria: { label: :description } %>
       </div>
+    </div>
+  </div>
 
+  <div class="card" data-component="accordion" id="accordion-duration">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-duration" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="duration">
+          <%= t("duration", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+
+    <div id="panel-duration" class="card-section">
       <div class="row column">
         <%= form.date_field :start_date %>
       </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -119,16 +119,18 @@
 
     <div id="panel-registrations" class="card-section">
       <div class="row column">
-        <%= form.check_box :registrations_enabled %>
+        <%= form.check_box :registrations_enabled, "data-toggle": "registrations_enabled_details" %>
       </div>
 
-      <div class="row column">
-        <p><%= t(".registrations_count", count: current_participatory_space.present? ? current_participatory_space.conference_registrations.count : 0) %></p>
-        <%= form.number_field :available_slots, help_text: t(".available_slots_help") %>
-      </div>
+      <div id="registrations_enabled_details" <%= form.object.registrations_enabled ? nil : "hidden" %>>
+        <div class="row column">
+          <p><%= t(".registrations_count", count: current_participatory_space.present? ? current_participatory_space.conference_registrations.count : 0) %></p>
+          <%= form.number_field :available_slots, help_text: t(".available_slots_help") %>
+        </div>
 
-      <div class="row column" id="conference_registrations_terms">
-        <%= form.translated :editor, :registration_terms, toolbar: :content, aria: { label: :registration_terms } %>
+        <div class="row column" id="conference_registrations_terms">
+          <%= form.translated :editor, :registration_terms, toolbar: :content, aria: { label: :registration_terms } %>
+        </div>
       </div>
     </div>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -29,37 +29,11 @@
       </div>
 
       <div class="row column">
-        <%= form.check_box :promoted %>
-      </div>
-
-      <div class="row column">
         <%= form.translated :editor, :short_description, aria: { label: :short_description } %>
       </div>
 
       <div class="row column">
         <%= form.translated :editor, :description, aria: { label: :description } %>
-      </div>
-
-      <div class="row column">
-        <%= form.translated :editor, :objectives, aria: { label: :objectives } %>
-      </div>
-
-      <div class="row column">
-        <%= form.text_field :location %>
-      </div>
-
-      <div class="row">
-        <div class="columns">
-          <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
-        </div>
-
-        <div class="columns">
-          <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
-        </div>
-      </div>
-
-      <div class="row column">
-        <%= form.check_box :show_statistics %>
       </div>
 
       <div class="row column">
@@ -69,20 +43,111 @@
       <div class="row column">
         <%= form.date_field :end_date %>
       </div>
+    </div>
+  </div>
 
+  <div class="card" data-component="accordion" id="accordion-images">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-images" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="images">
+          <%= t("images", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+
+    <div id="panel-images" class="card-section">
+      <div class="row">
+        <div class="columns">
+          <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
+        </div>
+
+        <div class="columns">
+          <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-metadata">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-metadata" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="metadata">
+          <%= t("metadata", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-metadata" class="card-section">
+
+      <div class="row column">
+        <%= form.translated :editor, :objectives, aria: { label: :objectives } %>
+      </div>
+
+      <div class="row column">
+        <%= form.text_field :location %>
+      </div>
+
+      <div class="row column">
+        <%= form.check_box :show_statistics %>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-registrations">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-registrations" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="registrations">
+          <%= t("registrations", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+
+    <div id="panel-registrations" class="card-section">
       <div class="row column">
         <%= form.check_box :registrations_enabled %>
       </div>
 
-    <div class="row column">
-      <p><%= t(".registrations_count", count: current_participatory_space.present? ? current_participatory_space.conference_registrations.count : 0) %></p>
-      <%= form.number_field :available_slots, help_text: t(".available_slots_help") %>
-    </div>
+      <div class="row column">
+        <p><%= t(".registrations_count", count: current_participatory_space.present? ? current_participatory_space.conference_registrations.count : 0) %></p>
+        <%= form.number_field :available_slots, help_text: t(".available_slots_help") %>
+      </div>
 
       <div class="row column" id="conference_registrations_terms">
         <%= form.translated :editor, :registration_terms, toolbar: :content, aria: { label: :registration_terms } %>
       </div>
+    </div>
+  </div>
 
+  <div class="card" data-component="accordion" id="accordion-visibility">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="visibility">
+          <%= t("visibility", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+
+    <div id="panel-visibility" class="card-section">
+      <div class="row column">
+        <%= form.check_box :promoted %>
+      </div>
+    </div>
+  </div>
+
+  <div class="card" data-component="accordion" id="accordion-related_spaces">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-related_spaces" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="related_spaces">
+          <%= t("related_spaces", scope: "decidim.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+
+    <div id="panel-related_spaces" class="card-section">
       <div class="row column">
         <% if @form.processes_for_select %>
           <%= form.select :participatory_processes_ids,
@@ -100,7 +165,6 @@
                           { multiple: true, class: "chosen-select" } %>
         <% end %>
       </div>
-
     </div>
   </div>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -133,6 +133,33 @@
     </div>
   </div>
 
+  <div class="card" data-component="accordion" id="accordion-taxonomies">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-taxonomies" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="taxonomies">
+          <%= t("taxonomies", scope: "decidim.conferences.admin.conferences.form") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-taxonomies" class="card-section">
+      <% if @form.taxonomy_filters.blank? %>
+        <div class="row column">
+          <p class="text-gray mr-2 mt-4">
+            <%= t("no_taxonomy_filters_found", scope: "decidim.conferences.admin.conferences.form") %>
+            <%= link_to(t("define_taxonomy_filters", scope: "decidim.conferences.admin.conferences.form"), decidim_admin.taxonomies_path, class: "button button__text-secondary") %>
+          </p>
+        </div>
+      <% else %>
+        <% @form.taxonomy_filters.each do |filter| %>
+          <div class="row column">
+            <%= filter_taxonomy_items_select_field form, :taxonomies, filter %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+
   <div class="card" data-component="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
@@ -178,33 +205,6 @@
                           { multiple: true, class: "chosen-select" } %>
         <% end %>
       </div>
-    </div>
-  </div>
-
-  <div class="card" data-component="accordion" id="accordion-taxonomies">
-    <div class="card-divider">
-      <button class="card-divider-button" data-open="true" data-controls="panel-taxonomies" type="button">
-        <%= icon "arrow-right-s-line" %>
-        <h2 class="card-title" id="taxonomies">
-          <%= t("taxonomies", scope: "decidim.conferences.admin.conferences.form") %>
-        </h2>
-      </button>
-    </div>
-    <div id="panel-taxonomies" class="card-section">
-      <% if @form.taxonomy_filters.blank? %>
-        <div class="row column">
-          <p class="text-gray mr-2 mt-4">
-            <%= t("no_taxonomy_filters_found", scope: "decidim.conferences.admin.conferences.form") %>
-            <%= link_to(t("define_taxonomy_filters", scope: "decidim.conferences.admin.conferences.form"), decidim_admin.taxonomies_path, class: "button button__text-secondary") %>
-          </p>
-        </div>
-      <% else %>
-        <% @form.taxonomy_filters.each do |filter| %>
-          <div class="row column">
-            <%= filter_taxonomy_items_select_field form, :taxonomies, filter %>
-          </div>
-        <% end %>
-      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -176,7 +176,7 @@ en:
           title: Deleted conferences
         new:
           create: Create
-          title: Conference
+          title: New conference
         update:
           error: There was a problem updating this conference.
           success: Conference successfully updated.

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -163,7 +163,12 @@ en:
         exports:
           registrations: Registrations
         form:
+          images: Images
+          metadata: Metadata
+          registrations: Registrations
+          related_spaces: Related spaces
           title: General Information
+          visibility: Visiblity
         index:
           published: Published
           unpublished: Unpublished

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
   activemodel:
     attributes:
       conference:
-        assemblies_ids: Related Assemblies
+        assemblies_ids: Related assemblies
         available_slots: Available slots
         banner_image: Banner image
         copy_categories: Copy categories

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -163,6 +163,7 @@ en:
         exports:
           registrations: Registrations
         form:
+          duration: Duration
           images: Images
           metadata: Metadata
           registrations: Registrations

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -17,7 +17,7 @@ shared_examples "manage conferences" do
     %w(description short_description objectives).each do |field|
       it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='conference-#{field}-tabs']", "full"
     end
-    it_behaves_like "having a rich text editor for field", "#conference_registrations_terms", "content"
+    it_behaves_like "having a rich text editor for field", "#conference_short_description_en", "full"
     it_behaves_like "having no taxonomy filters defined"
 
     it "creates a new conference", versioning: true do
@@ -108,7 +108,7 @@ shared_examples "manage conferences" do
     %w(description short_description objectives).each do |field|
       it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='conference-#{field}-tabs']", "full"
     end
-    it_behaves_like "having a rich text editor for field", "#conference_registrations_terms", "content"
+    it_behaves_like "having a rich text editor for field", "#conference_short_description_en", "full"
 
     it "update an conference without images does not delete them" do
       within_admin_sidebar_menu do


### PR DESCRIPTION
#### :tophat: What? Why?

This PR implements multiple minor changes to the Conferences' admin form, to make it consistent with the other Spaces forms (such as Processes and Assemblies). 

These improvements come from a UX test that we've done one week ago. These are:

- Move fields to cards to make it consistent
- Make the start/end date non-mandatory, as it shouldn't be necessary to publish the Conference
- Show the registrations fields only when it is enabled
- Fix title of this form to make it consistent with Processes/Assemblies

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/conferences/new

### :camera: Screenshots

<img width="1935" height="2048" alt="image" src="https://github.com/user-attachments/assets/be940e40-abae-43a2-acfb-465291298342" />


:hearts: Thank you!
