### PR TITLE
Update 0.28 maintance status

### DIFF
--- a/docs/modules/install/partials/version_matrix.adoc
+++ b/docs/modules/install/partials/version_matrix.adoc
@@ -8,7 +8,7 @@
 
 |v0.29 | 3.2.2 | 18.17.x | Bug fixes and security updates
 
-|v0.28 | 3.1.1 | 18.17.x | Security updates
+|v0.28 | 3.1.1 | 18.17.x | Not maintained
 
 |v0.27 | 3.0.2 | 16.18.x | Security updates
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15060 we have added the information about 0.30, and we forgot that 0.28 is out of the security maintenance period. This fixes that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15060

:hearts: Thank you!
