### PR TITLE
Unsubscribed page redesign  

### DIFF
--- a/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
@@ -1,4 +1,16 @@
-<div class="row">
-  <h4><%== t ".unsubscribe" %></h4>
-  <p><%== t ".check_subscription", link: decidim.notifications_settings_path %></p>
-</div>
+<main class="layout-1col cols-6">
+  <div class="text-center py-12">
+    <h1 class="h1 decorator inline-block text-left"><%== t ".unsubscribe" %></h1>
+  </div>
+  <div class="page__container">
+    <div class="editor-content">
+      <div class="rich-text-display">
+        <%== t ".check_subscription", link: decidim.notifications_settings_path %>
+      </div>
+      <br>
+      <div class="rich-text-display">
+        <%== t ".subscription_preferences", organization_name: translated_attribute(current_organization.name) %>
+      </div>
+    </div>
+  </div>
+</main>

--- a/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
@@ -5,11 +5,11 @@
   <div class="page__container">
     <div class="editor-content">
       <div class="rich-text-display">
-        <%== t ".check_subscription", link: decidim.notifications_settings_path %>
+        <%== t ".subscription_preferences", organization_name: translated_attribute(current_organization.name) %>
       </div>
       <br>
       <div class="rich-text-display">
-        <%== t ".subscription_preferences", organization_name: translated_attribute(current_organization.name) %>
+        <%== t ".check_subscription", link: decidim.notifications_settings_path %>
       </div>
     </div>
   </div>

--- a/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
@@ -5,7 +5,7 @@
   <div class="page__container">
     <div class="editor-content">
       <div class="rich-text-display">
-        <%== t ".subscription_preferences", organization_name: translated_attribute(current_organization.name) %>
+        <%= t ".subscription_preferences", organization_name: translated_attribute(current_organization.name) %>
       </div>
       <br>
       <div class="rich-text-display">

--- a/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
@@ -9,7 +9,7 @@
       </div>
       <br>
       <div class="rich-text-display">
-        <%== t ".check_subscription", link: decidim.notifications_settings_path %>
+        <%= t ".check_subscription_html", link: decidim.notifications_settings_path %>
       </div>
     </div>
   </div>

--- a/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
+++ b/decidim-core/app/views/decidim/newsletters/unsubscribe.html.erb
@@ -1,6 +1,6 @@
 <main class="layout-1col cols-6">
   <div class="text-center py-12">
-    <h1 class="h1 decorator inline-block text-left"><%== t ".unsubscribe" %></h1>
+    <h1 class="h1 decorator inline-block text-left"><%= t ".unsubscribe" %></h1>
   </div>
   <div class="page__container">
     <div class="editor-content">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1270,10 +1270,10 @@ en:
         main_image: Main image
     newsletters:
       unsubscribe:
-        check_subscription: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">configuration page</a>.
+        check_subscription: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">settings page</a>.
         error: There was a problem unsubscribing.
         success: You are unsubscribed successfully.
-        subscription_preferences: We've updated your subscription preferences, and you will no longer receive newsletters from %{organization_name}.
+        subscription_preferences: We have updated your subscription preferences, and you will no longer receive newsletters from %{organization_name}.
         token_error: The link has expired.
         unsubscribe: Unsubscribe from newsletter
     newsletters_opt_in:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1272,8 +1272,8 @@ en:
       unsubscribe:
         check_subscription: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">settings page</a>.
         error: There was a problem unsubscribing.
-        success: You are unsubscribed successfully.
         subscription_preferences: We have updated your subscription preferences, and you will no longer receive newsletters from %{organization_name}.
+        success: You are unsubscribed successfully.
         token_error: The link has expired.
         unsubscribe: Unsubscribe from newsletter
     newsletters_opt_in:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1270,7 +1270,7 @@ en:
         main_image: Main image
     newsletters:
       unsubscribe:
-        check_subscription: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">settings page</a>.
+        check_subscription_html: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">settings page</a>.
         error: There was a problem unsubscribing.
         subscription_preferences: We have updated your subscription preferences, and you will no longer receive newsletters from %{organization_name}.
         success: You are unsubscribed successfully.

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1270,11 +1270,12 @@ en:
         main_image: Main image
     newsletters:
       unsubscribe:
-        check_subscription: If you want to change your preferences, you can do so in the <a href="%{link}" target="_blank">configuration page</a>.
+        check_subscription: If you'd like to start receiving them again, you can re-enable your subscription anytime from the <a href="%{link}" target="_blank">configuration page</a>.
         error: There was a problem unsubscribing.
         success: You are unsubscribed successfully.
+        subscription_preferences: We've updated your subscription preferences, and you will no longer receive newsletters from %{organization_name}.
         token_error: The link has expired.
-        unsubscribe: Unsubscribe
+        unsubscribe: Unsubscribe from newsletter
     newsletters_opt_in:
       unauthorized: Sorry, this link is no longer available.
       update:


### PR DESCRIPTION
#### :tophat: What? Why?
This PR adds assets and configuration to allow user to access more "decorative" information once they hit the unsubscribe button from newletters.

#### :pushpin: Related Issues
- Fixes #15151

#### Testing
1. As an admin, send a newsletter
2. Go to http://localhost:3000/letter_opener
3. Click on the Unsubscribe link in the footer of the email ("To opt out of receiving this type of email, Unsubscribe. ")
4. See the page updated.

### :camera: Screenshots
<img width="1202" height="617" alt="image" src="https://github.com/user-attachments/assets/21942f05-634e-4ec9-a663-129a515c2c45" />


:hearts: Thank you!
