### PR TITLE
Bump versions in gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -546,7 +546,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0610)
+    mime-types-data (3.2025.0722)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -542,7 +542,7 @@ GEM
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2025.0610)
+    mime-types-data (3.2025.0722)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we upgrade all the dependencies to the latest patched versions. Please refer to the gemspec (or commit history) to see what has been upgraded.

Please note that if you run `bundle outdated --filter-patch`, you will see there is a dependency that has not been updated, `web-push`, and the reason is as follows: 

```
Could not find compatible versions

Because every version of decidim-core depends on web-push >= 3.0.2, < 4.A
  and web-push >= 3.0.2 depends on jwt ~> 3.0,
  every version of decidim-core requires jwt ~> 3.0.
And because every version of warden-jwt_auth depends on jwt ~> 2.1,
  every version of decidim-core is incompatible with warden-jwt_auth >= 0.
And because every version of devise-jwt depends on warden-jwt_auth ~> 0.10
  and every version of decidim-api depends on devise-jwt ~> 0.12.1,
  every version of decidim-core is incompatible with decidim-api >= 0.
And because every version of decidim-dev depends on decidim-api = 0.31.0.dev
  and every version of decidim depends on decidim-core = 0.31.0.dev,
  every version of decidim is incompatible with decidim-dev >= 0.
So, because Gemfile depends on decidim >= 0
  and Gemfile depends on decidim-dev >= 0,
  version solving has failed.
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Green pipeline 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
