### PR TITLE
Replace the 'Voting rules' checkboxes with radio buttons in budgets

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/budget_rule_toggler.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/budget_rule_toggler.component.js
@@ -1,50 +1,80 @@
+/**
+ * BudgetRuleTogglerComponent
+ *
+ * Handles showing and hiding rule-specific input containers
+ * based on the selected radio option.
+ */
 export default class BudgetRuleTogglerComponent {
+  /**
+   * @param {Object} options
+   * @param {HTMLInputElement[]} options.ruleRadios - Array of radio inputs controlling the rules
+   * @param {Record<string, string[]>} options.mapping - Mapping from radio values to selectors of containers to show
+   */
   constructor(options = {}) {
-    this.ruleCheckboxes = options.ruleCheckboxes;
-    this._runAll();
+    this.ruleRadios = options.ruleRadios;
+    this.mapping = options.mapping || {};
+    this._bindEvents();
+    this._runInitial();
   }
 
-  _runAll() {
-    this.ruleCheckboxes.each((_i, checkbox) => {
-      this._bindEvent(checkbox);
-      this.run(checkbox);
+  /**
+   * Bind change events on all radios
+   * @private
+   */
+  _bindEvents() {
+    this.ruleRadios.forEach((radio) => {
+      radio.addEventListener("change", (event) => {
+        this._run(event.target);
+      });
     });
   }
 
-  _bindEvent(target) {
-    $(target).on("change", (event) => {
-      this.run(event.target);
-    });
-  }
-
-  run(target) {
-    this.toggleTextInput(target);
-
-    if ($(target).prop("checked")) {
-      this.ruleCheckboxes.filter(
-        (_i, checkbox) => {
-          return checkbox !== target;
-        }).prop("checked", false).each(
-        (_i, checkbox) => {
-          this.toggleTextInput(checkbox);
-        });
-    }
-  }
-
-  toggleTextInput(target) {
-    const container = $(target).closest("div");
-    if (container.length < 1) {
-      return;
-    }
-    const containerClassPrefix = container.attr("class").
-      replace(/^vote_rule_/, "vote_").
-      replace(/_enabled_container$/, "");
-    const input = $(`[class^="${containerClassPrefix}"][class$="_container"]`);
-
-    if ($(target).prop("checked")) {
-      input.slideDown();
+  /**
+   * Run toggler logic on page load
+   * @private
+   */
+  _runInitial() {
+    const checked = this.ruleRadios.find((radio) => radio.checked);
+    if (checked) {
+      this._run(checked);
     } else {
-      input.slideUp();
+      this._hideAll();
     }
+  }
+
+  /**
+   * Show the containers associated with the selected radio
+   * @param {HTMLInputElement} target - The radio input that triggered the change
+   * @private
+   */
+  _run(target) {
+    this._hideAll();
+
+    const value = target.value;
+    const selectors = this.mapping[value] || [];
+
+    selectors.forEach((selector) => this._show(selector));
+  }
+
+  /**
+   * Hide all containers referenced in the mapping
+   * @private
+   */
+  _hideAll() {
+    const allSelectors = Object.values(this.mapping).flat();
+    allSelectors.forEach((selector) => {
+      const el = document.querySelector(selector);
+      if (el) el.style.display = "none";
+    });
+  }
+
+  /**
+   * Show a container by selector
+   * @param {string} selector - CSS selector of the container to show
+   * @private
+   */
+  _show(selector) {
+    const el = document.querySelector(selector);
+    if (el) el.style.display = "";
   }
 }

--- a/decidim-admin/app/packs/src/decidim/admin/budget_rule_toggler.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/budget_rule_toggler.component.js
@@ -5,14 +5,22 @@
  * based on the selected radio option.
  */
 export default class BudgetRuleTogglerComponent {
+
   /**
-   * @param {Object} options
+   * @param {Object} options - Configuration options
    * @param {HTMLInputElement[]} options.ruleRadios - Array of radio inputs controlling the rules
    * @param {Record<string, string[]>} options.mapping - Mapping from radio values to selectors of containers to show
    */
   constructor(options = {}) {
     this.ruleRadios = options.ruleRadios;
     this.mapping = options.mapping || {};
+  }
+
+  /**
+   * Initialize the component (bind events + run initial state).
+   * @returns {void}
+   */
+  init() {
     this._bindEvents();
     this._runInitial();
   }
@@ -20,6 +28,7 @@ export default class BudgetRuleTogglerComponent {
   /**
    * Bind change events on all radios
    * @private
+   * @returns {void}
    */
   _bindEvents() {
     this.ruleRadios.forEach((radio) => {
@@ -32,6 +41,7 @@ export default class BudgetRuleTogglerComponent {
   /**
    * Run toggler logic on page load
    * @private
+   * @returns {void}
    */
   _runInitial() {
     const checked = this.ruleRadios.find((radio) => radio.checked);
@@ -46,12 +56,16 @@ export default class BudgetRuleTogglerComponent {
    * Show the containers associated with the selected radio
    * @param {HTMLInputElement} target - The radio input that triggered the change
    * @private
+   * @returns {void}
    */
   _run(target) {
     this._hideAll();
 
-    const value = target.value;
-    const selectors = this.mapping[value] || [];
+    // Normalize radio value (snake_case → camelCase)
+    const rawValue = target.value;
+    const camelValue = rawValue.replace(/_([a-z])/g, (_match, letter) => letter.toUpperCase());
+
+    const selectors = this.mapping[camelValue] || [];
 
     selectors.forEach((selector) => this._show(selector));
   }
@@ -59,12 +73,15 @@ export default class BudgetRuleTogglerComponent {
   /**
    * Hide all containers referenced in the mapping
    * @private
+   * @returns {void}
    */
   _hideAll() {
     const allSelectors = Object.values(this.mapping).flat();
     allSelectors.forEach((selector) => {
       const el = document.querySelector(selector);
-      if (el) el.style.display = "none";
+      if (el) {
+        el.style.display = "none";
+      }
     });
   }
 
@@ -72,9 +89,12 @@ export default class BudgetRuleTogglerComponent {
    * Show a container by selector
    * @param {string} selector - CSS selector of the container to show
    * @private
+   * @returns {void}
    */
   _show(selector) {
     const el = document.querySelector(selector);
-    if (el) el.style.display = "";
+    if (el) {
+      el.style.display = "";
+    }
   }
 }

--- a/decidim-admin/app/packs/src/decidim/admin/form.js
+++ b/decidim-admin/app/packs/src/decidim/admin/form.js
@@ -7,22 +7,26 @@ import BudgetRuleTogglerComponent from "src/decidim/admin/budget_rule_toggler.co
 document.addEventListener("turbo:load", () => {
 
   const budgetTogglerRadios = Array.from(
-    document.querySelectorAll("input[type='radio'][name='component[settings][voting_rule]']")
+    document.querySelectorAll(
+      "input[type='radio'][name='component[settings][voting_rule]']"
+    )
   );
 
   const budgetTogglerMapping = {
-    threshold_percent: [".vote_threshold_percent_container"],
-    minimum_projects: [".vote_minimum_budget_projects_number_container"],
-    selected_projects: [
+    thresholdPercent: [".vote_threshold_percent_container"],
+    minimumProjects: [".vote_minimum_budget_projects_number_container"],
+    selectedProjects: [
       ".vote_selected_projects_minimum_container",
       ".vote_selected_projects_maximum_container"
     ]
   };
 
-  new BudgetRuleTogglerComponent({
+  const budgetToggler = new BudgetRuleTogglerComponent({
     ruleRadios: budgetTogglerRadios,
     mapping: budgetTogglerMapping
   });
+
+  budgetToggler.init();
 
   // Prevents readonly containers from being modified.
   const $readonlyContainer = $(".readonly_container input");

--- a/decidim-admin/app/packs/src/decidim/admin/form.js
+++ b/decidim-admin/app/packs/src/decidim/admin/form.js
@@ -5,11 +5,24 @@ import BudgetRuleTogglerComponent from "src/decidim/admin/budget_rule_toggler.co
 // Checks if the form contains fields with special CSS classes added in
 // Decidim::Admin::SettingsHelper and acts accordingly.
 document.addEventListener("turbo:load", () => {
-  const budgetRuleToggler = new BudgetRuleTogglerComponent({
-    ruleCheckboxes: $("input[id^='component_settings_vote_rule_']")
-  });
 
-  budgetRuleToggler.run();
+  const budgetTogglerRadios = Array.from(
+    document.querySelectorAll("input[type='radio'][name='component[settings][voting_rule]']")
+  );
+
+  const budgetTogglerMapping = {
+    threshold_percent: [".vote_threshold_percent_container"],
+    minimum_projects: [".vote_minimum_budget_projects_number_container"],
+    selected_projects: [
+      ".vote_selected_projects_minimum_container",
+      ".vote_selected_projects_maximum_container"
+    ]
+  };
+
+  new BudgetRuleTogglerComponent({
+    ruleRadios: budgetTogglerRadios,
+    mapping: budgetTogglerMapping
+  });
 
   // Prevents readonly containers from being modified.
   const $readonlyContainer = $(".readonly_container input");

--- a/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/component_form.rb
@@ -7,42 +7,16 @@ module Decidim
       # to a participatory process from the admin panel.
       #
       class ComponentForm < Decidim::Admin::ComponentForm
-        validate :budget_voting_rule_enabled_setting,
-                 :budget_voting_rule_threshold_value_setting,
+        validate :budget_voting_rule_threshold_value_setting,
                  :budget_voting_rule_minimum_value_setting,
                  :budget_voting_rule_projects_value_setting
 
         private
 
-        # Validations on budget settings:
-        # - a voting rule must be enabled.
-        def budget_voting_rule_enabled_setting
-          return unless manifest&.name == :budgets
-
-          rule_settings = [
-            :vote_rule_threshold_percent_enabled,
-            :vote_rule_minimum_budget_projects_enabled,
-            :vote_rule_selected_projects_enabled
-          ]
-          active_rules = rule_settings.select { |key| settings.public_send(key) == true }
-          i18n_error_scope = "decidim.components.budgets.settings.global.form.errors"
-          if active_rules.blank?
-            rule_settings.each do |key|
-              settings.errors.add(key, I18n.t(:budget_voting_rule_required, scope: i18n_error_scope))
-            end
-          end
-
-          if active_rules.length > 1
-            rule_settings.each do |key|
-              settings.errors.add(key, I18n.t(:budget_voting_rule_only_one, scope: i18n_error_scope))
-            end
-          end
-        end
-
         # - the value must be a valid number
         def budget_voting_rule_threshold_value_setting
           return unless manifest&.name == :budgets
-          return unless settings.vote_rule_threshold_percent_enabled
+          return unless settings.voting_rule == "threshold_percent"
 
           invalid_percent_number = settings.vote_threshold_percent.blank? || settings.vote_threshold_percent.to_i.negative?
           settings.errors.add(:vote_threshold_percent) if invalid_percent_number
@@ -50,7 +24,7 @@ module Decidim
 
         def budget_voting_rule_minimum_value_setting
           return unless manifest&.name == :budgets
-          return unless settings.vote_rule_minimum_budget_projects_enabled
+          return unless settings.voting_rule == "minimum_projects"
 
           invalid_minimum_number = settings.vote_minimum_budget_projects_number.blank? || (settings.vote_minimum_budget_projects_number.to_i < 1)
           settings.errors.add(:vote_minimum_budget_projects_number) if invalid_minimum_number
@@ -58,7 +32,7 @@ module Decidim
 
         def budget_voting_rule_projects_value_setting
           return unless manifest&.name == :budgets
-          return unless settings.vote_rule_selected_projects_enabled
+          return unless settings.voting_rule == "selected_projects"
 
           budget_voting_projects_value_setting_min
           budget_voting_projects_value_setting_max

--- a/decidim-budgets/app/models/decidim/budgets/order.rb
+++ b/decidim-budgets/app/models/decidim/budgets/order.rb
@@ -132,14 +132,14 @@ module Decidim
       def minimum_projects_rule?
         return unless budget
 
-        budget.settings.vote_rule_minimum_budget_projects_enabled
+        budget.settings.voting_rule == "minimum_projects"
       end
 
       # Public: Returns true if the project voting rule is enabled
       def projects_rule?
         return unless budget
 
-        budget.settings.vote_rule_selected_projects_enabled
+        budget.settings.voting_rule == "selected_projects"
       end
 
       # Public: Returns the required minimum projects to checkout

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -370,9 +370,9 @@ en:
             vote_threshold_percent: Vote threshold percent
             voting_rule: Voting rule
             voting_rule_choices:
-              threshold_percent: Minimum budget percentage
               minimum_projects: Minimum number of projects to be voted on
               selected_projects: Minimum and maximum number of projects to be voted on
+              threshold_percent: Minimum budget percentage
             workflow: Workflow
             workflow_choices:
               all: 'Vote in all: allows participants to vote in all budgets.'

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -368,6 +368,11 @@ en:
             vote_selected_projects_maximum: Maximum amount of projects to be selected
             vote_selected_projects_minimum: Minimum amount of projects to be selected
             vote_threshold_percent: Vote threshold percent
+            voting_rule: Voting rule
+            voting_rule_choices:
+              threshold_percent: Minimum budget percentage
+              minimum_projects: Minimum number of projects to be voted on
+              selected_projects: Minimum and maximum number of projects to be voted on
             workflow: Workflow
             workflow_choices:
               all: 'Vote in all: allows participants to vote in all budgets.'

--- a/decidim-budgets/db/migrate/20250912110212_move_voting_rules_to_radio_buttons.rb
+++ b/decidim-budgets/db/migrate/20250912110212_move_voting_rules_to_radio_buttons.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class MoveVotingRulesToRadioButtons < ActiveRecord::Migration[7.2]
+  class Component < ApplicationRecord
+    self.table_name = :decidim_components
+  end
+
+  def change
+    budgets_components = Component.where(manifest_name: "budgets")
+
+    budgets_components.each do |component|
+      settings = component["settings"]["global"]
+
+      settings["voting_rule"] = "threshold_percent" if settings["vote_rule_threshold_percent_enabled"]
+      settings["voting_rule"] = "minimum_projects" if settings["vote_rule_minimum_budget_projects_enabled"]
+      settings["voting_rule"] = "selected_projects" if settings["vote_rule_selected_projects_enabled"]
+
+      component["settings"]["global"] = settings
+      component.save
+    end
+  end
+end

--- a/decidim-budgets/lib/decidim/budgets/component.rb
+++ b/decidim-budgets/lib/decidim/budgets/component.rb
@@ -90,14 +90,16 @@ Decidim.register_component(:budgets) do |component|
     settings.attribute :taxonomy_filters, type: :taxonomy_filters
     settings.attribute :workflow, type: :enum, default: "one", choices: ->(_context) { Decidim::Budgets.workflows.keys.map(&:to_s) }
     settings.attribute :projects_per_page, type: :integer, default: 12
-    settings.attribute :vote_rule_threshold_percent_enabled, type: :boolean, default: true
+    settings.attribute :voting_rule, type: :enum, default: "threshold_percent", choices: %w(threshold_percent minimum_projects selected_projects)
+
     settings.attribute :vote_threshold_percent, type: :integer, default: 70
     settings.attribute :vote_threshold_percent, type: :integer, default: 70
-    settings.attribute :vote_rule_minimum_budget_projects_enabled, type: :boolean, default: false
+
     settings.attribute :vote_minimum_budget_projects_number, type: :integer, default: 1
-    settings.attribute :vote_rule_selected_projects_enabled, type: :boolean, default: false
+
     settings.attribute :vote_selected_projects_minimum, type: :integer, default: 0
     settings.attribute :vote_selected_projects_maximum, type: :integer, default: 1
+
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: true
     settings.attribute :geocoding_enabled, type: :boolean, default: false

--- a/decidim-budgets/lib/decidim/budgets/test/factories.rb
+++ b/decidim-budgets/lib/decidim/budgets/test/factories.rb
@@ -26,17 +26,12 @@ FactoryBot.define do
 
     trait :with_vote_threshold_percent do
       transient do
-        vote_rule_threshold_percent_enabled { true }
-        vote_rule_minimum_budget_projects_enabled { false }
-        vote_rule_projects_enabled { false }
         vote_threshold_percent { 70 }
       end
 
       settings do
         {
-          vote_rule_threshold_percent_enabled:,
-          vote_rule_minimum_budget_projects_enabled:,
-          vote_rule_selected_projects_enabled: vote_rule_projects_enabled,
+          voting_rule: "threshold_percent",
           vote_threshold_percent:
         }
       end
@@ -44,17 +39,12 @@ FactoryBot.define do
 
     trait :with_minimum_budget_projects do
       transient do
-        vote_rule_threshold_percent_enabled { false }
-        vote_rule_minimum_budget_projects_enabled { true }
-        vote_rule_projects_enabled { false }
         vote_minimum_budget_projects_number { 3 }
       end
 
       settings do
         {
-          vote_rule_threshold_percent_enabled:,
-          vote_rule_minimum_budget_projects_enabled:,
-          vote_rule_selected_projects_enabled: vote_rule_projects_enabled,
+          voting_rule: "minimum_projects",
           vote_minimum_budget_projects_number:
         }
       end
@@ -62,18 +52,13 @@ FactoryBot.define do
 
     trait :with_budget_projects_range do
       transient do
-        vote_rule_threshold_percent_enabled { false }
-        vote_rule_minimum_budget_projects_enabled { false }
-        vote_rule_projects_enabled { true }
         vote_minimum_budget_projects_number { 3 }
         vote_maximum_budget_projects_number { 6 }
       end
 
       settings do
         {
-          vote_rule_threshold_percent_enabled:,
-          vote_rule_minimum_budget_projects_enabled:,
-          vote_rule_selected_projects_enabled: vote_rule_projects_enabled,
+          voting_rule: "selected_projects",
           vote_selected_projects_minimum: vote_minimum_budget_projects_number,
           vote_selected_projects_maximum: vote_maximum_budget_projects_number
         }

--- a/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
+++ b/decidim-budgets/spec/lib/decidim/budgets/admin/component_spec.rb
@@ -23,22 +23,17 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
       ).with_context(current_organization: organization, current_user:)
     end
 
-    let(:percent_enabled) { false }
+    let(:voting_rule) { "" }
     let(:percent) { 70 }
-    let(:minimum_enabled) { false }
-    let(:projects_enabled) { false }
     let(:geocoding_enabled) { false }
     let(:minimum_number) { 3 }
     let(:maximum_number) { 6 }
-
     let(:settings) do
       {
         total_budget: 100_000_000,
-        vote_rule_threshold_percent_enabled: percent_enabled,
+        voting_rule:,
         vote_threshold_percent: percent,
-        vote_rule_minimum_budget_projects_enabled: minimum_enabled,
         vote_minimum_budget_projects_number: minimum_number,
-        vote_rule_selected_projects_enabled: projects_enabled,
         vote_selected_projects_minimum: minimum_number,
         vote_selected_projects_maximum: maximum_number,
         geocoding_enabled:
@@ -52,7 +47,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     describe "with maps enabled" do
       let(:geocoding_enabled) { true }
       # One budget rule must me activated
-      let(:percent_enabled) { true }
+      let(:voting_rule) { "threshold_percent" }
 
       it "updates the component" do
         expect do
@@ -62,7 +57,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     end
 
     describe "with minimum projects number to vote" do
-      let(:minimum_enabled) { true }
+      let(:voting_rule) { "minimum_projects" }
 
       context "when the minimum projects number is valid" do
         it "updates the component" do
@@ -84,7 +79,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     end
 
     describe "with projects rule enabled" do
-      let(:projects_enabled) { true }
+      let(:voting_rule) { "selected_projects" }
 
       context "when the projects rule is valid" do
         it "updates the component" do
@@ -126,7 +121,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     end
 
     describe "with threshold percent enabled" do
-      let(:percent_enabled) { true }
+      let(:voting_rule) { "threshold_percent" }
 
       context "when the threshold percent number is valid" do
         it "updates the component" do
@@ -147,10 +142,8 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
       end
     end
 
-    describe "with more than one voting rule enabled" do
-      let(:percent_enabled) { true }
-      let(:minimum_enabled) { true }
-      let(:projects_enabled) { true }
+    describe "with an invalid voting rule" do
+      let(:voting_rule) { "invalid" }
 
       it "does NOT update the component" do
         expect do
@@ -160,9 +153,7 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
     end
 
     describe "with no voting rule enabled" do
-      let(:percent_enabled) { false }
-      let(:minimum_enabled) { false }
-      let(:projects_enabled) { false }
+      let(:voting_rule) { "" }
 
       it "does NOT update the component" do
         expect do
@@ -191,9 +182,9 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         it_behaves_like "has mandatory config setting", :comments_max_length
       end
 
-      context "when minimum projects rule is checked" do
+      context "when minimum projects rule is selected" do
         before do
-          check "Enable rule: Minimum number of projects to be voted on"
+          choose "Minimum number of projects to be voted on"
         end
 
         it "is shown the number input" do
@@ -214,9 +205,9 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         end
       end
 
-      context "when projects rule is checked" do
+      context "when projects rule is selected" do
         before do
-          check "Enable rule: Minimum and maximum number of projects to be voted on"
+          choose "Minimum and maximum number of projects to be voted on"
         end
 
         it "is shown the number input" do
@@ -237,9 +228,9 @@ describe "Budgets component" do # rubocop:disable RSpec/DescribeClass
         end
       end
 
-      context "when threshold percent rule is checked" do
+      context "when threshold percent rule is selected" do
         before do
-          check "Enable rule: Minimum budget percentage"
+          choose "Minimum budget percentage"
         end
 
         it "is shown the percent input" do


### PR DESCRIPTION
#### :tophat: What? Why?

During the review of #14903, it was detected that the Budgets component configuration voting rules actually behaves like radio buttons.

We've talked about this same behavior in the past while discussing this form on @decidim/product in the past too.

This PR fixes this problem and do what's expected (migrating from check boxes to radio buttons) 

#### :pushpin: Related Issues
 
- Fixes #15171 

#### Testing

##### For the migration 

0. Before this patch, create three budgets, each with any of the "Vote rule"
1. Check out this patch
2. Run the migration
3. See that these three budgets components should have the same setting

### :camera: Screenshots

[Kooha-2025-09-12-15-48-35.webm](https://github.com/user-attachments/assets/6b30461c-f4d3-4df4-ba98-dbfff48a6aef)


:hearts: Thank you!
