### PR TITLE
Fixed formatting error in documentation

### DIFF
--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -36,8 +36,6 @@ If you are proficient with Docker you can use the docker-compose.yml file that w
 
 You can see the docker instructions at the https://github.com/decidim/docker/[Docker repository].
 
-----
-
 == Initializing your application for local development
 
 [NOTE]


### PR DESCRIPTION
#### :tophat: What? Why?
There was an error in the markup on this docs page which caused it to render incorrectly (the whole second part was one giant code block)

Check the rich diff preview to see what I mean (or just look at the live docs at https://docs.decidim.org/en/develop/install/)