### PR TITLE
Fix officialization view for users without nickname

### DIFF
--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -21,12 +21,21 @@
       <tbody>
       <% @users.each do |user| %>
         <tr data-user-id="<%= user.id %>">
-          <td data-label="<%= t(".name") %>">
-            <%= link_to_if user.nickname.present?, user.name, decidim.profile_path(user.nickname) %>
-          </td>
-          <td data-label="<%= t(".nickname") %>">
-            <%= link_to_if user.nickname.present?, user.nickname, decidim.profile_path(user.nickname) %>
-          </td>
+          <% if user.nickname.present? %>
+            <td data-label="<%= t(".name") %>">
+              <%= link_to user.name, decidim.profile_path(user.nickname) %>
+            </td>
+            <td data-label="<%= t(".nickname") %>">
+              <%= link_to user.nickname, decidim.profile_path(user.nickname) %>
+            </td>
+          <% else %>
+            <td data-label="<%= t(".name") %>">
+              <%= user.name %>
+            </td>
+            <td data-label="<%= t(".nickname") %>">
+              <%= user.nickname %>
+            </td>
+          <% end %>
           <td data-label="<%= t(".created_at") %>">
             <%= l user.created_at, format: :short %>
           </td>

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -66,6 +66,22 @@ describe "Admin manages officializations" do
     end
   end
 
+  describe "when user's nickname is blank" do
+    let!(:user) { create(:user, :managed, organization:, nickname: "") }
+
+    before do
+      within_admin_sidebar_menu do
+        click_on "Participants"
+      end
+    end
+
+    it "cannot be officialized" do
+      within "tr[data-user-id=\"#{user.id}\"]" do
+        expect(page).to have_no_link("Officialize")
+      end
+    end
+  end
+
   describe "officializating users" do
     context "when not yet officialized" do
       let!(:user) { create(:user, organization:) }


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a bug where the admin officializations page crashes when displaying users without nicknames, reported in #15121 .

##### The Problem

The previous implementation using `link_to_if` still evaluates the path argument even when the condition is false, causing `decidim.profile_path(user.nickname)` to throw a `ActionView::Template::Error` when nickname is nil or blank.

##### The Solution

- Replace `link_to_if` with explicit conditional rendering
- When nickname is present: render clickable links for both name and nickname
- When nickname is blank: render text without links

#### :pushpin: Related Issues
- Fixes #15121

#### Testing

Added test coverage to ensure the page handles users with blank nicknames correctly.

```console
cd decidim-admin
bundle exec rspec spec/system/admin_manages_officializations_spec.rb:70
```
Without this view fix, the test would fail.

### :camera: Screenshots

After applying the PR, *name* will be plain text without a link, and *nickname* will be empty.

(in English)

<img width="1169" height="412" alt="fixed-nickname-en" src="https://github.com/user-attachments/assets/bcb93cf2-a205-404a-87b1-dcdfd6c927bf" />

(in Japanese)

<img width="1178" height="388" alt="fixed-nickname" src="https://github.com/user-attachments/assets/f4a103b8-dd14-4d11-8d07-b7e4ed9649d6" />

:hearts: Thank you!
