### PR TITLE
Fix drag_and_drop on mobile without scrolling

### DIFF
--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -36,10 +36,6 @@ document.addEventListener("turbo:load", () => {
   });
 
   document.querySelectorAll(".js-sortable-check-box-collection").forEach((el) =>  {
-    const dragonDrop = new DragonDrop(el, {
-      handle: false,
-      item: ".js-collection-input"
-    });
 
     /**
     * Due to a bug reported in https://github.com/decidim/decidim/issues/15191
@@ -47,17 +43,24 @@ document.addEventListener("turbo:load", () => {
     * and enabling it back again after it.
     */
 
-    const preventScroll = function(event) {
+    let preventScroll = function(event) {
       event.preventDefault();
     }
 
-    dragonDrop.dragula.on("drag", () => {
-      document.addEventListener("touchmove", preventScroll, { passive: false });
+    el.addEventListener("touchmove", (event) => {
+      preventScroll(event);
+    }, { passive: false });
+
+    el.addEventListener("touchend", () => {
+      el.removeEventListener("touchmove", preventScroll)
     });
 
-    dragonDrop.dragula.on("dragend", () => {
-      document.removeEventListener("touchmove", preventScroll, { passive: false });
+    return new DragonDrop(el, {
+      handle: false,
+      item: ".js-collection-input"
     });
+
+
   });
 
   $(".response-questionnaire .question[data-conditioned='true']").each((idx, el) => {

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -35,10 +35,25 @@ document.addEventListener("turbo:load", () => {
     }
   });
 
-  document.querySelectorAll(".js-sortable-check-box-collection").forEach((el) => new DragonDrop(el, {
-    handle: false,
-    item: ".js-collection-input"
-  }));
+  document.querySelectorAll(".js-sortable-check-box-collection").forEach((el) =>  {
+    const dragonDrop = new DragonDrop(el, {
+      handle: false,
+      item: ".js-collection-input"
+    });
+
+    /**
+    * Due to a bug reported in https://github.com/decidim/decidim/issues/15191
+    * we have to listen to the `drag` event and prevent the scrolling
+    * and enabling it back again after it.
+    */
+    dragonDrop.dragula.on("drag", () => {
+      document.addEventListener("touchmove", function(e) { e.preventDefault(); }, { passive: false });
+    });
+
+    dragonDrop.dragula.on("dragend", () => {
+      document.removeEventListener("touchmove", function(e) { e.preventDefault(); }, { passive: false });
+    });
+  });
 
   $(".response-questionnaire .question[data-conditioned='true']").each((idx, el) => {
     createDisplayConditions({

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -46,16 +46,17 @@ document.addEventListener("turbo:load", () => {
     * we have to listen to the `drag` event and prevent the scrolling
     * and enabling it back again after it.
     */
+
+    const preventScroll = function(event) {
+      event.preventDefault();
+    }
+
     dragonDrop.dragula.on("drag", () => {
-      document.addEventListener("touchmove", function(event) {
-        event.preventDefault();
-      }, { passive: false });
+      document.addEventListener("touchmove", preventScroll, { passive: false });
     });
 
     dragonDrop.dragula.on("dragend", () => {
-      document.removeEventListener("touchmove", function(event) {
-        event.preventDefault();
-      }, { passive: false });
+      document.removeEventListener("touchmove", preventScroll, { passive: false });
     });
   });
 

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -47,11 +47,15 @@ document.addEventListener("turbo:load", () => {
     * and enabling it back again after it.
     */
     dragonDrop.dragula.on("drag", () => {
-      document.addEventListener("touchmove", function(e) { e.preventDefault(); }, { passive: false });
+      document.addEventListener("touchmove", function(event) {
+        event.preventDefault();
+      }, { passive: false });
     });
 
     dragonDrop.dragula.on("dragend", () => {
-      document.removeEventListener("touchmove", function(e) { e.preventDefault(); }, { passive: false });
+      document.removeEventListener("touchmove", function(event) {
+        event.preventDefault();
+      }, { passive: false });
     });
   });
 

--- a/decidim-forms/app/packs/src/decidim/forms/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/forms.js
@@ -59,8 +59,6 @@ document.addEventListener("turbo:load", () => {
       handle: false,
       item: ".js-collection-input"
     });
-
-
   });
 
   $(".response-questionnaire .question[data-conditioned='true']").each((idx, el) => {


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Fix the drag and drop on mobile when sorting the answers in a survey.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #15191 

#### Testing
*Describe the best way to test or validate your PR.*

Go to a survey that has a sorting question and, in mobile, sort it. Before applying this PR you are not able to do so, since the scroll also takes places.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

This is the demo of the sorting not working
https://github.com/user-attachments/assets/85b2853c-19f5-4844-8c4a-79e475ebe182

This one is after applying this commit
https://github.com/user-attachments/assets/96485e18-d31d-429c-b1c4-b3fedbcd6722


:hearts: Thank you!
