### PR TITLE
Fix 'Skip to main content' button visualization

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -2,7 +2,7 @@
   @apply flex flex-col min-h-screen;
 
   &__skip {
-    @apply absolute z-10 left-0 -translate-x-full py-1 px-4 bg-primary rounded-br-lg text-white cursor-pointer transition focus:translate-x-0;
+    @apply absolute z-[9999] left-0 -translate-x-full py-1 px-4 bg-primary rounded-br-lg text-white cursor-pointer transition focus:translate-x-0;
   }
 
   [data-content] {


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #15200, I noticed that the 'Skip to main navigation' doesn't work correctly. 

I think this is something that should be happening a couple of versions ago: I see the same behavior in https://try.decidim.org/ (v0.30) and also in https://www.decidim.barcelona/ (v0.29).

This PR fixes this bug. 

#### :pushpin: Related Issues
 
- Related to #15200 
 
#### Testing

1. Load a page
2. Press tab key
3. See the behavior of the page

### :camera: Screenshots

<img width="1253" height="539" alt="image" src="https://github.com/user-attachments/assets/d363209b-7346-4392-8740-ce1d6c5239d8" />

:hearts: Thank you!
