### PR TITLE
Fix aria-current on active filter in search page

### DIFF
--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -30,7 +30,7 @@
     </button>
     <ul id="dropdown-menu-search" aria-hidden="true">
       <li>
-        <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}" do %>
+        <%= link_to main_search_path, class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == nil}", "aria-current": params.dig(:filter, :with_resource_type) == nil ? "true" : "" do %>
           <%= resource_type_icon("all") %>
           <span><%= t("all", scope: "decidim.searches.filters.state") %></span>
           <span class="label ml-auto"><%= @results_count %></span>
@@ -42,7 +42,7 @@
             <% elements.each do |type, results| %>
               <% if results[:count].positive? %>
                 <li>
-                <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}" do %>
+                <%= link_to search_path_by_resource_type(type), class: "filter#{" is-active" if params.dig(:filter, :with_resource_type) == type}", "aria-current": params.dig(:filter, :with_resource_type) == type ? "true" : "" do %>
                   <%= resource_type_icon(type) %>
                   <span><%= searchable_resource_human_name(type) %></span>
                   <span class="label ml-auto"><%= results[:count] %></span>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds a `aria-current="true"` to the current filter in search page, to improve accessibility.

This PR comes form the audit of Angers city (page 53) and refers to criterias 1.3.3 and 1.4.1 from WCAG.

#### Testing

1. As a non logged in user, on the home page, go to the search input in the header and make a research by entering for example a word from the title of a process
2. On the search page, open your screenreader and navigate to the filter area
3. Ensure that when you are on the "All" filter, the information that it is the current filter is read
4. Select another filter, navigate again to that filter and ensure that the information on it being the current filter is read

### :camera: Screenshots
<img width="1110" height="730" alt="Capture d’écran 2025-08-25 à 11 31 49" src="https://github.com/user-attachments/assets/80b38169-d9dc-42a5-b7d5-8fe2688d8cb1" />

<img width="1163" height="720" alt="Capture d’écran 2025-08-25 à 11 32 55" src="https://github.com/user-attachments/assets/57c71bb7-504e-4382-acd0-01bda572b943" />

:hearts: Thank you!
