### PR TITLE
Remove unused password validator translation

### DIFF
--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2183,7 +2183,6 @@ en:
     name_included_in_password: is too similar to your name
     nickname_included_in_password: is too similar to your nickname
     not_enough_unique_characters: does not have enough unique characters
-    password_not_allowed: is not allowed
     password_repeated: cannot reuse old password
     password_too_common: is too common
     password_too_long: is too long


### PR DESCRIPTION
#### :tophat: What? Why?
I was doing some work with password validation and I noticed that this translation is not used anywhere (as far as I know).

EDIT:
After futher investigation:
- This originates from #3587
- #8455 rewrote this method as `blacklisted?` and added a new translation for that (`password_validator.blacklisted`), therefore the original translation `password_validator.password_not_allowed` no longer used after the rewrite.
- #10288 renamed the translation `password_validator.blacklisted` to the current translation `password_validator.denied` (not directly related to this PR but just FYI).

#### Testing
- See that tests are green
- Search the codebase with `password_not_allowed` -> see no other matches than in the `config/locales/*.yml` files.