### PR TITLE
Error saving survey with empty mandatory fields

### DIFF
--- a/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
@@ -50,7 +50,7 @@
       <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
     <% end %>
 
-    <% !%w[short_answer long_answer].include?(response&.question&.question_type) && response.errors.full_messages.each do |msg| %>
+    <% %w(short_answer long_answer).exclude?(response&.question&.question_type) && response.errors.full_messages.each do |msg| %>
       <small class="form-error is-visible"><%= msg %></small>
     <% end %>
 

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
@@ -50,7 +50,7 @@
       <small class="form-error max-choices-alert"><%= t(".max_choices_alert") %></small>
     <% end %>
 
-    <% response.errors.full_messages.each do |msg| %>
+    <% !%w[short_answer long_answer].include?(response&.question&.question_type) && response.errors.full_messages.each do |msg| %>
       <small class="form-error is-visible"><%= msg %></small>
     <% end %>
 

--- a/decidim-forms/app/views/decidim/forms/questionnaires/responses/_long_response.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/responses/_long_response.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= response_form.text_area :body, label: false, id: field_id, rows: 10, disabled:, maxlength:, class: "w-full" %>
+  <%= response_form.text_area :body, label: false, id: field_id, rows: 10, disabled:, maxlength:, class: "w-full", required: false %>
 </div>

--- a/decidim-forms/app/views/decidim/forms/questionnaires/responses/_short_response.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/responses/_short_response.html.erb
@@ -1,3 +1,3 @@
 <div>
-  <%= response_form.text_field :body, label: false, id: field_id, disabled:, maxlength:, class: "w-full" %>
+  <%= response_form.text_field :body, label: false, id: field_id, disabled:, maxlength:, class: "w-full", required: false %>
 </div>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -283,8 +283,9 @@ shared_examples_for "has questionnaire" do
         accept_confirm { click_on "Submit" }
       end
 
-      it "shows errors without submitting the form" do
-        expect(page).to have_no_css ".alert.flash"
+      it "submits the form and shows errors" do
+        expect(page).to have_css ".alert.flash"
+        expect(page).to have_admin_callout(callout_failure)
         different_error = I18n.t("decidim.forms.questionnaires.response.max_choices_alert")
         expect(different_error).to eq("There are too many choices selected")
         expect(page).to have_no_content(different_error)


### PR DESCRIPTION
#### :tophat: What? Why?
When a survey form includes a required field of type short_answer or long_answer left unanswered, the form cannot be submitted. As a result, the user is not redirected to the first page of the survey, and the flash alert is not displayed. By making these fields not required in their partial, the form can be submitted to the controller, allowing validations to be handled in the backend. This makes it possible to perform the redirection and show the flash alert.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14995 
