### PR TITLE
Add :unprocessable_entity state urls where form validation failed

### DIFF
--- a/decidim-accountability/app/controllers/decidim/accountability/admin/import_components_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/import_components_controller.rb
@@ -22,7 +22,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("import_components.create.invalid", scope: "decidim.accountability.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/milestones_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/milestones_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("milestones.create.invalid", scope: "decidim.accountability.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -51,7 +51,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("milestones.update.invalid", scope: "decidim.accountability.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/results_controller.rb
@@ -38,7 +38,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("results.create.invalid", scope: "decidim.accountability.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -62,7 +62,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("results.update.invalid", scope: "decidim.accountability.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/admin/statuses_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("statuses.create.invalid", scope: "decidim.accountability.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -50,7 +50,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("statuses.update.invalid", scope: "decidim.accountability.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-admin/app/controllers/concerns/decidim/admin/content_blocks/landing_page_content_blocks.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/content_blocks/landing_page_content_blocks.rb
@@ -55,7 +55,7 @@ module Decidim
                 redirect_to edit_resource_landing_page_path
               end
               on(:invalid) do
-                render "decidim/admin/shared/landing_page_content_blocks/edit"
+                render "decidim/admin/shared/landing_page_content_blocks/edit", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-admin/app/controllers/decidim/admin/area_types_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/area_types_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("area_types.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -56,7 +56,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("area_types.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/areas_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("areas.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -57,7 +57,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("areas.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/block_user_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
           on(:invalid) do
             flash[:alert] = I18n.t("officializations.block.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -65,7 +65,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("officializations.bulk_action.block.invalid", scope: "decidim.admin")
-            render :bulk_new
+            render :bulk_new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/component_permissions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/component_permissions_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("component_permissions.update.error", scope: "decidim.admin")
-            render action: :edit
+            render action: :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/components_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/components_controller.rb
@@ -47,7 +47,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("components.create.error", scope: "decidim.admin")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -74,7 +74,7 @@ module Decidim
 
           on(:invalid) do
             flash[:alert] = I18n.t("components.update.error", scope: "decidim.admin")
-            render action: :edit
+            render action: :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachment_collections.rb
@@ -39,7 +39,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("attachment_collections.create.error", scope: "decidim.admin")
-                render template: "decidim/admin/attachment_collections/new"
+                render template: "decidim/admin/attachment_collections/new", status: :unprocessable_entity
               end
             end
           end
@@ -64,7 +64,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("attachment_collections.update.error", scope: "decidim.admin")
-                render template: "decidim/admin/attachment_collections/edit"
+                render template: "decidim/admin/attachment_collections/edit", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_attachments.rb
@@ -39,7 +39,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("attachments.create.error", scope: "decidim.admin")
-                render template: "decidim/admin/attachments/new"
+                render template: "decidim/admin/attachments/new", status: :unprocessable_entity
               end
             end
           end
@@ -64,7 +64,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("attachments.update.error", scope: "decidim.admin")
-                render template: "decidim/admin/attachments/edit"
+                render template: "decidim/admin/attachments/edit", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users.rb
@@ -51,7 +51,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("participatory_space_private_users.update.error", scope: "decidim.admin")
-                render template: "decidim/admin/participatory_space_private_users/edit"
+                render template: "decidim/admin/participatory_space_private_users/edit", status: :unprocessable_entity
               end
             end
           end
@@ -68,7 +68,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("participatory_space_private_users.create.error", scope: "decidim.admin")
-                render template: "decidim/admin/participatory_space_private_users/new"
+                render template: "decidim/admin/participatory_space_private_users/new", status: :unprocessable_entity
               end
             end
           end
@@ -84,7 +84,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("participatory_space_private_users.destroy.error", scope: "decidim.admin")
-                render template: "decidim/admin/participatory_space_private_users/index"
+                render template: "decidim/admin/participatory_space_private_users/index", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users_csv_import.rb
+++ b/decidim-admin/app/controllers/decidim/admin/concerns/has_private_users_csv_import.rb
@@ -34,7 +34,7 @@ module Decidim
 
               on(:invalid) do
                 flash[:alert] = I18n.t("participatory_space_private_users_csv_imports.create.invalid", scope: "decidim.admin")
-                render template: "decidim/admin/participatory_space_private_users_csv_imports/new"
+                render template: "decidim/admin/participatory_space_private_users_csv_imports/new", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/conflicts_controller.rb
@@ -47,7 +47,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("error", scope: "decidim.admin.conflicts.transfer")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/impersonations_controller.rb
@@ -46,7 +46,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("impersonations.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/imports_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/imports_controller.rb
@@ -39,7 +39,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("decidim.admin.imports.error")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/managed_users/promotions_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("managed_users.promotion.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -56,7 +56,7 @@ module Decidim
           on(:invalid) do |newsletter|
             @newsletter = newsletter
             flash.now[:error] = I18n.t("newsletters.create.error", scope: "decidim.admin")
-            render action: :new
+            render action: :new, status: :unprocessable_entity
           end
         end
       end
@@ -80,7 +80,7 @@ module Decidim
           on(:invalid) do |newsletter|
             @newsletter = newsletter
             flash.now[:error] = I18n.t("newsletters.update.error", scope: "decidim.admin")
-            render action: :edit
+            render action: :edit, status: :unprocessable_entity
           end
         end
       end
@@ -128,12 +128,12 @@ module Decidim
 
           on(:invalid) do
             flash.now[:error] = I18n.t("newsletters.deliver.error", scope: "decidim.admin")
-            render action: :select_recipients_to_deliver
+            render action: :select_recipients_to_deliver, status: :unprocessable_entity
           end
 
           on(:no_recipients) do
             flash.now[:error] = I18n.t("newsletters.send.no_recipients", scope: "decidim.admin")
-            render action: :select_recipients_to_deliver
+            render action: :select_recipients_to_deliver, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/organization_appearance_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_appearance_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("organization.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("organization.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/organization_external_domain_allowlist_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/organization_external_domain_allowlist_controller.rb
@@ -25,7 +25,7 @@ module Decidim
           end
           on(:invalid) do
             flash[:notice] = t("domain_allowlist.update.error", scope: "decidim.admin")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/participatory_space/user_role_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/participatory_space/user_role_controller.rb
@@ -38,7 +38,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("create.error", scope: i18n_scope)
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -56,7 +56,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("update.error", scope: i18n_scope)
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-admin/app/controllers/decidim/admin/reminders_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/reminders_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("decidim.admin.reminders.create.error")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/resource_permissions_controller.rb
@@ -25,7 +25,7 @@ module Decidim
           end
 
           on(:invalid) do
-            render action: :edit
+            render action: :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/scope_types_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scope_types_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("scope_types.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -56,7 +56,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("scope_types.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/scopes_controller.rb
@@ -36,7 +36,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("scopes.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -58,7 +58,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("scopes.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/share_tokens_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/share_tokens_controller.rb
@@ -31,7 +31,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("share_tokens.create.invalid", scope: "decidim.admin")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -53,7 +53,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("share_tokens.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/static_page_topics_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/static_page_topics_controller.rb
@@ -30,7 +30,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("static_page_topics.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -52,7 +52,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("static_page_topics.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/static_pages_controller.rb
@@ -62,7 +62,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("static_pages.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -85,7 +85,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("static_pages.update.error", scope: "decidim.admin")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/taxonomies_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/taxonomies_controller.rb
@@ -39,7 +39,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("create.invalid", scope: "decidim.admin.taxonomies")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -66,7 +66,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.admin.taxonomies")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/taxonomy_filters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/taxonomy_filters_controller.rb
@@ -41,7 +41,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("create.error", scope: "decidim.admin.taxonomy_filters")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -63,7 +63,7 @@ module Decidim
           end
           on(:invalid) do
             flash.now[:alert] = I18n.t("update.error", scope: "decidim.admin.taxonomy_filters")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/taxonomy_items_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/taxonomy_items_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("create.invalid", scope: "decidim.admin.taxonomies")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -50,7 +50,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.admin.taxonomies")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/controllers/decidim/admin/users_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/users_controller.rb
@@ -38,7 +38,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("users.create.error", scope: "decidim.admin")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-admin/app/views/decidim/admin/taxonomies/edit.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomies/edit.html.erb
@@ -71,6 +71,16 @@
           setDrawerContent(data.body.innerHTML)
         }
       });
+
+      form.addEventListener("ajax:error", function(evt) {
+        var [data, _status, xhr] = event.detail;
+        if(xhr.responseURL.indexOf(location.pathname) > -1) {
+          location.href = xhr.responseURL;
+        } else {
+          setDrawerContent(data.body.innerHTML)
+        }
+      });
+
     }
 
     drawerButtons.forEach(function(button) {

--- a/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
@@ -146,14 +146,11 @@ describe "Admin manages taxonomies" do
 
     before do
       visit decidim_admin.taxonomies_path
-      click_delete_taxonomy
     end
 
     it "displays a success message" do
+      click_delete_taxonomy
       expect(page).to have_content("Taxonomy successfully destroyed.")
-    end
-
-    it "deletes the taxonomy" do
       expect(page).to have_no_content(taxonomy.name)
     end
   end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -37,7 +37,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("assemblies.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -63,7 +63,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("assemblies.update.error", scope: "decidim.admin")
-              render :edit, layout: "decidim/admin/assembly"
+              render :edit, layout: "decidim/admin/assembly", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_copies_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("assemblies_copies.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_imports_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_imports_controller.rb
@@ -23,7 +23,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("assembly_imports.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/posts_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("posts.create.invalid", scope: "decidim.blogs.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -48,7 +48,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("posts.update.invalid", scope: "decidim.blogs.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -36,7 +36,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("posts.create.invalid", scope: "decidim.blogs.admin")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -58,7 +58,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("posts.update.invalid", scope: "decidim.blogs.admin")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/budgets_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("budgets.create.invalid", scope: "decidim.budgets.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -48,7 +48,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("budgets.update.invalid", scope: "decidim.budgets.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/projects_controller.rb
@@ -39,7 +39,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("projects.create.invalid", scope: "decidim.budgets.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -62,7 +62,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("projects.update.invalid", scope: "decidim.budgets.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-budgets/app/controllers/decidim/budgets/admin/proposals_imports_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/admin/proposals_imports_controller.rb
@@ -24,7 +24,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("proposals_imports.create.invalid", scope: "decidim.budgets.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-budgets/spec/controllers/decidim/budgets/admin/projects_controller_spec.rb
+++ b/decidim-budgets/spec/controllers/decidim/budgets/admin/projects_controller_spec.rb
@@ -64,7 +64,7 @@ module Decidim
                 patch(:update, params:)
 
                 expect(flash[:alert]).not_to be_empty
-                expect(response).to have_http_status(:ok)
+                expect(response).to have_http_status(:unprocessable_entity)
                 expect(subject).to render_template(:edit)
                 expect(response.body).to include("There was a problem updating this project")
               end

--- a/decidim-collaborative_texts/app/controllers/decidim/collaborative_texts/admin/documents_controller.rb
+++ b/decidim-collaborative_texts/app/controllers/decidim/collaborative_texts/admin/documents_controller.rb
@@ -30,7 +30,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("documents.create.invalid", scope: "decidim.collaborative_texts.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -54,7 +54,7 @@ module Decidim
               flash.now[:alert] = I18n.t("documents.update.invalid", scope: "decidim.collaborative_texts.admin")
               # This is a safe-guard in case there is no body coming from the POST request (as this attribute is read-only in certain cases)
               @form.body = document.body if @form.body.blank?
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end
@@ -76,7 +76,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("documents.update_settings.invalid", scope: "decidim.collaborative_texts.admin")
-              render action: "edit_settings"
+              render action: "edit_settings", status: :unprocessable_entity
             end
           end
         end
@@ -91,7 +91,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("documents.publish.invalid", scope: "decidim.collaborative_texts.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -106,7 +106,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("documents.unpublish.invalid", scope: "decidim.collaborative_texts.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_duplicates_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_duplicates_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conferences_duplicates.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_invites_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_invites_controller.rb
@@ -41,7 +41,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conference_invites.create.error", scope: "decidim.conferences.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conference_speakers_controller.rb
@@ -36,7 +36,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("conference_speakers.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -58,7 +58,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conference_speakers.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end
@@ -85,7 +85,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conference_speakers.publish.invalid", scope: "decidim.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -101,7 +101,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conference_speakers.unpublish.invalid", scope: "decidim.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/conferences_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conferences.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -61,7 +61,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conferences.update.error", scope: "decidim.admin")
-              render :edit, layout: "decidim/admin/conference"
+              render :edit, layout: "decidim/admin/conference", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/diplomas_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/diplomas_controller.rb
@@ -28,7 +28,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("conferences.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/media_links_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/media_links_controller.rb
@@ -31,7 +31,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("media_links.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -55,7 +55,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("media_links.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/partners_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/partners_controller.rb
@@ -32,7 +32,7 @@ module Decidim
 
             on(:invalid) do
               flash[:alert] = I18n.t("partners.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -56,7 +56,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("partners.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-conferences/app/controllers/decidim/conferences/admin/registration_types_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/admin/registration_types_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("registration_types.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -59,7 +59,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("registration_types.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-core/app/controllers/decidim/account_controller.rb
+++ b/decidim-core/app/controllers/decidim/account_controller.rb
@@ -31,7 +31,7 @@ module Decidim
         on(:invalid) do |password|
           fetch_entered_password(password)
           flash[:alert] = t("account.update.error", scope: "decidim")
-          render action: :show
+          render action: :show, status: :unprocessable_entity
         end
       end
     end

--- a/decidim-core/app/controllers/decidim/amendments_controller.rb
+++ b/decidim-core/app/controllers/decidim/amendments_controller.rb
@@ -38,7 +38,7 @@ module Decidim
 
         on(:invalid) do
           flash.now[:alert] = t("created.error", scope: "decidim.amendments")
-          render :new
+          render :new, status: :unprocessable_entity
         end
       end
     end
@@ -62,7 +62,7 @@ module Decidim
 
         on(:invalid) do
           flash.now[:alert] = t("error", scope: "decidim.amendments.update_draft")
-          render :edit_draft
+          render :edit_draft, status: :unprocessable_entity
         end
       end
     end
@@ -100,7 +100,7 @@ module Decidim
 
         on(:invalid) do
           flash.now[:alert] = t("error", scope: "decidim.amendments.publish_draft")
-          render :edit_draft
+          render :edit_draft, status: :unprocessable_entity
         end
       end
     end
@@ -160,7 +160,7 @@ module Decidim
 
         on(:invalid) do
           flash.now[:alert] = t("accepted.error", scope: "decidim.amendments")
-          render :review
+          render :review, status: :unprocessable_entity
         end
       end
     end

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
           on(:invalid) do
             set_flash_message :notice, :success, kind: @form.provider.capitalize
-            render :new
+            render :new, status: :unprocessable_entity
           end
 
           on(:add_tos_errors) do

--- a/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/passwords_controller.rb
@@ -36,7 +36,7 @@ module Decidim
           on(:invalid) do
             flash.now[:alert] = t("passwords.update.error", scope: "decidim")
             resource.errors.errors.concat(@form.errors.errors)
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/registrations_controller.rb
@@ -40,7 +40,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("error", scope: "decidim.devise.registrations.create")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-core/app/controllers/decidim/newsletters_controller.rb
+++ b/decidim-core/app/controllers/decidim/newsletters_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("newsletters.unsubscribe.error", scope: "decidim")
-            render action: :unsubscribe
+            render action: :unsubscribe, status: :unprocessable_entity
           end
         end
       else

--- a/decidim-core/app/controllers/decidim/notifications_settings_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_settings_controller.rb
@@ -17,14 +17,14 @@ module Decidim
       UpdateNotificationsSettings.call(@notifications_settings) do
         on(:ok) do
           flash.now[:notice] = t("notifications_settings.update.success", scope: "decidim")
+          render action: :show
         end
 
         on(:invalid) do
           flash.now[:alert] = t("notifications_settings.update.error", scope: "decidim")
+          render action: :show, status: :unprocessable_entity
         end
       end
-
-      render action: :show
     end
   end
 end

--- a/decidim-debates/app/controllers/decidim/debates/admin/debate_closes_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debate_closes_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("debates.close.invalid", scope: "decidim.debates")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/admin/debates_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("debates.create.invalid", scope: "decidim.debates.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -57,7 +57,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("debates.update.invalid", scope: "decidim.debates.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
+++ b/decidim-debates/app/controllers/decidim/debates/debates_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("debates.create.invalid", scope: "decidim.debates")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -63,7 +63,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("debates.update.invalid", scope: "decidim.debates")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-demographics/app/controllers/decidim/demographics/admin/settings_controller.rb
+++ b/decidim-demographics/app/controllers/decidim/demographics/admin/settings_controller.rb
@@ -23,7 +23,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.demographics.admin.settings")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-elections/app/controllers/decidim/elections/admin/census_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/census_controller.rb
@@ -28,7 +28,7 @@ module Decidim
             end
             on(:invalid) do
               flash[:alert] = t("decidim.elections.admin.census.update.error")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("elections.create.invalid", scope: "decidim.elections.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -58,7 +58,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("elections.update.invalid", scope: "decidim.elections.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end
@@ -74,7 +74,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("elections.publish.invalid", scope: "decidim.elections.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -90,7 +90,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("elections.unpublish.invalid", scope: "decidim.elections.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/questions_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.elections.admin.questions")
-              render :edit_questions
+              render :edit_questions, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -56,7 +56,7 @@ module Decidim
                 on(:invalid) do
                   # i18n-tasks-use t("decidim.forms.admin.questionnaires.update.invalid")
                   flash.now[:alert] = I18n.t("update.invalid", scope: i18n_flashes_scope)
-                  render template: edit_template
+                  render template: edit_template, status: :unprocessable_entity
                 end
               end
             end
@@ -79,7 +79,7 @@ module Decidim
 
                 on(:invalid) do
                   flash.now[:alert] = I18n.t("update.invalid", scope: i18n_flashes_scope)
-                  render template: edit_questions_template
+                  render template: edit_questions_template, status: :unprocessable_entity
                 end
               end
             end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -41,7 +41,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("response.invalid", scope: i18n_flashes_scope)
-                render template: , status: :unprocessable_entity
+                render template:, status: :unprocessable_entity
               end
             end
           end

--- a/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
+++ b/decidim-forms/app/controllers/decidim/forms/concerns/has_questionnaire.rb
@@ -41,7 +41,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("response.invalid", scope: i18n_flashes_scope)
-                render template:
+                render template: , status: :unprocessable_entity
               end
             end
           end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -56,7 +56,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("initiatives.update.error", scope: "decidim.initiatives.admin")
-              render :edit, layout: "decidim/admin/initiative"
+              render :edit, layout: "decidim/admin/initiative", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_settings_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_settings_controller.rb
@@ -31,7 +31,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("initiatives_settings.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_type_scopes_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_type_scopes_controller.rb
@@ -32,7 +32,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("decidim.initiatives.admin.initiatives_type_scopes.create.error")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -56,7 +56,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("decidim.initiatives.admin.initiatives_type_scopes.update.error")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_types_controller.rb
@@ -40,7 +40,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("decidim.initiatives.admin.initiatives_types.create.error")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -68,7 +68,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("decidim.initiatives.admin.initiatives_types.update.error")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -104,7 +104,7 @@ module Decidim
           end
 
           on(:invalid) do
-            render :fill_data
+            render :fill_data, status: :unprocessable_entity
           end
         end
       end
@@ -119,7 +119,7 @@ module Decidim
           end
 
           on(:invalid) do
-            render :fill_data
+            render :fill_data, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -100,7 +100,7 @@ module Decidim
 
           on(:invalid) do
             flash[:alert] = I18n.t("sms_phone.invalid", scope: "decidim.initiatives.initiative_votes")
-            render :sms_phone_number
+            render :sms_phone_number, status: :unprocessable_entity
           end
         end
       end
@@ -140,7 +140,7 @@ module Decidim
 
               format.html do
                 flash[:alert] = I18n.t("sms_code.invalid", scope: "decidim.initiatives.initiative_votes")
-                render :sms_code
+                render :sms_code, status: :unprocessable_entity
               end
             end
           end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -104,7 +104,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("error", scope: "decidim.initiatives.update")
-            render :edit, layout: "decidim/initiative"
+            render :edit, layout: "decidim/initiative", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -149,7 +149,7 @@ describe Decidim::Initiatives::InitiativesController do
             }
 
         expect(flash[:alert]).not_to be_empty
-        expect(response).to have_http_status(:ok)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
 
       context "when the existing initiative has attachments and there are other errors on the form" do
@@ -179,7 +179,7 @@ describe Decidim::Initiatives::InitiativesController do
             }
 
             expect(flash[:alert]).not_to be_empty
-            expect(response).to have_http_status(:ok)
+            expect(response).to have_http_status(:unprocessable_entity)
             expect(subject).to render_template(:edit)
             expect(response.body).to include("There was a problem updating the initiative.")
           end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/agenda_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/agenda_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("agenda.create.invalid", scope: "decidim.meetings.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -51,7 +51,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("agenda.update.invalid", scope: "decidim.meetings.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -30,7 +30,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("invites.create.error", scope: "decidim.meetings.admin")
-              render :index
+              render :index, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_closes_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meetings.close.invalid", scope: "decidim.meetings.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_copies_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meeting_copies_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meeting_copies.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meetings.create.invalid", scope: "decidim.meetings.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -53,7 +53,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meetings.update.invalid", scope: "decidim.meetings.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end
@@ -69,7 +69,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meetings.publish.invalid", scope: "decidim.meetings.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -85,7 +85,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("meetings.unpublish.invalid", scope: "decidim.meetings.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/meetings_poll_controller.rb
@@ -47,7 +47,7 @@ module Decidim
             on(:invalid) do
               # i18n-tasks-use t("decidim.forms.admin.questionnaires.update.invalid")
               flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.meetings.admin.meetings_poll")
-              render template: "decidim/meetings/admin/poll/edit"
+              render template: "decidim/meetings/admin/poll/edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_attendees_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_attendees_controller.rb
@@ -43,7 +43,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("registrations_attendees.validate_registration_code.invalid", scope: "decidim.meetings.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -59,7 +59,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("registrations_attendees.mark_attendee.invalid", scope: "decidim.meetings.admin")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/registrations_controller.rb
@@ -24,7 +24,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("registrations.update.invalid", scope: "decidim.meetings.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meeting_closes_controller.rb
@@ -27,7 +27,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("meetings.close.invalid", scope: "decidim.meetings.admin")
-            render action: "edit"
+            render action: "edit", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -41,7 +41,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("meetings.create.invalid", scope: "decidim.meetings")
-            render action: "new"
+            render action: "new", status: :unprocessable_entity
           end
         end
       end
@@ -88,7 +88,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("meetings.update.invalid", scope: "decidim.meetings")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/registrations_controller.rb
@@ -22,12 +22,12 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t(joining_waitlist ? "registrations.waitlist.invalid" : "registrations.create.invalid", scope: "decidim.meetings")
-            render template: "decidim/forms/questionnaires/show"
+            render template: "decidim/forms/questionnaires/show", status: :unprocessable_entity
           end
 
           on(:invalid_form) do
             flash.now[:alert] = I18n.t("response.invalid", scope: i18n_flashes_scope)
-            render template: "decidim/forms/questionnaires/show"
+            render template: "decidim/forms/questionnaires/show", status: :unprocessable_entity
           end
         end
       end

--- a/decidim-pages/app/controllers/decidim/pages/admin/pages_controller.rb
+++ b/decidim-pages/app/controllers/decidim/pages/admin/pages_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("pages.update.invalid", scope: "decidim.pages.admin")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_copies_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_copies_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_processes_copies.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_groups_controller.rb
@@ -36,7 +36,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_processes_group.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -61,7 +61,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_process_groups.update.error", scope: "decidim.admin")
-              render :edit, layout: "decidim/admin/participatory_process_group"
+              render :edit, layout: "decidim/admin/participatory_process_group", status: :unprocessable_entity
             end
           end
         end
@@ -78,7 +78,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_process_groups.destroy.error", scope: "decidim.admin")
-              render :index
+              render :index, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_imports_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_imports_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_process_imports.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_steps_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_steps_controller.rb
@@ -32,7 +32,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_process_steps.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -54,7 +54,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_process_steps.update.error", scope: "decidim.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_processes_controller.rb
@@ -42,7 +42,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_processes.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -68,7 +68,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_processes.update.error", scope: "decidim.admin")
-              render :edit, layout: "decidim/admin/participatory_process"
+              render :edit, layout: "decidim/admin/participatory_process", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/participatory_texts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/participatory_texts_controller.rb
@@ -32,12 +32,12 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("participatory_texts.import.invalid", scope: "decidim.proposals.admin")
-              render action: "new_import"
+              render action: "new_import", status: :unprocessable_entity
             end
 
             on(:invalid_file) do
               flash.now[:alert] = I18n.t("participatory_texts.import.invalid_file", scope: "decidim.proposals.admin")
-              render action: "new_import"
+              render action: "new_import", status: :unprocessable_entity
             end
           end
         end
@@ -62,7 +62,7 @@ module Decidim
                 failures.each_pair { |id, msg| alert_msg << "ID:[#{id}] #{msg}" }
                 flash.now[:alert] = alert_msg.join("<br/>").html_safe
                 index
-                render action: "index"
+                render action: "index", status: :unprocessable_entity
               end
             end
           else
@@ -77,7 +77,7 @@ module Decidim
                 failures.each_pair { |id, msg| alert_msg << "ID:[#{id}] #{msg}" }
                 flash.now[:alert] = alert_msg.join("<br/>").html_safe
                 index
-                render action: "index"
+                render action: "index", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_answers_controller.rb
@@ -34,7 +34,7 @@ module Decidim
 
             on(:invalid) do
               flash.keep[:alert] = I18n.t("proposals.answer.invalid", scope: "decidim.proposals.admin")
-              render template: "decidim/proposals/admin/proposals/show"
+              render template: "decidim/proposals/admin/proposals/show", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_states_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposal_states_controller.rb
@@ -30,7 +30,7 @@ module Decidim
             on(:invalid) do
               flash.keep[:alert] = I18n.t("proposal_states.create.error", scope: "decidim.proposals.admin")
 
-              render action: :new
+              render action: :new, status: :unprocessable_entity
             end
           end
         end
@@ -54,7 +54,7 @@ module Decidim
             on(:invalid) do
               flash.now[:alert] = I18n.t("proposal_states.update.error", scope: "decidim.proposals.admin")
 
-              render action: :edit
+              render action: :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_controller.rb
@@ -44,7 +44,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("proposals.create.invalid", scope: "decidim.proposals.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -129,7 +129,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("proposals.update.error", scope: "decidim")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_imports_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/admin/proposals_imports_controller.rb
@@ -23,7 +23,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("proposals_imports.create.invalid", scope: "decidim.proposals.admin")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/collaborative_drafts_controller.rb
@@ -61,7 +61,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.collaborative_drafts.create.error", scope: "decidim")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -85,7 +85,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.collaborative_drafts.update.error", scope: "decidim")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -79,7 +79,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.create.error", scope: "decidim")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -101,7 +101,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.publish.error", scope: "decidim")
-            render :edit_draft
+            render :edit_draft, status: :unprocessable_entity
           end
         end
       end
@@ -124,7 +124,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.update_draft.error", scope: "decidim")
-            render :edit_draft
+            render :edit_draft, status: :unprocessable_entity
           end
         end
       end
@@ -140,7 +140,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.destroy_draft.error", scope: "decidim")
-            render :edit_draft
+            render :edit_draft, status: :unprocessable_entity
           end
         end
       end
@@ -161,7 +161,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-proposals/spec/controllers/decidim/proposals/admin/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/admin/proposals_controller_spec.rb
@@ -61,7 +61,7 @@ describe Decidim::Proposals::Admin::ProposalsController do
           patch(:update, params:)
 
           expect(flash[:alert]).not_to be_empty
-          expect(response).to have_http_status(:ok)
+          expect(response).to have_http_status(:unprocessable_entity)
           expect(subject).to render_template(:edit)
           expect(response.body).to include("There was a problem saving")
         end

--- a/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -187,7 +187,7 @@ module Decidim
               patch(:update, params:)
 
               expect(flash[:alert]).not_to be_empty
-              expect(response).to have_http_status(:ok)
+              expect(response).to have_http_status(:unprocessable_entity)
               expect(subject).to render_template(:edit)
               expect(response.body).to include("There was a problem saving")
             end

--- a/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
+++ b/decidim-sortitions/app/controllers/decidim/sortitions/admin/sortitions_controller.rb
@@ -33,7 +33,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("sortitions.update.error", scope: "decidim.sortitions.admin")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end
@@ -56,7 +56,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("sortitions.create.error", scope: "decidim.sortitions.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -79,7 +79,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("sortitions.destroy.error", scope: "decidim.sortitions.admin")
-              render :confirm_destroy
+              render :confirm_destroy, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-surveys/app/controllers/decidim/surveys/admin/settings/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/settings/surveys_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.surveys.admin.surveys")
-                render action: "edit"
+                render action: "edit", status: :unprocessable_entity
               end
             end
           end

--- a/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/admin/surveys_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("create.invalid", scope: "decidim.surveys.admin.surveys")
-              render action: "new"
+              render action: "new", status: :unprocessable_entity
             end
           end
         end
@@ -51,7 +51,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("update.invalid", scope: "decidim.surveys.admin.surveys")
-              render action: "edit"
+              render action: "edit", status: :unprocessable_entity
             end
           end
         end
@@ -66,7 +66,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("publish.invalid", scope: "decidim.surveys.admin.surveys")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end
@@ -81,7 +81,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("unpublish.invalid", scope: "decidim.surveys.admin.surveys")
-              render action: "index"
+              render action: "index", status: :unprocessable_entity
             end
           end
         end

--- a/decidim-system/app/controllers/decidim/system/admins_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/admins_controller.rb
@@ -24,7 +24,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("admins.create.error", scope: "decidim.system")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -46,7 +46,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("admins.update.error", scope: "decidim.system")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-system/app/controllers/decidim/system/api_users_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/api_users_controller.rb
@@ -51,7 +51,7 @@ module Decidim
 
           on(:invalid) do
             flash[:error] = I18n.t("api_user.create.error", scope: "decidim.system")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-system/app/controllers/decidim/system/oauth_applications_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/oauth_applications_controller.rb
@@ -30,7 +30,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("oauth_applications.create.error", scope: "decidim.system")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -55,7 +55,7 @@ module Decidim
           on(:invalid) do |application|
             @oauth_application = application
             flash.now[:error] = I18n.t("oauth_applications.update.error", scope: "decidim.system")
-            render action: :edit
+            render action: :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = t("organizations.create.error", scope: "decidim.system")
-            render :new
+            render :new, status: :unprocessable_entity
           end
         end
       end
@@ -55,7 +55,7 @@ module Decidim
 
           on(:invalid) do
             flash.now[:alert] = I18n.t("organizations.update.error", scope: "decidim.system")
-            render :edit
+            render :edit, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-templates/app/controllers/decidim/templates/admin/block_user_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/block_user_templates_controller.rb
@@ -62,7 +62,7 @@ module Decidim
             on(:invalid) do |template|
               @template = template
               flash.now[:error] = I18n.t("templates.update.error", scope: "decidim.admin")
-              render action: :edit
+              render action: :edit, status: :unprocessable_entity
             end
           end
         end
@@ -85,7 +85,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("templates.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-templates/app/controllers/decidim/templates/admin/proposal_answer_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/proposal_answer_templates_controller.rb
@@ -39,7 +39,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("templates.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -86,7 +86,7 @@ module Decidim
             on(:invalid) do |template|
               @template = template
               flash.now[:error] = I18n.t("templates.update.error", scope: "decidim.admin")
-              render action: :edit
+              render action: :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
+++ b/decidim-templates/app/controllers/decidim/templates/admin/questionnaire_templates_controller.rb
@@ -48,7 +48,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = I18n.t("templates.create.error", scope: "decidim.admin")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -87,7 +87,7 @@ module Decidim
             on(:invalid) do |template|
               @template = template
               flash.now[:error] = I18n.t("templates.update.error", scope: "decidim.admin")
-              render action: :edit
+              render action: :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -86,7 +86,7 @@ module Decidim
 
           on(:invalid) do
             flash[:alert] = t("authorizations.create.error", scope: "decidim.verifications")
-            render action: :new
+            render action: :new, status: :unprocessable_entity
           end
         end
       end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/config_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/config_controller.rb
@@ -33,7 +33,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = t("config.update.error", scope: "decidim.verifications.id_documents.admin")
-                render action: :edit
+                render action: :edit, status: :unprocessable_entity
               end
             end
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
@@ -35,7 +35,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = t("confirmations.create.error", scope: "decidim.verifications.id_documents.admin")
-                render action: :new
+                render action: :new, status: :unprocessable_entity
               end
             end
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/offline_confirmations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/offline_confirmations_controller.rb
@@ -33,7 +33,7 @@ module Decidim
 
               on(:invalid) do
                 flash.now[:alert] = t("offline_confirmations.create.error", scope: "decidim.verifications.id_documents.admin")
-                render action: :new
+                render action: :new, status: :unprocessable_entity
               end
             end
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/authorizations_controller.rb
@@ -42,7 +42,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("authorizations.create.error", scope: "decidim.verifications.id_documents")
-              render action: :new
+              render action: :new, status: :unprocessable_entity
             end
           end
         end
@@ -72,7 +72,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("authorizations.update.error", scope: "decidim.verifications.id_documents")
-              render action: :edit
+              render action: :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
@@ -29,7 +29,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("authorizations.create.error", scope: "decidim.verifications.postal_letter")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -53,7 +53,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("authorizations.update.error", scope: "decidim.verifications.postal_letter")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -27,7 +27,7 @@ module Decidim
             end
             on(:invalid) do
               flash.now[:alert] = t("authorizations.create.error", scope: "decidim.verifications.sms")
-              render :new
+              render :new, status: :unprocessable_entity
             end
           end
         end
@@ -52,7 +52,7 @@ module Decidim
 
             on(:invalid) do
               flash.now[:alert] = t("authorizations.update.error", scope: "decidim.verifications.sms")
-              render :edit
+              render :edit, status: :unprocessable_entity
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
In the preparing to phase down Rails-ujs, we need ensure that our controllers are following rails best practices. Adding those states will help us in the hotwire integration planned. 

In #14948 there are 3 links, and [second](https://cassey.dev/rails-ujs-to-turbo/#error-response-flash-notices), clearly states that the error branch needs to respond with status: :unprocessable_entity in order for Turbo to accept it and show the errors on your form that were working before.

In this PR i am preparing most controllers to respond with proper http status to ease up the migration, being a functionality independent of Hotwire or Rails-UJS 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14948

#### Testing
1. Green pipeline

:hearts: Thank you!
