### PR TITLE
Fix translation missing for duplicate landing blocks

### DIFF
--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         domain: Domain
         duplicate_categories: Duplicate categories
         duplicate_components: Duplicate components
+        duplicate_landing_page_blocks: Duplicate landing page blocks
         duplicate_steps: Duplicate steps
         end_date: End date
         hero_image: Home image


### PR DESCRIPTION
#### :tophat: What? Why?
Stumbled across an issue where a translation was missing for duplicate landing blocks. This PR adds the translation back. 

This was probably caused by #15047 and sheer no. of translations conducted on PR within the application.

#### :pushpin: Related Issues
- Fixes #15115

#### Testing

### :camera: Screenshots

:hearts: Thank you!
