### PR TITLE
Fix expiring Cloud Storage tokens

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -120,7 +120,28 @@ bin/rails decidim:verifications:revoke:sms
 bin/rails decidim_surveys:upgrade:fix_survey_permissions
 ```
 
-### 1.6. Follow the steps and commands detailed in these notes
+### 1.6. AWS/Azure/Google Clour assets storage
+
+As of this upgrade, you can avoid the asset caching issue due to the authentication token that expires. The rails team added an extra active storage parameter, `public: true` that you can add it to your s3 configuration in your storage.yml
+
+```yaml
+s3:
+  service: S3
+  public: true
+  access_key_id: <%= Decidim::Env.new("AWS_ACCESS_KEY_ID").to_s %>
+  secret_access_key: <%= Decidim::Env.new("AWS_SECRET_ACCESS_KEY").to_s %>
+  bucket: <%= Decidim::Env.new("AWS_BUCKET").to_s %>
+  <%= "region: #{Decidim::Env.new("AWS_REGION").to_s}" if Decidim::Env.new("AWS_REGION").present? %>
+  <%= "endpoint: #{ Decidim::Env.new("AWS_ENDPOINT").to_s}" if Decidim::Env.new("AWS_ENDPOINT").present? %>
+```
+
+The parameter will actually strip from any asset url the `X-Amz-Credential` parameter, leaving the asset storage url like: `https://BUCKET-NAME.s3.amazonaws.com/ASSET_ID`, making it easier to cache.
+
+To achive that, the Content Security Policy (found in [system panel](https://docs.decidim.org/en/develop/configure/system)) comes to your aid. Populate (or append to) the following fields with the bucket url (ex: https://decidim-bucket.s3.amazonaws.com/): `Default src`, `Img src`, `Media src` and `Connect src`.
+
+Apart of that, you also need to configure your preferred cloud service provider to suppoort this. We recommend you to follow the Rails official guide for [Active Storage configuration](https://guides.rubyonrails.org/v7.0/active_storage_overview.html#setup).
+
+### 1.7. Follow the steps and commands detailed in these notes
 
 ## 2. General notes
 

--- a/decidim-generators/lib/decidim/generators/app_templates/storage.yml
+++ b/decidim-generators/lib/decidim/generators/app_templates/storage.yml
@@ -8,6 +8,7 @@ local:
 
 s3:
   service: S3
+  public: true
   access_key_id: <%= Decidim::Env.new("AWS_ACCESS_KEY_ID").to_s %>
   secret_access_key: <%= Decidim::Env.new("AWS_SECRET_ACCESS_KEY").to_s %>
   bucket: <%= Decidim::Env.new("AWS_BUCKET").to_s %>
@@ -16,6 +17,7 @@ s3:
 
 azure:
   service: AzureStorage
+  public: true
   storage_account_name: <%= Decidim::Env.new("AZURE_STORAGE_ACCOUNT_NAME").to_s %>
   storage_access_key: <%= Decidim::Env.new("AZURE_STORAGE_ACCESS_KEY").to_s %>
   container: <%= Decidim::Env.new("AZURE_CONTAINER").to_s %>
@@ -24,6 +26,7 @@ gcs:
   service: GCS
   project: <%= Decidim::Env.new("GCS_PROJECT").to_s %>
   bucket: <%= Decidim::Env.new("GCS_BUCKET").to_s %>
+  public: true
   credentials:
     type: <%= Decidim::Env.new("GCS_TYPE", "service_account").to_s %>
     project_id: <%= Decidim::Env.new("GCS_PROJECT_ID").to_s %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR implements the required changes for the long overdue setting regarding the public access to Cloud storage providers. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13422
- Fixes #?

#### Testing
1. Add to your env params some Cloud storage credentials ( AWS ) 
2. Add your cloud storage library gem to Gemfile & run bundle install 
3. Reseed your application 
4. restart you app & see aws urls 
5. Configure your aws bucket like the below picture
6. Add to your storage.yml the `public: true` param 
7. Configure your bucket like in the pic below 
8. Add the following policy to your bucket: 
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Statement1",
            "Effect": "Allow",
            "Principal": {
                "AWS": "ARN OF USER THAT HAS THE AWS_ACCESS_KEY_ID"
            },
            "Action": [
                "s3:PutObject",
                "s3:GetObject",
                "s3:DeleteObject",
                "s3:PutObjectAcl"
            ],
            "Resource": "arn:aws:s3:::decidim-bucket/*"
        }
    ]
}
```
** Make sure that "arn:aws:s3:::decidim-bucket/*" actually matches your bucket name.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="949" height="405" alt="image" src="https://github.com/user-attachments/assets/e1f90695-53ab-4eec-8590-98d69697ef19" />

:hearts: Thank you!
