### PR TITLE
Fix order of tabs in accountability's Projects

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/project_cell.rb
@@ -19,20 +19,20 @@ module Decidim
       def tab_panel_items
         [
           {
-            enabled: ResultHistoryCell.new(result).render?,
-            id: "included_history",
-            text: t("decidim.history", scope: "activerecord.models", count: 2),
-            icon: resource_type_icon_key("history"),
-            method: :cell,
-            args: ["decidim/accountability/result_history", result]
-          },
-          {
             enabled: milestones.any?,
             id: "milestones",
             text: t("decidim.accountability.results.milestones.title"),
             icon: "route-line",
             method: :cell,
             args: ["decidim/accountability/project", result, { template: :milestones }]
+          },
+          {
+            enabled: ResultHistoryCell.new(result).render?,
+            id: "included_history",
+            text: t("decidim.history", scope: "activerecord.models", count: 2),
+            icon: resource_type_icon_key("history"),
+            method: :cell,
+            args: ["decidim/accountability/result_history", result]
           },
           {
             enabled: children.any?,


### PR DESCRIPTION
#### :tophat: What? Why?

During a meeting, it was detected that the tabs in accountability's Projects doesn't make much sense: you first see the tab "History" and then the "Milestones" if you have both of these things enabled. 

#### :pushpin: Related Issues
 
- Related to  #13290

#### Testing

1. Go to a project in accountability
2. Add a related proposal and some associated milestones in the project
3. See the tabs in the show page

### :camera: Screenshots

<img width="2366" height="1560" alt="image" src="https://github.com/user-attachments/assets/180c6c30-2108-4daa-8cfb-102e981d19ca" />

:hearts: Thank you!
