### PR TITLE
Implement hamburger menu 

### DIFF
--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -52,6 +52,18 @@ if (menuButton && menuContainer) {
 }
 
 if (menuContainer) {
+  document.addEventListener("keydown", function (event) {
+    if (event.key === "Escape") {
+      const isOpen = menuContainer.getAttribute("aria-hidden") === "true";
+
+      if (isOpen) {
+        menuContainer.setAttribute("aria-hidden", "true");
+        setMenuOpacity("1");
+        document.body.style.overflow = "scroll";
+      }
+    }
+  })
+
   document.addEventListener("click", function (event) {
     const isOpen = menuContainer.getAttribute("aria-hidden") === "false";
     const closeMenuButton = document.getElementById("main-dropdown-summary-desktop-close");

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -16,3 +16,44 @@ document.addEventListener("turbo:load", () => {
     })
   }
 });
+
+const menuContainer = document.getElementById("dropdown-menu-main-desktop");
+const menuButton = document.getElementById("main-dropdown-summary-desktop");
+const content = document.getElementById("content");
+const footer = document.querySelector("footer");
+const menuBar = document.getElementById("menu-bar-container");
+
+if (menuButton !== null) {
+  menuButton.addEventListener("click", function () {
+    if (menuContainer === null) {
+      return;
+    }
+
+    const isHidden = menuContainer.getAttribute("aria-hidden") === "true";
+
+    if (isHidden) {
+      menuContainer.setAttribute("aria-hidden", "false");
+      content.style.opacity = "0.3";
+      footer.style.opacity = "0.3";
+      menuBar.style.opacity = "0.3";
+    } else {
+      menuContainer.setAttribute("aria-hidden", "true");
+      content.style.opacity = "1";
+      footer.style.opacity = "1";
+      menuBar.style.opacity = "1";
+    }
+  });
+}
+
+if (menuContainer !== null) {
+  document.addEventListener("click", function (event) {
+    const isOpen = menuContainer.getAttribute("aria-hidden") === "false";
+    const clickedInsideMenu = menuContainer.contains(event.target) || menuButton.contains(event.target);
+
+    if (isOpen && !clickedInsideMenu) {
+      menuContainer.setAttribute("aria-hidden", "true");
+      content.style.opacity = "1";
+      footer.style.opacity = "1";
+    }
+  });
+}

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -17,43 +17,52 @@ document.addEventListener("turbo:load", () => {
   }
 });
 
+
+const setMenuOpacity = (opacity) => {
+  const content = document.getElementById("content");
+  const footer = document.querySelector("footer");
+  const menuBar = document.getElementById("menu-bar-container");
+
+  if (content) {
+    content.style.opacity = opacity;
+  }
+  if (footer) {
+    footer.style.opacity = opacity;
+  }
+  if (menuBar) {
+    menuBar.style.opacity = opacity;
+  }
+}
+
 const menuContainer = document.getElementById("dropdown-menu-main-desktop");
 const menuButton = document.getElementById("main-dropdown-summary-desktop");
-const content = document.getElementById("content");
-const footer = document.querySelector("footer");
-const menuBar = document.getElementById("menu-bar-container");
 
-if (menuButton !== null) {
+if (menuButton && menuContainer) {
   menuButton.addEventListener("click", function () {
-    if (menuContainer === null) {
+    const isHidden = menuContainer.getAttribute("aria-hidden") === "true";
+    if (!isHidden) {
       return;
     }
-
-    const isHidden = menuContainer.getAttribute("aria-hidden") === "true";
-
-    if (isHidden) {
+    setTimeout(() => {
+      setMenuOpacity("0.3");
+      document.body.style.overflow = "hidden";
       menuContainer.setAttribute("aria-hidden", "false");
-      content.style.opacity = "0.3";
-      footer.style.opacity = "0.3";
-      menuBar.style.opacity = "0.3";
-    } else {
-      menuContainer.setAttribute("aria-hidden", "true");
-      content.style.opacity = "1";
-      footer.style.opacity = "1";
-      menuBar.style.opacity = "1";
-    }
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }, 50);
   });
 }
 
-if (menuContainer !== null) {
+if (menuContainer) {
   document.addEventListener("click", function (event) {
     const isOpen = menuContainer.getAttribute("aria-hidden") === "false";
-    const clickedInsideMenu = menuContainer.contains(event.target) || menuButton.contains(event.target);
+    const closeMenuButton = document.getElementById("main-dropdown-summary-desktop-close");
+    const clickedInsideMenu = menuContainer.contains(event.target);
+    const clickCloseButton = closeMenuButton && closeMenuButton.contains(event.target);
 
-    if (isOpen && !clickedInsideMenu) {
+    if (isOpen && (!clickedInsideMenu || clickCloseButton)) {
       menuContainer.setAttribute("aria-hidden", "true");
-      content.style.opacity = "1";
-      footer.style.opacity = "1";
+      setMenuOpacity("1");
+      document.body.style.overflow = "scroll";
     }
   });
 }

--- a/decidim-core/app/packs/src/decidim/dropdown_menu.js
+++ b/decidim-core/app/packs/src/decidim/dropdown_menu.js
@@ -17,7 +17,6 @@ document.addEventListener("turbo:load", () => {
   }
 });
 
-
 const setMenuOpacity = (opacity) => {
   const content = document.getElementById("content");
   const footer = document.querySelector("footer");

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -163,7 +163,8 @@
   /* shared styles */
   &__highlight-metadata,
   &__grid-metadata {
-    @apply mt-auto flex items-center justify-between flex-wrap text-sm text-gray-2 [&>*]:flex [&>*]:items-center [&>*]:gap-1 first:[&>*]:flex-none;
+    @apply mt-auto flex gap-x-2 items-center justify-between flex-wrap text-sm text-gray-2 [&>*]:flex [&>*]:items-center
+    [&>*]:gap-1 first:[&>*]:flex-none;
 
     svg {
       @apply flex-none text-gray fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -34,7 +34,6 @@
 }
 
 [data-target="dropdown-menu-main-mobile"] {
-
   &[aria-expanded="true"] > span {
     @apply hidden;
   }

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -33,9 +33,21 @@
   }
 }
 
-[data-target="dropdown-menu-main-desktop"] {
-  > span:first-of-type {
+[data-target="dropdown-menu-main-mobile"] {
+
+  &[aria-expanded="true"] > span {
+    @apply hidden;
+  }
+
+  &[aria-expanded="false"] > span {
     @apply block;
+  }
+}
+
+[data-target="dropdown-menu-main-desktop"] {
+  > span,
+  > svg {
+    @apply hidden md:block #{!important};
   }
 }
 
@@ -70,7 +82,7 @@
   }
 
   > svg {
-    @apply w-5 h-6 flex-none text-xs font-normal text-black fill-current;
+    @apply w-fit h-6 flex-none text-xs font-normal text-black fill-current px-2;
   }
 
   & > ul {

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -46,7 +46,7 @@
 [data-target="dropdown-menu-main-desktop"] {
   > span,
   > svg {
-    @apply hidden md:block #{!important};
+    @apply hidden md:block;
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -471,7 +471,7 @@ header {
           & > span,
           & > svg:first-of-type {
             @apply text-gray-8;
-            @apply block #{!important};
+            display: block !important;
           }
 
           & > span {
@@ -480,7 +480,7 @@ header {
 
           & > svg:last-of-type {
             @apply text-gray-2  ml-1;
-            @apply block #{!important};
+            display: block !important;
           }
         }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -76,7 +76,7 @@ header {
         @apply block bg-transparent w-full px-4 py-2 h-full;
 
         &::placeholder {
-          @apply text-gray-8 text-sm ltr:pl-6 rtl:pr-6;
+          @apply text-gray-8 text-sm ltr:pl-0 rtl:pr-0;
         }
       }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -81,7 +81,7 @@ header {
       }
 
       button[type="submit"] {
-        @apply absolute ltr:left-4 rtl:right-4 inset-y-2;
+        @apply absolute ltr:left-4 rtl:right-4 inset-y-0 text-secondary px-2;
 
         svg {
           @apply fill-gray-8;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -81,7 +81,11 @@ header {
       }
 
       button[type="submit"] {
-        @apply absolute ltr:right-2 rtl:left-2 inset-y-0 text-secondary px-2;
+        @apply absolute ltr:right-4 rtl:left-4 inset-y-2;
+
+        svg {
+          @apply fill-gray-8;
+        }
       }
     }
 
@@ -106,7 +110,11 @@ header {
       @apply hidden lg:flex items-center justify-between text-center divide-x-2 divide-gray-3 ml-auto [&>*]:px-4 xl:[&>*]:px-6 first:[&>*]:pl-0 last:[&>*]:pr-0;
 
       &__item {
-        @apply flex flex-col items-center text-secondary px-2 py-1 rounded hover:underline hover:bg-background;
+        @apply flex items-center gap-x-2 text-secondary px-2 py-1 rounded;
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+        }
 
         &-wrapper {
           @apply flex gap-x-4 xl:gap-x-6;
@@ -117,13 +125,58 @@ header {
         }
       }
 
+      &__dropdown {
+        @apply flex items-end absolute top-full right-0 z-30;
+
+        .menu-bar {
+          &__main-dropdown {
+            @apply hidden lg:flex flex-col;
+
+            &__left {
+              @apply w-full;
+            }
+          }
+
+          &__dropdown-menu {
+            @apply w-full;
+
+            li {
+              @apply border-none;
+            }
+          }
+        }
+      }
+
+      &__trigger {
+        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
+
+        span {
+          @apply text-secondary;
+        }
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+
+          svg,
+          span {
+            @apply text-white;
+          }
+        }
+
+        &[aria-expended="true"] {
+          #content {
+            @apply bg-[rgb(0_0_0_/_0.5)];
+          }
+        }
+      }
+
       /* overwrite default dropdown styles */
       [data-target*="dropdown"] > span:only-of-type {
         @apply gap-0;
       }
 
       svg {
-        @apply w-5 h-5 fill-current;
+        @apply w-4 h-5 fill-current;
       }
 
       svg + span {
@@ -142,7 +195,16 @@ header {
         }
 
         span {
-          @apply text-sm first-letter:uppercase;
+          @apply text-secondary;
+        }
+
+        &:hover {
+          @apply bg-secondary rounded-[4px] text-white;
+
+          svg,
+          span {
+            @apply text-white;
+          }
         }
       }
 
@@ -243,7 +305,7 @@ header {
 
     /* overwrite default dropdown styles */
     [id*="dropdown-menu"] {
-      @apply py-0 mx-0 w-full;
+      @apply py-0 mx-0 w-full lg:w-fit;
 
       &[aria-hidden="true"] {
         @apply md:hidden;
@@ -390,18 +452,61 @@ header {
     }
 
     &__language-chooser {
-      @apply absolute top-full left-0 bg-white rounded w-full bg-gray-5;
+      @apply absolute top-full left-0 rounded w-full bg-gray-5;
+
+      &-desktop {
+        @apply border-r border-gray-6 pr-10;
+
+        & button {
+          @apply border border-gray-7 rounded px-4 py-2 gap-x-2;
+
+          & > span,
+          & > svg:first-of-type {
+            @apply text-gray-8;
+            @apply block #{!important};
+          }
+
+          & > span {
+            @apply text-sm font-normal;
+          }
+
+          & > svg:last-of-type {
+            @apply text-gray-2  ml-1;
+            @apply block #{!important};
+          }
+        }
+
+        #dropdown-menu-language-chooser {
+          @apply absolute top-full bg-white shadow-[1px_4px_8px_3px_rgba(0,0,0,0.15)] p-2;
+
+          ul {
+            @apply grid grid-cols-3;
+
+            li:hover {
+              @apply rounded;
+            }
+
+            .is-active {
+              @apply bg-[#fc9292] rounded;
+
+              &:hover {
+                @apply bg-[var(--secondary)];
+              }
+            }
+          }
+        }
+      }
     }
 
     &__dropdown-menu {
-      @apply w-full md:w-1/4 bg-primary px-4 md:px-8 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-white;
+      @apply w-full md:w-1/4 px-4 md:px-8 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-[var(--secondary)];
 
       > * {
-        @apply py-3 md:py-3.5;
+        @apply py-3 md:py-3.5 md:px-2;
       }
 
       a {
-        @apply flex items-center justify-start gap-1 font-semibold text-lg text-white;
+        @apply flex items-center justify-start gap-1 font-semibold text-xl text-[var(--secondary)] underline;
 
         span {
           @apply min-w-0 truncate;
@@ -411,13 +516,21 @@ header {
           @apply flex-none fill-current;
         }
       }
+
+      li:hover {
+        @apply bg-[var(--secondary)] rounded-[4px];
+
+        a {
+          @apply text-white;
+        }
+      }
     }
 
     &__main-dropdown {
-      @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[1280px] h-screen md:h-auto;
+      @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[530px] h-screen md:h-auto;
 
       &__left {
-        @apply flex flex-col justify-between p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
+        @apply p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
 
         &-top {
           @apply border-b-4 border-gray-3 pb-3;
@@ -471,6 +584,24 @@ header {
 
       &__subtitle {
         @apply hidden text-md md:flex md:text-lg text-gray-2 mt-5;
+      }
+    }
+
+    &__dropdown-desktop {
+      .card__highlight {
+        @apply flex-col ring-transparent rounded-lg shadow-[1px_4px_8px_3px_rgba(0,0,0,0.15)];
+
+        &-img {
+          @apply w-full aspect-[3/1] rounded-tl-lg rounded-tr-lg;
+        }
+
+        &-text {
+          @apply w-full items-start text-start bg-background-2 rounded-bl-lg rounded-br-lg;
+
+          h3 {
+            @apply font-bold;
+          }
+        }
       }
     }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -471,6 +471,7 @@ header {
           & > span,
           & > svg:first-of-type {
             @apply text-gray-8;
+
             display: block !important;
           }
 
@@ -480,6 +481,7 @@ header {
 
           & > svg:last-of-type {
             @apply text-gray-2  ml-1;
+
             display: block !important;
           }
         }

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -81,7 +81,7 @@ header {
       }
 
       button[type="submit"] {
-        @apply absolute ltr:right-4 rtl:left-4 inset-y-2;
+        @apply absolute ltr:left-4 rtl:right-4 inset-y-2;
 
         svg {
           @apply fill-gray-8;
@@ -126,11 +126,11 @@ header {
       }
 
       &__dropdown {
-        @apply flex items-end absolute top-full right-0 z-30;
+        @apply flex items-end absolute top-0 right-0 z-30 h-screen;
 
         .menu-bar {
           &__main-dropdown {
-            @apply hidden lg:flex flex-col;
+            @apply hidden lg:flex flex-col h-full md:p-8;
 
             &__left {
               @apply w-full;
@@ -141,9 +141,17 @@ header {
             @apply w-full;
 
             li {
-              @apply border-none;
+              @apply py-3 md:py-3.5 border-b last:border-0 border-gray-3;
+
+              a {
+                @apply no-underline;
+              }
             }
           }
+        }
+
+        #main-dropdown-summary-desktop-close {
+          @apply self-end;
         }
       }
 
@@ -321,14 +329,14 @@ header {
     }
 
     &__breadcrumb-desktop {
-      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black;
+      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black gap-x-2;
 
       .no-interactive {
-        @apply font-normal px-2;
+        @apply font-normal px-0;
       }
 
       &__dropdown-trigger {
-        @apply flex rounded py-1 z-20 pr-2 font-semibold;
+        @apply flex rounded py-1 z-20 font-semibold;
 
         &:hover {
           @apply z-10 relative before:content-[''] before:absolute before:w-[calc(100%+3rem+1px)] before:min-w-[10rem] before:h-40 before:left-1/2 before:top-1/2 before:-translate-x-1/2 before:-translate-y-1/4 before:-z-10;
@@ -499,7 +507,7 @@ header {
     }
 
     &__dropdown-menu {
-      @apply w-full md:w-1/4 px-4 md:px-8 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-[var(--secondary)];
+      @apply w-full md:w-1/4 px-4 md:px-0 pt-0 pb-3 md:py-3 divide-y divide-gray-3 text-[var(--secondary)];
 
       > * {
         @apply py-3 md:py-3.5 md:px-2;
@@ -530,7 +538,7 @@ header {
       @apply bg-white flex flex-row rounded-b shadow-lg text-black w-full lg:w-[530px] h-screen md:h-auto;
 
       &__left {
-        @apply p-4 md:p-8 space-y-5 hidden md:block md:w-3/4;
+        @apply p-4 md:py-8 md:px-0 space-y-5 hidden md:block md:w-3/4;
 
         &-top {
           @apply border-b-4 border-gray-3 pb-3;

--- a/decidim-core/app/presenters/decidim/breadcrumb_root_menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/breadcrumb_root_menu_item_presenter.rb
@@ -18,7 +18,7 @@ module Decidim
 
     def arrow_link(text, url, args = {})
       link_to url, class: args.with_indifferent_access[:class] do
-        "<span>#{text}</span> #{icon("arrow-right-line")}".html_safe
+        "<span>#{text}</span>".html_safe
       end
     end
   end

--- a/decidim-core/app/views/layouts/decidim/header/_main.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main.html.erb
@@ -16,16 +16,18 @@
       <% if current_user&.ephemeral? %>
         <%= render partial: "layouts/decidim/header/close_ephemeral_session" %>
       <% else %>
-        <div role="search" class="main-bar__search">
-          <%= render partial: "layouts/decidim/header/main_search" %>
+        <div class="flex justify-between gap-x-8">
+          <div role="search" class="main-bar__search">
+            <%= render partial: "layouts/decidim/header/main_search" %>
+          </div>
+          <nav role="navigation" aria-label="<%= t("layouts.decidim.header.user_menu") %>" class="main-bar__links-desktop">
+            <%= render partial: "layouts/decidim/header/main_links_desktop" %>
+          </nav>
+          <div class="main-bar__menu-mobile">
+            <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
+          </div>
+          <%= render partial: "layouts/decidim/header/main_links_mobile_account" if current_user %>
         </div>
-        <nav role="navigation" aria-label="<%= t("layouts.decidim.header.user_menu") %>" class="main-bar__links-desktop">
-          <%= render partial: "layouts/decidim/header/main_links_desktop" %>
-        </nav>
-        <div class="main-bar__menu-mobile">
-          <%= render partial: "layouts/decidim/header/main_menu_mobile" %>
-        </div>
-        <%= render partial: "layouts/decidim/header/main_links_mobile_account" if current_user %>
       <% end %>
     </div>
   <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -1,41 +1,53 @@
-<% if !current_user %>
-  <div>
-    <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>
-      <%= icon "user-line" %><span><%= t("layouts.decidim.header.log_in") %></span>
-    <% end %>
-  </div>
-<% else %>
-  <div class="main-bar__dropdown-container">
-    <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
-      <% unread_data = current_user_unread_data %>
-      <% if unread_data[:unread_items] %>
-        <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
-        <% if unread_data[:unread_notifications] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
-        <% end %>
-        <% if unread_data[:unread_conversations] %>
-          <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
-        <% end %>
+<div class="flex">
+  <% if !current_user %>
+    <div>
+      <%= link_to decidim.new_user_session_path, class: "main-bar__links-desktop__item", "aria-label": t("layouts.decidim.header.log_in") do %>
+        <%= icon "user-line" %><span><%= t("layouts.decidim.header.log_in") %></span>
       <% end %>
-      <% if current_user.avatar.attached? %>
-        <span class="main-bar__avatar">
-          <span>
-            <%= image_tag(
-                  current_user.attached_uploader(:avatar).variant_url(:thumb),
-                  alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
-                ) %>
-          </span>
-        </span>
-      <% else %>
-        <span class="main-bar__links-desktop__item-account">
-          <%= text_initials(current_user.name) %>
-        </span>
-      <% end %>
-    </button>
-    <div id="dropdown-menu-account" aria-hidden="true">
-      <ul class="dropdown dropdown__bottom main-bar__dropdown">
-        <%= render partial: "layouts/decidim/header/main_links_dropdown", locals: { unread_data: } %>
-      </ul>
     </div>
+  <% else %>
+    <div class="main-bar__dropdown-container">
+      <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
+        <% unread_data = current_user_unread_data %>
+        <% if unread_data[:unread_items] %>
+          <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>
+          <% if unread_data[:unread_notifications] %>
+            <%= content_tag :span, t("layouts.decidim.user_menu.unread_notifications"), class: "sr-only" %>
+          <% end %>
+          <% if unread_data[:unread_conversations] %>
+            <%= content_tag :span, t("layouts.decidim.user_menu.unread_conversations"), class: "sr-only" %>
+          <% end %>
+        <% end %>
+        <% if current_user.avatar.attached? %>
+          <span class="main-bar__avatar">
+            <span>
+              <%= image_tag(
+                    current_user.attached_uploader(:avatar).variant_url(:thumb),
+                    alt: t("decidim.author.avatar", name: decidim_sanitize(current_user.avatar.name))
+                  ) %>
+            </span>
+          </span>
+        <% else %>
+          <span class="main-bar__links-desktop__item-account">
+            <%= text_initials(current_user.name) %>
+          </span>
+        <% end %>
+      </button>
+      <div id="dropdown-menu-account" aria-hidden="true">
+        <ul class="dropdown dropdown__bottom main-bar__dropdown">
+          <%= render partial: "layouts/decidim/header/main_links_dropdown", locals: { unread_data: } %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+  <button id="main-dropdown-summary-desktop" class="main-bar__links-desktop__trigger"
+          data-controller="dropdown"
+          data-target="dropdown-menu-main-desktop">
+    <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
+    <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
+  </button>
+
+  <div id="dropdown-menu-main-desktop" class="main-bar__links-desktop__dropdown main-bar__links-desktop__dropdown-before" aria-hidden="true">
+    <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_desktop", locals: { id: "breadcrumb-main-dropdown-desktop" } %>
   </div>
-<% end %>
+</div>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -44,7 +44,6 @@
           data-controller="dropdown"
           data-target="dropdown-menu-main-desktop">
     <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
-    <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
   </button>
 
   <div id="dropdown-menu-main-desktop" class="main-bar__links-desktop__dropdown main-bar__links-desktop__dropdown-before" aria-hidden="true">

--- a/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_menu_mobile.html.erb
@@ -1,7 +1,7 @@
 <button id="main-dropdown-summary-mobile" class="main-bar__links-mobile__trigger p-0"
                                           data-controller="dropdown"
                                           data-target="dropdown-menu-main-mobile">
-  <%= icon "menu-line" %><span class="sr-only"><%= t("main_menu", scope: "layouts.decidim.header") %></span>
+  <%= icon "menu-line" %><span><%= t("menu", scope: "decidim.admin.titles") %></span>
   <%= icon "close-line" %>
 </button>
 <div aria-hidden="true" class="border-r border-gray-6 h-full"></div>

--- a/decidim-core/app/views/layouts/decidim/header/_main_search.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_search.html.erb
@@ -1,4 +1,7 @@
 <%= form_tag(decidim.search_path, method: :get, id: "form-search_topbar") do %>
+  <button type="submit" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
+    <%= icon "search-line" %>
+  </button>
   <%= text_field_tag(
     :term,
     nil,
@@ -9,7 +12,4 @@
     title: t("decidim.search.term_input_placeholder"),
     "aria-label": t("decidim.search.term_input_placeholder")
   ) %>
-  <button type="submit" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
-    <%= icon "search-line" %>
-  </button>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
@@ -1,4 +1,9 @@
-<div id="<%= id %>" class="menu-bar__main-dropdown menu-bar__dropdown-desktop">
+<div id="<%= id %>" class="menu-bar__main-dropdown menu-bar__dropdown-desktop test">
+  <button id="main-dropdown-summary-desktop-close" class="main-bar__links-desktop__trigger"
+          data-controller="dropdown"
+          data-target="dropdown-menu-main-desktop">
+    <%= icon "close-line" %><span><%= t("close", scope: "layouts.decidim.header") %></span>
+  </button>
   <%= breadcrumb_root_menu.render %>
   <div class="menu-bar__main-dropdown__left">
     <%= cell("decidim/highlighted_participatory_process", menu_highlighted_participatory_process) %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_main_dropdown_desktop.html.erb
@@ -1,10 +1,6 @@
-<div id="<%= id %>" class="menu-bar__main-dropdown">
-  <div class="menu-bar__main-dropdown__left">
-    <div class="menu-bar__main-dropdown__left-top">
-      <%= render partial: "layouts/decidim/header/menu_breadcrumb_main_dropdown_top_left" %>
-    </div>
-    <%= cell("decidim/highlighted_participatory_process", menu_highlighted_participatory_process) %>
-    <%= cell "decidim/content_blocks/menu_breadcrumb_last_activity", current_organization %>
-  </div>
+<div id="<%= id %>" class="menu-bar__main-dropdown menu-bar__dropdown-desktop">
   <%= breadcrumb_root_menu.render %>
+  <div class="menu-bar__main-dropdown__left">
+    <%= cell("decidim/highlighted_participatory_process", menu_highlighted_participatory_process) %>
+  </div>
 </div>

--- a/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
+++ b/decidim-core/lib/decidim/assets/tailwind/tailwind.config.js.erb
@@ -57,7 +57,8 @@ module.exports = {
         2: "#FAFBFC",
         3: "#EFEFEF",
         4: "#E4EEFF99", // 60% opacity
-        5: "#E9E9E9"
+        5: "#E9E9E9",
+        6: "#FAFAFA"
       }
     },
     container: {

--- a/decidim-core/spec/system/search_spec.rb
+++ b/decidim-core/spec/system/search_spec.rb
@@ -34,7 +34,7 @@ describe "Search" do
     end
 
     it "has all the resources to search" do
-      within ".search__filter" do
+      within "#dropdown-menu-search" do
         expect(page).to have_content("All").once
         expect(page).to have_content("Participants").once
         expect(page).to have_content("Participatory processes").once


### PR DESCRIPTION
#### :tophat: What? Why?
Introduce a hamburger menu for desktop viewports that consolidates navigation items into a collapsible panel. This menu would behave similarly to the mobile version:

- Navigation links are hidden behind a hamburger icon.
- Clicking the icon opens a side panel showing the navigation links.
- The menu closes when the user clicks outside it or clicks the close icon.
[Figma file](https://www.figma.com/design/GIPwk1eZEFBMUs3gcsTRXg/NGI?node-id=487-10360)

#### :pushpin: Related Issues
- Related to https://github.com/decidim/decidim/issues/14937
- Requires #15141

#### Testing

- Visit the platform on a desktop screen, when the header loads, you should see a hamburger menu icon
- Click the hamburger icon, then a menu panel opens displaying the full list of navigation links.
- Click outside the panel or click close, then the panel closes.
- The menu is closed, then you can open it again using the same icon.
- Navigate through the links inside the hamburger menu, you should be redirected to the corresponding section.

:hearts: Thank you!
