### PR TITLE
Improve the commentable GraphQL field

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -10,3 +10,4 @@ HTTPOK
 iat
 jti
 JWA
+tlh

--- a/decidim-comments/lib/decidim/comments/query_extensions.rb
+++ b/decidim-comments/lib/decidim/comments/query_extensions.rb
@@ -20,9 +20,21 @@ module Decidim
       end
 
       def commentable(id:, locale:, toggle_translations:, type:)
+        raise GraphQL::ExecutionError, "#{locale} is not a valid locale" unless available_locales.include?(locale)
+
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
-        type.constantize.find(id)
+        type.constantize.find_by(id:)
+      end
+
+      private
+
+      def available_locales
+        if context[:current_organization].present?
+          context[:current_organization].available_locales
+        else
+          I18n.available_locales.map(&:to_s)
+        end
       end
     end
   end

--- a/decidim-comments/spec/types/query_type_spec.rb
+++ b/decidim-comments/spec/types/query_type_spec.rb
@@ -24,5 +24,32 @@ module Decidim::Api
         end
       end
     end
+
+    describe "commentable" do
+      let(:model) { create(:dummy_resource, :published) }
+      let(:query) { %({ commentable(type: "#{model.commentable_type}", id: "#{id}", locale: "#{locale}", toggleTranslations: false) { id } }) }
+      let(:id) { model.id }
+      let(:locale) { "en" }
+
+      it "returns the commentable response" do
+        expect(response["commentable"]).to eq("id" => model.id.to_s)
+      end
+
+      context "with unknown locale" do
+        let(:locale) { "tlh" }
+
+        it "returns a proper GraphQL error" do
+          expect { response }.to raise_error("#{locale} is not a valid locale")
+        end
+      end
+
+      context "with unknown record id" do
+        let(:id) { model.id + 1000 }
+
+        it "returns nothing" do
+          expect(response["commentable"]).to be_nil
+        end
+      end
+    end
   end
 end

--- a/decidim-dev/lib/decidim/api/dummy_resource_type.rb
+++ b/decidim-dev/lib/decidim/api/dummy_resource_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Dev
+    class DummyResourceType < Decidim::Api::Types::BaseObject
+      graphql_name "DummyResource"
+      description "A dummy resource to allow testing the API against the dummy resources."
+
+      implements Decidim::Comments::CommentableInterface
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -15,6 +15,8 @@ require "decidim/dev/auth_engine"
 # Also, to avoid further headaches :)
 # require "decidim/dev/component"
 
+require "decidim/dev/api"
+
 module Decidim
   # Decidim::Dev holds all the convenience logic and libraries to be able to
   # create external libraries that create test apps and test themselves against

--- a/decidim-dev/lib/decidim/dev/api.rb
+++ b/decidim-dev/lib/decidim/dev/api.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Dev
+    autoload :DummyResourceType, "decidim/api/dummy_resource_type"
+  end
+end

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -45,6 +45,12 @@ module Decidim
           end
         end
       end
+
+      initializer "decidim_dev.graphql_api" do
+        next unless Decidim.module_installed?(:api)
+
+        Decidim::Api.add_orphan_type Decidim::Dev::DummyResourceType
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The `commentable` root level field will fail with an "internal server error" in one of the following cases:
1. The provided `locale` is not one of the available locales
2. The provided `id` is not found

This makes debugging the situation a bit harder as the issue with the query is not apparent and shown in the response. The reason for the failure of the query has to be checked through the server logs.

This PR will handle these cases gracefully by returning a proper GraphQL error in the first case and returning `null` in the second case.

#### Testing
1. Make sure you have some commentable record available in the system, e.g. a proposal
2. Run the following GraphQL query on it:
```graphql
{ commentable(type: "Decidim::Proposals::Proposal", id: "1", locale: "tlh", toggleTranslations: false) { id } }
```
4. Expect to see a GraphQL error in the response with the HTTP response code `200` (OK)
5. Run the following GraphQL query on it:
```graphql
{ commentable(type: "Decidim::Proposals::Proposal", id: "99999999999999999", locale: "en", toggleTranslations: false) { id } }
```
6. Expect to see `null` in the response with the HTTP response code `200` (OK)
  * Full body should look like: `{"data": {"commentable": null}}`