### PR TITLE
Check if initiatives is installed within the example initializer

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_templates/initiatives_initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initiatives_initializer.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
 
-Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_handler) do |workflow|
-  workflow.form = "DummySignatureHandler"
-  workflow.authorization_handler_form = "DummyAuthorizationHandler"
-  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
-  workflow.promote_authorization_validation_errors = true
-  workflow.sms_verification = true
-  workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
-end
+if Decidim.module_installed?(:initiatives)
+  Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_handler) do |workflow|
+    workflow.form = "DummySignatureHandler"
+    workflow.authorization_handler_form = "DummyAuthorizationHandler"
+    workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
+    workflow.promote_authorization_validation_errors = true
+    workflow.sms_verification = true
+    workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
+  end
 
-Decidim::Initiatives::Signatures.register_workflow(:ephemeral_dummy_signature_handler) do |workflow|
-  workflow.form = "DummySignatureHandler"
-  workflow.ephemeral = true
-  workflow.authorization_handler_form = "DummyAuthorizationHandler"
-  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
-  workflow.promote_authorization_validation_errors = true
-  workflow.sms_verification = true
-  workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
-end
+  Decidim::Initiatives::Signatures.register_workflow(:ephemeral_dummy_signature_handler) do |workflow|
+    workflow.form = "DummySignatureHandler"
+    workflow.ephemeral = true
+    workflow.authorization_handler_form = "DummyAuthorizationHandler"
+    workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
+    workflow.promote_authorization_validation_errors = true
+    workflow.sms_verification = true
+    workflow.sms_mobile_phone_validator = "DummySmsMobilePhoneValidator"
+  end
 
-Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_with_sms_handler) do |workflow|
-  workflow.sms_verification = true
-end
+  Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_with_sms_handler) do |workflow|
+    workflow.sms_verification = true
+  end
 
-Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_with_personal_data_handler) do |workflow|
-  workflow.form = "DummySignatureHandler"
-  workflow.authorization_handler_form = "DummyAuthorizationHandler"
-  workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
-  workflow.promote_authorization_validation_errors = true
-end
+  Decidim::Initiatives::Signatures.register_workflow(:dummy_signature_with_personal_data_handler) do |workflow|
+    workflow.form = "DummySignatureHandler"
+    workflow.authorization_handler_form = "DummyAuthorizationHandler"
+    workflow.action_authorizer = "DummySignatureHandler::DummySignatureActionAuthorizer"
+    workflow.promote_authorization_validation_errors = true
+  end
 
-# Flow that reproduces the old signature feature. Change the following options
-# to adapt to the configuration
-Decidim::Initiatives::Signatures.register_workflow(:legacy_signature_handler) do |workflow|
-  # Enable this form to enable the same user data collection and store the same
-  # fields in the vote metadata when the "Collect participant personal data on
-  # signature" were checked
-  workflow.form = "Decidim::Initiatives::LegacySignatureHandler"
+  # Flow that reproduces the old signature feature. Change the following options
+  # to adapt to the configuration
+  Decidim::Initiatives::Signatures.register_workflow(:legacy_signature_handler) do |workflow|
+    # Enable this form to enable the same user data collection and store the same
+    # fields in the vote metadata when the "Collect participant personal data on
+    # signature" were checked
+    workflow.form = "Decidim::Initiatives::LegacySignatureHandler"
 
-  # Change this form and use the same handler selected in the "Authorization to
-  # verify document number on signatures" field
-  workflow.authorization_handler_form = "DummyAuthorizationHandler"
+    # Change this form and use the same handler selected in the "Authorization to
+    # verify document number on signatures" field
+    workflow.authorization_handler_form = "DummyAuthorizationHandler"
 
-  # This setting prevents the automatic creation of authorizations as in the
-  # old feature. You can remove this setting if the workflow does not use an
-  # authorization handler form. The default value is true.
-  workflow.save_authorizations = false
+    # This setting prevents the automatic creation of authorizations as in the
+    # old feature. You can remove this setting if the workflow does not use an
+    # authorization handler form. The default value is true.
+    workflow.save_authorizations = false
 
-  # Set this setting to false to skip SMS verification step
-  workflow.sms_verification = true
+    # Set this setting to false to skip SMS verification step
+    workflow.sms_verification = true
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The `decidim-initiatives` gem should be installed when the `--demo` flag is given to the generator as defined here:
https://github.com/decidim/decidim/blob/812a6e386b93b6a0bffe2432eb577d556343c354/decidim-generators/lib/decidim/generators/app_generator.rb#L202

However, this is completely skipped in case the `--skip_gemfile` flag is provided as defined here:
https://github.com/decidim/decidim/blob/812a6e386b93b6a0bffe2432eb577d556343c354/decidim-generators/lib/decidim/generators/app_generator.rb#L181

But the initiatives generator is still added even if the gem is not installed:
https://github.com/decidim/decidim/blob/812a6e386b93b6a0bffe2432eb577d556343c354/decidim-generators/lib/decidim/generators/app_generator.rb#L397

Both these flags are defined for the test app generation:
https://github.com/decidim/decidim/blob/812a6e386b93b6a0bffe2432eb577d556343c354/decidim-dev/lib/tasks/generators.rake#L31
https://github.com/decidim/decidim/blob/812a6e386b93b6a0bffe2432eb577d556343c354/decidim-dev/lib/tasks/generators.rake#L33

Therefore, in case the 3rd party module does not install `decidim-initiatives` in its root Gemfile would fail to generate the test app.

This fixes the issue by ensuring that the initiatives module is installed within this initializer.

Sidenote: why is the `--demo` flag even added in the default test/development app generation as I would imagine most external modules don't want all these "demo" modules to be installed?

#### Testing
- Create a new external Decidim module (outside of the main Decidim repository)
- Try to generate the test app there