### PR TITLE
Change the dropdown data selector from component to controller

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/milestones/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/milestones/index.html.erb
@@ -29,7 +29,7 @@
               <%= translated_attribute(milestone.title) %>
             </td>
             <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.accountability") %>">
-              <button type="button" data-component="dropdown" data-target="actions-milestone-<%= milestone.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(milestone.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-milestone-<%= milestone.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(milestone.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_actions.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-result-<%= result.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: "Result") %>">
+<button type="button" data-controller="dropdown" data-target="actions-result-<%= result.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: "Result") %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
@@ -3,7 +3,7 @@
     id="js-bulk-actions-button"
     class="button button__sm button__transparent-secondary hide"
     type="button"
-    data-component="dropdown"
+    data-controller="dropdown"
     data-target="js-bulk-actions-dropdown"
     data-action-button>
     <%= t(".actions") %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/statuses/index.html.erb
@@ -33,7 +33,7 @@
               <%= status.progress %>
             </td>
             <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.accountability") %>">
-              <button type="button" data-component="dropdown" data-target="actions-status-<%= status.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: t("models.status.name", scope: "decidim.accountability.admin")) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-status-<%= status.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: t("models.status.name", scope: "decidim.accountability.admin")) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-accountability/spec/shared/manage_attachment_collections_examples.rb
+++ b/decidim-accountability/spec/shared/manage_attachment_collections_examples.rb
@@ -5,7 +5,7 @@ shared_examples "manage accountability attachment collections" do
 
   before do
     within "tr", text: translated(result.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add folder"
     end
   end

--- a/decidim-accountability/spec/shared/manage_attachments_examples.rb
+++ b/decidim-accountability/spec/shared/manage_attachments_examples.rb
@@ -8,7 +8,7 @@ shared_examples "manage accountability attachments" do
 
   before do
     within "tr", text: translated(result.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add attachment"
     end
   end

--- a/decidim-accountability/spec/shared/manage_child_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_child_results_examples.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples "manage child results" do
   it "updates a result" do
     within "tr", text: translated(child_result.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -28,7 +28,7 @@ RSpec.shared_examples "manage child results" do
 
   it "allows the user to preview the result" do
     within "tr", text: translated(child_result.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       preview_window = window_opened_by { click_on "Preview" }
 
       within_window preview_window do
@@ -75,14 +75,14 @@ RSpec.shared_examples "manage child results" do
     before do
       visit current_path
       within "tr", text: translated(result.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Add result"
       end
     end
 
     it "moves to the trash a result" do
       within "tr", text: translated(child_result.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Move to trash" }
       end
 

--- a/decidim-accountability/spec/shared/manage_milestone_examples.rb
+++ b/decidim-accountability/spec/shared/manage_milestone_examples.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples "manage milestone" do
     visit current_path
 
     within("tr", text: translated_attribute(milestone.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -29,7 +29,7 @@ shared_examples "manage results" do
 
     it "updates a result" do
       within "tr", text: translated(result.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -90,7 +90,7 @@ shared_examples "manage results" do
 
   it "allows the user to preview the result" do
     within "tr", text: translated(result.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       preview_window = window_opened_by { click_on "Preview" }
 
       within_window preview_window do
@@ -109,7 +109,7 @@ shared_examples "manage results" do
 
     it "deletes a result" do
       within "tr", text: translated(result2.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Move to trash" }
       end
 

--- a/decidim-accountability/spec/shared/manage_statuses_examples.rb
+++ b/decidim-accountability/spec/shared/manage_statuses_examples.rb
@@ -5,7 +5,7 @@ RSpec.shared_examples "manage statuses" do
 
   it "updates a status" do
     within "tr", text: status.key do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -63,7 +63,7 @@ RSpec.shared_examples "manage statuses" do
 
     it "deletes a status" do
       within "tr", text: status2.key do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
@@ -32,7 +32,7 @@ describe "Admin manages accountability" do
   describe "child results" do
     before do
       within "tr[data-id='#{result.id}'] .table-list__actions" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Add result"
       end
     end
@@ -54,7 +54,7 @@ describe "Admin manages accountability" do
     before do
       visit_component_admin
       within "tr", text: translated(result.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Add milestone"
       end
     end

--- a/decidim-admin/app/helpers/decidim/admin/filterable_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/filterable_helper.rb
@@ -73,7 +73,7 @@ module Decidim
       end
 
       def dropdown_link(key, menu_id)
-        link_to("#", class: "dropdown__button", data: { component: "dropdown", target: "dropdown-filters-#{menu_id}" }) do
+        link_to("#", class: "dropdown__button", data: { controller: "dropdown", target: "dropdown-filters-#{menu_id}" }) do
           safe_join([
                       content_tag(:span) { extract_html_value(key) },
                       icon("arrow-right-s-line", class: "fill-secondary absolute right-2"),

--- a/decidim-admin/app/views/decidim/admin/area_types/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/area_types/index.html.erb
@@ -31,7 +31,7 @@
               <%= translated_attribute(area_type.plural) %>
             </td>
             <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-              <button type="button" data-component="dropdown" data-target="actions-area-type-<%= area_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(area_type.name)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-area-type-<%= area_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(area_type.name)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/areas/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/areas/index.html.erb
@@ -35,7 +35,7 @@
               <%= area.area_type ? translated_attribute(area.area_type.name) : "-" %>
             </td>
             <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-              <button type="button" data-component="dropdown" data-target="actions-area-<%= area.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(area.name)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-area-<%= area.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(area.name)) %>">
                 <%= icon "more-fill" , class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachment_collections/index.html.erb
@@ -25,7 +25,7 @@
                 <%= link_to translated_attribute(attachment_collection.name), edit_polymorphic_path([collection_for, attachment_collection]) %><br>
               </td>
               <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-                <button type="button" data-component="dropdown" data-target="actions-attachment-collection-<%= attachment_collection.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(attachment_collection.name)) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-attachment-collection-<%= attachment_collection.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(attachment_collection.name)) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/attachments/index.html.erb
@@ -37,7 +37,7 @@
                 <%= attachment.file? ? number_to_human_size(attachment.file_size) : "-" %>
               </td>
               <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-                <button type="button" data-component="dropdown" data-target="actions-attachment-<%= attachment.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(attachment.title)) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-attachment-<%= attachment.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(attachment.title)) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-component-<%= component.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: component.manifest.name) %>">
+<button type="button" data-controller="dropdown" data-target="actions-component-<%= component.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: component.manifest.name) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-admin/app/views/decidim/admin/components/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/index.html.erb
@@ -7,7 +7,7 @@
 
       <% if allowed_to?(:create, :component) %>
       <div class="relative">
-        <button class="button button__sm button__secondary" data-component="dropdown" data-target="add-component-dropdown">
+        <button class="button button__sm button__secondary" data-controller="dropdown" data-target="add-component-dropdown">
           <%= t "components.index.add", scope: "decidim.admin" %>
           <%= icon "arrow-down-s-line", class: "!fill-white" %>
           <%= icon "arrow-down-s-line", class: "!fill-white" %>

--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -1,5 +1,5 @@
 <div class="relative">
-  <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="<%= dropdown_id(filters) %>">
+  <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="<%= dropdown_id(filters) %>">
     <% if filters.present? %>
       <%= t("actions.export-selection", scope: "decidim.admin") %>
     <% else %>

--- a/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/impersonatable_users/index.html.erb
@@ -16,7 +16,7 @@
 
 <div class="filters__section">
   <div class="relative">
-    <button class="button button__xs button__transparent-secondary" data-component="dropdown" data-target="dropdown-filters">
+    <button class="button button__xs button__transparent-secondary" data-controller="dropdown" data-target="dropdown-filters">
       <%= t("filter_label", scope: "decidim.admin.filters") %>
       <%= icon "arrow-down-s-line", class: "!fill-secondary" %>
       <%= icon "arrow-down-s-line", class: "!fill-secondary" %>
@@ -69,7 +69,7 @@
               <%= user.managed? ? t(".managed") : t(".not_managed") %>
             </td>
             <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-              <button type="button" data-component="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/_dropdown.html.erb
@@ -1,5 +1,5 @@
 <div class="relative">
-  <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="import-dropdown">
+  <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="import-dropdown">
     <%= t "actions.import", scope: "decidim.admin" %>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/imports/new.html.erb
+++ b/decidim-admin/app/views/decidim/admin/imports/new.html.erb
@@ -6,7 +6,7 @@
     <div class="flex align-middle gap-x-4 ml-auto">
       <% if import_manifest.has_example? %>
         <div class="relative">
-          <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="example-dropdown">
+          <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="example-dropdown">
             <%= t(".download_example") %>
             <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
             <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>

--- a/decidim-admin/app/views/decidim/admin/moderated_users/bulk_actions/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/bulk_actions/_dropdown.html.erb
@@ -3,7 +3,7 @@
     id="js-bulk-actions-button"
     class="button button__sm button__transparent-secondary"
     type="button"
-    data-component="dropdown"
+    data-controller="dropdown"
     data-target="js-bulk-actions-dropdown">
     <%= t("decidim.admin.moderated_users.index.actions.bulk_actions.actions_dropdown") %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -68,7 +68,7 @@
         </td>
 
         <td class="table-list__actions" data-label="<%= t(".actions.title") %>">
-          <button type="button" data-component="dropdown" data-target="actions-user-<%= moderation.user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: moderation.user.nickname) %>">
+          <button type="button" data-controller="dropdown" data-target="actions-user-<%= moderation.user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: moderation.user.nickname) %>">
             <%= icon "more-fill", class: "text-secondary" %>
           </button>
 

--- a/decidim-admin/app/views/decidim/admin/moderations/_moderation-tr.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/_moderation-tr.html.erb
@@ -48,7 +48,7 @@
 
   <td data-label="<%= t("actions.title", scope: "decidim.moderations") %>" class="table-list__actions">
 
-    <button type="button" data-component="dropdown" data-target="actions-moderation-<%= moderation.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: moderation.reportable.id) %>">
+    <button type="button" data-controller="dropdown" data-target="actions-moderation-<%= moderation.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: moderation.reportable.id) %>">
       <%= icon "more-fill", class: "text-secondary" %>
     </button>
 

--- a/decidim-admin/app/views/decidim/admin/moderations/bulk_actions/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderations/bulk_actions/_dropdown.html.erb
@@ -3,7 +3,7 @@
     id="js-bulk-actions-button"
     class="button button__sm button__secondary"
     type="button"
-    data-component="dropdown"
+    data-controller="dropdown"
     data-target="js-bulk-actions-dropdown">
     <%= t("decidim.admin.moderations.index.actions.actions_dropdown") %>
     <%= icon "arrow-down-s-line", class: "!fill-white" %>

--- a/decidim-admin/app/views/decidim/admin/newsletters/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletters/index.html.erb
@@ -54,7 +54,7 @@
             </td>
 
             <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-newsletter-<%= newsletter.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: t("models.newsletter.name", scope: "decidim.admin")) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-newsletter-<%= newsletter.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: t("models.newsletter.name", scope: "decidim.admin")) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -40,7 +40,7 @@
             <%= user.report_count %>
           </td>
           <td data-label="<%= t(".actions") %>" class="table-list__actions">
-            <button type="button" data-component="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.nickname.presence || user.id) %>">
+            <button type="button" data-controller="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.nickname.presence || user.id) %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/participatory_space_private_users/index.html.erb
@@ -60,7 +60,7 @@
                 <% end %>
               </td>
               <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-                <button type="button" data-component="dropdown" data-target="actions-private-user-<%= private_user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: private_user.user.name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-private-user-<%= private_user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: private_user.user.name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb
@@ -35,7 +35,7 @@
               <%= translated_attribute(scope_type.plural) %>
             </td>
             <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-scope-type-<%= scope_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(scope_type.name)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-scope-type-<%= scope_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(scope_type.name)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/scopes/index.html.erb
@@ -32,7 +32,7 @@
               <%= scope.scope_type ? translated_attribute(scope.scope_type.name) : "-" %>
             </td>
             <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-scope-<%= scope.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(scope.name)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-scope-<%= scope.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(scope.name)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-admin/app/views/decidim/admin/share_tokens/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/share_tokens/index.html.erb
@@ -42,7 +42,7 @@
                 <%= share_token.times_used %>
               </td>
                 <td data-label="<%= t("models.share_token.fields.actions", scope: "decidim.admin") %>" class="table-list__actions">
-                  <button type="button" data-component="dropdown" data-target="actions-share-token-<%= share_token.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: share_token.token) %>">
+                  <button type="button" data-controller="dropdown" data-target="actions-share-token-<%= share_token.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: share_token.token) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/shared/_filters.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/_filters.html.erb
@@ -1,7 +1,7 @@
 <div class="filters__section">
   <div class="fcell">
     <% dropdown_id = "top-#{SecureRandom.uuid}" %>
-    <a href="#" class="button button__xs button__transparent-secondary" data-component="dropdown" data-target="dropdown-filters-<%= dropdown_id %>">
+    <a href="#" class="button button__xs button__transparent-secondary" data-controller="dropdown" data-target="dropdown-filters-<%= dropdown_id %>">
       <%= t("filter_label", scope: "decidim.admin.filters") %>
       <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>
       <%= icon "arrow-down-s-line", class: "dropdown-filter-icon" %>

--- a/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
+++ b/decidim-admin/app/views/decidim/admin/shared/landing_page/_content_blocks.html.erb
@@ -6,7 +6,7 @@
       <%= content_blocks_title %>
 
       <div class="relative">
-        <button class="button button__sm button__secondary" data-component="dropdown" data-target="add-content-block-dropdown">
+        <button class="button button__sm button__secondary" data-controller="dropdown" data-target="add-content-block-dropdown">
           <%= add_content_block_text %>
           <%= icon "arrow-down-s-line", class: "!fill-white" %>
           <%= icon "arrow-down-s-line", class: "!fill-white" %>

--- a/decidim-admin/app/views/decidim/admin/static_page_topics/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_page_topics/index.html.erb
@@ -25,7 +25,7 @@
                 <%= link_to translated_attribute(topic.title), [:edit, topic] %>
               </td>
               <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-                <button type="button" data-component="dropdown" data-target="actions-topic-<%= topic.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(topic.title)) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-topic-<%= topic.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(topic.title)) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/static_pages/_topic.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_topic.html.erb
@@ -39,7 +39,7 @@
               </td>
 
               <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-                 <button type="button" data-component="dropdown" data-target="actions-static-page-<%= page.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(page.title)) %>">
+                 <button type="button" data-controller="dropdown" data-target="actions-static-page-<%= page.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(page.title)) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/decidim/admin/taxonomies/_taxonomy_actions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomies/_taxonomy_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-taxonomy-<%= taxonomy.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: taxonomy.name) %>">
+<button type="button" data-controller="dropdown" data-target="actions-taxonomy-<%= taxonomy.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: taxonomy.name) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomy_filters/_table.html.erb
@@ -21,7 +21,7 @@
             <%= taxonomy_filter.components_count %>
           </td>
           <td data-label="<%= t(".actions") %>" class="table-list__actions">
-            <button type="button" data-component="dropdown" data-target="actions-taxonomy-filter-<%= taxonomy_filter.id %>" aria-label="<%= t(".actions") %>">
+            <button type="button" data-controller="dropdown" data-target="actions-taxonomy-filter-<%= taxonomy_filter.id %>" aria-label="<%= t(".actions") %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-admin/app/views/decidim/admin/taxonomy_filters_selector/_component_table.html.erb
+++ b/decidim-admin/app/views/decidim/admin/taxonomy_filters_selector/_component_table.html.erb
@@ -18,7 +18,7 @@
             <%= taxonomy_filter.translated_internal_name %>
           </td>
           <td data-label="<%= t("decidim.admin.taxonomy_filters.table.actions") %>" class="table-list__actions">
-            <button type="button" data-component="dropdown" data-target="taxonomy-filter-actions-<%= taxonomy_filter.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: taxonomy_filter.translated_name ) %>">
+            <button type="button" data-controller="dropdown" data-target="taxonomy-filter-actions-<%= taxonomy_filter.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: taxonomy_filter.translated_name ) %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-admin/app/views/decidim/admin/users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/users/index.html.erb
@@ -49,7 +49,7 @@
             </td>
             <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
               <% if (allowed_to?(:invite, :admin_user, user: user) && user.invited_to_sign_up?) || (allowed_to? :destroy, :admin_user, user: user) %>
-                <button type="button" data-component="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-user-<%= user.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: user.name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_sidebar_menu.html.erb
@@ -5,7 +5,7 @@
       <div class="hidden md:block">
         <%= sidebar_menu(secondary_root_menu).render %>
       </div>
-      <button data-component="dropdown" data-target="dropdown-menu-sidebar" data-auto-close="true" data-scroll-to-menu="true">
+      <button data-controller="dropdown" data-target="dropdown-menu-sidebar" data-auto-close="true" data-scroll-to-menu="true">
         <span><%= t("menu", scope: "decidim.admin.titles") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar.html.erb
@@ -10,7 +10,7 @@
       <% end %>
       <% if available_locales.length > 1 %>
         <div class="language-choose relative">
-          <%= button_tag id: "admin-menu-trigger", data: { component: "dropdown", target: "admin-dropdown-menu-language" }, class: "dropdown__trigger" do %>
+          <%= button_tag id: "admin-menu-trigger", data: { controller: "dropdown", target: "admin-dropdown-menu-language" }, class: "dropdown__trigger" do %>
               <%= t("name", scope: "locale") %>
               <%= icon "arrow-down-s-line" %>
           <% end %>
@@ -28,7 +28,7 @@
       <% end %>
 
       <div class="user-login relative">
-        <%= button_tag current_user.email, id: "admin-dropdown-menu-login-trigger", data: { component: "dropdown", target: "admin-dropdown-menu-login" } , class: "dropdown__trigger" do %>
+        <%= button_tag current_user.email, id: "admin-dropdown-menu-login-trigger", data: { controller: "dropdown", target: "admin-dropdown-menu-login" } , class: "dropdown__trigger" do %>
           <%= current_user.email %>
           <%= icon "arrow-down-s-line" %>
         <% end %>

--- a/decidim-admin/app/views/layouts/decidim/admin/_title_bar_responsive.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_title_bar_responsive.html.erb
@@ -11,7 +11,7 @@
       <% end %>
       <% if available_locales.length > 1 %>
         <div class="language-choose relative">
-          <%= button_tag id: "admin-menu-trigger-responsive", data: { component: "dropdown", target: "admin-dropdown-menu-language-responsive" }, class: "dropdown__trigger" do %>
+          <%= button_tag id: "admin-menu-trigger-responsive", data: { controller: "dropdown", target: "admin-dropdown-menu-language-responsive" }, class: "dropdown__trigger" do %>
               <%= t("name", scope: "locale") %>
               <%= icon "arrow-down-s-line" %>
           <% end %>
@@ -29,7 +29,7 @@
       <% end %>
 
       <div class="user-login relative">
-        <%= button_tag current_user.email, id: "admin-dropdown-menu-login-trigger-responsive", data: { component: "dropdown", target: "admin-dropdown-menu-login-responsive" } , class: "dropdown__trigger" do %>
+        <%= button_tag current_user.email, id: "admin-dropdown-menu-login-trigger-responsive", data: { controller: "dropdown", target: "admin-dropdown-menu-login-responsive" } , class: "dropdown__trigger" do %>
           <%= current_user.email %>
           <%= icon "arrow-down-s-line" %>
         <% end %>

--- a/decidim-admin/lib/decidim/admin/test/invite_participatory_space_moderators_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/invite_participatory_space_moderators_shared_examples.rb
@@ -29,7 +29,7 @@ shared_examples "inviting participatory space moderators" do
 
       within ".table-list" do
         within("tr", text: translated(participatory_space.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Manage moderations"
         end
       end
@@ -61,7 +61,7 @@ shared_examples "inviting participatory space moderators" do
       within ".table-list" do
         expect(page).to have_i18n_content(participatory_space.title)
         within("tr", text: translated(participatory_space.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Manage moderations"
         end
       end

--- a/decidim-admin/lib/decidim/admin/test/invite_participatory_space_users_shared_context.rb
+++ b/decidim-admin/lib/decidim/admin/test/invite_participatory_space_users_shared_context.rb
@@ -28,7 +28,7 @@ shared_context "when inviting participatory space users" do
     visit participatory_space_user_roles_path
 
     within "tr", text: username do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
   end

--- a/decidim-admin/lib/decidim/admin/test/manage_attachment_collections_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachment_collections_examples.rb
@@ -16,7 +16,7 @@ shared_examples "manage attachment collections examples" do
 
   it "can view an attachment collection details" do
     within "#attachment_collections table" do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -57,7 +57,7 @@ shared_examples "manage attachment collections examples" do
   it "can update an attachment collection" do
     within "#attachment_collections" do
       within "tr", text: translated(attachment_collection.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -92,7 +92,7 @@ shared_examples "manage attachment collections examples" do
 
       it "can delete the attachment collection" do
         within "tr", text: translated(attachment_collection2.name) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Delete" }
         end
 
@@ -113,7 +113,7 @@ shared_examples "manage attachment collections examples" do
 
       it "cannot delete it" do
         within "tr", text: translated(attachment_collection.name) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_no_css(".button", text: "Delete")
         end
       end

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -19,7 +19,7 @@ shared_examples "manage attachments examples" do
 
     it "can view an attachment details" do
       within "tr", text: translated(attachment.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -153,7 +153,7 @@ shared_examples "manage attachments examples" do
       within "#attachments" do
         within "tr", text: translated(attachment.title) do
           expect(page).to have_text(translated(attachment_collection.name, locale: :en))
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -173,7 +173,7 @@ shared_examples "manage attachments examples" do
 
     it "can delete an attachment from a process" do
       within "tr", text: translated(attachment.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -185,7 +185,7 @@ shared_examples "manage attachments examples" do
     it "can update an attachment" do
       within "#attachments" do
         within "tr", text: translated(attachment.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end

--- a/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_component_permissions_examples.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 shared_examples "access permissions form" do
   it "can view the permissions" do
     within "tr", text: row_text do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Manage permissions"
     end
     expect(page).to have_content("Edit permissions")
@@ -46,7 +46,7 @@ shared_examples "Managing component permissions" do
   context "when setting permissions" do
     before do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Manage permissions"
       end
     end
@@ -78,7 +78,7 @@ shared_examples "Managing component permissions" do
     before do
       allow_any_instance_of(Decidim::Admin::PermissionsForm).to receive(:valid?).and_return(false)
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Manage permissions"
       end
       within "#components form" do
@@ -110,7 +110,7 @@ shared_examples "Managing component permissions" do
       )
 
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Manage permissions"
       end
     end
@@ -146,7 +146,7 @@ shared_examples "Managing component permissions" do
       )
 
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Manage permissions"
       end
     end

--- a/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_moderations_examples.rb
@@ -82,7 +82,7 @@ shared_examples "manage moderations" do
 
     it "user can un-report a resource" do
       within "tr[data-id=\"#{moderation.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Undo the report"
       end
 
@@ -91,7 +91,7 @@ shared_examples "manage moderations" do
 
     it "user can hide a resource" do
       within "tr[data-id=\"#{moderation.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Hide"
       end
 
@@ -134,7 +134,7 @@ shared_examples "manage moderations" do
 
     it "user can see moderation details" do
       within "tr[data-id=\"#{moderation.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Expand"
       end
 
@@ -192,7 +192,7 @@ shared_examples "manage moderations" do
 
     it "user cannot unreport them" do
       within "tr[data-id=\"#{hidden_moderations.first.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_no_css("a", text: "Undo the report")
       end
     end
@@ -237,7 +237,7 @@ shared_examples "manage moderations" do
     it "user can hide them" do
       moderation_id = moderations.first.id
       within "tr[data-id=\"#{moderation_id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Hide"
       end
 

--- a/decidim-admin/lib/decidim/admin/test/manage_participatory_space_publications_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_participatory_space_publications_examples.rb
@@ -14,7 +14,7 @@ shared_examples "manage participatory space publications" do
       visit admin_page_path
 
       within("tr", text: translated_attribute(participatory_space.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Publish", visible: true).click
       end
     end
@@ -46,7 +46,7 @@ shared_examples "manage participatory space publications" do
       # we cannot use "a 404 page" shared example as we want to check it
       # inside an example
       within("tr", text: translated_attribute(participatory_space.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Unpublish"
       end
 

--- a/decidim-admin/lib/decidim/admin/test/manage_resource_soft_deletion_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_resource_soft_deletion_examples.rb
@@ -21,7 +21,7 @@ shared_examples "manage soft deletable component or space" do |resource_name|
       accept_confirm do
         within("tr", text: title[:en]) do
           # To remove once all the actions are migrated to dropdowns
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Move to trash"
         end
       end
@@ -42,7 +42,7 @@ shared_examples "manage soft deletable component or space" do |resource_name|
     it "does not allow to move it to the trash" do
       within("tr", text: title[:en]) do
         # To remove once all the actions are migrated to dropdowns
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         have_css(".dropdown__button-disabled span", text: "Move to trash")
       end
     end
@@ -77,7 +77,7 @@ shared_examples "manage soft deletable resource" do |resource_name|
     expect(page).to have_content(title[:en])
 
     within(resource_row) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       accept_confirm { click_on "Move to trash" }
     end
 
@@ -114,7 +114,7 @@ shared_examples "manage trashed resource" do |resource_name|
     it "restores the #{resource_name} from the trash" do
       # To remove once all the actions are migrated to dropdowns
       within("tr", text: title[:en]) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Restore"
       end
 

--- a/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_taxonomy_filters_examples.rb
@@ -19,7 +19,7 @@ shared_examples "manage taxonomy filters in settings" do
 
     before do
       within "tr", text: translated_attribute(component.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
     end
@@ -40,7 +40,7 @@ shared_examples "manage taxonomy filters in settings" do
       within ".js-current-filters" do
         expect(page).to have_css("td", text: "Internal taxonomy filter name")
         expect(page).to have_css("td", text: "Public taxonomy filter name")
-        expect(page).to have_css("button[data-component='dropdown']", count: 1)
+        expect(page).to have_css("button[data-controller='dropdown']", count: 1)
       end
 
       expect(component.reload.settings.taxonomy_filters).to eq([taxonomy_filter.id.to_s])
@@ -57,13 +57,13 @@ shared_examples "manage taxonomy filters in settings" do
         expect(page).to have_css("td", text: "Internal taxonomy filter name")
         expect(page).to have_css("td", text: "Public taxonomy filter name")
         expect(page).to have_css("td", text: "Another filter")
-        expect(page).to have_css("button[data-component='dropdown']", count: 2)
+        expect(page).to have_css("button[data-controller='dropdown']", count: 2)
       end
       expect(component.reload.settings.taxonomy_filters).to contain_exactly(taxonomy_filter.id.to_s, another_taxonomy_filter.id.to_s)
 
       click_on "Update"
       within "tr", text: translated(component.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
       within ".js-current-filters" do
@@ -78,7 +78,7 @@ shared_examples "manage taxonomy filters in settings" do
     let(:taxonomy_filter) { nil }
     before do
       within "tr", text: translated(component.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
     end
@@ -95,7 +95,7 @@ shared_examples "manage taxonomy filters in settings" do
     before do
       component.update!(settings: { taxonomy_filters: [another_taxonomy_filter.id.to_s, taxonomy_filter.id.to_s] })
       within "tr", text: translated(component.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
     end
@@ -103,7 +103,7 @@ shared_examples "manage taxonomy filters in settings" do
     it "can be removed from settings" do
       within ".js-current-filters" do
         within "tr", text: "Internal taxonomy filter name" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -129,13 +129,13 @@ shared_examples "manage taxonomy filters in settings" do
         expect(page).to have_css("td", text: "Internal taxonomy filter name")
         expect(page).to have_css("td", text: "Public taxonomy filter name")
         within "table" do
-          expect(page).to have_css("button[data-component='dropdown']", count: 2)
+          expect(page).to have_css("button[data-controller='dropdown']", count: 2)
         end
       end
 
       click_on "Update"
       within "tr", text: translated(component.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
       within ".js-current-filters" do

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -140,7 +140,7 @@ shared_examples "manage impersonations examples" do
       expect(page).to have_content("expired")
 
       within "tr", text: impersonated_user.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_link("Impersonate")
       end
     end
@@ -151,7 +151,7 @@ shared_examples "manage impersonations examples" do
       navigate_to_impersonations_page
 
       within "tr", text: impersonated_user.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_link("Impersonate")
       end
     end
@@ -255,7 +255,7 @@ shared_examples "manage impersonations examples" do
       navigate_to_impersonations_page
 
       within "tr", text: managed_user.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Promote"
       end
 
@@ -290,7 +290,7 @@ shared_examples "manage impersonations examples" do
       navigate_to_impersonations_page
 
       within "tr", text: managed_user.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_no_link("Promote")
       end
     end
@@ -351,7 +351,7 @@ shared_examples "manage impersonations examples" do
     navigate_to_impersonations_page
 
     within "tr", text: user.name do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Impersonate"
     end
 
@@ -371,7 +371,7 @@ shared_examples "manage impersonations examples" do
 
   def check_impersonation_logs
     within "tr", text: impersonated_user.name do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "View logs"
     end
 

--- a/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
+++ b/decidim-admin/spec/system/admin_manage_moderated_users_spec.rb
@@ -34,7 +34,7 @@ describe "Admin manages moderated users" do
     describe "blocking a user" do
       it "can block them" do
         within "tr", text: first_user.name do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Block"
         end
 
@@ -50,7 +50,7 @@ describe "Admin manages moderated users" do
 
       it "cannot block itself" do
         within "tr", text: admin.name do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_no_css(".button", text: "Block")
         end
       end
@@ -137,7 +137,7 @@ describe "Admin manages moderated users" do
 
     it "user cannot unreport them" do
       within "tr", text: first_user.name, match: :first do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_no_css(".button", text: "Undo the report")
       end
     end

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -182,11 +182,11 @@ describe "Admin manages global moderations" do
           click_on "Hidden"
 
           within "tr", text: "Dummy resource" do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             expect(page).to have_link("Undo the hide")
           end
           within "tr", text: "Comment" do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             expect(page).to have_no_link("Unhide")
           end
 

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -132,7 +132,7 @@ describe "Admin manages newsletters" do
         visit decidim_admin.newsletters_path
 
         within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           perform_enqueued_jobs do
             click_on "Send me a test email"
           end
@@ -150,7 +150,7 @@ describe "Admin manages newsletters" do
     it "allows a newsletter to be updated" do
       visit decidim_admin.newsletters_path
       within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -545,7 +545,7 @@ describe "Admin manages newsletters" do
       visit decidim_admin.newsletters_path
 
       within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -76,7 +76,7 @@ describe "Admin manages officializations" do
         end
 
         within "tr[data-user-id=\"#{user.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Officialize"
         end
       end
@@ -125,7 +125,7 @@ describe "Admin manages officializations" do
         end
 
         within "tr[data-user-id=\"#{user.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Reofficialize"
         end
       end
@@ -158,7 +158,7 @@ describe "Admin manages officializations" do
       end
 
       within "tr[data-user-id=\"#{user.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Unofficialize"
       end
     end
@@ -183,7 +183,7 @@ describe "Admin manages officializations" do
 
     it "redirect to conversation path" do
       within "tr[data-user-id=\"#{user.id}\"]" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Send message"
       end
       expect(page).to have_current_path decidim.new_conversation_path(recipient_id: user.id)
@@ -242,7 +242,7 @@ describe "Admin manages officializations" do
     it "shows the users emails to admin users and logs the action" do
       users.each do |user|
         within "tr[data-user-id=\"#{user.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Show email"
         end
 

--- a/decidim-admin/spec/system/admin_manages_organization_admins_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_admins_spec.rb
@@ -70,7 +70,7 @@ describe "Organization admins" do
 
       it "can resend the invitation" do
         within "tr[data-user-id=\"#{user.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 
@@ -81,7 +81,7 @@ describe "Organization admins" do
         expect(page).to have_content(other_admin.name)
 
         within "tr[data-user-id=\"#{other_admin.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Delete" }
         end
 
@@ -90,11 +90,11 @@ describe "Organization admins" do
 
       it "cannot remove admin rights from self" do
         within "tr[data-user-id=\"#{admin.id}\"]" do
-          expect(page).to have_no_css("button[data-component='dropdown']")
+          expect(page).to have_no_css("button[data-controller='dropdown']")
         end
 
         within "tr[data-user-id=\"#{other_admin.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_link("Delete")
         end
       end

--- a/decidim-admin/spec/system/admin_manages_organization_area_types_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_area_types_spec.rb
@@ -62,7 +62,7 @@ describe "Admin manages area types" do
 
     it "can edit them" do
       within "tr", text: translated(area_type.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -93,7 +93,7 @@ describe "Admin manages area types" do
 
     it "can delete them" do
       within "tr", text: translated(area_type.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_areas_spec.rb
@@ -58,7 +58,7 @@ describe "Organization Areas" do
 
       it "can edit them" do
         within "tr", text: translated(area.name) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -103,7 +103,7 @@ describe "Organization Areas" do
 
   def click_delete_area
     within "tr", text: translated(area.name) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       accept_confirm { click_on "Delete" }
     end
   end

--- a/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_scope_types_spec.rb
@@ -62,7 +62,7 @@ describe "Admin manages scope types" do
 
     it "can edit them" do
       within "tr", text: translated(scope_type.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -93,7 +93,7 @@ describe "Admin manages scope types" do
 
     it "can delete them" do
       within "tr", text: translated(scope_type.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-admin/spec/system/admin_manages_organization_scopes_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_scopes_spec.rb
@@ -51,7 +51,7 @@ describe "Organization scopes" do
 
       it "can edit them" do
         within "tr", text: translated(scope.name) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -72,7 +72,7 @@ describe "Organization scopes" do
 
       it "can delete them" do
         within "tr", text: translated(scope.name) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Delete" }
         end
 

--- a/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_taxonomies_spec.rb
@@ -228,14 +228,14 @@ describe "Admin manages taxonomies" do
 
   def click_delete_taxonomy
     within "tr", text: translated(taxonomy.name) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       accept_confirm { click_on "Delete" }
     end
   end
 
   def click_edit_taxonomy
     within "tr", text: translated(taxonomy.name) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
   end

--- a/decidim-admin/spec/system/admin_manages_taxonomy_filters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_taxonomy_filters_spec.rb
@@ -69,7 +69,7 @@ describe "Admin manages taxonomy filters" do
     before do
       visit decidim_admin.taxonomy_filters_path(taxonomy_id: another_root_taxonomy.id)
       within "tr", text: translated(another_taxonomy_filter.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -84,7 +84,7 @@ describe "Admin manages taxonomy filters" do
   context "when editing a taxonomy with items" do
     before do
       within "tr", text: translated(taxonomy_filter.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -114,7 +114,7 @@ describe "Admin manages taxonomy filters" do
   context "when destroying a taxonomy filter" do
     before do
       within "tr", text: translated(taxonomy_filter.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
     end

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -136,7 +136,7 @@ describe "Content pages" do
 
       it "can delete them" do
         within "tr", text: translated(topic.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Delete" }
         end
 
@@ -208,7 +208,7 @@ describe "Content pages" do
       context "when displaying the page form" do
         before do
           within "tr", text: translated(decidim_page.title) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
         end
@@ -218,7 +218,7 @@ describe "Content pages" do
 
       it "can edit them" do
         within "tr", text: translated(decidim_page.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -249,7 +249,7 @@ describe "Content pages" do
 
       it "can delete them" do
         within "tr", text: translated(decidim_page.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Delete" }
         end
 
@@ -263,7 +263,7 @@ describe "Content pages" do
       it "can visit them" do
         new_window = window_opened_by do
           within "tr", text: translated(decidim_page.title) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "View"
           end
         end

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_assembly_row.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_assembly_row.html.erb
@@ -48,7 +48,7 @@
     <% end %>
   </td>
   <td class="table-list__actions" data-label="<%= t("models.assembly.fields.actions", scope: "decidim.admin") %>">
-    <button type="button" data-component="dropdown" data-target="actions-assembly-<%= assembly.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(assembly.title)) %>">
+    <button type="button" data-controller="dropdown" data-target="actions-assembly-<%= assembly.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(assembly.title)) %>">
       <%= icon "more-fill", class: "text-secondary" %>
     </button>
 

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_user_roles/index.html.erb
@@ -44,7 +44,7 @@
               <%= t("#{role.role}", scope: "decidim.admin.models.assembly_user_role.roles") %><br>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.assembly_user_role.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-assembly-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-assembly-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/_manage_assemblies.html.erb
@@ -1,5 +1,5 @@
 <div class="inline-block relative">
-  <%= button_tag data: { component: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+  <%= button_tag data: { controller: "dropdown", target: "assemblies-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
     <span>
       <%= t("menu.manage", scope: "decidim.admin") %>
     </span>

--- a/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_admin_manage_assembly_components_examples.rb
@@ -55,7 +55,7 @@ shared_examples "assembly admin manage assembly components" do
     context "and then edit it" do
       before do
         within "tr", text: "My component" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
       end
@@ -97,7 +97,7 @@ shared_examples "assembly admin manage assembly components" do
 
     it "updates the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -125,7 +125,7 @@ shared_examples "assembly admin manage assembly components" do
       expect(page).to have_content("My updated component")
 
       within "tr", text: "My updated component" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -154,12 +154,12 @@ shared_examples "assembly admin manage assembly components" do
     context "when the component is unpublished" do
       it "publishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Hide")
         end
       end
@@ -169,7 +169,7 @@ shared_examples "assembly admin manage assembly components" do
         create(:follow, followable: assembly, user: follower)
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
@@ -191,12 +191,12 @@ shared_examples "assembly admin manage assembly components" do
 
       it "hides the component from the menu" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Hide"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
       end
@@ -208,12 +208,12 @@ shared_examples "assembly admin manage assembly components" do
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Publish")
         end
       end

--- a/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
@@ -3,7 +3,7 @@
 shared_examples "manage assemblies announcements" do
   it "can customize a general announcement for the assembly" do
     within("tr", text: translated(assembly.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -30,7 +30,7 @@ shared_examples "manage assemblies announcements" do
 
     new_window = window_opened_by do
       within "tr", text: translated(assembly.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Preview"
       end
     end

--- a/decidim-assemblies/spec/shared/copy_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/copy_assemblies_examples.rb
@@ -13,7 +13,7 @@ shared_examples "copy assemblies" do
   context "without any context" do
     it "copies the assembly with the basic fields" do
       within("tr", text: translated_attribute(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -38,7 +38,7 @@ shared_examples "copy assemblies" do
   context "with context" do
     before do
       within("tr", text: translated_attribute(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -61,7 +61,7 @@ shared_examples "copy assemblies" do
       expect(page).to have_content("successfully")
 
       within "tr", text: "Copy assembly" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
       within_admin_sidebar_menu do
@@ -84,7 +84,7 @@ shared_examples "copy assemblies" do
       click_on "Assemblies", match: :first
 
       within("tr", text: translated_attribute(assembly_parent.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -10,7 +10,7 @@ shared_examples "manage assemblies" do
 
     before do
       within("tr", text: translated(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -67,7 +67,7 @@ shared_examples "manage assemblies" do
   describe "updating an assembly without images" do
     before do
       within("tr", text: translated(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -101,7 +101,7 @@ shared_examples "manage assemblies" do
       it "allows the user to preview the unpublished assembly" do
         new_window = window_opened_by do
           within("tr", text: translated(assembly.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Preview"
           end
         end
@@ -120,7 +120,7 @@ shared_examples "manage assemblies" do
       it "allows the user to preview the unpublished assembly" do
         new_window = window_opened_by do
           within("tr", text: translated(assembly.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Preview"
           end
         end
@@ -148,14 +148,14 @@ shared_examples "manage assemblies" do
 
     it "publishes the assembly" do
       within("tr", text: translated_attribute(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Publish", visible: true).click
       end
 
       expect(page).to have_content("successfully published")
 
       within("tr", text: translated_attribute(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_content("Unpublish")
       end
 
@@ -175,7 +175,7 @@ shared_examples "manage assemblies" do
 
     it "unpublishes the assembly" do
       within("tr", text: translated_attribute(assembly.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Unpublish", visible: true).click
       end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_admins_examples.rb
@@ -56,7 +56,7 @@ shared_examples "manage assembly admins examples" do
     it "updates an assembly admin", versioning: true do
       within "#assembly_admins" do
         within "#assembly_admins tr", text: other_user.email do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -78,7 +78,7 @@ shared_examples "manage assembly admins examples" do
 
     it "deletes an assembly_user_role" do
       within "#assembly_admins tr", text: other_user.email do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -107,7 +107,7 @@ shared_examples "manage assembly admins examples" do
 
       it "resends the invitation to the user" do
         within "#assembly_admins tr", text: "test@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -60,7 +60,7 @@ shared_examples "manage assembly components" do
     context "and then edit it" do
       before do
         within "tr", text: translated(attributes[:name]) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
       end
@@ -102,7 +102,7 @@ shared_examples "manage assembly components" do
 
     it "updates the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -128,7 +128,7 @@ shared_examples "manage assembly components" do
       expect(page).to have_content(translated(attributes[:name]))
 
       within "tr", text: translated(attributes[:name]) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -160,12 +160,12 @@ shared_examples "manage assembly components" do
     context "when the component is unpublished" do
       it "publishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Hide")
         end
       end
@@ -175,7 +175,7 @@ shared_examples "manage assembly components" do
         create(:follow, followable: assembly, user: follower)
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
@@ -197,12 +197,12 @@ shared_examples "manage assembly components" do
 
       it "hides the component from the menu" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Hide"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
       end
@@ -214,12 +214,12 @@ shared_examples "manage assembly components" do
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Publish")
         end
       end

--- a/decidim-assemblies/spec/shared/manage_assembly_private_users_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_private_users_examples.rb
@@ -62,7 +62,7 @@ shared_examples "manage assembly private users examples" do
 
     it "deletes an assembly_private_user" do
       within "#private_users tr", text: other_user.email do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -90,7 +90,7 @@ shared_examples "manage assembly private users examples" do
 
       it "resends the invitation to the user" do
         within "#private_users tr", text: "test@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -55,7 +55,7 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Unpublished")
 
       within "tr", text: "Import assembly" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
@@ -22,7 +22,7 @@ describe "Admin manages assembly publication" do
     visit admin_page_path
 
     within("tr", text: translated_attribute(participatory_space.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Publish"
     end
 

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -36,7 +36,7 @@ describe "Assembly admin accesses admin sections" do
     before do
       visit decidim_admin_assemblies.assemblies_path
       within "tr", text: translated(assembly.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end

--- a/decidim-blogs/app/views/decidim/blogs/admin/posts/_actions.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/admin/posts/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-post-<%= post.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: post.title) %>">
+<button type="button" data-controller="dropdown" data-target="actions-post-<%= post.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: post.title) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-blogs/spec/shared/manage_attachment_collections_examples.rb
+++ b/decidim-blogs/spec/shared/manage_attachment_collections_examples.rb
@@ -5,7 +5,7 @@ shared_examples "manage posts attachment collections" do
 
   before do
     within "tr", text: translated(post.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add folder"
     end
   end

--- a/decidim-blogs/spec/shared/manage_attachments_examples.rb
+++ b/decidim-blogs/spec/shared/manage_attachments_examples.rb
@@ -8,7 +8,7 @@ shared_examples "manage posts attachments" do
 
   before do
     within "tr", text: translated(post.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add attachment"
     end
   end

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -6,7 +6,7 @@ shared_examples "manage posts" do |audit_check: true|
   it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='post-body-tabs']", "full" do
     before do
       within "tr", text: translated(post1.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -15,7 +15,7 @@ shared_examples "manage posts" do |audit_check: true|
 
   it "updates a post", versioning: true do
     within "tr", text: translated(post1.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -84,7 +84,7 @@ shared_examples "manage posts" do |audit_check: true|
 
     it "deletes a post" do
       within "tr", text: translated(post1.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Move to trash" }
       end
 
@@ -137,7 +137,7 @@ shared_examples "manage posts" do |audit_check: true|
 
     it "can update the blog as the organization" do
       within "tr", text: translated(post1.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -194,7 +194,7 @@ shared_examples "manage posts" do |audit_check: true|
 
     it "can update the blog as the user" do
       within "tr", text: translated(post1.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -212,7 +212,7 @@ shared_examples "manage posts" do |audit_check: true|
 
     it "changes the publish time" do
       within "tr", text: translated(post1.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
       within ".edit_post" do

--- a/decidim-budgets/app/views/decidim/budgets/admin/budgets/_actions.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/budgets/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-post-<%= budget.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(budget.title)) %>">
+<button type="button" data-controller="dropdown" data-target="actions-post-<%= budget.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(budget.title)) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/_actions.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-post-<%= project.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: project.title) %>">
+<button type="button" data-controller="dropdown" data-target="actions-post-<%= project.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: project.title) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/admin/projects/bulk_actions/_dropdown.html.erb
@@ -3,7 +3,7 @@
     id="js-bulk-actions-button"
     class="button button__sm button__transparent-secondary"
     type="button"
-    data-component="dropdown"
+    data-controller="dropdown"
     data-target="js-bulk-actions-dropdown">
     <%= t("decidim.budgets.admin.projects.index.actions") %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/order_progress_summary/_content_responsive.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/order_progress_summary/_content_responsive.html.erb
@@ -16,7 +16,7 @@
         <%= render partial: "decidim/budgets/projects/order_progress_summary/progress_box" %>
         <button
           id="progress-summary-button"
-          data-component="dropdown"
+          data-controller="dropdown"
           data-target="progress-summary-dropdown-menu"
           data-open="<%= show_hint ? "true" : "false" %>"
           aria-expanded="<%= show_hint ? "true" : "false" %>"

--- a/decidim-budgets/spec/shared/manage_attachment_collections_examples.rb
+++ b/decidim-budgets/spec/shared/manage_attachment_collections_examples.rb
@@ -5,12 +5,12 @@ shared_examples "manage projects attachment collections" do
 
   before do
     within "tr", text: translated(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
 
     within "tr", text: translated(project.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add folder"
     end
   end

--- a/decidim-budgets/spec/shared/manage_attachments_examples.rb
+++ b/decidim-budgets/spec/shared/manage_attachments_examples.rb
@@ -8,12 +8,12 @@ shared_examples "manage project attachments" do
 
   before do
     within "tr", text: translated(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
 
     within "tr", text: translated(project.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add attachment"
     end
   end

--- a/decidim-budgets/spec/shared/manage_projects_examples.rb
+++ b/decidim-budgets/spec/shared/manage_projects_examples.rb
@@ -80,7 +80,7 @@ shared_examples "manage projects" do
 
   it "updates a project" do
     within "tr", text: translated(project.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -106,7 +106,7 @@ shared_examples "manage projects" do
   context "when previewing projects" do
     it "allows the user to preview the project" do
       within "tr", text: translated(project.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         preview_window = window_opened_by { click_on "Preview" }
 
         within_window preview_window do
@@ -175,7 +175,7 @@ shared_examples "manage projects" do
 
     it "deletes a project" do
       within "tr", text: translated(project2.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Move to trash" }
       end
 
@@ -194,7 +194,7 @@ shared_examples "manage projects" do
 
     it "updates a project", versioning: true do
       within "tr", text: translated(project.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -223,7 +223,7 @@ shared_examples "manage projects" do
       expect(project.linked_resources(:proposals, "included_proposals").count).to eq(5)
 
       within "tr", text: translated(project.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 

--- a/decidim-budgets/spec/system/admin_filters_searches_and_paginates_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_filters_searches_and_paginates_projects_spec.rb
@@ -13,7 +13,7 @@ describe "Admin filters, searches, and paginates projects" do
   before do
     visit_component_admin
     within "tr", text: translated_attribute(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
   end

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -49,7 +49,7 @@ describe "Admin manages budgets" do
   describe "updating a budget", versioning: true do
     it "updates a budget" do
       within "tr", text: translated(budget.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -74,7 +74,7 @@ describe "Admin manages budgets" do
   describe "previewing budgets" do
     it "links the budget correctly" do
       within "tr", text: translated(budget.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         preview_window = window_opened_by { click_on "Preview" }
         within_window preview_window do
           expect(page).to have_current_path(Decidim::EngineRouter.main_proxy(budget.component).budget_projects_path(budget))
@@ -87,7 +87,7 @@ describe "Admin manages budgets" do
     it "moves to the trash a budget" do
       within "tr", text: translated(budget.title) do
         accept_confirm do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Move to trash"
         end
       end

--- a/decidim-budgets/spec/system/admin_manages_project_permissions_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_project_permissions_spec.rb
@@ -14,11 +14,11 @@ describe "Admin manages project permissions" do
     login_as user, scope: :user
     visit_component_admin
     within "tr", text: translated(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
     within "tr", text: translated(project.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Manage permissions"
     end
   end
@@ -32,11 +32,11 @@ describe "Admin manages project permissions" do
     click_on "Submit"
     expect(page).to have_content("Permissions updated successfully")
     within "tr", text: translated(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
     within "tr", text: translated(project.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Manage permissions"
     end
     within "fieldset", text: "Vote" do

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -22,7 +22,7 @@ describe "Admin manages projects" do
     visit_component_admin
 
     within "tr", text: translated(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
   end

--- a/decidim-budgets/spec/system/admin_orders_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_orders_projects_spec.rb
@@ -30,7 +30,7 @@ describe "Admin orders projects" do
   before do
     visit_component_admin
     within "tr", text: translated_attribute(budget.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add projects"
     end
   end

--- a/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/suggestion.js
+++ b/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/suggestion.js
@@ -221,7 +221,7 @@ export default class Suggestion {
     this.text = this.item.querySelector(".collaborative-texts-suggestions-box-item-text");
     this.text.innerHTML = this.summary;
     this.boxItems.appendChild(this.item);
-    this.dropdown = this.item.querySelector('[data-component="dropdown"]');
+    this.dropdown = this.item.querySelector('[data-controller="dropdown"]');
     if (this.doc.dataset.collaborativeTextsRolloutUrl) {
       createDropdown(this.dropdown);
     } else {

--- a/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/test/suggestions.test.js
+++ b/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/test/suggestions.test.js
@@ -60,7 +60,7 @@ describe("SuggestionsList", () => {
           <div class="relative">
             <button class="collaborative-texts-suggestions-box-item-dropdown"
                     id="dropdown-trigger-{{ID}}"
-                    data-component="dropdown"
+                    data-controller="dropdown"
                     data-target="dropdown-menu-{{ID}}"
                     data-auto-close="true">
             </button>

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_actions.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-post-<%= document.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: document.title) %>">
+<button type="button" data-controller="dropdown" data-target="actions-post-<%= document.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: document.title) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_item_template.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_item_template.html.erb
@@ -3,7 +3,7 @@
   <div class="relative z-1">
     <button class="collaborative-texts-suggestions-box-item-dropdown"
             id="dropdown-trigger-{{ID}}"
-            data-component="dropdown"
+            data-controller="dropdown"
             data-target="dropdown-menu-{{ID}}"
             data-auto-close="true"
             aria-label="<%= t("decidim.collaborative_texts.document.controls_label") %>">

--- a/decidim-collaborative_texts/spec/system/admin/admin_edits_document_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_edits_document_spec.rb
@@ -15,7 +15,7 @@ describe "Admin edits documents" do
   it "edits an existing document" do
     expect(document.accepting_suggestions?).to be false
     within("tr", text: "This is my document new title") do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
     expect(page).to have_content("Edit collaborative texts")
@@ -28,7 +28,7 @@ describe "Admin edits documents" do
     expect(page).to have_admin_callout "Document successfully updated"
 
     within("tr", text: "This is an edited title test") do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Configure"
     end
 
@@ -48,7 +48,7 @@ describe "Admin edits documents" do
   context "when title is invalid" do
     before do
       within("tr", text: "This is my document new title") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -69,7 +69,7 @@ describe "Admin edits documents" do
 
     it "does not allow to edit the document the body" do
       within("tr", text: "This is my document new title") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
       expect(page).to have_content("Edit collaborative texts")
@@ -91,7 +91,7 @@ describe "Admin edits documents" do
     it "can discard suggestions by creating a new version" do
       expect(document.current_version.suggestions.count).to eq(1)
       within("tr", text: "This is my document new title") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
       expect(page).to have_content("Edit collaborative texts")
@@ -105,7 +105,7 @@ describe "Admin edits documents" do
       expect(document.current_version.suggestions.count).to eq(0)
       expect(document.draft?).to be true
       within("tr", text: "This is my document new title") do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
       expect(page).to have_content("Version 1")

--- a/decidim-collaborative_texts/spec/system/admin/admin_publishes_and_unpublishes_document_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_publishes_and_unpublishes_document_spec.rb
@@ -24,13 +24,13 @@ describe "Admin publish and unpublish documents" do
     expect(page).to have_content("Configure")
 
     within "tr", text: title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Publish"
     end
     expect(page).to have_admin_callout "Document successfully published"
 
     within "tr", text: title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Unpublish"
     end
     expect(page).to have_admin_callout "Document successfully unpublished"

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -31,7 +31,7 @@
       <% end %>
 
       <div class="relative ml-auto">
-        <button id="dropdown-trigger-<%= context_menu_id %>" data-component="dropdown" data-target="dropdown-menu-<%= context_menu_id %>" aria-label="<%= t("decidim.components.comment.controls_label") %>">
+        <button id="dropdown-trigger-<%= context_menu_id %>" data-controller="dropdown" data-target="dropdown-menu-<%= context_menu_id %>" aria-label="<%= t("decidim.components.comment.controls_label") %>">
           <%# NOTE: having two times the icon call is intentional, as that is how the `dropdown` CSS code is done %>
           <%= icon "more-fill" %>
           <%= icon "more-fill" %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_registrations/index.html.erb
@@ -6,7 +6,7 @@
       <%= t(".registrations") %>
       <% if allowed_to? :export_conference_registrations, :conference, conference: conference %>
         <div class="relative">
-          <a class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="export-dropdown">
+          <a class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="export-dropdown">
             <%= t "actions.export", scope: "decidim.admin" %>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-down-s-line" %>
@@ -52,7 +52,7 @@
             </td>
             <td class="table-list__actions" data-label="<%= t("models.conference_registration.fields.actions", scope: "decidim.conferences") %>">
               <% if allowed_to?(:confirm, :conference_registration, conference_registration: registration) && !registration.confirmed? %>
-                <button type="button" data-component="dropdown" data-target="actions-conference-registration-<%= registration.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: registration.user.name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-conference-registration-<%= registration.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: registration.user.name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_speakers/index.html.erb
@@ -49,7 +49,7 @@
               <%= translated_attribute(speaker.affiliation) %>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.conference_speaker.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-conference-speaker-<%= speaker.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: speaker_presenter.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-conference-speaker-<%= speaker.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: speaker_presenter.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conference_user_roles/index.html.erb
@@ -44,7 +44,7 @@
               <%= t("#{role.role}", scope: "decidim.admin.models.conference_user_role.roles") %><br>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.conference_user_role.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-conference-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-conference-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_actions.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-conference-<%= conference.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(conference.title)) %>">
+<button type="button" data-controller="dropdown" data-target="actions-conference-<%= conference.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(conference.title)) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/media_links/index.html.erb
@@ -31,7 +31,7 @@
               <%= l(media_link.date, format: :decidim_short ) %>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.media_link.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-media-link-<%= media_link.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(media_link.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-media-link-<%= media_link.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(media_link.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/partners/index.html.erb
@@ -39,7 +39,7 @@
               <% end %>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.partner.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-partner-<%= partner.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: partner.name || t("models.partner.name", scope: "decidim.admin")) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-partner-<%= partner.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: partner.name || t("models.partner.name", scope: "decidim.admin")) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/registration_types/index.html.erb
@@ -40,7 +40,7 @@
             </td>
 
             <td class="table-list__actions" data-label="<%= t("models.registration_type.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-conference-registration-type-<%= registration_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(registration_type.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-conference-registration-type-<%= registration_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(registration_type.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -24,7 +24,7 @@ edit_link(
 
   <%= content_for :aside do %>
     <div class="conference__nav-container">
-      <button id="dropdown-trigger-conference" data-component="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-scroll-to-menu="true">
+      <button id="dropdown-trigger-conference" data-controller="dropdown" data-target="dropdown-menu-conference" data-auto-close="true" data-scroll-to-menu="true">
         <span><%= t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-conferences/spec/shared/duplicate_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/duplicate_conferences_examples.rb
@@ -13,7 +13,7 @@ shared_examples "duplicate conferences" do
   context "without any context" do
     it "copies the conference with the basic fields" do
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -38,7 +38,7 @@ shared_examples "duplicate conferences" do
   context "with context" do
     before do
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -61,7 +61,7 @@ shared_examples "duplicate conferences" do
       expect(page).to have_content("successfully")
 
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 

--- a/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_admins_examples.rb
@@ -55,7 +55,7 @@ shared_examples "manage conference admins examples" do
     it "updates a conference admin", versioning: true do
       within "#conference_admins" do
         within "#conference_admins tr", text: other_user.email do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -77,7 +77,7 @@ shared_examples "manage conference admins examples" do
 
     it "deletes a conference_user_role" do
       within "#conference_admins tr", text: other_user.email do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -109,7 +109,7 @@ shared_examples "manage conference admins examples" do
 
       it "resends the invitation to the user" do
         within "#conference_admins tr", text: "test@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -60,7 +60,7 @@ shared_examples "manage conference components" do
     context "and then edit it" do
       before do
         within "tr", text: translated(attributes[:name]) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
       end
@@ -102,7 +102,7 @@ shared_examples "manage conference components" do
 
     it "updates the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -128,7 +128,7 @@ shared_examples "manage conference components" do
       expect(page).to have_content(translated(attributes[:name]))
 
       within "tr", text: translated(attributes[:name]) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -160,12 +160,12 @@ shared_examples "manage conference components" do
     context "when the component is unpublished" do
       it "publishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Hide")
         end
       end
@@ -175,7 +175,7 @@ shared_examples "manage conference components" do
         create(:follow, followable: conference, user: follower)
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
@@ -197,12 +197,12 @@ shared_examples "manage conference components" do
 
       it "hides the component from the menu" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Hide"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
       end
@@ -214,12 +214,12 @@ shared_examples "manage conference components" do
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Publish")
         end
       end

--- a/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_speakers_examples.rb
@@ -72,7 +72,7 @@ shared_examples "manage conference speakers examples" do
 
     it "updates a conference speaker", versioning: true do
       within "#conference_speakers tr", text: conference_speaker.full_name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -97,7 +97,7 @@ shared_examples "manage conference speakers examples" do
 
     it "deletes the conference speaker" do
       within "#conference_speakers tr", text: conference_speaker.full_name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage conferences" do
 
     before do
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -100,7 +100,7 @@ shared_examples "manage conferences" do
   describe "updating a conference without images" do
     before do
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -138,7 +138,7 @@ shared_examples "manage conferences" do
 
       it "allows the user to preview the unpublished conference" do
         within "tr", text: translated(conference.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Preview"
         end
 
@@ -152,7 +152,7 @@ shared_examples "manage conferences" do
       it "allows the user to preview the unpublished conference" do
         new_window = window_opened_by do
           within "tr", text: translated(conference.title) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Preview"
           end
         end
@@ -180,14 +180,14 @@ shared_examples "manage conferences" do
 
     it "publishes the conference" do
       within("tr", text: translated_attribute(conference.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Publish", visible: true).click
       end
 
       expect(page).to have_content("successfully published")
 
       within("tr", text: translated_attribute(conference.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_content("Unpublish")
       end
 
@@ -207,7 +207,7 @@ shared_examples "manage conferences" do
 
     it "unpublishes the conference" do
       within("tr", text: translated_attribute(conference.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Unpublish", visible: true).click
       end
 

--- a/decidim-conferences/spec/shared/manage_diplomas_examples.rb
+++ b/decidim-conferences/spec/shared/manage_diplomas_examples.rb
@@ -10,7 +10,7 @@ shared_examples "manage diplomas" do
   context "when diploma configuration not exists" do
     it "configure the diploma settings" do
       within "tr", text: translated(conference.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -41,7 +41,7 @@ shared_examples "manage diplomas" do
       context "and diplomas has not been sent" do
         before do
           within "tr", text: translated(conference.title) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -72,7 +72,7 @@ shared_examples "manage diplomas" do
 
         it "cannot send the diplomas" do
           within "tr", text: translated(conference.title) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -91,7 +91,7 @@ shared_examples "manage diplomas" do
 
       it "cannot send the diplomas" do
         within "tr", text: translated(conference.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 

--- a/decidim-conferences/spec/shared/manage_media_links_examples.rb
+++ b/decidim-conferences/spec/shared/manage_media_links_examples.rb
@@ -57,7 +57,7 @@ shared_examples "manage media links examples" do
 
     it "updates a conference media links", versioning: true do
       within "#media_links tr", text: translated(media_link.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -83,7 +83,7 @@ shared_examples "manage media links examples" do
 
     it "deletes the conference media link" do
       within "#media_links tr", text: translated(media_link.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-conferences/spec/shared/manage_partners_examples.rb
+++ b/decidim-conferences/spec/shared/manage_partners_examples.rb
@@ -51,7 +51,7 @@ shared_examples "manage partners examples" do
 
     it "updates a conference partners", versioning: true do
       within "#partners tr", text: conference_partner.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -93,7 +93,7 @@ shared_examples "manage partners examples" do
 
     it "deletes the conference partner" do
       within "#partners tr", text: conference_partner.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-conferences/spec/shared/manage_registration_types_examples.rb
+++ b/decidim-conferences/spec/shared/manage_registration_types_examples.rb
@@ -49,7 +49,7 @@ shared_examples "manage registration types examples" do
 
     it "updates a conference registration types" do
       within "#registration_types tr", text: translated(registration_type.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -73,7 +73,7 @@ shared_examples "manage registration types examples" do
 
     it "deletes the conference registration type" do
       within "#registration_types tr", text: translated(registration_type.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
@@ -22,7 +22,7 @@ describe "Admin manages conference publication" do
     visit admin_page_path
 
     within("tr", text: translated_attribute(participatory_space.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Publish"
     end
 

--- a/decidim-conferences/spec/system/admin/conference_admin_accesses_admin_sections_spec.rb
+++ b/decidim-conferences/spec/system/admin/conference_admin_accesses_admin_sections_spec.rb
@@ -11,7 +11,7 @@ describe "Conference admin accesses admin sections" do
     visit decidim_admin_conferences.conferences_path
 
     within("tr", text: translated(conference.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
   end

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -86,7 +86,7 @@ describe "Conference speakers" do
         click_on "Speakers"
 
         within "tr", text: speaker2.full_name do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_link("Publish")
           click_link_or_button "Publish"
         end
@@ -119,7 +119,7 @@ describe "Conference speakers" do
         click_on "Speakers"
 
         within "tr", text: speaker1.full_name do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_link("Unpublish")
           click_link_or_button "Unpublish"
         end

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,5 +1,5 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-component="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-open-md="true">
+  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-open-md="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/cells/decidim/resource_types_filter/show.erb
+++ b/decidim-core/app/cells/decidim/resource_types_filter/show.erb
@@ -1,5 +1,5 @@
 <div id="<%= id %>" class="filter-container">
-  <button id="dropdown-trigger-resource" data-component="dropdown" data-target="dropdown-menu-resource" data-open-md="true">
+  <button id="dropdown-trigger-resource" data-controller="dropdown" data-target="dropdown-menu-resource" data-open-md="true">
     <% resource_types.each do |resource_type| %>
       <span data-value="<%= resource_type[0] %>" class="<%= "is-active" if filter_param == resource_type[0] %>">
         <%= text_with_resource_icon(*resource_type) %>

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -184,7 +184,12 @@ const initializer = (element = document) => {
 
   element.querySelectorAll('[data-component="accordion"]').forEach((component) => createAccordion(component))
 
-  element.querySelectorAll('[data-component="dropdown"]').forEach((component) => createDropdown(component))
+
+  element.querySelectorAll('[data-controller="dropdown"]').forEach((component) => createAccordion(component))
+
+  element.querySelectorAll('[data-component="dropdown"]').forEach((component) => {
+    alert(`${window.location.href} Using dropdwon component`);
+  })
 
   element.querySelectorAll("[data-dialog]").forEach((component) => createDialog(component))
 

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -185,8 +185,7 @@ const initializer = (element = document) => {
   element.querySelectorAll('[data-component="accordion"]').forEach((component) => createAccordion(component))
 
 
-  element.querySelectorAll('[data-controller="dropdown"]').forEach((component) => createAccordion(component))
-
+  element.querySelectorAll('[data-controller="dropdown"]').forEach((component) => createDropdown(component))
   element.querySelectorAll('[data-component="dropdown"]').forEach((component) => {
     alert(`${window.location.href} Using dropdwon component`);
   })

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -184,9 +184,9 @@ const initializer = (element = document) => {
 
 
   element.querySelectorAll('[data-controller="dropdown"]').forEach((component) => createDropdown(component))
-  element.querySelectorAll('[data-component="dropdown"]').forEach(() => {
-    // eslint-disable-next-line no-alert
-    alert(`${window.location.href} Using dropdown component`);
+  element.querySelectorAll('[data-component="dropdown"]').forEach((component) => {
+    console.error(`${window.location.href} Using dropdown component`);
+    createDropdown(component);
   })
 
   element.querySelectorAll("[data-dialog]").forEach((component) => createDialog(component))

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 /**
  * External dependencies
  */
@@ -186,8 +184,9 @@ const initializer = (element = document) => {
 
 
   element.querySelectorAll('[data-controller="dropdown"]').forEach((component) => createDropdown(component))
-  element.querySelectorAll('[data-component="dropdown"]').forEach((component) => {
-    alert(`${window.location.href} Using dropdwon component`);
+  element.querySelectorAll('[data-component="dropdown"]').forEach(() => {
+    // eslint-disable-next-line no-alert
+    alert(`${window.location.href} Using dropdown component`);
   })
 
   element.querySelectorAll("[data-dialog]").forEach((component) => createDialog(component))

--- a/decidim-core/app/views/decidim/application/_collection.html.erb
+++ b/decidim-core/app/views/decidim/application/_collection.html.erb
@@ -1,6 +1,6 @@
 <% unless attachment_collection.unused? %>
 <div class="documents__dropdown-container">
-  <button id="dropdown-documents-trigger-<%= attachment_collection.id %>" class="documents__collection-trigger" data-component="dropdown" data-target="dropdown-menu-documents-<%= attachment_collection.id %>" aria-expanded="false">
+  <button id="dropdown-documents-trigger-<%= attachment_collection.id %>" class="documents__collection-trigger" data-controller="dropdown" data-target="dropdown-menu-documents-<%= attachment_collection.id %>" aria-expanded="false">
    <div class="documents-details">
       <span>
         <span class="documents__collection-trigger__icon">

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -11,7 +11,7 @@
 
   <div class="vertical-tabs">
     <nav role="navigation" aria-label="<%= I18n.t("layouts.decidim.navigation.aria_label", title: translated_attribute(page.title)) %>">
-      <button id="dropdown-trigger-pages" data-component="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
+      <button id="dropdown-trigger-pages" data-controller="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
         <span>
           <%= translated_attribute(page.title) %>
         </span>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -16,7 +16,7 @@
         </button>
       <% end %>
     </div>
-    <button id="dropdown-trigger-search" data-component="dropdown" data-target="dropdown-menu-search" data-auto-close="true" aria-expanded="true">
+    <button id="dropdown-trigger-search" data-controller="dropdown" data-target="dropdown-menu-search" data-auto-close="true" aria-expanded="true">
       <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>
       <% @blocks.each do |elements| %>
         <% elements.each do |type, results| %>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -4,7 +4,7 @@
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
   <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", component: "accordion" } do |form| %>
 
-    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
+    <button id="dropdown-trigger-filters" data-controller="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
       <%= icon "arrow-down-s-line" %>
       <%= icon "arrow-up-s-line" %>
       <span>

--- a/decidim-core/app/views/decidim/shared/_orders.html.erb
+++ b/decidim-core/app/views/decidim/shared/_orders.html.erb
@@ -1,4 +1,4 @@
-<button class="order-by__button <%= b_css_class if defined?(b_css_class) %>" id="dropdown-trigger-order" data-component="dropdown" data-target="dropdown-menu-order" data-open-md="true">
+<button class="order-by__button <%= b_css_class if defined?(b_css_class) %>" id="dropdown-trigger-order" data-controller="dropdown" data-target="dropdown-menu-order" data-open-md="true">
   <%= icon "arrow-down-s-line" %>
   <%= icon "arrow-up-s-line" %>
   <span><%= t("#{i18n_scope}.label") %></span>

--- a/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
+++ b/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
@@ -1,6 +1,6 @@
 <div class="relative ml-auto">
   <button id="dropdown-trigger-resource-<%= resource.id %>"
-          data-component="dropdown"
+          data-controller="dropdown"
           data-target="dropdown-menu-resource-<%= resource.id %>"
           aria-label="<%= t("decidim.resource.controls_label") %>">
     <span class="sr-only"><%= t("decidim.resource.controls_label") %></span>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_language_chooser.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
   <div class="main-footer__language-container">
-    <button id="trigger-dropdown-language-chooser" data-component="dropdown" data-target="dropdown-menu-language-chooser" class="main-footer__language-trigger">
+    <button id="trigger-dropdown-language-chooser" data-controller="dropdown" data-target="dropdown-menu-language-chooser" class="main-footer__language-trigger">
       <%= icon "global-line" %>
       <span><%= t("name", scope: "locale" ) %></span>
       <%= icon "arrow-down-s-line" %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -26,7 +26,7 @@
   </div>
 <% else %>
   <div class="main-bar__dropdown-container">
-    <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-component="dropdown" data-target="dropdown-menu-account">
+    <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
       <% unread_data = current_user_unread_data %>
       <% if unread_data[:unread_items] %>
         <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_item_account.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_item_account.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <button id="dropdown-trigger-links-mobile" class="main-bar__links-mobile__item" data-component="dropdown" data-target="dropdown-menu-account-mobile">
+  <button id="dropdown-trigger-links-mobile" class="main-bar__links-mobile__item" data-controller="dropdown" data-target="dropdown-menu-account-mobile">
     <% if current_user.notifications.any? %>
       <span class="main-bar__notification"></span>
     <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
@@ -1,5 +1,5 @@
 <button id="main-dropdown-summary-mobile" class="main-bar__links-mobile__trigger p-0"
-                                          data-component="dropdown"
+                                          data-controller="dropdown"
                                           data-target="dropdown-menu-main-mobile">
   <%= icon "menu-line" %><span class="sr-only"><%= t("main_menu", scope: "layouts.decidim.header") %></span>
   <%= icon "close-line" %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
@@ -2,7 +2,7 @@
   <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-desktop__dropdown-trigger", onmouseenter: "document.getElementById('main-dropdown-summary').click()" do %>
     <%= icon "home-2-line", class: "pointer-events-none" %><span class="sr-only"><%= t("decidim.menu.home") %></span>
   <% end %>
-  <button id="main-dropdown-summary" class="menu-bar__breadcrumb-desktop__dropdown-trigger" data-component="dropdown" data-hover="true" data-target="main-dropdown-menu">
+  <button id="main-dropdown-summary" class="menu-bar__breadcrumb-desktop__dropdown-trigger" data-controller="dropdown" data-hover="true" data-target="main-dropdown-menu">
     <%= icon "arrow-drop-down-line" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
   </button>
 </div>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_items.html.erb
@@ -11,7 +11,7 @@
         <% end %>
         <button id="secondary-dropdown-summary-<%= i %>"
           class="menu-bar__breadcrumb-desktop__dropdown-trigger"
-          data-component="dropdown"
+          data-controller="dropdown"
           data-hover="true"
           data-target="secondary-dropdown-menu-<%= i %>">
           <%= icon "arrow-drop-down-line" %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile_tablet.html.erb
@@ -16,7 +16,7 @@
     <% end %>
   </span>
   <% if dropdown_item.present? %>
-    <button id="secondary-dropdown-trigger-mobile" data-component="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile">
+    <button id="secondary-dropdown-trigger-mobile" data-controller="dropdown" data-hover="true" data-target="secondary-dropdown-menu-mobile">
       <%= icon "arrow-down-s-line", class: "flex-none w-6 h-6 fill-current" %><span class="sr-only"><%= t("layouts.decidim.header.main_menu") %></span>
     </button>
   <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_mobile_language_choose.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
     <div>
-        <button id="dropdown-trigger-language-chooser-mobile" data-component="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10 border border-gray outline outline-1 outline-transparent">
+        <button id="dropdown-trigger-language-chooser-mobile" data-controller="dropdown" data-target="dropdown-menu-language-chooser-mobile" class="mt-8 rounded-lg py-0 bg-gray-5 h-10 border border-gray outline outline-1 outline-transparent">
             <span class="ml-2"><%= t("name", scope: "locale" ) %></span>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/shared/_layout_user_profile.html.erb
@@ -14,7 +14,7 @@
 
   <div class="vertical-tabs">
     <nav aria-label="menu-vertical">
-      <button id="dropdown-trigger-profile" data-open-md="true" data-component="dropdown" data-target="dropdown-menu-profile">
+      <button id="dropdown-trigger-profile" data-open-md="true" data-controller="dropdown" data-target="dropdown-menu-profile">
         <span><%= user_menu.active_item&.label || t("decidim.searches.filters.jump_to") %></span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>

--- a/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb
@@ -116,7 +116,7 @@ shared_examples "manage resource share tokens" do
         expect(page).to have_content("Yes")
       end
       within ".share_tokens tbody tr", text: last_token.token do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -143,7 +143,7 @@ shared_examples "manage resource share tokens" do
 
     it "allows copying the share link from the share token" do
       within ".share_tokens tbody tr", text: last_token.token do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Copy link"
         expect(page).to have_content("copied!")
         expect(page).to have_css("[data-clipboard-copy-label]")
@@ -155,7 +155,7 @@ shared_examples "manage resource share tokens" do
     it "has a share link for each token" do
       urls = share_tokens.map(&:url)
       within ".share_tokens tbody tr", text: last_token.token do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         share_window = window_opened_by { click_on "Preview" }
 
         within_window share_window do
@@ -166,7 +166,7 @@ shared_examples "manage resource share tokens" do
 
     it "has a share button that opens the share url for the resource" do
       within ".share_tokens tbody tr", text: last_token.token do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         share_window = window_opened_by { click_on "Preview", wait: 2 }
 
         within_window share_window do
@@ -177,7 +177,7 @@ shared_examples "manage resource share tokens" do
 
     it "can delete tokens" do
       within ".share_tokens tbody tr", text: last_token.token do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -219,7 +219,7 @@ shared_examples "manage component share tokens" do
 
     within("tr", text: resource_name) do
       #  To remove once all the actions are migrated to dropdowns
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Share link"
     end
   end
@@ -241,7 +241,7 @@ shared_examples "manage participatory space share tokens" do
 
     within("tr", text: resource_name) do
       #  To remove once all the actions are migrated to dropdowns
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Share link"
     end
   end

--- a/decidim-core/spec/system/components_spec.rb
+++ b/decidim-core/spec/system/components_spec.rb
@@ -15,7 +15,7 @@ describe "Components can be navigated" do
     it "renders the content of the page" do
       within "#menu-bar" do
         expect(page).to have_content("Processes")
-        find("a.menu-bar__breadcrumb-desktop__dropdown-trigger", text: translated(participatory_space.title)).sibling("button[data-component='dropdown']").hover
+        find("a.menu-bar__breadcrumb-desktop__dropdown-trigger", text: translated(participatory_space.title)).sibling("button[data-controller='dropdown']").hover
         click_on(translated(component.name))
       end
 

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_actions.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-post-<%= debate.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: debate.title) %>">
+<button type="button" data-controller="dropdown" data-target="actions-post-<%= debate.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: debate.title) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -48,7 +48,7 @@ RSpec.shared_examples "manage debates" do
   describe "updating a debate" do
     it "updates a debate", versioning: true do
       within "tr", text: translated(debate.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -75,7 +75,7 @@ RSpec.shared_examples "manage debates" do
 
       it "cannot edit the debate" do
         within "tr", text: translated(debate.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_no_content("Edit")
         end
       end
@@ -87,7 +87,7 @@ RSpec.shared_examples "manage debates" do
 
       it "prevents admin from updating debate layout once comments have been posted" do
         within "tr", text: translated(debate.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -107,7 +107,7 @@ RSpec.shared_examples "manage debates" do
   describe "previewing debates" do
     it "links the debate correctly" do
       within "tr", text: translated(debate.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         link = find("a", text: "Preview")
         expect(link[:href]).to include(resource_locator(debate).path)
       end
@@ -248,7 +248,7 @@ RSpec.shared_examples "manage debates" do
         expect(page).to have_admin_callout "Debate successfully created"
 
         within "tr[data-id=\"#{Decidim::Debates::Debate.last.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -267,7 +267,7 @@ RSpec.shared_examples "manage debates" do
     context "when editing a debate with attachments" do
       before do
         within "tr[data-id=\"#{debate.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -289,7 +289,7 @@ RSpec.shared_examples "manage debates" do
         expect(page).to have_admin_callout "Debate successfully updated"
 
         within "tr[data-id=\"#{debate.id}\"]" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -314,7 +314,7 @@ RSpec.shared_examples "manage debates" do
   describe "closing a debate", versioning: true do
     it "closes a debate" do
       within "tr", text: translated(debate.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Close"
       end
 
@@ -328,7 +328,7 @@ RSpec.shared_examples "manage debates" do
 
       within "table" do
         within "tr", text: translated(debate.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Close"
         end
       end
@@ -344,7 +344,7 @@ RSpec.shared_examples "manage debates" do
 
       it "cannot close the debate" do
         within "tr", text: translated(debate.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_no_content("Close")
         end
       end

--- a/decidim-demographics/app/views/decidim/demographics/admin/responses/index.html.erb
+++ b/decidim-demographics/app/views/decidim/demographics/admin/responses/index.html.erb
@@ -60,7 +60,7 @@
               <%= l participant.responded_at, format: :short %>
             </td>
             <td data-label="<%= t("actions.title", scope: "decidim.demographics") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-participant-<%= idx %>" aria-label="<%= t("decidim.admin.actions.actions_label") %>">
+              <button type="button" data-controller="dropdown" data-target="actions-participant-<%= idx %>" aria-label="<%= t("decidim.admin.actions.actions_label") %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
+++ b/decidim-design/app/views/decidim/design/components/dropdowns.html.erb
@@ -20,7 +20,7 @@
 
   <p><%= t("decidim.design.helpers.dropdowns_demo_1_description") %></p>
 
-  <button id="dropdown-trigger-element" data-component="dropdown" data-target="dropdown-menu-element" data-auto-close="true">
+  <button id="dropdown-trigger-element" data-controller="dropdown" data-target="dropdown-menu-element" data-auto-close="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -206,7 +206,7 @@ en:
         dropdowns_description_html: Dropdowns are a javascript feature available thanks to an external library called %{link}.
         dropdowns_usage_1_description: 2. A hideable element, whose <code>id</code> matches the data-target value the trigger refers to.
         dropdowns_usage_description: 'An dropdown requires two elements:'
-        dropdowns_usage_description_html: 1. A user actionable element, with the data-attributes <code>data-component="dropdown" data-target="dropdown-menu-element"</code>.
+        dropdowns_usage_description_html: 1. A user actionable element, with the data-attributes <code>data-controller="dropdown" data-target="dropdown-menu-element"</code>.
         dummy_description: Dummy resource description
         dummy_title: Dummy resource title
         follow_button: Follow Button

--- a/decidim-design/config/locales/es-MX.yml
+++ b/decidim-design/config/locales/es-MX.yml
@@ -206,7 +206,7 @@ es-MX:
         dropdowns_description_html: Los menús desplegables son una característica <i>JavaScript</i> disponible gracias a una biblioteca externa llamada %{link}.
         dropdowns_usage_1_description: 2. Un elemento modal, cuya <code>id</code> coincide con el valor de los controles de datos al que se refiere el activador.
         dropdowns_usage_description: 'Un menú desplegable requiere dos elementos:'
-        dropdowns_usage_description_html: 1. Un elemento accionable por la participante, con los atributos de datos <code>data-component="dropdown" data-target="dropdown-menu-element"</code>.
+        dropdowns_usage_description_html: 1. Un elemento accionable por la participante, con los atributos de datos <code>data-controller="dropdown" data-target="dropdown-menu-element"</code>.
         dummy_description: Descripción del recurso ficticio
         dummy_title: Título del recurso ficticio
         follow_button: Botón "Seguir"

--- a/decidim-elections/app/views/decidim/elections/admin/elections/_actions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-election-<%= election.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: present(election).title(html_escape: true)) %>">
+<button type="button" data-controller="dropdown" data-target="actions-election-<%= election.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: present(election).title(html_escape: true)) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -76,7 +76,7 @@ describe "Admin manages elections" do
   describe "updating an election" do
     it "updates an election" do
       within "tr", text: translated(election.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit election"
       end
 

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/responses/index.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/responses/index.html.erb
@@ -42,7 +42,7 @@
               <%= l participant.responded_at, format: :short %>
             </td>
             <td data-label="<%= t("actions.actions", scope: "decidim.admin") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-participant-<%= participant.id %>"
+              <button type="button" data-controller="dropdown" data-target="actions-participant-<%= participant.id %>"
                 aria-label="<%= t("decidim.admin.actions.actions_label", resource: participant.session_token) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_responses.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaire_responses.rb
@@ -25,7 +25,7 @@ shared_examples_for "manage questionnaire responses" do
 
     it "shows the response admin link" do
       within "tr", text: decidim_sanitize_translated(survey.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Questions"
       end
       expect(page).to have_content("Responses")
@@ -34,7 +34,7 @@ shared_examples_for "manage questionnaire responses" do
     context "and managing responses page" do
       before do
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Questions"
         end
         click_on "Responses"
@@ -53,7 +53,7 @@ shared_examples_for "manage questionnaire responses" do
 
       it "has a detail link" do
         within "tr", text: decidim_sanitize_translated(response1.body) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_link("Show responses")
         end
       end
@@ -62,7 +62,7 @@ shared_examples_for "manage questionnaire responses" do
         expect(page).to have_link(response1.body)
         expect(page).to have_link(response2.body)
         within "tr", text: decidim_sanitize_translated(response1.body) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_link("Export")
         end
       end
@@ -87,7 +87,7 @@ shared_examples_for "manage questionnaire responses" do
 
         it "shows the responses page with custom body" do
           within "tr", text: decidim_sanitize_translated(response1.session_token) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             new_window = window_opened_by { click_on "Show responses" }
             page.within_window(new_window) do
               within "#responses" do
@@ -105,7 +105,7 @@ shared_examples_for "manage questionnaire responses" do
 
       before do
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Questions"
         end
         click_on "Responses"

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -43,7 +43,7 @@
           </td>
 
           <td class="table-list__actions" data-label="<%= t "actions", scope: "decidim.admin.models.initiatives_committee_member.fields" %>">
-            <button type="button" data-component="dropdown" data-target="actions-initiative-committee-request-<%= request.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: request.user.name) %>">
+            <button type="button" data-controller="dropdown" data-target="actions-initiative-committee-request-<%= request.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: request.user.name) %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -1,6 +1,6 @@
 <% menu_id = "top-#{SecureRandom.uuid}" %>
 <div class="relative">
-  <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="dropdown-exports-<%= menu_id %>-<%= dropdown_id(collection_ids) %>">
+  <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="dropdown-exports-<%= menu_id %>-<%= dropdown_id(collection_ids) %>">
     <% if collection_ids.present? %>
       <%= t("actions.export-selection", scope: "decidim.admin") %>
     <% else %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -45,7 +45,7 @@
             <td class="table-list__date" data-label="<%= t("models.initiatives.fields.created_at", scope: "decidim.admin") %>"><%= l initiative.created_at, format: :short %></td>
             <td class="table-list__date" data-label="<%= t("models.initiatives.fields.published_at", scope: "decidim.admin") %>"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
             <td class="table-list__actions" data-label="<%= t(".actions_title") %>">
-              <button type="button" data-component="dropdown" data-target="actions-initiative-<%= initiative.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(initiative.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-initiative-<%= initiative.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(initiative.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
@@ -35,7 +35,7 @@
             </td>
             <td class="table-list__actions" data-label="<%= t("models.initiatives_type_scope.fields.actions", scope: "decidim.admin") %>">
               <% if allowed_to? :edit, :initiative_type_scope, initiative_type_scope: s %>
-                <button type="button" data-component="dropdown" data-target="actions-initiative-type-scope-<%= s.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: s.scope_name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-initiative-type-scope-<%= s.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: s.scope_name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/index.html.erb
@@ -29,7 +29,7 @@
             <% end %>
           <td data-label="<%= t("models.initiatives_types.fields.created_at", scope: "decidim.admin") %>"><%= l initiative_type.created_at, format: :short %></td>
           <td class="table-list__actions" data-label="<%= t("initiatives_type.actions.title", scope: "decidim.resources") %>">
-            <button type="button" data-component="dropdown" data-target="actions-initiative-type-<%= initiative_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: initiative_type.title) %>">
+            <button type="button" data-controller="dropdown" data-target="actions-initiative-type-<%= initiative_type.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: initiative_type.title) %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-initiatives/app/views/layouts/decidim/admin/_manage_initiatives.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/_manage_initiatives.html.erb
@@ -1,5 +1,5 @@
 <div class="inline-block relative">
-  <%= button_tag data: { component: "dropdown", target: "initiatives-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+  <%= button_tag data: { controller: "dropdown", target: "initiatives-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
     <span>
       <%= t("menu.manage", scope: "decidim.admin") %>
     </span>

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -67,7 +67,7 @@ describe "Admin manages initiative components" do
     context "and then edit it" do
       before do
         within "tr", text: translated(attributes[:name]) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
       end
@@ -109,7 +109,7 @@ describe "Admin manages initiative components" do
 
     it "updates the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -135,7 +135,7 @@ describe "Admin manages initiative components" do
       expect(page).to have_content(translated(attributes[:name]))
 
       within "tr", text: translated(attributes[:name]) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -171,7 +171,7 @@ describe "Admin manages initiative components" do
 
     it "soft deletes the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on("Move to trash") }
       end
 
@@ -196,12 +196,12 @@ describe "Admin manages initiative components" do
     context "when the component is unpublished" do
       it "publishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Hide")
         end
       end
@@ -212,12 +212,12 @@ describe "Admin manages initiative components" do
 
       it "hides the component from the menu" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Hide"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
       end
@@ -229,12 +229,12 @@ describe "Admin manages initiative components" do
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Publish")
         end
       end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_scopes_spec.rb
@@ -46,7 +46,7 @@ describe "Admin manages initiatives types scopes" do
 
     it "updates the initiative type scope" do
       within "#panel-initiative_type_scope tr", text: translated_attribute(initiative_type_scope.scope_name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
       click_on "Update"

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -52,7 +52,7 @@ describe "Admin manages initiatives types" do
   context "when updating an initiative type" do
     it "updates the initiative type" do
       within "tr", text: translated(initiatives_type.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -86,7 +86,7 @@ describe "Admin manages initiatives types" do
   context "when deleting an initiative type" do
     it "deletes the initiative type" do
       within "tr", text: translated(initiatives_type.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm do
           click_on "Delete"
         end

--- a/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/answer_initiative_spec.rb
@@ -14,7 +14,7 @@ describe "User answers the initiative" do
 
     it "answer is allowed" do
       within("tr", text: translated(initiative.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer"
       end
 
@@ -43,7 +43,7 @@ describe "User answers the initiative" do
       context "and signature dates are editable" do
         it "can be edited in answer" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Answer"
           end
 
@@ -71,7 +71,7 @@ describe "User answers the initiative" do
         context "when dates are invalid" do
           it "returns an error message" do
             within("tr", text: translated(initiative.title)) do
-              find("button[data-component='dropdown']").click
+              find("button[data-controller='dropdown']").click
               click_on "Answer"
             end
 
@@ -109,7 +109,7 @@ describe "User answers the initiative" do
 
       it "signature dates are not displayed" do
         within("tr", text: translated(initiative.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Answer"
         end
 

--- a/decidim-initiatives/spec/system/admin/export_initiative_signatures_spec.rb
+++ b/decidim-initiatives/spec/system/admin/export_initiative_signatures_spec.rb
@@ -16,7 +16,7 @@ describe "Admin export initiatives' signature" do
     visit decidim_admin_initiatives.initiatives_path
 
     within("tr", text: translated(initiative.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 

--- a/decidim-initiatives/spec/system/admin/preview_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/preview_initiative_spec.rb
@@ -15,7 +15,7 @@ describe "User previews initiative" do
     it "shows the details of the given initiative" do
       preview_window = window_opened_by do
         within("tr", text: translated(initiative.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Preview"
         end
       end

--- a/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/print_initiative_spec.rb
@@ -138,7 +138,7 @@ describe "User prints the initiative" do
 
         it "shows a printable form with all available data about the initiative", :download do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Print"
           end
           expect(File.basename(download_path)).to include("initiative_submit_#{initiative.id}.pdf")
@@ -150,7 +150,7 @@ describe "User prints the initiative" do
 
         it "does not show the print link" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             expect(page).to have_no_content("Print")
           end
         end

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -17,7 +17,7 @@ describe "User prints the initiative" do
 
       it "Updates published initiative data" do
         within("tr", text: translated(initiative.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -37,7 +37,7 @@ describe "User prints the initiative" do
 
       it "updates the initiative" do
         within("tr", text: translated(initiative.title)) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -68,7 +68,7 @@ describe "User prints the initiative" do
 
         it "updates type, scope and signature type" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -87,7 +87,7 @@ describe "User prints the initiative" do
 
         it "displays initiative attachments" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -103,7 +103,7 @@ describe "User prints the initiative" do
 
         it "updates type, scope and signature type" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -122,7 +122,7 @@ describe "User prints the initiative" do
 
         it "displays initiative attachments" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -138,7 +138,7 @@ describe "User prints the initiative" do
 
         it "update of type, scope and signature type are disabled" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -151,7 +151,7 @@ describe "User prints the initiative" do
 
         it "displays initiative attachments" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 
@@ -170,7 +170,7 @@ describe "User prints the initiative" do
 
         it "update of type, scope and signature type are disabled" do
           within("tr", text: translated(initiative.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Edit"
           end
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-meeting-<%= meeting.id %>" aria-label="<%= t("actions.actions_label", scope: "decidim.admin") %>">
+<button type="button" data-controller="dropdown" data-target="actions-meeting-<%= meeting.id %>" aria-label="<%= t("actions.actions_label", scope: "decidim.admin") %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations/edit.html.erb
@@ -8,7 +8,7 @@
 
       <% if allowed_to? :export_registrations, :meeting, meeting: meeting %>
         <div class="relative">
-          <button class="button button__sm button__transparent-secondary" data-component="dropdown" data-target="export-dropdown">
+          <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="export-dropdown">
             <%= t "actions.export", scope: "decidim.admin" %>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-down-s-line" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/registrations_attendees/index.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/registrations_attendees/index.html.erb
@@ -7,7 +7,7 @@
 
       <% if allowed_to? :export_registrations, :meeting, meeting: meeting %>
         <div class="relative">
-          <button class="exports button button__sm button__transparent-secondary button--title" data-component="dropdown" data-target="export-dropdown">
+          <button class="exports button button__sm button__transparent-secondary button--title" data-controller="dropdown" data-target="export-dropdown">
             <%= t "actions.export", scope: "decidim.admin" %>
             <%= icon "arrow-down-s-line" %>
             <%= icon "arrow-down-s-line" %>
@@ -89,7 +89,7 @@
                 </td>
                 <td class="table-list__actions" data-label="<%= t("models.registration.actions", scope: "decidim.meetings") %>">
                   <% if allowed_to? :update, :meeting, meeting: meeting %>
-                    <button type="button" data-component="dropdown" data-target="actions-meeting-registration-<%= registration.id %>" aria-label="<%= t("actions.actions_label", scope: "decidim.admin", resource: translated_attribute(meeting.title)) %>">
+                    <button type="button" data-controller="dropdown" data-target="actions-meeting-registration-<%= registration.id %>" aria-label="<%= t("actions.actions_label", scope: "decidim.admin", resource: translated_attribute(meeting.title)) %>">
                       <%= icon "more-fill", class: "text-secondary" %>
                     </button>
 

--- a/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
+++ b/decidim-meetings/spec/shared/duplicate_meetings_examples.rb
@@ -23,7 +23,7 @@ shared_examples "duplicate meetings" do
     visit meetings_path
 
     within "tr", text: translated(meeting.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Duplicate"
     end
     click_on "Copy"

--- a/decidim-meetings/spec/shared/manage_agenda_examples.rb
+++ b/decidim-meetings/spec/shared/manage_agenda_examples.rb
@@ -91,7 +91,7 @@ shared_examples "manage agenda" do
     visit_component_admin
 
     within "tr", text: translated(meeting.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Agenda"
     end
   end

--- a/decidim-meetings/spec/shared/manage_attachment_collections_examples.rb
+++ b/decidim-meetings/spec/shared/manage_attachment_collections_examples.rb
@@ -5,7 +5,7 @@ shared_examples "manage meetings attachment collections" do
 
   before do
     within "tr", text: translated(meeting.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add folder"
     end
   end

--- a/decidim-meetings/spec/shared/manage_attachments_examples.rb
+++ b/decidim-meetings/spec/shared/manage_attachments_examples.rb
@@ -8,7 +8,7 @@ shared_examples "manage meetings attachments" do
 
   before do
     within "tr", text: translated(meeting.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Add attachment"
     end
   end

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -2,7 +2,7 @@
 
 def visit_meeting_invites_page
   within "tr", text: translated(meeting.title) do
-    find("button[data-component='dropdown']").click
+    find("button[data-controller='dropdown']").click
     click_on "Registrations"
   end
 

--- a/decidim-meetings/spec/shared/manage_registrations_attendees_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_attendees_examples.rb
@@ -2,7 +2,7 @@
 
 def visit_registrations_attendees_page
   within "tr", text: translated(meeting.title) do
-    find("button[data-component='dropdown']").click
+    find("button[data-controller='dropdown']").click
     click_on "Registrations"
   end
   click_on "View registrations"
@@ -62,7 +62,7 @@ shared_examples "manage registrations attendees" do
       it "can mark user as attendee" do
         within "tr", text: registration.user.email do
           expect(page).to have_content "Not attended"
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Mark as attendee"
         end
 

--- a/decidim-meetings/spec/shared/manage_registrations_examples.rb
+++ b/decidim-meetings/spec/shared/manage_registrations_examples.rb
@@ -2,7 +2,7 @@
 
 def visit_edit_registrations_page
   within "tr", text: translated(meeting.title) do
-    find("button[data-component='dropdown']").click
+    find("button[data-controller='dropdown']").click
     click_on "Registrations"
   end
 end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
@@ -27,7 +27,7 @@ describe "Admin copies meetings" do
 
     it "creates a new Online meeting", :slow do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -81,7 +81,7 @@ describe "Admin copies meetings" do
 
     it "creates a new hybrid meeting", :slow do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -143,7 +143,7 @@ describe "Admin copies meetings" do
 
     it "creates a new In person meeting", :slow do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
@@ -28,7 +28,7 @@ describe "Admin manages meetings" do
   describe "linking a meeting" do
     it "creates a new link" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_polls_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_polls_spec.rb
@@ -22,7 +22,7 @@ describe "Admin manages meetings polls" do
     it "shows manage poll action" do
       visit current_path
       within "tr", text: translated(meeting.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Manage poll"
       end
 

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -46,14 +46,14 @@ describe "Admin manages meetings" do
       visit current_path
 
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Unpublish" }
       end
 
       expect(page).to have_admin_callout("successfully")
 
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_content("Publish")
       end
 
@@ -64,7 +64,7 @@ describe "Admin manages meetings" do
       expect(page).to have_admin_callout("successfully")
 
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_content("Unpublish")
       end
 
@@ -98,7 +98,7 @@ describe "Admin manages meetings" do
   describe "when rendering the text in the update page" do
     before do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -170,7 +170,7 @@ describe "Admin manages meetings" do
   it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='meeting-description-tabs']", "full" do
     before do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -178,7 +178,7 @@ describe "Admin manages meetings" do
 
   it "updates a meeting" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -215,7 +215,7 @@ describe "Admin manages meetings" do
 
   it "sets registration enabled to true when registration type is on this platform" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -231,7 +231,7 @@ describe "Admin manages meetings" do
 
   it "sets registration enabled to false when registration type is not on this platform" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -247,7 +247,7 @@ describe "Admin manages meetings" do
 
   it "adds a few services to the meeting" do
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -263,7 +263,7 @@ describe "Admin manages meetings" do
     expect(page).to have_admin_callout("successfully")
 
     within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit"
     end
 
@@ -274,7 +274,7 @@ describe "Admin manages meetings" do
   describe "previewing" do
     it "allows the user to preview a published meeting" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         preview_window = window_opened_by { click_on "Preview" }
 
         within_window preview_window do
@@ -290,7 +290,7 @@ describe "Admin manages meetings" do
         visit current_path
 
         within "tr", text: Decidim::Meetings::MeetingPresenter.new(unpublished_meeting).title do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           preview_window = window_opened_by { click_on "Preview" }
 
           within_window preview_window do
@@ -523,7 +523,7 @@ describe "Admin manages meetings" do
 
     it "deletes a meeting" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting2).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Move to trash" }
       end
 
@@ -550,7 +550,7 @@ describe "Admin manages meetings" do
 
     it "updates a meeting" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -650,7 +650,7 @@ describe "Admin manages meetings" do
 
     it "closes a meeting with a report" do
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Close"
       end
 
@@ -704,7 +704,7 @@ describe "Admin manages meetings" do
 
       before do
         within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Close"
         end
       end
@@ -721,7 +721,7 @@ describe "Admin manages meetings" do
 
       it "can update the information" do
         within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Close"
         end
 
@@ -741,7 +741,7 @@ describe "Admin manages meetings" do
 
       it "does not display the proposal picker" do
         within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Close"
         end
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
@@ -37,7 +37,7 @@
               <% end %>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.participatory_process_group.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-process-group-<%= group.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(group.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-process-group-<%= group.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(group.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/index.html.erb
@@ -42,7 +42,7 @@
                 <% end %>
               </td>
               <td class="table-list__actions" data-label="<%= t("models.participatory_process_step.fields.actions", scope: "decidim.admin") %>">
-                <button type="button" data-component="dropdown" data-target="actions-process-step-<%= step.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(step.title)) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-process-step-<%= step.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(step.title)) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_user_roles/index.html.erb
@@ -45,7 +45,7 @@
               <%= t("#{role.role}", scope: "decidim.admin.models.participatory_process_user_role.roles") %><br>
             </td>
             <td class="table-list__actions" data-label="<%= t("models.participatory_process_user_role.fields.actions", scope: "decidim.admin") %>">
-              <button type="button" data-component="dropdown" data-target="actions-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-user-role-<%= role.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: role.user.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_process_row.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_process_row.html.erb
@@ -29,7 +29,7 @@
     <% end %>
   </td>
   <td class="table-list__actions" data-label="<%= t("models.participatory_process.fields.actions", scope: "decidim.admin") %>">
-    <button type="button" data-component="dropdown" data-target="actions-process-<%= process.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(process.title)) %>">
+    <button type="button" data-controller="dropdown" data-target="actions-process-<%= process.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(process.title)) %>">
       <%= icon "more-fill", class: "text-secondary" %>
     </button>
 

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/_manage_processes.html.erb
@@ -1,5 +1,5 @@
 <div class="inline-block relative">
-  <%= button_tag data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+  <%= button_tag data: { controller: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
     <span>
       <%= t("menu.manage", scope: "decidim.admin") %>
     </span>

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     <% end %>
     <div class="inline-block relative">
-      <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
+      <%= button_tag id: "processes-menu-trigger", data: { controller: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
         <span>
           <%= t("menu.manage", scope: "decidim.admin") %>
         </span>

--- a/decidim-participatory_processes/spec/shared/manage_participatory_process_private_users_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_participatory_process_private_users_examples.rb
@@ -62,7 +62,7 @@ shared_examples "manage participatory process private users examples" do
 
     it "deletes an assembly_private_user" do
       within "#private_users tr", text: other_user.email do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -90,7 +90,7 @@ shared_examples "manage participatory process private users examples" do
 
       it "resends the invitation to the user" do
         within "#private_users tr", text: "test@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_admins_examples.rb
@@ -57,7 +57,7 @@ shared_examples "manage process admins examples" do
     it "updates a process admin", versioning: true do
       within "#process_admins" do
         within "#process_admins tr", text: other_user.email do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
       end
@@ -80,7 +80,7 @@ shared_examples "manage process admins examples" do
 
     it "deletes a participatory_process_user_role" do
       within "#process_admins tr", text: other_user.email do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -112,7 +112,7 @@ shared_examples "manage process admins examples" do
 
       it "resends the invitation to the user" do
         within "#process_admins tr", text: "test@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Resend invitation"
         end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -68,7 +68,7 @@ shared_examples "manage process components" do
       context "and then edit it" do
         before do
           within "tr", text: translated(attributes[:name]) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Configure"
           end
         end
@@ -142,7 +142,7 @@ shared_examples "manage process components" do
       context "and then edit it" do
         before do
           within "tr", text: "My component" do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Configure"
           end
         end
@@ -192,7 +192,7 @@ shared_examples "manage process components" do
 
     it "updates the component" do
       within ".component-#{component.id}" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -218,7 +218,7 @@ shared_examples "manage process components" do
       expect(page).to have_content(translated(attributes[:name]))
 
       within "tr", text: translated(attributes[:name]) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Configure"
       end
 
@@ -239,7 +239,7 @@ shared_examples "manage process components" do
 
       it "updates the default step settings" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
 
@@ -254,7 +254,7 @@ shared_examples "manage process components" do
         expect(page).to have_admin_callout("successfully")
 
         within "tr", text: "My component" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Configure"
         end
 
@@ -280,12 +280,12 @@ shared_examples "manage process components" do
     context "when the component is unpublished" do
       it "publishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Hide")
         end
       end
@@ -295,7 +295,7 @@ shared_examples "manage process components" do
         create(:follow, followable: participatory_process, user: follower)
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Publish"
         end
 
@@ -317,12 +317,12 @@ shared_examples "manage process components" do
 
       it "hides the component from the menu" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Hide"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
       end
@@ -334,12 +334,12 @@ shared_examples "manage process components" do
 
       it "unpublishes the component" do
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
 
         within ".component-#{component.id}" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Publish")
         end
       end

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -64,7 +64,7 @@ shared_examples "manage process steps examples" do
   it "updates a participatory_process_step", versioning: true do
     within "#steps" do
       within "tr", text: translated(process_step.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end
@@ -97,7 +97,7 @@ shared_examples "manage process steps examples" do
 
     it "deletes a participatory_process_step" do
       within "tr", text: translated(process_step2.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -112,7 +112,7 @@ shared_examples "manage process steps examples" do
   context "when activating a step" do
     it "activates a step" do
       within "tr", text: translated(process_step.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Activate"
       end
 

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -51,7 +51,7 @@ shared_examples "manage processes examples" do
       it "allows the user to preview the unpublished process" do
         new_window = window_opened_by do
           within("tr", text: translated(participatory_process.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Preview"
           end
         end
@@ -69,7 +69,7 @@ shared_examples "manage processes examples" do
       it "allows the user to preview the published process" do
         new_window = window_opened_by do
           within("tr", text: translated(participatory_process.title)) do
-            find("button[data-component='dropdown']").click
+            find("button[data-controller='dropdown']").click
             click_on "Preview"
           end
         end
@@ -145,14 +145,14 @@ shared_examples "manage processes examples" do
 
     it "publishes the process" do
       within("tr", text: translated_attribute(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Publish", visible: true).click
       end
 
       expect(page).to have_content("successfully published")
 
       within("tr", text: translated_attribute(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_content("Unpublish")
       end
 
@@ -172,7 +172,7 @@ shared_examples "manage processes examples" do
 
     it "unpublishes the process" do
       within("tr", text: translated_attribute(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         find("a", text: "Unpublish", visible: true).click
       end
 

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -30,7 +30,7 @@ shared_examples "manage processes announcements" do
 
     new_window = window_opened_by do
       within("tr", text: translated(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Preview"
       end
     end

--- a/decidim-participatory_processes/spec/system/admin/admin_copy_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_copy_participatory_process_spec.rb
@@ -17,7 +17,7 @@ describe "Admin copies participatory process" do
   context "without any context" do
     it "copies the process with the basic fields" do
       within("tr", text: translated(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -42,7 +42,7 @@ describe "Admin copies participatory process" do
   context "with context" do
     before do
       within("tr", text: translated(participatory_process.title)) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
@@ -72,7 +72,7 @@ describe "Admin manages participatory process groups" do
 
     it "can edit them" do
       within "tr", text: participatory_process_group.title["en"] do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -106,7 +106,7 @@ describe "Admin manages participatory process groups" do
 
     it "validates the group attributes" do
       within "tr", text: participatory_process_group.title["en"] do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -127,7 +127,7 @@ describe "Admin manages participatory process groups" do
 
     it "can remove its image" do
       within "tr", text: participatory_process_group.title["en"] do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -145,7 +145,7 @@ describe "Admin manages participatory process groups" do
 
     it "can delete them" do
       within "tr", text: participatory_process_group.title["en"] do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -158,7 +158,7 @@ describe "Admin manages participatory process groups" do
 
     it "has a link to the landing page" do
       within "tr", text: participatory_process_group.title["en"] do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_publication_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_publication_spec.rb
@@ -22,7 +22,7 @@ describe "Admin manages participatory process publication" do |_options|
     visit admin_page_path
 
     within("tr", text: translated_attribute(participatory_space.title)) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Publish"
     end
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
@@ -31,7 +31,7 @@
               </strong>
             </td>
             <td data-label="<%= t("actions.title", scope: "decidim.proposals") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-proposal-state-<%= state.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(state.title)) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-proposal-state-<%= state.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(state.title)) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_actions.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-component="dropdown" data-target="actions-proposal-<%= proposal.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: proposal.title) %>">
+<button type="button" data-controller="dropdown" data-target="actions-proposal-<%= proposal.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: proposal.title) %>">
   <%= icon "more-fill", class: "text-secondary" %>
 </button>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/bulk_actions/_dropdown.html.erb
@@ -3,7 +3,7 @@
     id="js-bulk-actions-button"
     class="button button__sm button__transparent-secondary"
     type="button"
-    data-component="dropdown"
+    data-controller="dropdown"
     data-target="js-bulk-actions-dropdown">
     <%= t("decidim.proposals.admin.proposals.index.actions") %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_voting_rules.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_voting_rules.html.erb
@@ -1,5 +1,5 @@
 <div id="proposal-voting-rules" class="flash flex-col p-0 gap-0">
-  <button id="dropdown-trigger-proposal-voting-rules" data-component="dropdown" data-target="dropdown-menu-proposal-voting-rules" class="flash__title">
+  <button id="dropdown-trigger-proposal-voting-rules" data-controller="dropdown" data-target="dropdown-menu-proposal-voting-rules" class="flash__title">
       <%= t("title", scope: "decidim.proposals.proposals.voting_rules") %>
       <%= icon "arrow-down-s-line" %>
       <%= icon "arrow-up-s-line" %>

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -17,7 +17,7 @@ shared_examples "manage proposals" do
   context "when previewing proposals" do
     it "allows the user to preview the proposal" do
       within "tr", text: proposal_title do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         preview_window = window_opened_by { click_on "Preview" }
 
         within_window preview_window do
@@ -506,7 +506,7 @@ shared_examples "manage proposals" do
   def go_to_admin_proposal_page(proposal)
     proposal_title = translated(proposal.title)
     within "tr", text: proposal_title do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Answer proposal"
     end
   end

--- a/decidim-proposals/spec/shared/manage_proposals_settings_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_settings_examples.rb
@@ -9,7 +9,7 @@ shared_examples "manage settings" do
     end
 
     within "tr", text: translated(component.name) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Configure"
     end
   end

--- a/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_answers_proposal_spec.rb
@@ -30,7 +30,7 @@ describe "Admin answers proposals" do
 
     it "when accepting, can submit answer with a text answer" do
       within "tr", text: translated(proposals.first.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer proposal"
       end
       find("label[for='proposal_answer_internal_state_accepted']").click
@@ -48,7 +48,7 @@ describe "Admin answers proposals" do
 
       before do
         within "tr", text: translated(proposals.first.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Answer proposal"
         end
         fill_in_i18n_editor(

--- a/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
@@ -38,7 +38,7 @@ describe "Admin creates proposals" do
 
     click_on("Create")
     within "tr", text: translated_attribute(new_title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Edit proposal"
     end
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -30,7 +30,7 @@ describe "Admin edits proposals" do
       visit_component_admin
 
       within "tr[data-id='#{proposal.id}']" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit proposal"
       end
       expect(page).to have_content "Update proposal"
@@ -40,7 +40,7 @@ describe "Admin edits proposals" do
       click_on "Update"
 
       within "tr[data-id='#{proposal.id}']" do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         preview_window = window_opened_by { click_on "Preview" }
 
         within_window preview_window do
@@ -65,7 +65,7 @@ describe "Admin edits proposals" do
 
         expect(page).to have_content(translated(proposal.title))
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           expect(page).to have_css(".dropdown__button-disabled span", text: "Edit proposal")
         end
         visit current_path + "proposals/#{proposal.id}/edit"
@@ -96,7 +96,7 @@ describe "Admin edits proposals" do
       it "can be remove attachment" do
         visit_component_admin
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
         within ".item__edit-form" do
@@ -107,7 +107,7 @@ describe "Admin edits proposals" do
 
         visit_component_admin
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
         expect(page).to have_no_content("Current file")
@@ -116,7 +116,7 @@ describe "Admin edits proposals" do
       it "can attach a file" do
         visit_component_admin
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
         dynamically_attach_file(:proposal_documents, image_path)
@@ -130,7 +130,7 @@ describe "Admin edits proposals" do
         click_on("Update")
 
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
 
@@ -148,7 +148,7 @@ describe "Admin edits proposals" do
       expect(page).to have_content(translated(proposal.title))
 
       within "tr", text: translated_attribute(proposal.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         expect(page).to have_css(".dropdown__button-disabled span", text: "Edit proposal")
       end
 

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_evaluators_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_evaluators_spec.rb
@@ -202,7 +202,7 @@ describe "Admin manages proposals evaluators" do
 
       visit current_path
       within "tr", text: translated(proposal.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer proposal"
       end
     end

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
@@ -128,7 +128,7 @@ describe "Admin manages proposals states" do
 
     it "updates a proposal state" do
       within "tr", text: translated(proposal_state.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -161,7 +161,7 @@ describe "Admin manages proposals states" do
 
     it "updates the label and announcement previews" do
       within "tr", text: translated(proposal_state.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -210,7 +210,7 @@ describe "Admin manages proposals states" do
 
     it "deletes the proposal state" do
       within "tr", text: translated(state.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
       expect(page).to have_admin_callout("successfully")

--- a/decidim-proposals/spec/system/admin/evaluator_manages_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/evaluator_manages_proposals_spec.rb
@@ -52,7 +52,7 @@ describe "Evaluator manages proposals" do
   context "when in the proposal page" do
     before do
       within "tr", text: translated(assigned_proposal.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer proposal"
       end
     end

--- a/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
@@ -158,7 +158,7 @@ describe "Admin filters proposals" do
 
       it "stores the filters in the session and recovers it when visiting the component page" do
         within("tr[data-id='#{answered_proposal_with_taxonomy1.id}']") do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on("Answer proposal")
         end
 
@@ -192,7 +192,7 @@ describe "Admin filters proposals" do
         ids = find_all("tr[data-id]").map { |node| node["data-id"].to_i }
 
         within("tr[data-id='#{ids[0]}']") do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on("Answer proposal")
         end
 

--- a/decidim-proposals/spec/system/admin/index_proposal_notes_spec.rb
+++ b/decidim-proposals/spec/system/admin/index_proposal_notes_spec.rb
@@ -27,7 +27,7 @@ describe "Index Proposal Notes" do
 
   before do
     within "tr", text: translated(proposal.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Answer proposal"
     end
     click_on "Private notes"

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -265,7 +265,7 @@ describe "Admin views proposal details from admin" do
 
   def go_to_admin_proposal_page(proposal)
     within "tr", text: translated(proposal.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Answer proposal"
     end
   end

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -36,7 +36,7 @@
             <%= l sortition.created_at, format: :short %>
           </td>
           <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.sortitions.admin") %>">
-            <button type="button" data-component="dropdown" data-target="actions-sortition-<%= sortition.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: sortition.title) %>">
+            <button type="button" data-controller="dropdown" data-target="actions-sortition-<%= sortition.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: sortition.title) %>">
               <%= icon "more-fill", class: "text-secondary" %>
             </button>
 

--- a/decidim-sortitions/spec/shared/cancel_sortitions_examples.rb
+++ b/decidim-sortitions/spec/shared/cancel_sortitions_examples.rb
@@ -7,7 +7,7 @@ shared_examples "cancel sortitions" do
     before do
       visit_component_admin
       within "tr", text: decidim_escape_translated(sortition.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Cancel the sortition"
       end
     end

--- a/decidim-sortitions/spec/shared/update_sortitions_examples.rb
+++ b/decidim-sortitions/spec/shared/update_sortitions_examples.rb
@@ -8,7 +8,7 @@ shared_examples "update sortitions" do
     before do
       visit_component_admin
       within "tr", text: decidim_escape_translated(sortition.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
     end

--- a/decidim-sortitions/spec/system/decidim/sortitions/admin/index_spec.rb
+++ b/decidim-sortitions/spec/system/decidim/sortitions/admin/index_spec.rb
@@ -19,7 +19,7 @@ describe "index" do
 
   it "Contains a button that shows sortition details" do
     within "tr", text: decidim_escape_translated(sortition.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       expect(page).to have_link("Sortition details")
     end
   end

--- a/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
@@ -61,7 +61,7 @@
               <%= l participant.responded_at, format: :short %>
             </td>
             <td data-label="<%= t("actions.title", scope: "decidim.surveys") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-participant-<%= idx %>" aria-label="<%= t("decidim.admin.actions.actions_label") %>">
+              <button type="button" data-controller="dropdown" data-target="actions-participant-<%= idx %>" aria-label="<%= t("decidim.admin.actions.actions_label") %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -34,7 +34,7 @@
               <%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %>
             </td>
             <td data-label="<%= t("actions.title", scope: "decidim.surveys") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-survey-<%= survey.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: survey.title) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-survey-<%= survey.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: survey.title) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-surveys/spec/shared/export_survey_user_responses_examples.rb
+++ b/decidim-surveys/spec/shared/export_survey_user_responses_examples.rb
@@ -12,7 +12,7 @@ shared_examples "export survey user responses" do
   it "exports a CSV" do
     visit_component_admin
     within "tr", text: decidim_sanitize_translated(survey.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Questions"
     end
     click_on "Responses"
@@ -32,7 +32,7 @@ shared_examples "export survey user responses" do
   it "exports a JSON" do
     visit_component_admin
     within "tr", text: decidim_sanitize_translated(survey.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Questions"
     end
     click_on "Responses"
@@ -52,7 +52,7 @@ shared_examples "export survey user responses" do
   it "exports a PDF" do
     visit_component_admin
     within "tr", text: decidim_sanitize_translated(survey.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Questions"
     end
     click_on "Responses"
@@ -73,7 +73,7 @@ shared_examples "export survey user responses" do
 
     visit_component_admin
     within "tr", text: decidim_sanitize_translated(survey.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Questions"
     end
     click_on "Responses"
@@ -81,7 +81,7 @@ shared_examples "export survey user responses" do
     expect(Decidim::PrivateExport.count).to eq(0)
 
     within "tr", text: "hola2" do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       perform_and_wait_for_enqueued_jobs { click_on "Export" }
     end
 

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -24,7 +24,7 @@ describe "Admin manages surveys" do
   context "with a new survey" do
     before do
       within "tr", text: decidim_sanitize_translated(survey.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Questions"
       end
     end
@@ -63,7 +63,7 @@ describe "Admin manages surveys" do
 
       it "shows warning message" do
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Questions"
         end
         expect(page).to have_content("The form is not published")
@@ -71,7 +71,7 @@ describe "Admin manages surveys" do
 
       it "allows editing questions" do
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Questions"
         end
         click_on "Expand all"
@@ -81,7 +81,7 @@ describe "Admin manages surveys" do
 
       it "deletes responses after published" do
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Questions"
         end
         click_on "Expand all"
@@ -95,13 +95,13 @@ describe "Admin manages surveys" do
         all("a", text: translated_attribute(component.name))[0].click
 
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
         expect(page).to have_admin_callout "Survey successfully unpublished"
 
         within "tr", text: decidim_sanitize_translated(survey.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on("Publish") }
         end
         expect(page).to have_admin_callout "Survey successfully published"
@@ -127,12 +127,12 @@ describe "Admin manages surveys" do
               all("a", text: translated_attribute(component.name))[0].click
 
               within "tr", text: decidim_sanitize_translated(survey.title) do
-                find("button[data-component='dropdown']").click
+                find("button[data-controller='dropdown']").click
                 click_on "Unpublish"
               end
 
               within "tr", text: decidim_sanitize_translated(survey.title) do
-                find("button[data-component='dropdown']").click
+                find("button[data-controller='dropdown']").click
                 click_on "Publish"
               end
 
@@ -145,7 +145,7 @@ describe "Admin manages surveys" do
               all("a", text: translated_attribute(component.name))[0].click
 
               within "tr", text: decidim_sanitize_translated(survey.title) do
-                find("button[data-component='dropdown']").click
+                find("button[data-controller='dropdown']").click
                 click_on "Edit"
               end
 

--- a/decidim-system/app/views/decidim/system/organizations/_advanced_settings.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/_advanced_settings.html.erb
@@ -1,4 +1,4 @@
-<button id="advanced-settings-trigger" data-component="dropdown" data-target="advanced-settings-panel" type="button" class="button button__sm md:button__lg button__primary w-fit" aria-expanded="false">
+<button id="advanced-settings-trigger" data-controller="dropdown" data-target="advanced-settings-panel" type="button" class="button button__sm md:button__lg button__primary w-fit" aria-expanded="false">
   <span><%= t(".show") %></span>
   <span><%= t(".hide") %></span>
 </button>

--- a/decidim-system/app/views/layouts/decidim/system/application.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/application.html.erb
@@ -13,7 +13,7 @@
 
   <main class="grow">
     <div class="flex md:hidden items-center gap-2 bg-primary p-4 text-white font-bold text-lg">
-      <button id="aside-trigger" class="flex-none md:hidden" data-component="dropdown" data-target="aside-system" data-disabled-md="true">
+      <button id="aside-trigger" class="flex-none md:hidden" data-controller="dropdown" data-target="aside-system" data-disabled-md="true">
         <%= icon "menu-line", class: "w-6 h-6 text-white fill-current" %>
       </button>
 

--- a/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/block_user_templates/index.html.erb
@@ -28,7 +28,7 @@
               <%= l template.created_at, format: :long %>
             </td>
             <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-              <button type="button" data-component="dropdown" data-target="actions-block-user-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-block-user-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
@@ -37,7 +37,7 @@
                 <%= l template.created_at, format: :long %>
               </td>
               <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-                <button type="button" data-component="dropdown" data-target="actions-proposal-answer-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-proposal-answer-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/questionnaire_templates/index.html.erb
@@ -36,7 +36,7 @@
                 <%= l template.created_at, format: :long %>
               </td>
               <td data-label="<%= t("decidim.admin.actions.actions") %>" class="table-list__actions">
-                <button type="button" data-component="dropdown" data-target="actions-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-template-<%= template.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: template.name) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-templates/spec/system/admin/admin_chooses_block_user_template_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_chooses_block_user_template_spec.rb
@@ -23,7 +23,7 @@ describe "Admin chooses user block templates when blocking user" do
     before do
       visit decidim_admin.moderated_users_path
       within "tr", text: user.name do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Block User"
       end
     end

--- a/decidim-templates/spec/system/admin/admin_manages_proposal_answer_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_manages_proposal_answer_templates_spec.rb
@@ -126,7 +126,7 @@ describe "Admin manages proposal answer templates" do
 
     it "copies the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -142,7 +142,7 @@ describe "Admin manages proposal answer templates" do
 
     it "destroys the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 
@@ -161,7 +161,7 @@ describe "Admin manages proposal answer templates" do
     before do
       visit Decidim::EngineRouter.admin_proxy(templatable).root_path
       within "tr", text: translated_attribute(proposal.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer proposal"
       end
     end
@@ -187,7 +187,7 @@ describe "Admin manages proposal answer templates" do
         template.destroy!
         visit Decidim::EngineRouter.admin_proxy(templatable).root_path
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Answer proposal"
         end
       end
@@ -204,7 +204,7 @@ describe "Admin manages proposal answer templates" do
       before do
         visit Decidim::EngineRouter.admin_proxy(templatable).root_path
         within "tr", text: translated_attribute(proposal.title) do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Answer proposal"
         end
       end

--- a/decidim-templates/spec/system/admin/admin_manages_questionnaire_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_manages_questionnaire_templates_spec.rb
@@ -216,7 +216,7 @@ describe "Admin manages questionnaire templates" do
 
     it "copies the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -234,7 +234,7 @@ describe "Admin manages questionnaire templates" do
 
     it "shows a functional questionnaire form" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Edit"
       end
 
@@ -280,7 +280,7 @@ describe "Admin manages questionnaire templates" do
 
     it "destroys the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-templates/spec/system/admin/admin_manages_user_block_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_manages_user_block_templates_spec.rb
@@ -124,7 +124,7 @@ describe "Admin manages user block templates" do
 
     it "copies the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Duplicate"
       end
 
@@ -142,7 +142,7 @@ describe "Admin manages user block templates" do
 
     it "destroys the template" do
       within "tr", text: translated(template.name) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         accept_confirm { click_on "Delete" }
       end
 

--- a/decidim-templates/spec/system/admin/evaluator_uses_proposal_answer_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/evaluator_uses_proposal_answer_templates_spec.rb
@@ -23,7 +23,7 @@ describe "Evaluator uses proposal answer templates" do
     login_as user, scope: :user
     visit Decidim::EngineRouter.admin_proxy(templatable).root_path
     within "tr", text: translated_attribute(proposal.title) do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Answer proposal"
     end
   end
@@ -51,7 +51,7 @@ describe "Evaluator uses proposal answer templates" do
       template.destroy!
       visit Decidim::EngineRouter.admin_proxy(templatable).root_path
       within "tr", text: translated_attribute(proposal.title) do
-        find("button[data-component='dropdown']").click
+        find("button[data-controller='dropdown']").click
         click_on "Answer proposal"
       end
     end

--- a/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/csv_census/admin/census/index.html.erb
@@ -40,7 +40,7 @@
                 <%= last_login_info[:last_sign_in] %>
               </td>
               <td data-label="<%= t("index.fields.actions", scope: "decidim.verifications.csv_census.admin") %>" class="table-list__actions">
-                <button type="button" data-component="dropdown" data-target="actions-census-log-<%= data.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: data.id) %>">
+                <button type="button" data-controller="dropdown" data-target="actions-census-log-<%= data.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: data.id) %>">
                   <%= icon "more-fill", class: "text-secondary" %>
                 </button>
 

--- a/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/postal_letter/admin/pending_authorizations/index.html.erb
@@ -35,7 +35,7 @@
               <%= authorization.letter_sent_at %>
             </td>
             <td class="table-list__actions" data-label="<%= t("decidim.admin.actions.actions") %>">
-              <button type="button" data-component="dropdown" data-target="actions-authorization-<%= authorization.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: authorization.user.name) %>">
+              <button type="button" data-controller="dropdown" data-target="actions-authorization-<%= authorization.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: authorization.user.name) %>">
                 <%= icon "more-fill", class: "text-secondary" %>
               </button>
 

--- a/decidim-verifications/spec/system/admin_manages_census_spec.rb
+++ b/decidim-verifications/spec/system/admin_manages_census_spec.rb
@@ -66,7 +66,7 @@ describe "Admin manages census" do
         expect(page).to have_content("this_email_does_not_exist@example.org")
 
         within "tr", text: "this_email_does_not_exist@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           click_on "Edit"
         end
 
@@ -80,7 +80,7 @@ describe "Admin manages census" do
 
       it "deletes the added census record" do
         within "tr", text: "this_email_does_not_exist@example.org" do
-          find("button[data-component='dropdown']").click
+          find("button[data-controller='dropdown']").click
           accept_confirm { click_on "Destroy" }
         end
         expect(page).to have_content("Census data record have been deleted.")

--- a/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
+++ b/decidim-verifications/spec/system/postal_letter/postal_letter_admin_spec.rb
@@ -62,7 +62,7 @@ describe "Postal letter management" do
 
   it "marks letters as sent" do
     within "table tbody tr", text: letter_not_sent.user.name do
-      find("button[data-component='dropdown']").click
+      find("button[data-controller='dropdown']").click
       click_on "Mark as sent"
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes a selector from `data-component="dropdown"` to `data-controller="dropdown"` aiming to simplify the PR that adds the HotWire & Stimulus

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14948 

#### Testing
1. Green pipeline 
2. Dropdowns in website should work

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
