### PR TITLE
Backport 'Define the generated app's sidekiq version based on the redis version' to v0.29

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -227,8 +227,26 @@ module Decidim
           end
         RUBY
 
-        add_production_gems do
-          gem "sidekiq"
+        redis_version = begin
+          require "redis"
+          ver = Redis.new.call("INFO").lines(chomp: true).find { |l| l.start_with?("redis_version:") }.split(":", 2).last
+          Gem::Version.new(ver)
+        rescue LoadError, Redis::CannotConnectError
+          # This does not have to be the actual Redis version, it can be
+          # anything that is above any of the version checks below to default to
+          # the latest Sidekiq version.
+          Gem::Version.new("8.0.0")
+        end
+
+        if redis_version < Gem::Version.new("6.2.0")
+          # Sidekiq 7.x requires Redis 6.2.0 or newer
+          append_file "Gemfile", %(gem "sidekiq", "~> 6.5")
+        elsif redis_version < Gem::Version.new("7.0.0")
+          # Sidekiq 8.x requires Redis 7.0.0 or newer
+          append_file "Gemfile", %(gem "sidekiq", "~> 7.3")
+        else
+          # Assume latest
+          append_file "Gemfile", %(gem "sidekiq")
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15055 to v0.29

:hearts: Thank you!