### PR TITLE
Remove the `parallel_tests/tasks` from `common_rake`

### DIFF
--- a/decidim-dev/lib/decidim/dev/common_rake.rb
+++ b/decidim-dev/lib/decidim/dev/common_rake.rb
@@ -3,7 +3,6 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require "decidim/dev"
-require "parallel_tests/tasks"
 
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = "--format progress --format RspecJunitFormatter -o ~/rspec/rspec.xml" if ENV["CI"]


### PR DESCRIPTION
#### :tophat: What? Why?
While we worked to release the 0.31.0.dev  we have noticed the following error: 

```
NoMethodError: undefined method `config' for nil (NoMethodError)

        Rails.application.config.load_database_yaml
                         ^^^^^^^
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/home/alecslupu/Sites/decidim/decidim30/decidim-dev/lib/decidim/dev/common_rake.rb:6:in `<top (required)>'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/home/alecslupu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/home/alecslupu/Sites/decidim/decidim30/decidim-accountability/Rakefile:3:in `<top (required)>'
(See full trace by running task with --trace)
rake aborted!
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13839

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
