### PR TITLE
Clean-up usage of the DECIDIM_SPAM_DETECTION_BACKEND env vars

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -74,8 +74,6 @@ jobs:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
-      DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE: "memory"
-      DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -24,8 +24,6 @@ env:
   RAILS_ENV: development
   RAILS_BOOST_PERFORMANCE: "true"
   SHAKAPACKER_RUNTIME_COMPILE: "false"
-  DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE: "memory"
-  DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -48,8 +48,6 @@ jobs:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
-      DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE: "memory"
-      DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -49,8 +49,6 @@ jobs:
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
       DATABASE_HOST: localhost
-      DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE: "memory"
-      DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
     services:
       validator:
         image: ghcr.io/validator/validator:latest

--- a/decidim-ai/spec/spec_helper.rb
+++ b/decidim-ai/spec/spec_helper.rb
@@ -3,8 +3,6 @@
 require "decidim/dev"
 
 ENV["ENGINE_ROOT"] = File.dirname(__dir__)
-ENV["DECIDIM_SPAM_DETECTION_BACKEND_USER"] ||= "memory"
-ENV["DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE"] ||= "memory"
 
 Decidim::Dev.dummy_app_path = File.expand_path(File.join("..", "spec", "decidim_dummy_app"))
 


### PR DESCRIPTION
#### :tophat: What? Why?

This is a follow-up on #14991. As we already have the `DECIDIM_SPAM_DETECTION_BACKEND_RESOURCE`and `DECIDIM_SPAM_DETECTION_BACKEND_USER` env vars defined in the `base_spec_helper.rb`: 

https://github.com/tremend-cofe/decidim/blob/c628d5038cd7acefb69b7ddb0d4bce6cad010f3d/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb#L10

I think it is no longer needed to have it polluting other places.  

#### Testing

CI should be green 

:hearts: Thank you!
