### PR TITLE
Show the question confirmation when unpublishing a meeting

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting_actions.html.erb
@@ -151,7 +151,7 @@
       <li class="dropdown__item">
         <% if allowed_to?(:update, :meeting, meeting: meeting) %>
           <% if meeting.published? %>
-            <%= link_to unpublish_meeting_path(meeting), method: :put, data: { confirm: t("actions.unpublish", scope: "decidim.admin") }, class: "dropdown__button" do %>
+            <%= link_to unpublish_meeting_path(meeting), method: :put, data: { confirm: t("actions.confirm_unpublish_meeting", scope: "decidim.meetings") }, class: "dropdown__button" do %>
               <%= icon "close-circle-line" %>
               <%= t("actions.unpublish", scope: "decidim.admin") %>
             <% end %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -286,6 +286,7 @@ en:
         agenda: Agenda
         close: Close
         confirm_delete_meeting: Are you sure you want to delete this meeting?
+        confirm_unpublish_meeting: Are you sure you want to unpublish this meeting?
         deleted_meetings_info: Deleted meetings can be restored from the trash.
         edit: Edit
         invalid_destroy:

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -42,6 +42,16 @@ describe "Admin manages meetings" do
       expect(page).to have_css("tbody tr:last-child", text: Decidim::Meetings::MeetingPresenter.new(old_meeting).title)
     end
 
+    it "shows the unpublish modal" do
+      visit current_path
+
+      within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
+        find("button[data-controller='dropdown']").click
+        click_on "Unpublish"
+        expect(accept_confirm).to eq("Are you sure you want to unpublish this meeting?")
+      end
+    end
+
     it "allows to publish/unpublish meetings" do
       visit current_path
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #15162, I noticed that we're not showing the question for confirmation ('Are you sure you want to unpublish this meeting?") while an admin does this action.

This PR adds it. 

#### :pushpin: Related Issues
 
- Related to #14651 (as I think this modal was added with this PR)
 

#### Testing

1. Sign in as admin
2. Unpublish a meeting

### :camera: Screenshots

#### Before

<img width="1130" height="529" alt="image" src="https://github.com/user-attachments/assets/66ce570d-a4f7-4f2e-adb7-82cc31c45b2b" />

#### After

<img width="1015" height="462" alt="image" src="https://github.com/user-attachments/assets/d0b15b22-ffc0-412f-a20d-6b402956e605" />

:hearts: Thank you!
