### PR TITLE
Fix focus with tab navigation on small avatar images

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_author.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_author.scss
@@ -14,6 +14,10 @@
 
     &-container {
       @apply rounded-full overflow-hidden inline-block w-6 h-6 align-top;
+
+      &:focus-within {
+        @apply ring-2 ring-primary;
+      }
     }
 
     &-counter {


### PR DESCRIPTION
#### :tophat: What? Why?

On an accessibility auditory organized by a Decidim partner, it was detected that currently we have a bug regarding accessibility (a11y) with the avatar images and the focus, as it isn't showing any kind of outline.

This PR fixes that.

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/15031#issuecomment-3233971642 (as it was also mentioned by @alecslupu on that PR)

#### Testing

1. Go to a page with these avatars. I could find it on:
1.1. The proposal page with a participant author
1.2. Any resource page with comments 
1.3. The homepage with the "Last activity" content block 
2. Navigate with the tab key
3. (Before this patch) See that the focus isn't shown visually
4. (After this patch) See that the focus is shown

### :camera: Screenshots
<img width="1812" height="586" alt="image" src="https://github.com/user-attachments/assets/2f6444d3-1e58-429c-b5dd-8cc2a503d285" />

<img width="1273" height="788" alt="image" src="https://github.com/user-attachments/assets/645e3548-1d29-44b8-ad37-c453fe012203" />

<img width="1812" height="586" alt="image" src="https://github.com/user-attachments/assets/5f18ca31-056a-4366-98cf-e3913d8f4abe" />

:hearts: Thank you!
