### PR TITLE
Fix deploy for Netlify documentation project

### DIFF
--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -16,8 +16,5 @@ jobs:
       run: |
         curl --fail --show-error \
         --request POST \
-        --user "decidim-bot:${{ secrets.DOCS_WORKFLOW_PAT }}" \
-        --header "Accept: application/vnd.github.everest-preview+json" \
-        --header "Content-Type: application/json" \
-        https://api.github.com/repos/decidim/documentation/actions/workflows/trigger_build.yml/dispatches \
-        --data '{"ref": "develop"}'
+        --data '{}' \
+        https://api.netlify.com/build_hooks/${{ secrets.DOCS_WORKFLOW_PAT }}"

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - develop
+    - 'release/*'
     paths:
     - 'docs/**'
 


### PR DESCRIPTION
#### :tophat: What? Why?

I checked out some changes from the last few weeks on https://docs.decidim.org/en/develop/configure/environment_variables and I couldn't find the changes. 

That's because there were changes in the Netlify API and we need to adapt the build hook to a new system.

I also added the release branches so when we do backports with docs these also go to the deploy. 

#### Testing

1. Change something in `docs/` on a PR once this is merged
2. See that this action gets triggered
3. Wait a few minutes
4. See the change in https://docs.decidim.org/en/develop/ (on the page). 

:hearts: Thank you!
