### PR TITLE
Prevent reload on filters when the 'Skip to' links are clicked

### DIFF
--- a/decidim-core/app/helpers/decidim/map_helper.rb
+++ b/decidim-core/app/helpers/decidim/map_helper.rb
@@ -81,7 +81,7 @@ module Decidim
 
       help = content_tag(:div, class: "map__skip-container") do
         sr_content = content_tag(:p, t("screen_reader_explanation", scope: "decidim.map.dynamic"), class: "sr-only")
-        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "##{bottom_id}", class: "map__skip")
+        link = link_to(t("skip_button", scope: "decidim.map.dynamic"), "##{bottom_id}", class: "map__skip", "data-skip-to-content": true)
 
         sr_content + link
       end

--- a/decidim-core/app/packs/src/decidim/controllers/form_filter/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/form_filter/controller.js
@@ -213,6 +213,12 @@ export default class extends Controller {
     this.changeEvents = false;
     this._clearForm();
 
+    // Prevent filtering again on anchor link "Skip to main content", "Skip map", or "Skip to results"
+    const filterSkipValues = [...document.querySelectorAll("[data-skip-to-content]")].map((el) => el.hash);
+    if (filterSkipValues.includes(window.location.hash)) {
+      return;
+    }
+
     const filterParams = this._parseLocationFilterValues();
     const currentOrder = this._parseLocationOrderValue();
 

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -14,7 +14,7 @@
 
     <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
-        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem" %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem", "data-skip-to-content": true %>
       <% end %>
 
       <p id="filter-help-text" class="filter-help" role="menuitem" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>

--- a/decidim-core/app/views/layouts/decidim/_application.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_application.html.erb
@@ -8,7 +8,7 @@
 
   <body class="text-black text-md form-defaults<%= yield (:body_class) %>">
     <!--noindex--><!--googleoff: all-->
-    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip" %>
+    <%= link_to t("skip_button", scope: "decidim.accessibility"), "#content", class: "layout-container__skip", "data-skip-to-content": true %>
     <%= cell("decidim/data_consent", current_organization) %>
     <!--googleon: all--><!--/noindex-->
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's an accessibility problem with the current "Skip to main content", "Skip to results" and "Skip map" links in all the pages with filters. The problem is that the filter is executed again when any of these links is clicked.

This shouldn't happen, as the filters shouldn't change by this action. It is specially painful in meetings#index page, as it has these three links and also there's a map. There's a full explanation about this issue at #11522.

You can check out the reload of the filters through the "Network" tab of your browsers' web developer tools. 

#### :pushpin: Related Issues

- Fixes #11522 

#### Testing

1. Go to `/meetings` (or any other view with filters and map)
2. Using tab navigation, click the "Skip to content" link
3. See that the dynamic filtering triggers
4. Repeat the exercise by going to the "Skip to map" link
5. See the same behavior
6. Apply this patch
7. See that these behaviors are corrected

(I also found this same problem with the "Skip to results"  link) 

### :camera: Screenshots

<img width="721" height="552" alt="image" src="https://github.com/user-attachments/assets/47da73b0-ae73-4f81-b231-fdbf1a97aac6" />


:hearts: Thank you!
