### PR TITLE
Remove the word "new" in front of GDPR from the newsletter opt-in mail

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1283,7 +1283,7 @@ en:
         success: Newsletter settings successfully updated.
     newsletters_opt_in_mailer:
       notify:
-        body_1: The processing of personal data and its protection is becoming increasingly important for all of us. With the new General Data Protection Regulation (GDPR) of May 25, 2018, individuals have better control over their personal data. For this reason we need your "OK" to continue sending relevant information about the activities of the %{organization_name}.
+        body_1: The processing of personal data and its protection is becoming increasingly important for all of us. With the General Data Protection Regulation (GDPR) of May 25, 2018, individuals have better control over their personal data. For this reason we need your "OK" to continue sending relevant information about the activities of the %{organization_name}.
         body_2: 'How can you give us your consent? Just click the following button:'
         body_3: With this consent you will be able to continue receiving information about the services of the platform. If, on the contrary, we do not receive a positive confirmation on your part we will stop sending you our messages. If you confirm that you want to keep being informed, you will always have the option to cancel at any time.
         button: Yes, I want to continue receiving relevant information


### PR DESCRIPTION
#### :tophat: What? Why?
I noticed that the newsletter opt-in email words GDPR as a "new" regulation but I guess this is not the case anymore since it's been in force for a long time.

This removes the word "new" from the translation.

#### Testing
See that there is no longer the word "new" in front of the GDPR.