### PR TITLE
Backport 'Fix translation missing for duplicate landing blocks' to v0.30

### DIFF
--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
         area_id: Area
         copy_categories: Copy categories
         copy_components: Copy components
+        copy_landing_page_blocks: Duplicate landing page blocks
         copy_steps: Copy steps
         decidim_area_id: Area
         description: Description


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15211 to v0.30

:hearts: Thank you!