### PR TITLE
Fix some accessibility violations in design's a11y page

### DIFF
--- a/decidim-design/app/packs/stylesheets/design.scss
+++ b/decidim-design/app/packs/stylesheets/design.scss
@@ -72,7 +72,8 @@
   @apply pb-10 border-b border-background;
 }
 
-.design__heading__description, .design__section {
+.design__heading__description,
+.design__section {
   @apply mt-10 text-gray-2 text-md font-normal [&>*+*]:mt-4 [&_a]:underline;
 }
 

--- a/decidim-design/app/packs/stylesheets/design.scss
+++ b/decidim-design/app/packs/stylesheets/design.scss
@@ -72,7 +72,7 @@
   @apply pb-10 border-b border-background;
 }
 
-.design__heading__description {
+.design__heading__description, .design__section {
   @apply mt-10 text-gray-2 text-md font-normal [&>*+*]:mt-4 [&_a]:underline;
 }
 

--- a/decidim-design/app/views/decidim/design/foundations/accessibility.html.erb
+++ b/decidim-design/app/views/decidim/design/foundations/accessibility.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <% content_for :description do %>
-  <p><%= t(".decidim_follows_html") %></p>
+  <p><%= t(".decidim_follows_html", link: link_to(t(".wcag_guidelines"), "https://www.w3.org/WAI/standards-guidelines/wcag/", target: "_blank", rel: "noopener noreferrer")) %></p>
 <% end %>
 
 <% content_for :toc do %>

--- a/decidim-design/app/views/decidim/design/foundations/accessibility.html.erb
+++ b/decidim-design/app/views/decidim/design/foundations/accessibility.html.erb
@@ -23,7 +23,7 @@
 
   <p><%= t(".illogical_heading_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_illogical_heading_order", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".illogical_heading_order"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_illogical_heading_order", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="unique-h1" class="design__section">
@@ -31,7 +31,7 @@
 
   <p><%= t(".unique_h1_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_unique_h1_on_every_page", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".unique_h1"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_unique_h1_on_every_page", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="one-heading" class="design__section">
@@ -39,7 +39,7 @@
 
   <p><%= t(".important_sections_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_heading_on_important_sections", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".important_sections_heading"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_heading_on_important_sections", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="color-contrast" class="design__section">
@@ -47,7 +47,7 @@
 
   <p><%= t(".color_contrast_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_color_contrast ", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".color_contrast"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_color_contrast ", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="links-buttons" class="design__section">
@@ -55,7 +55,7 @@
 
   <p><%= t(".links_and_buttons_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_links_and_buttons", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".color_contrast"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_links_and_buttons", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="a11y-labels" class="design__section">
@@ -63,7 +63,7 @@
 
   <p><%= t(".accessibility_labels_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_accessibility_labels", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".accessibility_labels"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_accessibility_labels", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="adjacent-links" class="design__section">
@@ -71,7 +71,7 @@
 
   <p><%= t(".adjacent_links_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_adjacent_links_for_the_same_resource", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".adjacent_links_header"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_adjacent_links_for_the_same_resource", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="dynamic-changes" class="design__section">
@@ -79,7 +79,7 @@
 
   <p><%= t(".dynamic_changes_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_dynamic_functionality_changes_the_page_context_unintuitively", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".dynamic_changes_header"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_dynamic_functionality_changes_the_page_context_unintuitively", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="aria" class="design__section">
@@ -87,7 +87,7 @@
 
   <p><%= t(".use_aria_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_use_aria_attributes_where_possible", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".use_aria_header"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_use_aria_attributes_where_possible", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>
 
 <section id="elements-hidden" class="design__section">
@@ -95,5 +95,5 @@
 
   <p><%= t(".elements_hidden_paragraph") %></p>
 
-  <p><%= t(".see_further_info_html", link: link_to(t(".here_link"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_elements_hidden_from_the_accessibility_api", target: "_blank", rel: "noopener noreferrer")) %></p>
+  <p><%= t(".learn_more_about_html", link: link_to(t(".elements_hidden_header"), "https://docs.decidim.org/en/develop/develop/guide_accessibility.html#_elements_hidden_from_the_accessibility_api", target: "_blank", rel: "noopener noreferrer")) %></p>
 </section>

--- a/decidim-design/app/views/layouts/decidim/design/_layout.html.erb
+++ b/decidim-design/app/views/layouts/decidim/design/_layout.html.erb
@@ -53,7 +53,7 @@
     </ul>
   </aside>
 
-  <main>
+  <main id="content">
     <% if content_for?(:heading) %>
       <section class="design__heading__section">
         <h1 class="design__heading__5xl">

--- a/decidim-design/app/views/layouts/decidim/design/application.html.erb
+++ b/decidim-design/app/views/layouts/decidim/design/application.html.erb
@@ -1,13 +1,17 @@
 <% add_decidim_page_title(strip_tags(yield(:heading).lines.last).strip) if content_for?(:heading) %>
 <% add_decidim_page_title("Decidim Design Guide") %>
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
     <title><%= decidim_page_title %></title>
     <%= render partial: "layouts/decidim/design/head" %>
   </head>
 
   <body class="relative text-black text-md form-defaults">
+    <!--noindex--><!--googleoff: all-->
+    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
+    <!--googleon: all--><!--/noindex-->
+
     <%= render layout: "layouts/decidim/design/layout" do %>
       <%= yield %>
     <% end %>

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -94,7 +94,6 @@ en:
           elements_hidden_header: Elements hidden from the accessibility API
           elements_hidden_paragraph: To hide an element from assistive technologies, use the aria-hidden="true" attribute on it.
           heading_on: Heading on important sections
-          here_link: here
           illogical_heading_order: Illogical heading order
           illogical_heading_paragraph: Every page should have a logical heading order when using the <h1>, <h2>, <h3>, <h4>, <h5> and <h6> heading elements.
           important_sections_heading: Heading on important sections

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -99,9 +99,9 @@ en:
           illogical_heading_paragraph: Every page should have a logical heading order when using the <h1>, <h2>, <h3>, <h4>, <h5> and <h6> heading elements.
           important_sections_heading: Heading on important sections
           important_sections_paragraph: It is highly important that each important section of the page has a heading to make it easier to understand what important sections are on the page just by browsing through its headings.
+          learn_more_about_html: Learn more about %{link}
           links_and_buttons: Links and Buttons
           links_and_buttons_paragraph: The anchor elements (i.e. links) are meant to link to different pages or to anchor positions within the page. If the element is supposed to e.g. open some hidden item on that page, you should use the <button> element instead.
-          see_further_info_html: See further info %{link}
           unique_h1: Unique H1
           unique_h1_paragraph: Every page should have a unique H1 heading on it
           use_aria: Use ARIA

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -87,7 +87,7 @@ en:
           adjacent_links_paragraph: If the same resource has multiple adjacent links pointing to it, it makes it difficult for such users to glance through the page because they might need to go through multiple links to get to the next resource.
           color_contrast: Color contrast
           color_contrast_paragraph: When creating user interfaces or modifying the colors, always make sure that you are not breaking accessibility with your changes. You can use the Color contrast checker to ensure that your colors have enough contrast against the background color where they are displayed at.
-          decidim_follows_html: Decidim follows the <u>Web Content Accessibility Guidelines (WCAG) 2.1</u>
+          decidim_follows_html: Decidim follows the %{link}
           dynamic_changes_header: Dynamic functionality changes the page context unintuitively
           dynamic_changes_paragraph: Changes in the form inputs should not change the context of the page automatically.
           elements_hidden: Elements hidden
@@ -107,6 +107,7 @@ en:
           use_aria: Use ARIA
           use_aria_header: Use ARIA attributes where possible
           use_aria_paragraph: Many elements that provide interactive functionality on the website require ARIA attributes on them to make them accessible.
+          wcag_guidelines: Web Content Accessibility Guidelines (WCAG)
         color:
           color_header: Color
           description_p1: We provide a Base palette with few colors so simple customizations are easy. You can modify the Base palette either in the Administration area or in the Tailwind configuration file if you need more advanced customization.

--- a/decidim-design/spec/system/foundations_spec.rb
+++ b/decidim-design/spec/system/foundations_spec.rb
@@ -11,7 +11,7 @@ describe "Foundations" do
   end
 
   context "when on accessibility page" do
-    it_behaves_like "showing the design page", "Accessibility", "Web Content Accessibility Guidelines (WCAG) 2.1"
+    it_behaves_like "showing the design page", "Accessibility", "Web Content Accessibility Guidelines (WCAG)"
   end
 
   # TBD: fix `undefined method `cards_table' for` exception


### PR DESCRIPTION
#### :tophat: What? Why?

In #12227 it was reported that the Design's accessibility page have some accessibility violations. This PR fixes those violations.

#### :pushpin: Related Issues

- Fixes #12227

#### Testing

These a11y violations should be solved:

- [ ] The page define a `lang` attribute for the top level `<html>` element
- [ ] When doing the first tab you have a "Skip to main content" button and when clicking on it the focus is moved to the main content (skipping the sidebar menu) - ⚠️ there's currently a bug here, see #15201
- [ ] The links are correctly labeled
- [ ] The `target="_blank"`is indicated that it opens in a new tab (this was already fixed on other PR)
- [ ] The underlined texts are all links and all the links are underlined 

### :camera: Screenshots

#### Before

<img width="1165" height="844" alt="image" src="https://github.com/user-attachments/assets/28cf7dcd-49df-458a-96a5-a70a92e88c07" />


#### After

<img width="1255" height="810" alt="image" src="https://github.com/user-attachments/assets/aa4c4e57-bb5a-486f-b687-a47a5997f249" />


:hearts: Thank you!
