### PR TITLE
Change the accordion data selector from component to controller

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -16,7 +16,7 @@
     </div>
   </div>
   <% if form.object.settings? %>
-    <div class="card" data-component="accordion" id="accordion-global_settings">
+    <div class="card" data-controller="accordion" id="accordion-global_settings">
       <div class="card-divider">
         <button class="card-divider-button" data-open="true" data-controls="panel-global_settings" type="button">
           <%= icon "arrow-right-s-line" %>
@@ -44,7 +44,7 @@
     </div>
   <% end %>
   <% if current_participatory_space.has_steps? %>
-    <div class="card" data-component="accordion" id="accordion-step_settings">
+    <div class="card" data-controller="accordion" id="accordion-step_settings">
       <div class="card-divider">
         <button class="card-divider-button" data-open="true" data-controls="panel-step_settings" type="button">
           <%= icon "arrow-right-s-line" %>
@@ -82,7 +82,7 @@
       </div>
     </div>
   <% elsif form.object.default_step_settings? %>
-    <div class="card" data-component="accordion" id="accordion-default_step_settings">
+    <div class="card" data-controller="accordion" id="accordion-default_step_settings">
       <div class="card-divider">
         <button class="card-divider-button" data-open="true" data-controls="panel-default_step_settings" type="button">
           <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/help_sections/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/help_sections/_form.html.erb
@@ -9,7 +9,7 @@
     <% f.object.sections.each do |section| %>
       <%= f.fields_for "sections[]", section do |section_form| %>
         <div class="form__wrapper">
-          <div class="card" data-component="accordion" id="accordion-<%= translated_attribute section.name %>">
+          <div class="card" data-controller="accordion" id="accordion-<%= translated_attribute section.name %>">
             <div class="card-divider">
               <button class="card-divider-button" data-open="true" data-controls="panel-<%= translated_attribute section.name %>" type="button">
                 <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_admin_terms_of_service.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_admin_terms_of_service.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-admin_terms_of_service">
+<div class="card" data-controller="accordion" id="accordion-admin_terms_of_service">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-admin_terms_of_service" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_basic_configuration.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_basic_configuration.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-basic_configuration">
+<div class="card" data-controller="accordion" id="accordion-basic_configuration">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-basic_configuration" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_colors.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-colors">
+<div class="card" data-controller="accordion" id="accordion-colors">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-colors" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-extra_features">
+<div class="card" data-controller="accordion" id="accordion-extra_features">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-extra_features" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_logos.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_logos.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-layout_appearance_title">
+<div class="card" data-controller="accordion" id="accordion-layout_appearance_title">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-layout_appearance_title" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_welcome_notification.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_welcome_notification.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-welcome_notification">
+<div class="card" data-controller="accordion" id="accordion-welcome_notification">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-welcome_notification" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -53,7 +53,7 @@
       </div>
     </div>
   </div>
-  <div class="card" data-component="accordion" id="accordion-duration">
+  <div class="card" data-controller="accordion" id="accordion-duration">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-duration" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -86,7 +86,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-images">
+  <div class="card" data-controller="accordion" id="accordion-images">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-images" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -109,7 +109,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-metadata">
+  <div class="card" data-controller="accordion" id="accordion-metadata">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-metadata" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -149,7 +149,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-taxonomies">
+  <div class="card" data-controller="accordion" id="accordion-taxonomies">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-taxonomies" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -176,7 +176,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-visibility">
+  <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -212,7 +212,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-other">
+  <div class="card" data-controller="accordion" id="accordion-other">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-other" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_addition_selector.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_addition_selector.html.erb
@@ -1,4 +1,4 @@
-<%= filter_form_for filter, url_for, data: { filters: "", component: "accordion" } do |form| %>
+<%= filter_form_for filter, url_for, data: { filters: "", controller: "accordion" } do |form| %>
   <%= form.collection_radio_buttons(
         :addition_type,
         filter_addition_type_values,

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -64,7 +64,7 @@ edit_link(
     </section>
     <section class="layout-main__section">
       <% if tabs.any? %>
-        <div class="mt-8" data-component="accordion" data-multiselectable="false" data-collapsible="false">
+        <div class="mt-8" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
           <ul class="tab-x-container">
             <% tabs.each_with_index do |tab, i| %>
               <li>

--- a/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/suggestion.js
+++ b/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/suggestion.js
@@ -189,7 +189,7 @@ export default class Suggestion {
   // Because the A11y accordion has not an API to programmatically toggle the
   // accordion, we need to destroy and recreate it to reset the state
   _resetAccordion() {
-    let accordion = this.boxWrapper.querySelector('[data-component="accordion"]');
+    let accordion = this.boxWrapper.querySelector('[data-controller="accordion"]');
     Accordions.destroy(accordion.id);
     createAccordion(accordion);
   }

--- a/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/test/suggestions.test.js
+++ b/decidim-collaborative_texts/app/packs/src/decidim/collaborative_texts/test/suggestions.test.js
@@ -42,7 +42,7 @@ describe("SuggestionsList", () => {
       </div>
 
       <script type="text/template" class="decidim-template" id="collaborative-texts-suggestions-box-template">
-        <div data-component="accordion" id="collaborative-texts-box-{{ID}}">
+        <div data-controller="accordion" id="collaborative-texts-box-{{ID}}">
           <button data-controls="panel-box-{{ID}}" aria-label="<%= t("decidim.collaborative_texts.document.toggle") %>" aria-expanded="false">
             <span>
             </span>

--- a/decidim-collaborative_texts/app/packs/stylesheets/decidim/collaborative_texts/collaborative_texts.scss
+++ b/decidim-collaborative_texts/app/packs/stylesheets/decidim/collaborative_texts/collaborative_texts.scss
@@ -203,7 +203,7 @@
       @apply flex items-center justify-between;
     }
 
-    [data-component="accordion"] {
+    [data-controller="accordion"] {
       @apply relative bg-gray-5;
 
       > button {

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_template.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_template.html.erb
@@ -1,4 +1,4 @@
-<div data-component="accordion" id="collaborative-texts-box-{{ID}}">
+<div data-controller="accordion" id="collaborative-texts-box-{{ID}}">
   <button class="button button__sm button__text-secondary mt-2 mb-4 px-2" data-controls="panel-box-{{ID}}" aria-label="<%= t("decidim.collaborative_texts.document.toggle") %>" aria-expanded="false">
     <span>
       <%= icon("award-line", class: "icon icon-pending") %>

--- a/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
@@ -1,6 +1,6 @@
 <%= render partial: "decidim/comments/comments/delete", formats: [:html], locals: { comment: model } %>
 
-<div data-comment-footer data-component="accordion" id="accordion-<%= model.id %>">
+<div data-comment-footer data-controller="accordion" id="accordion-<%= model.id %>">
   <div id="comment-<%= model.id %>-replies" class="<%= "comment-reply" if has_replies_in_children? %>">
     <% if has_replies_in_children? %>
       <%= render :replies %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -83,7 +83,7 @@
       </div>
     </div>
 
-    <div data-comment-footer data-component="accordion" id="accordion-<%= model.id %>" class="relative">
+    <div data-comment-footer data-controller="accordion" id="accordion-<%= model.id %>" class="relative">
       <div class="comment__footer-grid">
         <div class="comment__votes-actions">
           <%= render :actions %>

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -233,7 +233,7 @@ describe("CommentsComponent", () => {
         <div class="comment__content">
           <div><p>${content}</p></div>
         </div>
-        <div data-comment-footer data-component="accordion" role="presentation">
+        <div data-comment-footer data-controller="accordion" role="presentation">
           <div class="comment__footer-grid">
             <div class="comment__actions">
               <button class="button button__sm button__text-secondary" data-controls="panel-comment${commentId}-reply" role="button" tabindex="0" aria-controls="panel-comment${commentId}-reply" aria-expanded="false" aria-disabled="false">

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -162,7 +162,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-visibility">
+  <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -179,7 +179,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-related_spaces">
+  <div class="card" data-controller="accordion" id="accordion-related_spaces">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-related_spaces" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -38,7 +38,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-duration">
+  <div class="card" data-controller="accordion" id="accordion-duration">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-duration" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -59,7 +59,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-images">
+  <div class="card" data-controller="accordion" id="accordion-images">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-images" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -82,7 +82,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-metadata">
+  <div class="card" data-controller="accordion" id="accordion-metadata">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-metadata" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -107,7 +107,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-registrations">
+  <div class="card" data-controller="accordion" id="accordion-registrations">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-registrations" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -135,7 +135,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-taxonomies">
+  <div class="card" data-controller="accordion" id="accordion-taxonomies">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-taxonomies" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-conferences/app/views/decidim/conferences/conference_program/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_program/show.html.erb
@@ -20,7 +20,7 @@ end
     <span class="sr-only"><%= t(".program") %> (<%= translated_attribute current_participatory_space.title %>)</span>
   </h1>
 
-  <div data-component="accordion" data-multiselectable="false" data-collapsible="false">
+  <div data-controller="accordion" data-multiselectable="false" data-collapsible="false">
     <% if meeting_days.any? %>
       <ul class="conference__program-selector">
         <% meeting_days.each_with_index do |day, i| %>

--- a/decidim-core/app/cells/decidim/collapsible_authors/show.erb
+++ b/decidim-core/app/cells/decidim/collapsible_authors/show.erb
@@ -1,4 +1,4 @@
-<div class="author__coauthors" data-component="accordion">
+<div class="author__coauthors" data-controller="accordion">
   <% visible_authors.each do |author| %>
     <%= cell "decidim/author", author, layout: :compact %>
   <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -12,7 +12,7 @@
 
 <% if description_text.present? %>
   <% should_truncate = strip_tags(description_text).length > 300 %>
-  <div class="content-block__description editor-content" <%= "data-component='accordion'" if should_truncate %>>
+  <div class="content-block__description editor-content" <%= "data-controller='accordion'" if should_truncate %>>
     <% if should_truncate %>
       <% seed = SecureRandom.hex(4) %>
       <div id="panel-view-more-<%= seed %>" class="editor-content" inert>

--- a/decidim-core/app/cells/decidim/data_consent/modal.erb
+++ b/decidim-core/app/cells/decidim/data_consent/modal.erb
@@ -5,7 +5,7 @@
       <p id="dialog-desc-dc-modal">
         <%= t("layouts.decidim.data_consent.modal.description") %>
       </p>
-      <div class="mt-8" data-component="accordion" data-multiselectable="false">
+      <div class="mt-8" data-controller="accordion" data-multiselectable="false">
         <% categories.each do |category| %>
           <%= render(
             {

--- a/decidim-core/app/cells/decidim/data_consent/modal.erb
+++ b/decidim-core/app/cells/decidim/data_consent/modal.erb
@@ -6,6 +6,7 @@
         <%= t("layouts.decidim.data_consent.modal.description") %>
       </p>
       <div class="mt-8" data-controller="accordion" data-multiselectable="false">
+        dsga
         <% categories.each do |category| %>
           <%= render(
             {

--- a/decidim-core/app/cells/decidim/data_consent/modal.erb
+++ b/decidim-core/app/cells/decidim/data_consent/modal.erb
@@ -6,7 +6,6 @@
         <%= t("layouts.decidim.data_consent.modal.description") %>
       </p>
       <div class="mt-8" data-controller="accordion" data-multiselectable="false">
-        dsga
         <% categories.each do |category| %>
           <%= render(
             {

--- a/decidim-core/app/cells/decidim/tab_panels/show.erb
+++ b/decidim-core/app/cells/decidim/tab_panels/show.erb
@@ -1,5 +1,5 @@
 <% if tabs.length > 0 %>
-  <div class="layout-main__section" data-component="accordion" data-multiselectable="false" data-collapsible="false">
+  <div class="layout-main__section" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
     <ul class="tab-x-container tabs-<%= tabs.length %>">
       <% tabs.each_with_index do |tab, i| %>
         <li>

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -188,8 +188,7 @@ const initializer = (element = document) => {
     {
       return;
     }
-    // eslint-disable-next-line no-alert
-    alert(`${window.location.href} Using accordion component`);
+    console.error(`${window.location.href} Using accordion component`);
     createAccordion(component);
   })
 

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -183,9 +183,14 @@ const initializer = (element = document) => {
   scrollToLastChild(element)
 
   element.querySelectorAll('[data-controller="accordion"]').forEach((component) => createAccordion(component))
-  element.querySelectorAll('[data-component="accordion"]').forEach(() => {
+  element.querySelectorAll('[data-component="accordion"]').forEach((component) => {
+    if (component.hasAttribute("data-controller"))
+    {
+      return;
+    }
     // eslint-disable-next-line no-alert
     alert(`${window.location.href} Using accordion component`);
+    createAccordion(component);
   })
 
   element.querySelectorAll('[data-component="dropdown"]').forEach((component) => createDropdown(component))

--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -114,7 +114,7 @@ window.initFoundation = (element) => {
   $document.off("click.zf.trigger", window.Foundation.Triggers.Listeners.Basic.openListener);
   $document.on("click.zf.trigger", "[data-open]", (ev, ...restArgs) => {
     // Do not apply for the accordion triggers.
-    const accordion = ev.currentTarget?.closest("[data-component='accordion']");
+    const accordion = ev.currentTarget?.closest("[data-controller='accordion']");
     if (accordion) {
       return;
     }
@@ -182,7 +182,11 @@ const initializer = (element = document) => {
 
   scrollToLastChild(element)
 
-  element.querySelectorAll('[data-component="accordion"]').forEach((component) => createAccordion(component))
+  element.querySelectorAll('[data-controller="accordion"]').forEach((component) => createAccordion(component))
+  element.querySelectorAll('[data-component="accordion"]').forEach(() => {
+    // eslint-disable-next-line no-alert
+    alert(`${window.location.href} Using accordion component`);
+  })
 
   element.querySelectorAll('[data-component="dropdown"]').forEach((component) => createDropdown(component))
 

--- a/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
@@ -1,13 +1,13 @@
-[data-component="accordion"] [id*="panel"][aria-hidden="true"] {
+[data-controller="accordion"] [id*="panel"][aria-hidden="true"] {
   display: none;
 }
 
-[data-component="accordion"]
+[data-controller="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="true"] {
   display: none;
 }
 
-[data-component="accordion"]
+[data-controller="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="false"] {
   display: block;
 }
@@ -57,7 +57,7 @@
     @apply mr-4;
   }
 
-  &-section.content-block__description[data-component="accordion"] {
+  &-section.content-block__description[data-controller="accordion"] {
     @apply pb-4 mb-4 text-md;
 
     padding-left: 1.85rem;

--- a/decidim-core/app/packs/stylesheets/decidim/_callout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_callout.scss
@@ -21,7 +21,7 @@
     @apply text-secondary;
   }
 
-  &[data-component="accordion"] {
+  &[data-controller="accordion"] {
     [id*="panel"][aria-hidden="true"] {
       @apply block max-h-14 overflow-hidden relative before:content-[''] before:absolute before:inset-0 before:h-full before:w-full before:bg-gradient-to-b before:from-transparent before:to-white after:content-[''] after:absolute after:inset-0 after:h-full after:w-full after:bg-gradient-to-b after:from-transparent after:to-secondary/5;
     }

--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -8,7 +8,7 @@
   &__description {
     @apply text-lg prose max-w-2xl;
 
-    &[data-component="accordion"] {
+    &[data-controller="accordion"] {
       [id*="panel"][aria-hidden="true"] {
         @apply block max-h-40 overflow-hidden relative first:[&_*]:mt-0 before:content-[''] before:absolute before:inset-0 before:h-full before:w-full before:bg-gradient-to-b before:from-transparent before:to-white after:content-[''] after:absolute after:inset-0 after:h-full after:w-full after:bg-gradient-to-b after:from-transparent after:to-white;
       }

--- a/decidim-core/app/presenters/decidim/log/base_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/base_presenter.rb
@@ -157,7 +157,7 @@ module Decidim
       # Returns an HTML-safe String.
       def present_action_log
         classes = ["logs__log"] + action_log_extra_classes.to_a
-        h.content_tag(:div, id: "accordion-#{h.dom_id(action_log)}", class: classes.join(" "), data: { component: "accordion" }) do
+        h.content_tag(:div, id: "accordion-#{h.dom_id(action_log)}", class: classes.join(" "), data: { controller: "accordion" }) do
           h.concat(present_content)
           h.concat(present_diff)
         end

--- a/decidim-core/app/views/decidim/account/show.html.erb
+++ b/decidim-core/app/views/decidim/account/show.html.erb
@@ -45,7 +45,7 @@
         <%= render partial: "password_fields", locals: { form: f, user: current_user } %>
         <%= render partial: "old_password_field", locals: { form: f, show_help_text: true } %>
       <% elsif current_organization.sign_in_enabled? %>
-        <div data-component="accordion" id="accordion-password">
+        <div data-controller="accordion" id="accordion-password">
           <%= button_tag(
             class: "text-lg font-semibold text-secondary underline block cursor-pointer",
             id: "accordion-trigger-panel-password",

--- a/decidim-core/app/views/decidim/application/_accordion_section.html.erb
+++ b/decidim-core/app/views/decidim/application/_accordion_section.html.erb
@@ -1,4 +1,4 @@
-<div class="card-accordion" data-component="accordion">
+<div class="card-accordion" data-controller="accordion">
   <div class="card-accordion-divider">
     <button class="card-accordion-divider-button" data-open="<%= open_accordion ||= false %>" data-controls="panel-title--<%= panel_id %>" type="button">
       <h2 class="card-accordion-title" id="title">

--- a/decidim-core/app/views/decidim/application/_radio_accordion.html.erb
+++ b/decidim-core/app/views/decidim/application/_radio_accordion.html.erb
@@ -11,7 +11,7 @@
     </h2>
   </label>
 
-  <div data-component="accordion" class="radio-accordion-section content-block__description editor-content">
+  <div data-controller="accordion" class="radio-accordion-section content-block__description editor-content">
     <div id="panel-title--<%= panel_id %>" aria-hidden="true">
       <%= yield %>
     </div>

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -22,7 +22,7 @@ edit_link(
       <div class="space-y-6">
         <h2 class="h2 decorator"><%= t "decidim.pages.index.topics" %></h2>
 
-        <div class="space-y-6" data-component="accordion" id="topics-accordion">
+        <div class="space-y-6" data-controller="accordion" id="topics-accordion">
           <% @topics.each_with_index do |topic, ix| %>
             <% if topic.pages.any? %>
               <div class="page__accordion">

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -2,7 +2,7 @@
 <% search_label = t("decidim.searches.filters.search") unless local_assigns.has_key?(:search_label) %>
 
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
-  <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", component: "accordion" } do |form| %>
+  <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", controller: "accordion" } do |form| %>
 
     <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
       <%= icon "arrow-down-s-line" %>

--- a/decidim-design/app/views/decidim/design/components/accordions.html.erb
+++ b/decidim-design/app/views/decidim/design/components/accordions.html.erb
@@ -17,7 +17,7 @@
 
   <p><%= t(".demo_description") %></p>
 
-  <div data-component="accordion" data-multiselectable="false" id="example-accordion-1">
+  <div data-controller="accordion" data-multiselectable="false" id="example-accordion-1">
     <ul class="tab-x-container">
       <% 3.times do |tab| %>
         <li>
@@ -53,7 +53,7 @@
 
     <code>
       <textarea spellcheck="false" rows="8">
-<div data-component="accordion" id="example-accordion">
+<div data-controller="accordion" id="example-accordion">
   <button id="trigger" data-controls="panel">
     <%= t(".trigger") %>
   </button>

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -14,7 +14,7 @@ en:
           trigger: Trigger
           usage: Usage
           usage_p: An accordion requires at least three elements
-          usage_p_1_html: 1. A wrapper <code>div</code>, with the data-attribute <code>data-component="accordion"</code>, over all the available triggers and panels.
+          usage_p_1_html: 1. A wrapper <code>div</code>, with the data-attribute <code>data-controller="accordion"</code>, over all the available triggers and panels.
           usage_p_2_html: 2. A trigger element, user actionable (as a button), pointing to the collapsable element through <code>data-controls="panel"</code>, where <i>panel</i> is the <code>id</code> of the panel.
           usage_p_3_html: 3. A hideable element, whose <code>id</code> matches the data-controls value the trigger refers to.
         activities:

--- a/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
@@ -1,7 +1,7 @@
 <% disable_fields = @election&.published? %>
 <div class="form__wrapper">
   <div class="card-section election-fields">
-    <div class="card form-basic" data-component="accordion" id="accordion-basic">
+    <div class="card form-basic" data-controller="accordion" id="accordion-basic">
       <div class="row column">
         <button type="button" class="card-divider-button" data-controls="panel-basic" data-open="true">
           <%= icon "arrow-right-s-line" %>
@@ -33,7 +33,7 @@
       </div>
     </div>
 
-    <div class="card form-calendar" data-component="accordion" id="accordion-calendar">
+    <div class="card form-calendar" data-controller="accordion" id="accordion-calendar">
       <div class="row column">
         <button type="button" class="card-divider-button" data-controls="panel-calendar" data-open="true">
           <%= icon "arrow-right-s-line" %>
@@ -67,7 +67,7 @@
       </div>
     </div>
 
-    <div class="card form-results" data-component="accordion" id="accordion-results">
+    <div class="card form-results" data-controller="accordion" id="accordion-results">
       <div class="row column">
         <button type="button" class="card-divider-button" data-controls="panel-results" data-open="true">
           <%= icon "arrow-right-s-line" %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
@@ -1,7 +1,7 @@
 <% question = form.object %>
 <% is_expanded = question.errors.any? %>
 <div class="card questionnaire-question" id="accordion-<%= id %>-field">
-  <div class="form__wrapper" data-component="accordion">
+  <div class="form__wrapper" data-controller="accordion">
     <div class="card-divider">
       <h2 class="card-title flex items-center">
         <span>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
@@ -1,7 +1,7 @@
 <% question = form.object %>
 <% is_expanded = question.errors.any? %>
 <div class="card questionnaire-question" id="accordion-<%= id %>-field">
-  <div class="form__wrapper" data-component="accordion">
+  <div class="form__wrapper" data-controller="accordion">
     <div class="card-divider">
       <h2 class="card-title flex items-center">
         <span>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_title_and_description.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_title_and_description.html.erb
@@ -2,7 +2,7 @@
 <% is_expanded = question.errors.any? %>
 
 <div class="card questionnaire-question" id="accordion-<%= id %>-field">
-  <div data-component="accordion">
+  <div data-controller="accordion">
     <div class="card-divider">
       <h2 class="card-title flex items-center">
         <span>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-settings">
+  <div class="card" data-controller="accordion" id="accordion-settings">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-settings" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -110,7 +110,7 @@
       <% end %>
     </div>
   </div>
-  <div class="card" data-component="accordion" id="accordion-homepage_attachments">
+  <div class="card" data-controller="accordion" id="accordion-homepage_attachments">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-homepage_attachments" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-options">
+  <div class="card" data-controller="accordion" id="accordion-options">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-options" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -81,7 +81,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-signature-workflow">
+  <div class="card" data-controller="accordion" id="accordion-signature-workflow">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-signature-workflow" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_initiative_type_scopes.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-initiative_type_scope">
+<div class="card" data-controller="accordion" id="accordion-initiative_type_scope">
   <div class="card-divider">
     <h2 class="card-title gap-2" id="<%= t("initiatives_types.initiative_type_scopes.title", scope: "decidim.initiatives.admin") %>">
       <button class="card-divider-button" data-open="true" data-controls="panel-initiative_type_scope" type="button">

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -181,7 +181,7 @@ edit_link(
 
 <section class="layout-main__section">
   <% if tabs.any? %>
-    <div class="mt-8" data-component="accordion" data-multiselectable="false" data-collapsible="false">
+    <div class="mt-8" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
       <ul class="tab-x-container">
         <% tabs.each_with_index do |tab, i| %>
           <li>

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper attendee-fields">
-  <div class="card" data-component="accordion" id="accordion-attendee">
+  <div class="card" data-controller="accordion" id="accordion-attendee">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-attendee" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_linked_spaces.html.erb
@@ -1,6 +1,6 @@
 <%= append_stylesheet_pack_tag "decidim_proposals", media: "all" %>
 
-<div class="card" data-component="accordion" id="accordion-linked-spaces">
+<div class="card" data-controller="accordion" id="accordion-linked-spaces">
   <div class="card-divider">
     <button class="card-divider-button" data-open="false" data-controls="panel-linked-spaces" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_reminders.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_reminders.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-reminders">
+<div class="card" data-controller="accordion" id="accordion-reminders">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-reminders" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_services.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_services.html.erb
@@ -1,4 +1,4 @@
-<div class="card" data-component="accordion" id="accordion-services">
+<div class="card" data-controller="accordion" id="accordion-services">
   <div class="card-divider">
     <button class="card-divider-button" data-open="true" data-controls="panel-services" type="button">
       <%= icon "arrow-right-s-line" %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -1,7 +1,7 @@
 <% question = form.object %>
 <% is_expanded = question.errors.any? %>
 <div class="card questionnaire-question" id="<%= id %>-field">
-  <div class="form__wrapper" data-component="accordion">
+  <div class="form__wrapper" data-controller="accordion">
     <div class="card-divider">
       <h2 class="card-title">
         <span>

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_step/show.erb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_step/show.erb
@@ -3,7 +3,7 @@
     <%= icon "flag-line" %>
     <h3 id="dialog-title-process-steps-modal" data-dialog-title><%= t("participatory_process_steps.index.process_steps", scope: "decidim") %></h3>
     <div>
-      <div class="participatory-space__metadata-modal__list-container" data-component="accordion" data-multiselectable="false" data-collapsible="false">
+      <div class="participatory-space__metadata-modal__list-container" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
         <ol class="participatory-space__metadata-modal__list">
           <% steps.each_with_index do |step, i| %>
             <% active = step == active_step %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-metadata">
+  <div class="card" data-controller="accordion" id="accordion-metadata">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-metadata" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -71,7 +71,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-visibility">
+  <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -1,5 +1,5 @@
 <div class="form__wrapper">
-  <div class="card" data-component="accordion" id="accordion-title">
+  <div class="card" data-controller="accordion" id="accordion-title">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-title" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -41,7 +41,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-duration">
+  <div class="card" data-controller="accordion" id="accordion-duration">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-duration" type="button">
         <svg viewBox="0 0 24 24" id="ri-arrow-right-s-line">
@@ -67,7 +67,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-images">
+  <div class="card" data-controller="accordion" id="accordion-images">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-images" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -86,7 +86,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-metadata">
+  <div class="card" data-controller="accordion" id="accordion-metadata">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-metadata" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -122,7 +122,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-taxonomies">
+  <div class="card" data-controller="accordion" id="accordion-taxonomies">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-taxonomies" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -149,7 +149,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-visibility">
+  <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
         <%= icon "arrow-right-s-line" %>
@@ -177,7 +177,7 @@
     </div>
   </div>
 
-  <div class="card" data-component="accordion" id="accordion-related_processes">
+  <div class="card" data-controller="accordion" id="accordion-related_processes">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-related_processes" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -16,7 +16,7 @@
             <div class="row column">
               <p class="mt-3"><%= t(".info_1") %></p>
               <ul id="participatory-text" class="draggable-list js-connect js-list-actives mt-2.5 ml-2.5 mr-2.5"
-                  data-component="accordion"
+                  data-controller="accordion"
                   data-accordion
                   data-sort-url="#"
                   data-multi-expand="true"

--- a/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/participatory_texts/index.html.erb
@@ -17,7 +17,6 @@
               <p class="mt-3"><%= t(".info_1") %></p>
               <ul id="participatory-text" class="draggable-list js-connect js-list-actives mt-2.5 ml-2.5 mr-2.5"
                   data-controller="accordion"
-                  data-accordion
                   data-sort-url="#"
                   data-multi-expand="true"
                   data-allow-all-closed="true">

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_notes/_proposal_notes.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_notes/_proposal_notes.html.erb
@@ -1,4 +1,4 @@
-<div class="component__show_notes" data-component="accordion" id="accordion-notes">
+<div class="component__show_notes" data-controller="accordion" id="accordion-notes">
   <button type="button" class="card-divider-button" data-controls="panel-notes">
     <%= icon "arrow-right-s-line" %>
     <h2 class="card-title">

--- a/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_view_index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/participatory_texts/_view_index.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container self-stretch" data-component="accordion">
+<div class="filter-container self-stretch" data-controller="accordion">
   <button id="trigger-menu" data-controls="panel-dropdown-menu-index" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR changes a selector from `data-component="accordion"` to `data-controller="accordion"` aiming to simplify the PR that adds the HotWire & Stimulus

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14948 

#### Testing
1. Green pipeline 
2. Dropdowns in website should work

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
