### PR TITLE
Fix tooltip display on mobile

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/tooltip/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/tooltip/controller.js
@@ -259,6 +259,7 @@ export default class extends Controller {
         this.tooltip.setAttribute("aria-hidden", false)
       })
       this.tooltip.addEventListener("mouseleave", () => this.hideTooltip())
+      this.element.addEventListener("click", (event) => this.toggleTooltip(event))
     }
   }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15064 we have added some changes to the tooltip. It seems that clicking the tooltip while on mobile is not possible. This PR fixes this.

Please note* that the responsiveness view of the Tooltip being centered to the right, is a fix completed via the scope of #15075

#### :pushpin: Related Issues

- Related to #15075

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
<img width="590" height="1280" alt="image" src="https://github.com/user-attachments/assets/5f8a88d9-368f-49c3-bfbe-da3b96908bea" />

:hearts: Thank you!
