### PR TITLE
Fix editor mention selection range when selecting item with mouse

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/common/suggestion.js
+++ b/decidim-core/app/packs/src/decidim/editor/common/suggestion.js
@@ -106,7 +106,17 @@ export const createSuggestionRenderer = (node, { itemConverter } = {}) => () => 
       suggestionItem.textContent = label;
       suggestion.append(suggestionItem);
 
-      suggestionItem.addEventListener("click", () => selectItem(idx));
+      suggestionItem.addEventListener("click", (ev) => {
+        ev.preventDefault();
+
+        if (currentRange) {
+          // Increase the current range by 1 since the ENTER key would do the
+          // same when doing the selection through keyboard.
+          currentRange.to += 1;
+        }
+
+        selectItem(idx);
+      });
     });
   }
 


### PR DESCRIPTION
#### :tophat: What? Why?
A while back I was asked a question (by @mllocs) about the editor mention leaving the last character within the editor text when the selection is done through a mouse:
https://github.com/decidim/decidim/pull/14184#issuecomment-2730078612

I investigated this a bit and noticed that the reason is that the `ENTER` press actually increases the selection range by one (i.e. the number of characters the `ENTER` key would produce).

To fix this issue, the selection range can be also increased by one when the selection is done through a mouse.

#### :pushpin: Related Issues
- Related to #14184

#### Testing
- Make sure you have a process with the proposals component already included in it with some proposals
- Go to the same process
- Go to the meetings component (or add it if it's not already there)
- Edit a meeting or create a new meeting
- Within the editor, write a forward slash character `/` and start typing the name of some proposal
- Once it appears on top of the editor, select that proposal USING THE MOUSE
- See that the last character is no longer left to the editor

### :camera: Screenshots

This is the state of the editor when mentioning a proposal (no difference before or after):
<img width="663" height="239" alt="Editor when mentioning a proposal" src="https://github.com/user-attachments/assets/8f5f7c06-fea1-4aa6-a217-d803aaf72ffe" />

This is what used to happen **before** this change when the selection was done using the mouse:
<img width="663" height="239" alt="How the editor was after the selection is done using the mouse" src="https://github.com/user-attachments/assets/155753ef-0661-41e1-ba65-746bb27d2991" />

This is what happens **after** this change when the selection is done using the mouse:
<img width="663" height="239" alt="How the editor will be after the selection is done using the mouse" src="https://github.com/user-attachments/assets/84cfa0e4-2c15-4ed3-ab7f-0a411ff98658" />