### PR TITLE
Bump charlock_holmes to v0.7.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     cells-rails (0.1.5)
       actionpack (>= 5.0)
       cells (>= 4.1.6, < 5.0.0)
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     cmdparse (3.0.7)
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     cells-rails (0.1.5)
       actionpack (>= 5.0)
       cells (>= 4.1.6, < 5.0.0)
-    charlock_holmes (0.7.7)
+    charlock_holmes (0.7.9)
     cmdparse (3.0.7)
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates `charlock_holmes` to 0.7.9, as it currently fails installing on my computer with the following stack: 

Note, this particular library has already been upgraded in the 0.30 branch via #13835

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/charlock_holmes-0.7.7/ext/charlock_holmes
/home/alecslupu/.rbenv/versions/3.2.2/bin/ruby extconf.rb
checking for -licui18n... yes
checking for unicode/ucnv.h... yes
checking for -lz... yes
checking for -licuuc... yes
checking for -licudata... yes
creating Makefile

current directory: /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/charlock_holmes-0.7.7/ext/charlock_holmes
make DESTDIR\= sitearchdir\=./.gem.20250922-1035139-owbvtt sitelibdir\=./.gem.20250922-1035139-owbvtt clean

current directory: /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/charlock_holmes-0.7.7/ext/charlock_holmes
make DESTDIR\= sitearchdir\=./.gem.20250922-1035139-owbvtt sitelibdir\=./.gem.20250922-1035139-owbvtt
compiling converter.c
converter.c: In function ‘_init_charlock_converter’:
converter.c:53:6: warning: old-style function definition [-Wold-style-definition]
   53 | void _init_charlock_converter() {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
compiling encoding_detector.c
encoding_detector.c: In function ‘rb_encdec_binarymatch’:
encoding_detector.c:50:14: warning: old-style function definition [-Wold-style-definition]
   50 | static VALUE rb_encdec_binarymatch() {
      |              ^~~~~~~~~~~~~~~~~~~~~
encoding_detector.c: In function ‘_init_charlock_encoding_detector’:
encoding_detector.c:366:6: warning: old-style function definition [-Wold-style-definition]
  366 | void _init_charlock_encoding_detector()
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
compiling ext.c
ext.c: In function ‘Init_charlock_holmes’:
ext.c:9:6: warning: old-style function definition [-Wold-style-definition]
    9 | void Init_charlock_holmes() {
      |      ^~~~~~~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
compiling transliterator.cpp
In file included from /usr/include/unicode/unistr.h:37,
                 from /usr/include/unicode/translit.h:27,
                 from transliterator.cpp:5:
/usr/include/unicode/char16ptr.h:317:10: error: ‘is_convertible_v’ is not a member of ‘std’; did you mean ‘is_convertible’?
  317 |     std::is_convertible_v<T, std::u16string_view>
      |          ^~~~~~~~~~~~~~~~
      |          is_convertible
/usr/include/unicode/char16ptr.h:317:28: error: expected primary-expression before ‘,’ token
  317 |     std::is_convertible_v<T, std::u16string_view>
      |                            ^
/usr/include/unicode/char16ptr.h:331:13: error: ‘u16string_view’ in namespace ‘std’ does not name a type; did you mean ‘u16string’?
  331 | inline std::u16string_view toU16StringView(std::u16string_view sv) { return sv; }
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:339:13: error: ‘u16string_view’ in namespace ‘std’ does not name a type; did you mean ‘u16string’?
  339 | inline std::u16string_view toU16StringView(std::basic_string_view<uint16_t> sv) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:360:36: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
  360 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:360:36: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:360:47: error: expected ‘>’ before ‘<’ token
  360 |           typename = typename std::enable_if_t<!std::is_pointer_v<std::remove_reference_t<T>>>>
      |                                               ^
/usr/include/unicode/char16ptr.h:361:13: error: ‘u16string_view’ in namespace ‘std’ does not name a type; did you mean ‘u16string’?
  361 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
/usr/include/unicode/char16ptr.h:370:36: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
  370 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                    ^~~~~~~~~~~
/usr/include/unicode/char16ptr.h:370:36: note: ‘std::enable_if_t’ is only available from C++14 onwards
/usr/include/unicode/char16ptr.h:370:47: error: expected ‘>’ before ‘<’ token
  370 |           typename = typename std::enable_if_t<std::is_pointer_v<std::remove_reference_t<T>>>,
      |                                               ^
/usr/include/unicode/char16ptr.h:372:13: error: ‘u16string_view’ in namespace ‘std’ does not name a type; did you mean ‘u16string’?
  372 | inline std::u16string_view toU16StringViewNullable(const T& text) {
      |             ^~~~~~~~~~~~~~
      |             u16string
In file included from /usr/include/unicode/unistr.h:40:
/usr/include/unicode/stringpiece.h:134:29: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
  134 |             typename = std::enable_if_t<
      |                             ^~~~~~~~~~~
/usr/include/unicode/stringpiece.h:134:24: note: ‘std::enable_if_t’ is only available from C++14 onwards
  134 |             typename = std::enable_if_t<
      |                        ^~~
/usr/include/unicode/stringpiece.h:134:40: error: expected ‘>’ before ‘<’ token
  134 |             typename = std::enable_if_t<
      |                                        ^
/usr/include/unicode/stringpiece.h:185:19: error: expected type-specifier
  185 |   inline operator std::string_view() const {
      |                   ^~~
/usr/include/unicode/unistr.h:346:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:346:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:346:51: error: expected ‘>’ before ‘<’ token
  346 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:381:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:381:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:381:51: error: expected ‘>’ before ‘<’ token
  381 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:1959:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:1959:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:1959:51: error: expected ‘>’ before ‘<’ token
 1959 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2226:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2226:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2226:51: error: expected ‘>’ before ‘<’ token
 2226 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:2299:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:2299:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:2299:51: error: expected ‘>’ before ‘<’ token
 2299 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3035:19: error: expected type-specifier
 3035 |   inline operator std::u16string_view() const {
      |                   ^~~
/usr/include/unicode/unistr.h:3273:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3273:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3273:51: error: expected ‘>’ before ‘<’ token
 3273 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3599:40: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                        ^~~~~~~~~~~
/usr/include/unicode/unistr.h:3599:35: note: ‘std::enable_if_t’ is only available from C++14 onwards
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                   ^~~
/usr/include/unicode/unistr.h:3599:51: error: expected ‘>’ before ‘<’ token
 3599 |   template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                   ^
/usr/include/unicode/unistr.h:3755:60: error: ‘std::u16string_view’ has not been declared
 3755 |   static UnicodeString readOnlyAliasFromU16StringView(std::u16string_view text);
      |                                                            ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3871:64: error: ‘std::u16string_view’ has not been declared
 3871 |   UnicodeString& doReplace(int32_t start, int32_t length, std::u16string_view src);
      |                                                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:3875:32: error: ‘std::u16string_view’ has not been declared
 3875 |   UnicodeString& doAppend(std::u16string_view src);
      |                                ^~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function ‘bool icu_76::UnicodeString::operator==(const S&) const’:
/usr/include/unicode/unistr.h:348:10: error: ‘u16string_view’ is not a member of ‘std’; did you mean ‘u16string’?
  348 |     std::u16string_view sv(internal::toU16StringView(text));
      |          ^~~~~~~~~~~~~~
      |          u16string
/usr/include/unicode/unistr.h:350:46: error: ‘sv’ was not declared in this scope
  350 |     return !isBogus() && (len = length()) == sv.length() && doEquals(sv.data(), len);
      |                                              ^~
/usr/include/unicode/unistr.h: In member function ‘icu_76::UnicodeString& icu_76::UnicodeString::operator=(const S&)’:
/usr/include/unicode/unistr.h:1962:45: error: ‘toU16StringView’ is not a member of ‘icu_76::internal’
 1962 |     return doReplace(0, length(), internal::toU16StringView(src));
      |                                             ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function ‘icu_76::UnicodeString& icu_76::UnicodeString::operator+=(const S&)’:
/usr/include/unicode/unistr.h:2228:31: error: ‘toU16StringView’ is not a member of ‘icu_76::internal’
 2228 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In member function ‘icu_76::UnicodeString& icu_76::UnicodeString::append(const S&)’:
/usr/include/unicode/unistr.h:2301:31: error: ‘toU16StringView’ is not a member of ‘icu_76::internal’
 2301 |     return doAppend(internal::toU16StringView(src));
      |                               ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In constructor ‘icu_76::UnicodeString::UnicodeString(const S&)’:
/usr/include/unicode/unistr.h:3276:24: error: ‘toU16StringViewNullable’ is not a member of ‘icu_76::internal’
 3276 |     doAppend(internal::toU16StringViewNullable(text));
      |                        ^~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: In static member function ‘static icu_76::UnicodeString icu_76::UnicodeString::readOnlyAlias(const S&)’:
/usr/include/unicode/unistr.h:3601:53: error: ‘toU16StringView’ is not a member of ‘icu_76::internal’
 3601 |     return readOnlyAliasFromU16StringView(internal::toU16StringView(text));
      |                                                     ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4116:38: error: ‘enable_if_t’ in namespace ‘std’ does not name a template type
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                      ^~~~~~~~~~~
/usr/include/unicode/unistr.h:4116:33: note: ‘std::enable_if_t’ is only available from C++14 onwards
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                 ^~~
/usr/include/unicode/unistr.h:4116:49: error: expected ‘>’ before ‘<’ token
 4116 | template<typename S, typename = std::enable_if_t<ConvertibleToU16StringView<S>>>
      |                                                 ^
/usr/include/unicode/unistr.h: In function ‘icu_76::UnicodeString icu_76::operator+(const UnicodeString&, const S&)’:
/usr/include/unicode/unistr.h:4118:46: error: ‘toU16StringView’ is not a member of ‘icu_76::internal’
 4118 |   return unistr_internalConcat(s1, internal::toU16StringView(s2));
      |                                              ^~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:4118:10: error: there are no arguments to ‘unistr_internalConcat’ that depend on a template parameter, so a declaration of ‘unistr_internalConcat’ must be
available [-fpermissive]
 4118 |   return unistr_internalConcat(s1, internal::toU16StringView(s2));
      |          ^~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/unistr.h:4118:10: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
/usr/include/unicode/unistr.h: At global scope:
/usr/include/unicode/unistr.h:4125:53: error: ‘std::u16string_view’ has not been declared
 4125 | unistr_internalConcat(const UnicodeString &s1, std::u16string_view s2);
      |                                                     ^~~~~~~~~~~~~~
In file included from /usr/include/unicode/uenum.h:25,
                 from /usr/include/unicode/utrans.h:22,
                 from /usr/include/unicode/translit.h:29:
/usr/include/unicode/localpointer.h:561:26: error: parameter declared ‘auto’
  561 | template <typename Type, auto closeFunction>
      |                          ^~~~
/usr/include/unicode/localpointer.h:573:76: error: template argument 2 is invalid
  573 |     explicit LocalOpenPointer(std::unique_ptr<Type, decltype(closeFunction)> &&p)
      |                                                                            ^
/usr/include/unicode/localpointer.h:583:78: error: template argument 2 is invalid
  583 |     LocalOpenPointer &operator=(std::unique_ptr<Type, decltype(closeFunction)> &&p) {
      |                                                                              ^
/usr/include/unicode/localpointer.h:599:59: error: template argument 2 is invalid
  599 |     operator std::unique_ptr<Type, decltype(closeFunction)> () && {
      |                                                           ^
/usr/include/unicode/uenum.h:69:1: note: invalid template non-type parameter
   69 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUEnumerationPointer, UEnumeration, uenum_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/unicode/uset.h:361:1: note: invalid template non-type parameter
  361 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUSetPointer, USet, uset_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/unicode/utrans.h:23:
/usr/include/unicode/uset.h:1655:10: error: ‘u16string_view’ in namespace ‘std’ does not name a type; did you mean ‘u16string’?
 1655 |     std::u16string_view operator*() const {
      |          ^~~~~~~~~~~~~~
      |          u16string
/usr/include/unicode/utrans.h:258:1: note: invalid template non-type parameter
  258 | U_DEFINE_LOCAL_OPEN_POINTER(LocalUTransliteratorPointer, UTransliterator, utrans_close);
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~
make: *** [Makefile:240: transliterator.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/charlock_holmes-0.7.7 for inspection.
Results logged to /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/extensions/x86_64-linux/3.2.0/charlock_holmes-0.7.7/gem_make.out

  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:119:in `run'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:51:in `block in make'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:43:in `each'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:43:in `make'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/ext_conf_builder.rb:41:in `build'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:187:in `build_extension'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:221:in `block in build_extensions'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in `each'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/ext/builder.rb:218:in `build_extensions'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/installer.rb:843:in `build_extensions'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/source/rubygems.rb:200:in `install'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/installer/gem_installer.rb:54:in `install'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/installer/parallel_installer.rb:155:in `do_install'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/installer/parallel_installer.rb:146:in `block in worker_pool'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/worker.rb:62:in `apply_func'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/worker.rb:57:in `block in process_queue'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/worker.rb:54:in `loop'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/worker.rb:54:in `process_queue'
  /home/alecslupu/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/bundler-2.4.6/lib/bundler/worker.rb:90:in `block (2 levels) in create_threads'

An error occurred while installing charlock_holmes (0.7.7), and Bundler cannot continue.

In Gemfile:
  decidim-dev was resolved to 0.29.4, which depends on
    decidim was resolved to 0.29.4, which depends on
      decidim-accountability was resolved to 0.29.4, which depends on
        decidim-comments was resolved to 0.29.4, which depends on
          decidim-core was resolved to 0.29.4, which depends on
            charlock_holmes

```


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
