### PR TITLE
Fix admin officialization specs

### DIFF
--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -75,9 +75,10 @@ describe "Admin manages officializations" do
       end
     end
 
-    it "cannot be officialized" do
+    it "has no user link" do
       within "tr[data-user-id=\"#{user.id}\"]" do
-        expect(page).to have_no_link("Officialize")
+        expect(page).to have_content(user.name)
+        expect(page).to have_no_link(user.name)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
After I have merged #15122, i have noticed that the Backport PRs have started to fail, as the link is still there. 
This PR, fixes that test by testing that the managed user name does not have a link to its profile when the nickname is empty.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15122
- Related to #15244
- Related to #15245
- Related to #15246

#### Testing
Make sure this PR has same fix as the backport PRS. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
