### PR TITLE
Fix meetings' seeds with 'Reminder time in hours before the meeting' field

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/seeds.rb
+++ b/decidim-meetings/lib/decidim/meetings/seeds.rb
@@ -80,6 +80,7 @@ module Decidim
           registration_terms: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
+          send_reminders_before_hours: 48,
           published_at: ::Faker::Boolean.boolean(true_ratio: 0.8) ? Time.current : nil
         }
 


### PR DESCRIPTION
#### :tophat: What? Why?

I was checking out the meetings locally and found out that currently the seeds have an error, and you can't edit any existing meeting.

This PR fixes it. 

#### :pushpin: Related Issues 

- Related to #14470 (as this field was introduced there)
 
#### Testing

1. (Before) run the seeds
2. Sign in as admin
3. Edit a meeting and save
4. See the error

1. (After) run the seeds
2. Sign in as admin
3. Edit a meeting and save
4. See that it can save correctly

### :camera: Screenshots 

<img width="1554" height="926" alt="2025-09-26-153143_hyprshot" src="https://github.com/user-attachments/assets/f69e2ae5-e7a9-4a25-8340-f958a131a5d2" />

:hearts: Thank you!
