### PR TITLE
Fix fetching comments through the API for accountability and budgets

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -10,3 +10,4 @@ HTTPOK
 iat
 jti
 JWA
+subcomment

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -11,3 +11,4 @@ iat
 jti
 JWA
 subcomment
+subcomments

--- a/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
+++ b/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
@@ -18,7 +18,11 @@ module Decidim
       def public_read_result_action?
         return unless permission_action.action == :read && permission_action.subject == :result
 
-        allow! if result && !result.deleted?
+        if result && !result.deleted?
+          allow!
+        else
+          disallow!
+        end
       end
 
       def result

--- a/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
+++ b/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
@@ -4,12 +4,7 @@ module Decidim
   module Accountability
     class Permissions < Decidim::DefaultPermissions
       def permissions
-        if permission_action.scope == :public
-          public_read_result_action?
-
-          return permission_action
-        end
-
+        return permission_action if permission_action.scope == :public && public_read_result_action?
         return permission_action unless user
 
         # Delegate the admin permission checks to the admin permissions class

--- a/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
+++ b/decidim-accountability/app/permissions/decidim/accountability/permissions.rb
@@ -4,12 +4,30 @@ module Decidim
   module Accountability
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        if permission_action.scope == :public
+          public_read_result_action?
+
+          return permission_action
+        end
+
         return permission_action unless user
 
         # Delegate the admin permission checks to the admin permissions class
         return Decidim::Accountability::Admin::Permissions.new(user, permission_action, context).permissions if permission_action.scope == :admin
 
         permission_action
+      end
+
+      private
+
+      def public_read_result_action?
+        return unless permission_action.action == :read && permission_action.subject == :result
+
+        allow! if result && !result.deleted?
+      end
+
+      def result
+        @result ||= context.fetch(:result, nil)
       end
     end
   end

--- a/decidim-api/lib/decidim/api/graphql_permissions.rb
+++ b/decidim-api/lib/decidim/api/graphql_permissions.rb
@@ -17,8 +17,8 @@ module Decidim
           subject = determine_subject_name(object)
           context[subject] = object
 
-          chain.unshift(allowed_to?(:read, :participatory_space, object, context)) if object.respond_to?(:participatory_space)
-          chain.unshift(allowed_to?(:read, :component, object, context)) if object.respond_to?(:component) && object.component.present?
+          chain.unshift(allowed_to?(:read, :participatory_space, object.participatory_space, context)) if object.respond_to?(:participatory_space)
+          chain.unshift(allowed_to?(:read, :component, object.component, context)) if object.respond_to?(:component) && object.component.present?
 
           super && chain.all?
         end
@@ -65,7 +65,12 @@ module Decidim
         #
         # @return Hash
         def local_context(object, context)
-          context[:current_participatory_space] = object.participatory_space if object.respond_to?(:participatory_space)
+          context[:current_participatory_space] =
+            if object.respond_to?(:participatory_space)
+              object.participatory_space
+            elsif object.is_a?(Decidim::Participable)
+              object
+            end
           context[:current_component] =
             if object.is_a?(Decidim::Component)
               object
@@ -103,7 +108,9 @@ module Decidim
             Decidim::Permissions
           ]
 
-          if object.is_a?(Decidim::Component)
+          if object.is_a?(Decidim::Participable)
+            permissions.unshift(object.manifest.permissions_class)
+          elsif object.is_a?(Decidim::Component)
             permissions.unshift(object.participatory_space.manifest.permissions_class)
             permissions.unshift(object.manifest.permissions_class)
           else

--- a/decidim-api/lib/decidim/api/test/shared_examples/commentable_interface_examples.rb
+++ b/decidim-api/lib/decidim/api/test/shared_examples/commentable_interface_examples.rb
@@ -10,4 +10,61 @@ shared_examples_for "commentable interface" do
       expect(response["totalCommentsCount"]).to eq(model.comments_count)
     end
   end
+
+  describe "with comments" do
+    let(:comments) { create_list(:comment, 5, commentable: model) }
+    let(:subcomments_level1) do
+      comments.map do |comment|
+        create_list(:comment, 2, commentable: comment)
+      end.flatten
+    end
+    let!(:subcomments_level2) do
+      subcomments_level1.map do |comment|
+        create(:comment, commentable: comment)
+      end
+    end
+
+    let(:query) do
+      %(
+        {
+          comments {
+            ...dataFragment
+            comments {
+              ...dataFragment
+              comments {
+                ...dataFragment
+              }
+            }
+          }
+        }
+        fragment dataFragment on Comment {
+          id
+          body
+          createdAt
+          author { name }
+        }
+      )
+    end
+
+    it "includes the comments" do
+      expect(response["comments"]).to be_a(Array)
+      expect(response["comments"].count).to eq(5)
+
+      response["comments"].each do |comment|
+        expect(comment["comments"]).to be_a(Array)
+        expect(comment["comments"].count).to eq(2)
+
+        subcomments = subcomments_level1.select { |c| c.commentable.id == comment["id"].to_i }
+        expect(comment["comments"].map { |c| c["id"].to_i }).to match_array(subcomments.map(&:id))
+
+        comment["comments"].each do |subcomment|
+          expect(subcomment["comments"]).to be_a(Array)
+          expect(subcomment["comments"].count).to eq(1)
+
+          subsubcomments = subcomments_level2.select { |c| c.commentable.id == subcomment["id"].to_i }
+          expect(subcomment["comments"].map { |c| c["id"].to_i }).to match_array(subsubcomments.map(&:id))
+        end
+      end
+    end
+  end
 end

--- a/decidim-api/lib/decidim/api/test/shared_examples/commentable_interface_examples.rb
+++ b/decidim-api/lib/decidim/api/test/shared_examples/commentable_interface_examples.rb
@@ -61,8 +61,8 @@ shared_examples_for "commentable interface" do
           expect(subcomment["comments"]).to be_a(Array)
           expect(subcomment["comments"].count).to eq(1)
 
-          subsubcomments = subcomments_level2.select { |c| c.commentable.id == subcomment["id"].to_i }
-          expect(subcomment["comments"].map { |c| c["id"].to_i }).to match_array(subsubcomments.map(&:id))
+          subcomments2 = subcomments_level2.select { |c| c.commentable.id == subcomment["id"].to_i }
+          expect(subcomment["comments"].map { |c| c["id"].to_i }).to match_array(subcomments2.map(&:id))
         end
       end
     end

--- a/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
+++ b/decidim-budgets/app/permissions/decidim/budgets/permissions.rb
@@ -4,6 +4,7 @@ module Decidim
   module Budgets
     class Permissions < Decidim::DefaultPermissions
       def permissions
+        return permission_action if permission_action.scope == :public && public_action_allowed?
         return permission_action unless user
 
         # Delegate the admin permission checks to the admin permissions class
@@ -42,6 +43,16 @@ module Decidim
 
       def workflow
         @workflow ||= context.fetch(:workflow, nil)
+      end
+
+      def public_action_allowed?
+        return unless permission_action.subject == :project && permission_action.action == :read
+
+        if project && !project.deleted? && !project.budget.deleted?
+          allow!
+        else
+          disallow!
+        end
       end
 
       def can_vote?(active_allow)

--- a/decidim-budgets/spec/types/integration_schema_spec.rb
+++ b/decidim-budgets/spec/types/integration_schema_spec.rb
@@ -276,7 +276,7 @@ describe "Decidim::Api::QueryType" do
           let!(:current_user) { nil }
 
           it "should be visible" do
-            expect(response["participatoryProcess"]["components"].first[lookout_key]).to eq(query_result.merge("projects" => [nil, nil]))
+            expect(response["participatoryProcess"]["components"].first[lookout_key]).to eq(query_result)
           end
         end
 
@@ -426,7 +426,7 @@ describe "Decidim::Api::QueryType" do
           let!(:current_user) { nil }
 
           it "is visible" do
-            expect(response["assembly"]["components"].first[lookout_key]).to eq(query_result.merge("projects" => [nil, nil]))
+            expect(response["assembly"]["components"].first[lookout_key]).to eq(query_result)
           end
         end
 

--- a/decidim-comments/lib/decidim/comments/test/factories.rb
+++ b/decidim-comments/lib/decidim/comments/test/factories.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     transient do
       skip_injection { false }
     end
-    author { build(:user, organization: commentable.organization, skip_injection:) }
+    author { build(:user, :confirmed, organization: commentable.organization, skip_injection:) }
     commentable { build(:dummy_resource, :published, skip_injection:) }
     root_commentable { commentable }
     body { Decidim::Faker::Localized.paragraph }

--- a/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
@@ -183,7 +183,7 @@ describe Decidim::OpenDataExporter do
         let(:file_data) { zip_contents.glob("README.md").first.get_input_stream.read }
 
         it "includes the help description for all the entities" do
-          expect(file_data).to include("## users (15 resources)")
+          expect(file_data).to include("## users (17 resources)")
           expect(file_data).to include("## proposals (15 resources)")
           expect(file_data).to include("## proposal_comments (1 resource)")
           expect(file_data).to include("## results (1 resource)")


### PR DESCRIPTION
#### :tophat: What? Why?
Currently fetching comments through the API for accountability results or budgeting projects is broken.

This is caused by the API authorization checks introduced at #13759.

Affected versions `0.28.5` and up.

#### :pushpin: Related Issues
- Related to #13759

#### Testing
1. Ensure that both the accountabiltiy result and budgeting project with IDs 1 have comments in them.
2. Run the following query to the API to see either an exception or no results (repeat for both resource types `Decidim::Accountability::Result` and `Decidim::Budgets::Project`)
```graphql
{
  commentable(type: "Decidim::Accountability::Result", id: "1", locale: "en", toggleTranslations: false) {
    totalCommentsCount
    comments {
      ...dataFragment
      comments {
        ...dataFragment
        comments {
          ...dataFragment
        }
      }
    }
  }
}

fragment dataFragment on Comment {
  id
  body
  author { name }
  createdAt
}
```