### PR TITLE
Remove unused translations in `decidim-budgets`

### DIFF
--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -404,13 +404,6 @@ en:
           updated_at: The date and time when the order was updated
       show:
         projects: Projects export
-    events:
-      budgets:
-        budget_published:
-          email_intro: 'The %{resource_title} budget is now active for %{participatory_space_title}. You can see it from this page:'
-          email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
-          email_subject: The %{resource_title} budget is now active for %{participatory_space_title}.
-          notification_title: The <a href="%{resource_path}">%{resource_title}</a> budget is now active for %{participatory_space_title}.
     open_data:
       help:
         projects:


### PR DESCRIPTION
#### :tophat: What? Why?
I was reviewing some translations related to different events in the system and I noticed that this event `budget_published` is not referred to from anywhere. Also, I do not see how you could publish/unpublish budgets (which to me would seem redundant anyways) + searching the whole codebase with `budget_published` I do not see any hits anywhere else than the `*.yml` translation files.

It is likely added by mistake and therefore I suggest removing it to create less confusion. It originates from #6223.

#### :pushpin: Related Issues
- Related to #6223

#### Testing
See that the tests are passing after these translations are removed. There should be no changes in system behavior after removing these strings.