### PR TITLE
Fix error unexpected value at params[:host]

### DIFF
--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -44,23 +44,20 @@ module Decidim
       # @param options The options for the URL that are the normal route options
       #   Rails route helpers accept
       # @return [String] The URL of the asset
-      def url(options = {})
+      def url(**options)
         case asset
         when ActiveStorage::Attached
           ensure_current_host(asset.record, **options)
-          options.delete_if { |key, _value| key == :host }
-          blob_url(**options)
+          blob_url(**options.except(:host))
         when ActiveStorage::Blob
           blob_url(**options)
         else # ActiveStorage::VariantWithRecord, ActiveStorage::Variant
           if blob && blob.attachments.any?
             ensure_current_host(blob.attachments.first&.record, **options)
-            options.delete_if { |key, _value| key == :host }
-            representation_url(**options)
+            representation_url(**options.except(:host))
           else
             ensure_current_host(nil, **options)
-            options.delete_if { |key, _value| key == :host }
-            representation_url(**options, only_path: true)
+            representation_url(**options.except(:host), only_path: true)
           end
         end
       end

--- a/decidim-core/lib/decidim/asset_router/storage.rb
+++ b/decidim-core/lib/decidim/asset_router/storage.rb
@@ -44,20 +44,23 @@ module Decidim
       # @param options The options for the URL that are the normal route options
       #   Rails route helpers accept
       # @return [String] The URL of the asset
-      def url(**)
+      def url(options = {})
         case asset
         when ActiveStorage::Attached
-          ensure_current_host(asset.record, **)
-          blob_url(**)
+          ensure_current_host(asset.record, **options)
+          options.delete_if { |key, _value| key == :host }
+          blob_url(**options)
         when ActiveStorage::Blob
-          blob_url(**)
+          blob_url(**options)
         else # ActiveStorage::VariantWithRecord, ActiveStorage::Variant
           if blob && blob.attachments.any?
-            ensure_current_host(blob.attachments.first&.record, **)
-            representation_url(**)
+            ensure_current_host(blob.attachments.first&.record, **options)
+            options.delete_if { |key, _value| key == :host }
+            representation_url(**options)
           else
-            ensure_current_host(nil, **)
-            representation_url(**, only_path: true)
+            ensure_current_host(nil, **options)
+            options.delete_if { |key, _value| key == :host }
+            representation_url(**options, only_path: true)
           end
         end
       end

--- a/decidim-core/spec/models/decidim/push_notification_message_spec.rb
+++ b/decidim-core/spec/models/decidim/push_notification_message_spec.rb
@@ -37,7 +37,7 @@ module Decidim
         let(:favicon) { Decidim::Dev.test_file("icon.png", "image/png") }
 
         it "returns the organization's favicon" do
-          expect(subject.icon).to start_with("http://")
+          expect(subject.icon).to end_with("icon.png")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR  I am trying to fix the error that happens within the applications using S3. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #14668
- Relates to #12576

#### Testing
1. Create an app that is actually using the S3 storage. 
2. Add various images on the organization

#### Note to reviewer: 
The ActiveStorage class states. So no specs possible to be added.
```
    # When implementing changes to the logic, please keep the remote storage
    # options and performance implications in mind because the specs for this
    # utility do not cover the remote storage options because the extra
    # configuration needed to test, the service itself needed for testing and
    # the extra dependency overhead for adding these remote storage gems when
    # they are not needed.
```

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
