### PR TITLE
Fix failing spec in `admin_manages_elections_spec.rb`

### DIFF
--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -19,8 +19,8 @@ describe "Admin manages elections" do
   let!(:published_results_election) { create(:election, :published, :published_results, component: current_component) }
 
   let(:attributes) { attributes_for(:election, component: current_component) }
-  let(:start_time) { Time.current.change(day: 10, hour: 12, min: 50) }
-  let(:end_time) { Time.current.change(day: 12, hour: 12, min: 50) }
+  let(:start_time) { 1.day.from_now }
+  let(:end_time) { 3.days.from_now }
 
   before do
     visit_component_admin


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #14903, I found a failing spec locally in elections. 

I see that it is already fixed in #14915, but that is still under review, so I'm expediting this fix so we don't have flakys.  

#### Testing

Run `bin/rspec decidim-elections/spec/system/admin/admin_manages_elections_spec.rb:75`

(At least locally is failing 100% of the times in my machine)

### :camera: Stacktrace

#### Before

```bash
$ bin/rspec decidim-elections/spec/system/admin/admin_manages_elections_spec.rb:75
Run options: include {:locations=>{"./spec/system/admin/admin_manages_elections_spec.rb"=>[75]}}

Randomized with seed 53496

Admin manages elections
  updating an election
2025-09-02 12:19:13 +0200 SEVERE: http://1.lvh.me:5000/admin/participatory_processes/outside-satisfaction-1/components/26/manage/elections/139 - Failed to load resource: the server responded with a status of 422 (Unprocessable Content)
    updates an election (FAILED - 1)

Failures:

  1) Admin manages elections updating an election updates an election
     Failure/Error: expect(page).to have_admin_callout "Election updated successfully"
       expected to find text "Election updated successfully" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nMraz Group\nSee site\nEnglish\nuser1@example.org\n/\nProcesses\n/\n<script>alert(\"participatory_process_title\");</script> Neque animi enim. 49\n/\nComponents\n/\n<script>alert(\"component_name\");</script> Voluptates non repellat. 205\nSee process\nThere was a problem updating the election.\n  About this process\nLanding page layout\nPhases\nComponents\n<script>alert(\"component_name\");</script> Voluptates non repellat. 205\nAttachments\nProcess admins\nModerations\nAccess links\nMain\nQuestions\nCensus\nDashboard\nSave and continue\nBasic info\nTitle*\nRequired field\nEnglish\nCatalà\nCastellano\nDescription\nEnglish\nCatalà\nCastellano\nNormal\nHeading 2\nHeading 3\nHeading 4\nHeading 5\nHeading 6\nSuscipit voluptas est. 313\nAdd an image gallery (optional)\nAdd images\nCalendar\nCheck that the organization time zone is correct in the organization settings. The current configuration is UTC (September 02, 2025 10:19).\nManual start\nStart time\nmust be before Thu, 04 Sep 2025 10:19:10 +0000\nFormat: dd/mm/yyyyFormat: hh:mm\nEnd time*\nRequired field\nmust be after Wed, 10 Sep 2025 12:50:00 +0000\nFormat: dd/mm/yyyyFormat: hh:mm\nResults availability\nReal time\nautomatically publish results during the election while voting\nQuestion by question\nmanually handle voting and publish results for each question\nAfter elections end\npublish results when the election is finished"

     [Screenshot Image]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_elections_updating_an_election_updates_an_election_597.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_elections_updating_an_election_updates_an_election_597.html




     # ./spec/system/admin/admin_manages_elections_spec.rb:89:in `block (3 levels) in <top (required)>'
     # /home/apereira/Work/decidim/decidim/.devenv/state/.bundle/ruby/3.3.0/gems/webmock-3.24.0/lib/webmock/rspec.rb:39:in `block (2 levels) in <main>'

Top 1 slowest examples (19.12 seconds, 42.8% of total time):
  Admin manages elections updating an election updates an election
    19.12 seconds ./spec/system/admin/admin_manages_elections_spec.rb:75

Finished in 44.62 seconds (files took 5.44 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_elections_spec.rb:75 # Admin manages elections updating an election updates an election

Randomized with seed 53496
```

#### After

```bash
$ bin/rspec decidim-elections/spec/system/admin/admin_manages_elections_spec.rb:75
Run options: include {:locations=>{"./spec/system/admin/admin_manages_elections_spec.rb"=>[75]}}

Randomized with seed 63519

Admin manages elections
  updating an election
    updates an election

Top 1 slowest examples (7.64 seconds, 77.2% of total time):
  Admin manages elections updating an election updates an election
    7.64 seconds ./spec/system/admin/admin_manages_elections_spec.rb:75

Finished in 9.9 seconds (files took 4.97 seconds to load)
1 example, 0 failures

Randomized with seed 63519


:hearts: Thank you!
