### PR TITLE
Upgrade Chrome and ChromeDriver to 139.0.7258.66

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -36,7 +36,7 @@ on:
       chrome_version:
         description: 'Chrome & Chromedriver version'
         required: false
-        default: "136.0.7103.92"
+        default: "139.0.7258.66"
         type: string
 
 jobs:


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we are upgrading the Chrome & Driver to the one of the latest versions, so that we can backport to 0.30 & 0.29 where we are using lower versions what cannot be found anymore on Google servers. 

#### :pushpin: Related Issues

- Fixes #https://github.com/decidim/decidim/pull/15066

#### Testing
Green pipelines

### :camera: Screenshots
<img width="1355" height="188" alt="image" src="https://github.com/user-attachments/assets/c5815f77-b78a-47ca-ad37-f8db19d7439e" />
:hearts: Thank you!
