### PR TITLE
Fix accessibility on avatars links

### DIFF
--- a/decidim-core/app/cells/decidim/author/avatar.erb
+++ b/decidim-core/app/cells/decidim/author/avatar.erb
@@ -1,6 +1,6 @@
 <%= content_tag :span, class: "author__avatar-container" do %>
   <% if profile_path? %>
-    <%= link_to profile_path do %>
+    <%= link_to profile_path, tabindex: 0 do %>
       <%= render :avatar_image %>
     <% end %>
   <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR allows avatars links to be accessible when navigating with Voice Over or another screen reader.
This PR is issued from the audit of Angers city (page 21) and is rrlatd to criterias critères 1.4.1 and R.4.7 from WCAG.

#### Testing

1. As a user, enable Voice Over
2. On processes index page, click on the home icon to open the dropdown menu
3. Navigate with voice over in the menu and see that the focus is well displayed on avatars links and that you can access them (cf screenshot one)
4. Go to the show of a proposal and navigate with voice over on the page, see that the avatar link gets the focus and that you can access it (cf screenshot two)

### :camera: Screenshots
**ONE**
<img width="1159" height="789" alt="Capture d’écran 2025-07-30 à 09 18 45" src="https://github.com/user-attachments/assets/fcbb343e-36bd-46ed-8c61-740dc7b75cd8" />

**TWO**
<img width="839" height="659" alt="Capture d’écran 2025-07-30 à 09 19 51" src="https://github.com/user-attachments/assets/77eeddd2-6add-4d66-bcde-b2e3a0c8d82c" />


:hearts: Thank you!
