### PR TITLE
Allow password validator to use the fallback translation

### DIFF
--- a/decidim-core/app/validators/password_validator.rb
+++ b/decidim-core/app/validators/password_validator.rb
@@ -55,7 +55,9 @@ class PasswordValidator < ActiveModel::EachValidator
   attr_reader :record, :attribute, :value
 
   def get_message(reason)
-    I18n.t "password_validator.#{reason}"
+    I18n.t! "password_validator.#{reason}"
+  rescue I18n::MissingTranslationData
+    I18n.t "password_validator.fallback"
   end
 
   def organization

--- a/decidim-core/spec/validators/password_validator_spec.rb
+++ b/decidim-core/spec/validators/password_validator_spec.rb
@@ -5,7 +5,8 @@ require "spec_helper"
 describe PasswordValidator do
   describe "#validate_each" do
     let(:organization) { create(:organization) }
-    let(:validator) { described_class.new(options).validate_each(record, attribute, value) }
+    let(:validator_instance) { described_class.new(options) }
+    let(:validator) { validator_instance.validate_each(record, attribute, value) }
 
     let(:errors) { ActiveModel::Errors.new(attribute.to_s => []) }
     let(:record) do
@@ -282,6 +283,35 @@ describe PasswordValidator do
           expect(validator).to be(true)
           expect(record.errors[attribute]).to be_empty
         end
+      end
+    end
+
+    # This could happen in case the validator is customized.
+    describe "missing validator translation" do
+      let(:value) { "password" }
+
+      around do |example|
+        methods = described_class.const_get(:VALIDATION_METHODS)
+        described_class.class_eval do
+          remove_const(:VALIDATION_METHODS)
+          const_set(:VALIDATION_METHODS, [:speakeasy?])
+        end
+
+        example.run
+
+        described_class.class_eval do
+          remove_const(:VALIDATION_METHODS)
+          const_set(:VALIDATION_METHODS, methods)
+        end
+      end
+
+      before do
+        allow(validator_instance).to receive(:speakeasy?).and_return(true)
+      end
+
+      it "shows the fallback error" do
+        expect(validator).to be(false)
+        expect(record.errors[attribute]).to include("is not valid")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
In case there is no translation available for the given validation, allow the validator to use the fallback translation.

I noticed that there was a translation available for this but it is not used anywhere:

https://github.com/decidim/decidim/blob/add5ba872b8dbcb7f5619c0fc1cd3bdfc3b51c2b/decidim-core/config/locales/en.yml#L2182

#### Testing
Run the added spec to test this case.