### PR TITLE
Use proper translation in default taxonomy in accountability

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Decidim.register_component(:accountability) do |component|
+  include Decidim::TranslatableAttributes
+
   component.engine = Decidim::Accountability::Engine
   component.admin_engine = Decidim::Accountability::AdminEngine
   component.icon = "media/images/decidim_accountability.svg"
@@ -32,7 +34,7 @@ Decidim.register_component(:accountability) do |component|
     settings.attribute :display_progress_enabled, type: :boolean, default: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false
     settings.attribute :default_taxonomy, type: :select, include_blank: true, raw_choices: true, choices: lambda { |context|
-      context[:component].available_root_taxonomies.map { |taxonomy| [taxonomy.name["en"], taxonomy.id] }
+      context[:component].available_root_taxonomies.map { |taxonomy| [translated_attribute(taxonomy.name), taxonomy.id] }
     }
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
https://github.com/decidim/decidim/pull/14067 introduced a default taxonomy in accountability.
However always assumes english for its name, breaking the application if no english is used. A part from not respecting the current translation.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
