### PR TITLE
Fix size of the search button and contrast of the search form

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -69,7 +69,7 @@ header {
       @apply hidden md:block col-span-2 col-start-5 xl:col-start-4;
 
       form {
-        @apply block relative rounded text-md bg-background;
+        @apply block relative rounded text-md bg-background leading-relaxed;
       }
 
       input[type="text"] {
@@ -77,7 +77,7 @@ header {
       }
 
       button[type="submit"] {
-        @apply absolute ltr:right-2 rtl:left-2 inset-y-2 text-secondary;
+        @apply absolute ltr:right-2 rtl:left-2 inset-y-0 text-secondary px-2;
       }
     }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -69,7 +69,7 @@ header {
       @apply hidden md:block col-span-2 col-start-5 xl:col-start-4;
 
       form {
-        @apply block relative rounded text-md bg-background leading-relaxed;
+        @apply block relative rounded text-md border border-neutral-200 outline outline-1 outline-transparent rounded bg-background-2 leading-relaxed;
       }
 
       input[type="text"] {


### PR DESCRIPTION
#### :tophat: What? Why?

On an accessibility auditory organized by a Decidim partner, it was detected that currently we have a bug regarding accessibility (a11y) with the search bar that's visible in almost all the frontend pages. There are two problems:

- The size of the search button ("magnifiying glass") is too small. It should at least be 24x24 pixels. Not complying with this requirement is a violation of the success criterion ["WCAG 2.2 - 2.5.8 Target Size (Minimum) (A)"](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum)
- The contrast of the search form border is not correct, as it isn't enough. This doesn't comply with having a contrast of at least 3.0:1 in the clickable objects and its adjacent colours. Not complying with this requirement is a violation of the success criterion ["WCAG 2.2 - 1.4.11 Non-text Contrast (AA)"](https://www.w3.org/TR/WCAG22/#non-text-contrast)

This PR fixes those problems.

⚠️ this will change with the menu revamp from #14934, so we will need to take into account these two criterion one implementing the new search box there

#### Testing

Inspect element in the search box and check out these success criterion. 

### :camera: Screenshots

##### Before

<img width="1892" height="678" alt="image" src="https://github.com/user-attachments/assets/ef1e13d0-0489-4917-80ec-18007eb31f6f" />

##### After

<img width="872" height="237" alt="image" src="https://github.com/user-attachments/assets/e4f78be2-ffc7-4401-ac5a-d21c0754bb7d" />
<img width="1828" height="691" alt="image" src="https://github.com/user-attachments/assets/9f4b9b58-113e-4f63-9506-6a5fa6111be0" />


:hearts: Thank you!
