### PR TITLE
Previewing questionnaires as a process admin

### DIFF
--- a/decidim-surveys/app/permissions/decidim/surveys/admin/permissions.rb
+++ b/decidim-surveys/app/permissions/decidim/surveys/admin/permissions.rb
@@ -4,6 +4,8 @@ module Decidim
   module Surveys
     module Admin
       class Permissions < Decidim::DefaultPermissions
+        include Decidim::UserRoleChecker
+
         def permissions
           return permission_action unless user
 
@@ -12,7 +14,7 @@ module Decidim
           case permission_action.subject
           when :questionnaire
             case permission_action.action
-            when :export_responses, :update, :create, :destroy
+            when :export_responses, :update, :create, :destroy, :preview
               permission_action.allow!
             end
           when :questionnaire_responses

--- a/decidim-surveys/spec/permissions/decidim/surveys/admin/permissions_spec.rb
+++ b/decidim-surveys/spec/permissions/decidim/surveys/admin/permissions_spec.rb
@@ -78,7 +78,7 @@ describe Decidim::Surveys::Admin::Permissions do
     it { is_expected.to be true }
   end
 
-  context "when previewing a survey as a process admin" do
+  context "when previewing a survey questionnaire as a process admin" do
     let(:action) do
       { scope: :admin, action: :preview, subject: :questionnaire }
     end

--- a/decidim-surveys/spec/permissions/decidim/surveys/admin/permissions_spec.rb
+++ b/decidim-surveys/spec/permissions/decidim/surveys/admin/permissions_spec.rb
@@ -77,4 +77,12 @@ describe Decidim::Surveys::Admin::Permissions do
 
     it { is_expected.to be true }
   end
+
+  context "when previewing a survey as a process admin" do
+    let(:action) do
+      { scope: :admin, action: :preview, subject: :questionnaire }
+    end
+
+    it { is_expected.to be true }
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Missing permissions were needed to allow configured process administrators to preview already made survey questionnaires within the Participatory Process space. 

#### :pushpin: Related Issues
- Fixes #13601 

#### Testing
1. Login as a admin
2. Configure a Participatory Process space (if you don't have)
3. Configure a Survey component (if you don't have)
4. Fill that suvery with questions 
5. Save and head out to the index of the newly created PP space
6. Click process admins
7. Assign a process admin Administrator to the space
8. Logout 
9. Login as the newly created process admin
10. Head to the space and click suverys
11. Click within the hamburger menu and see you can preview the questionnaire 

RSPEC 

Create a failing unit test using by removing the `:preview` object within the `admin/permissions.rb` file and running: `decidim-surveys/spec/permissions/decidim/surveys/admin/permissions_spec.rb`


### :camera: Screenshots
<img width="2669" height="813" alt="image" src="https://github.com/user-attachments/assets/2ccefb58-a74a-4397-b683-7627a58849d0" />

:hearts: Thank you!
