### PR TITLE
Update documentation instructions for Ubuntu 24.04 

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -14,7 +14,7 @@ The compatibility between the different versions of the components is the follow
 
 include::install:partial$version_matrix.adoc[]
 
-We are starting with an Ubuntu 22.04.3 LTS. This is an opinionated guide, so you are free to use the technology that you are most comfortable. If you have any doubts and you are blocked you can go and ask on https://matrix.to/#/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
+We are starting with an Ubuntu 24.04.3 LTS. This is an opinionated guide, so you are free to use the technology that you are most comfortable. If you have any doubts and you are blocked you can go and ask on https://matrix.to/#/#decidimdevs:matrix.org[our Matrix.org chat room for developers].
 
 We recommend to have at least some basic proficiency in GNU/Linux (i.e. how to use the command-line, packages, etc), networking knowledge, server administration, development in general, and some basic knowledge about software package managers. It would be great to have Ruby on Rails development basics (a good starting point is http://guides.rubyonrails.org/getting_started.html[Getting Started with Ruby on Rails]) and have some knowledge on how package libraries are working (we use `bundler` for handling ruby packages, and `npm`/`yarn` for handling javascript).
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -27,7 +27,7 @@ First, we are going to install https://github.com/rbenv/rbenv[rbenv], for managi
 [source,bash]
 ----
 sudo apt update
-sudo apt install -y build-essential curl git libssl-dev zlib1g-dev
+sudo apt install -y build-essential curl git libssl-dev zlib1g-dev libffi-dev libyaml-dev
 git clone https://github.com/rbenv/rbenv.git ~/.rbenv
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -55,13 +55,10 @@ An important component for Decidim is Node.js and Yarn. With this commands you w
 
 [source,bash]
 ----
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-sudo apt-get update && sudo apt-get install -y nodejs
-curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/yarnkey.gpg >/dev/null
-echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-sudo apt-get update && sudo apt-get install -y yarn
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+source "$HOME/.nvm/nvm.sh"
+nvm install 24
+npm install -g yarn
 ----
 
 == 4. Installing Decidim

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -76,25 +76,18 @@ Then we can create an application with the `decidim` executable, where `decidim_
 [source,bash]
 ----
 decidim decidim_application
-cd decidim_application
-----
-
-We recommend that you save it all on Git.
-
-[source,bash]
-----
-git add .
-git commit -m "Initial commit. Generated with Decidim https://decidim.org"
 ----
 
 == 5. Configure the database
 
-Modify your secrets (see `config/database.yml`). For this you can use https://github.com/laserlemon/figaro[figaro], https://github.com/bkeepers/dotenv[dotenv] or https://github.com/rbenv/rbenv-vars[rbenv-vars]. You
-should always be careful of not uploading your plain secrets on git or your version control system. You can also upload the encrypted secrets, using the sekrets gem or if you are on Ruby on Rails greater than 5.1 you can do it natively.
+For configuring the database and other parts of Decidim, we use xref:configure:environment_variables.adoc[Environment variables]. We recommend using https://github.com/rbenv/rbenv-vars[rbenv-vars].
 
-For a development environment, and if you are using rbenv, we strongly recommend you to use the https://github.com/rbenv/rbenv-vars[rbenv-vars] to facilitate the edition of ENV vars.
+[NOTE]
+====
+Be careful with your `.rbenv-vars` file, as if you put it in the same folder of your decidim generated application you could publish it without you noticing and there will be secrets there. We strongly recommend adding it to other directory
+====
 
-First you will need to install the rbenv-vars plugin:
+For installing `rbenv-vars`:
 
 [source,bash]
 ----
@@ -112,14 +105,16 @@ DATABASE_PASSWORD=thepassword
 EOF
 ----
 
-Be careful where you put the `.rbenv-vars` file, as if you put it in the same folder of your decidim generated application, and if you use a version control system (like `git`, which we strongly recommend), then you should ignore this file (ie with the `.gitignore` file).
+== 6. Initializing your app for local development
+
+At this point we recommend that you save it all on Git.
 
 [source,bash]
 ----
-echo -e "\n\n# Ignore environment variables\n.rbenv-vars" >> .gitignore
+cd decidim_application
+git add .
+git commit -m "Initial commit. Generated with Decidim https://decidim.org"
 ----
-
-== 6. Initializing your app for local development
 
 [NOTE]
 ====

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -8,7 +8,7 @@ In order to develop on decidim, you will need:
 * *NodeJS* 22.14.x
 * *Npm* 10.9.x
 * *ImageMagick*
-* *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
+* *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver] (if you need to run specs/tests)
 
 The compatibility between the different versions of the components is the following:
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -3,10 +3,10 @@
 In order to develop on decidim, you will need:
 
 * *Git* 2.34+
-* *PostgreSQL* 14.5+
+* *PostgreSQL* 17.4+
 * *Ruby* 3.3.0
 * *NodeJS* 22.14.x
-* *Npm* 9.6.x
+* *Npm* 10.9.x
 * *ImageMagick*
 * *Chrome* browser and https://sites.google.com/a/chromium.org/chromedriver/[chromedriver].
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR updates the installation instructions to the latest Ubuntu LTS version (24.04, "Noble Numbat").  

Heads-up for the backports, as we should fix the versions for the different Decidim/ruby/node versions. 

#### :pushpin: Related Issues

#### Testing

As usual, I try all the steps on a clean linux container (LXC):

``` 
lxc launch ubuntu:noble ubuntu
lxc exec ubuntu -- /bin/bash
su - ubuntu
```

:hearts: Thank you!
