### PR TITLE
Comments extra actions

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -41,7 +41,7 @@
           <ul class="dropdown dropdown__bottom divide-y divide-gray-3">
             <% unless reloaded? %>
               <li class="dropdown__item">
-                <%= cell("decidim/report_button", model, only_button: true, button_classes: "dropdown__button flex flex-row-reverse", modal_id: "flagModalComment#{model.id}") %>
+                <%= cell("decidim/report_button", model, only_button: true, button_classes: "dropdown__button", modal_id: "flagModalComment#{model.id}") %>
               </li>
             <% end %>
             <li class="dropdown__item">

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -105,7 +105,7 @@ module Decidim
             "#{icon(action[:icon]) if action[:icon].present?}#{action[:label]}",
             action[:url],
             {
-              class: "dropdown__item"
+              class: "dropdown__button"
             }
           ].tap do |link|
             link[2][:method] = action[:method] if action[:method].present?

--- a/decidim-core/app/cells/decidim/report_button/content.erb
+++ b/decidim-core/app/cells/decidim/report_button/content.erb
@@ -1,0 +1,2 @@
+<%= icon(icon_name, class: icon_classes) if icon_name.present? %>
+<%= content_tag(:span, text, class: text_classes) if text.present? %>

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -96,7 +96,7 @@
       @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-start !p-2;
 
       span {
-        @apply mr-4 font-normal;
+        @apply mr-16 font-normal;
       }
 
       &-disabled {

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -96,7 +96,7 @@
       @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-end !p-2;
 
       span {
-        @apply mr-16 font-normal;
+        @apply mr-4 font-normal;
       }
 
       &-disabled {

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -93,7 +93,7 @@
     }
 
     .dropdown__button {
-      @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-end !p-2;
+      @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-start !p-2;
 
       span {
         @apply mr-4 font-normal;

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -93,7 +93,7 @@
     }
 
     .dropdown__button {
-      @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-start !p-2;
+      @apply font-normal button button__sm button__text button__text-secondary w-full flex justify-end !p-2;
 
       span {
         @apply mr-16 font-normal;


### PR DESCRIPTION
#### :tophat: What? Why?
`def extra_actions` method affecting the extra actions dropdown within comments was incorrectly assigned the wrong element `dropdown__item`. This has been updated to `dropdown__button` to create consistency within the comments module CSS. 

This was detected within the co-authorship feature of proposals.

#### :pushpin: Related Issues
- Fixes #15059 

#### Testing
1. Login as user@example...
2. Go to proposals & create a proposal
3. With admin visit the proposal and add a comment
4. With user refresh that proposal, see comment and mark the admin as coauthor
5. See correct assigned dropdown element.

### :camera: Screenshots
DESKTOP
<img width="2596" height="1363" alt="image" src="https://github.com/user-attachments/assets/ebd85ff2-69a3-4b05-a6f6-cd47cbf2f29d" />

MOBILE VIEW 
<img width="1464" height="1056" alt="image" src="https://github.com/user-attachments/assets/127d862e-213f-423c-9ca8-486a309f94ef" />


:hearts: Thank you!
