### PR TITLE
Comment sorting dropdown not working properly

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/order_control.erb
@@ -16,7 +16,6 @@
         <% end %>
       </select>
     </div>
-    <% order = "older" if order.nil? %>
     <div class="hidden md:block">
       <label for="order" class="comments-label-dropdown"><%= t("decidim.components.comment.sort_by") %></label>
       <select id="order" aria-label="<%= t("decidim.components.comment.sort_by") %>" data-desktop-order-comment-select="true">

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -108,7 +108,7 @@ module Decidim
       end
 
       def order
-        options[:order]
+        options[:order] || "older"
       end
 
       def decidim

--- a/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
@@ -10,6 +10,7 @@
   $comments.html(commentsHtml);
 
   // Re-mount the component
+  component.order = "<%= order %>"
   component.mountComponent();
 
   // Update the comments count


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR, I refactored the handling of the default value for the "order" parameter and ensured that the selected sorting order is preserved across the component. Previously, this value was lost, causing the sorting dropdown issue.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/14952

#### Testing

1. Navigate to a proposal/meeting page on Nightly.
2. Log in and add some comments.
3. Use the "Sort by" dropdown to change the comment sorting order.
4. Verify that the comments are reordered according to the selected sorting criteria, and that the dropdown text updates to reflect the current selection.

### :camera: Screenshots
Now, the "Sort by" dropdown sorts the comments by the selected criteria: 

https://github.com/user-attachments/assets/ec44d419-1214-422c-b6ed-4c643c856968


:hearts: Thank you!
