### PR TITLE
Remove `Platoniq/decidim-install` references

### DIFF
--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -32,7 +32,7 @@ You can see the xref:install:manual.adoc[official manual installation tutorial] 
 
 === B. Docker / docker-compose
 
-If you are proeficient with Docker you can use the docker-compose.yml file that we provide as an example. The main limitation that you will have is that you cannot use modules with this image, only the official ones. It can be a good starting point if you want to check out Decidim locally quickly and before going to the manual installation approach.
+If you are proficient with Docker you can use the docker-compose.yml file that we provide as an example. The main limitation that you will have is that you cannot use modules with this image, only the official ones. It can be a good starting point if you want to check out Decidim locally quickly and before going to the manual installation approach.
 
 You can see the docker instructions at the https://github.com/decidim/docker/[Docker repository].
 

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -28,17 +28,14 @@ gem install decidim
 decidim decidim_application
 ----
 
-You can see the xref:install:manual.adoc[official manual installation tutorial], and also you have https://platoniq.github.io/decidim-install/[another manual installation tutorial] made by the nice people of http://www.platoniq.net/[Platoniq].
+You can see the xref:install:manual.adoc[official manual installation tutorial] for all the instructions on how to install Decidim.
 
-=== B. Installation script [experimental]
+=== B. Docker / docker-compose
 
-There is also an installation script made by http://www.platoniq.net/[Platoniq] that allows you to install Decidim automatically. You can even check it on a Vagrant virtual machine if you want to. https://platoniq.github.io/decidim-install/script/[More information].
+If you are proeficient with Docker you can use the docker-compose.yml file that we provide as an example. The main limitation that you will have is that you cannot use modules with this image, only the official ones. It can be a good starting point if you want to check out Decidim locally quickly and before going to the manual installation approach.
 
-[source,console]
-----
-wget -O install-decidim.sh https://raw.githubusercontent.com/Platoniq/decidim-install/master/script/install-decidim.sh
-chmod +x install-decidim.sh
-./install-decidim.sh decidim_application
+You can see the docker instructions at the https://github.com/decidim/docker/[Docker repository].
+
 ----
 
 == Initializing your application for local development

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -18,7 +18,7 @@ We are starting with an Ubuntu 22.04.3 LTS. This is an opinionated guide, so you
 
 We recommend to have at least some basic proficiency in GNU/Linux (i.e. how to use the command-line, packages, etc), networking knowledge, server administration, development in general, and some basic knowledge about software package managers. It would be great to have Ruby on Rails development basics (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how package libraries are working (we use `bundler` for handling ruby packages, and `npm`/`yarn` for handling javascript).
 
-In this guide, we will see how to install rbenv, PostgreSQL, Node.js and, Decidim, and how to configure everything together for a development environment. Mind that if you want to make a production deployment with real users this guide is not enough, you should configure a web server (like nginx), backups, monitoring, etc. This is out of the scope of this guide, but you can follow the https://platoniq.github.io/decidim-install/[Platoniq guide].
+In this guide, we will see how to install rbenv, PostgreSQL, Node.js and, Decidim, and how to configure everything together for a development environment. Mind that if you want to make a production deployment with real users this guide is not enough, you should configure a web server (like nginx), backups, monitoring, etc. This is out of the scope of this guide, but you can follow any Ruby on Rails guide on how to configure it for production or use a service like Render, Fly.io, Heroku, etc.
 
 == 1. Installing rbenv
 
@@ -152,7 +152,7 @@ Visit http://localhost:3000 to see your app running. 🎉 🎉
 
 [NOTE]
 ====
-With these steps you would only have an initial installation for trying Decidim, but it still needs lots of things to take in account. If you want a working production system then we recommend that you follow the https://platoniq.github.io/decidim-install/[Decidim Install guide by Platoniq].
+With these steps you would only have an initial installation for trying Decidim, but it still needs lots of things to take in account.
 ====
 
 == Extra notes

--- a/docs/modules/install/pages/update.adoc
+++ b/docs/modules/install/pages/update.adoc
@@ -1,7 +1,5 @@
 = Updating Decidim
 
-IMPORTANT: This section was initially copied from https://platoniq.github.io/decidim-install/decidim-update/[Platoniq's Guide]
-
 Because Decidim is a gem in our system, to update it we will have to edit our `Gemfile` and specify the new version number.
 
 To keep our system up to date, we can visit the page https://github.com/decidim/decidim/releases[Releases] and compare with our `Gemfile`. See if the lines specifying the gem called "decidim-something" are followed by the number corresponding to the latest release:


### PR DESCRIPTION
#### :tophat: What? Why?

We have some outdated references in our installation documentation, so this PR fixes that.

Basically, the https://github.com/Platoniq/decidim-install repository isn't maintained anymore ([last commit was 3 years ago](https://github.com/Platoniq/decidim-install/commits/main/)), so we need to drop it. 

We should backport this PR as it is a problem with older versions too (v0.30, v0.29, etc)

Related to this, I'm preparing another PR to update the instructions to a newish Ubuntu version.

#### Testing

All the links should work and the words should make sense 😄  

:hearts: Thank you!
