### PR TITLE
Trashable components when published

### DIFF
--- a/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_actions.html.erb
@@ -94,9 +94,20 @@
 
       <% if allowed_to?(:soft_delete, :component, trashable_deleted_resource: component) %>
         <% resources_count = component.primary_stat || 0 %>
-        <% if !component.published? %>
+        <% if component.published? %>
           <hr>
-
+          <li class="dropdown__item">
+            <div class="dropdown__button-disabled">
+              <%= with_tooltip t("tooltips.deleted_component_info", scope: "decidim.admin") do %>
+                <%= icon "delete-bin-line", class: "text-gray" %>
+                <span>
+                  <%= t("actions.soft_delete", scope: "decidim.admin") %>
+                </span>
+              <% end %>
+            </div>
+          </li>
+        <% else %>
+          <hr>
           <li class="dropdown__item">
             <%= link_to url_for(action: :soft_delete, id: component, controller: "components"), method: :patch, class: "dropdown__button dropdown__button--danger", data: { confirm: t("actions.confirm_delete_component", scope: "decidim.admin", resources_count:) } do %>
               <%= icon "delete-bin-line" %>


### PR DESCRIPTION
#### :tophat: What? Why?
This fix incorporates a tooltip over a disabled trash-able button in the action drop down for users to see, displayed on the condition unpublished components can be deleted. 

#### :pushpin: Related Issues
- Fixes #15131 

#### Testing
1. Login 
2. Head over to any space with configured components
3. Click the action drop down and see the trash-able disabled button

### :camera: Screenshots
<img width="1622" height="558" alt="image" src="https://github.com/user-attachments/assets/aa07bdc8-1c8f-4b6f-9786-cb5e61b9c120" />
:hearts: Thank you!
