### PR TITLE
Define the generated app's sidekiq version based on the redis version

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -258,10 +258,10 @@ module Decidim
           Gem::Version.new("8.0.0")
         end
 
-        if redis_version < Gem::Version("6.2.0")
+        if redis_version < Gem::Version.new("6.2.0")
           # Sidekiq 7.x requires Redis 6.2.0 or newer
           append_file "Gemfile", %(gem "sidekiq", "~> 6.5")
-        elsif redis_version < Gem::Version("7.0.0")
+        elsif redis_version < Gem::Version.new("7.0.0")
           # Sidekiq 8.x requires Redis 7.0.0 or newer
           append_file "Gemfile", %(gem "sidekiq", "~> 7.3")
         else

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -248,9 +248,10 @@ module Decidim
         RUBY
 
         redis_version = begin
+          require "redis"
           ver = Redis.new.call("INFO").lines(chomp: true).find { |l| l.start_with?("redis_version:") }.split(":", 2).last
           Gem::Version.new(ver)
-        rescue Redis::CannotConnectError
+        rescue LoadError, Redis::CannotConnectError
           # This does not have to be the actual Redis version, it can be
           # anything that is above any of the version checks below to default to
           # the latest Sidekiq version.

--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -247,7 +247,26 @@ module Decidim
           end
         RUBY
 
-        append_file "Gemfile", %(gem "sidekiq")
+        redis_version = begin
+          ver = Redis.new.call("INFO").lines(chomp: true).find { |l| l.start_with?("redis_version:") }.split(":", 2).last
+          Gem::Version.new(ver)
+        rescue Redis::CannotConnectError
+          # This does not have to be the actual Redis version, it can be
+          # anything that is above any of the version checks below to default to
+          # the latest Sidekiq version.
+          Gem::Version.new("8.0.0")
+        end
+
+        if redis_version < Gem::Version("6.2.0")
+          # Sidekiq 7.x requires Redis 6.2.0 or newer
+          append_file "Gemfile", %(gem "sidekiq", "~> 6.5")
+        elsif redis_version < Gem::Version("7.0.0")
+          # Sidekiq 8.x requires Redis 7.0.0 or newer
+          append_file "Gemfile", %(gem "sidekiq", "~> 7.3")
+        else
+          # Assume latest
+          append_file "Gemfile", %(gem "sidekiq")
+        end
       end
 
       def add_production_gems(&block)


### PR DESCRIPTION
#### :tophat: What? Why?
Ubuntu 22.04 comes with Redis 6.0 which is not supported by latest Sidekiq version.

This adds a feature to the generator that locks Sidekiq to the correct version based on the available Redis version.

#### Testing
See that the generator works fine.

If you want to test the different configs particularly, change the Redis version and see that the correct Sidekiq version lock is set within the Gemfile.