### PR TITLE
Add published/unpublished state in the Meetings' admin index page

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
@@ -35,6 +35,14 @@
     <%= present(meeting).taxonomy_names.join(", ") %>
   </td>
 
+  <td class="table-list__state" data-label="<%= t("models.meeting.fields.published", scope: "decidim.meetings") %>">
+    <% if meeting.published? %>
+      <span class="label success !text-sm"><%= t("admin.meetings.index.published", scope: "decidim.meetings") %></span>
+    <% else %>
+      <span class="label alert !text-sm"><%= t("admin.meetings.index.unpublished", scope: "decidim.meetings") %></span>
+    <% end %>
+  </td>
+
   <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.meetings") %>">
     <% if is_linked %>
       <%= t("index.linked_meeting_warning_html", href: edit_meeting_path(meeting), name: present(meeting).space_title, scope: "decidim.meetings.admin.meetings") %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
@@ -21,6 +21,9 @@
   <th>
     <%= sort_link(query, :scope_name, t("models.meeting.fields.taxonomies", scope: "decidim.meetings") ) %>
   </th>
+  <th>
+    <%= sort_link(query, :published_at, t("models.meeting.fields.published", scope: "decidim.meetings")) %>
+  </th>
   <th><%= t("actions.title", scope: "decidim.meetings") %></th>
 </tr>
 </thead>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
@@ -22,7 +22,7 @@
     <%= sort_link(query, :scope_name, t("models.meeting.fields.taxonomies", scope: "decidim.meetings") ) %>
   </th>
   <th>
-    <%= sort_link(query, :published_at, t("models.meeting.fields.published", scope: "decidim.meetings")) %>
+    <%= t("models.meeting.fields.published", scope: "decidim.meetings") %>
   </th>
   <th><%= t("actions.title", scope: "decidim.meetings") %></th>
 </tr>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -384,7 +384,9 @@ en:
             select_an_iframe_access_level: Please select an iframe access level
           index:
             linked_meeting_warning_html: This meeting must be edited from <br><a href="%{href}">%{name}</a>
+            published: Published
             title: Meetings
+            unpublished: Unpublished
           linked_spaces:
             assign: Assign
             link_a_space: Link a space
@@ -677,6 +679,7 @@ en:
             id: ID
             map: Map
             official_meeting: Official meeting
+            published: Published
             start_time: Start date
             taxonomies: Taxonomies
             title: Title

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -50,7 +50,11 @@ describe "Admin manages meetings" do
         accept_confirm { click_on "Unpublish" }
       end
 
-      expect(page).to have_admin_callout("successfully")
+      within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
+        expect(page).to have_content("Unpublished")
+      end
+
+      expect(page).to have_admin_callout("Meeting successfully unpublished")
 
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
         find("button[data-controller='dropdown']").click
@@ -61,7 +65,11 @@ describe "Admin manages meetings" do
         click_on "Publish"
       end
 
-      expect(page).to have_admin_callout("successfully")
+      within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
+        expect(page).to have_content("Published")
+      end
+
+      expect(page).to have_admin_callout("Meeting successfully published")
 
       within "tr", text: Decidim::Meetings::MeetingPresenter.new(meeting).title do
         find("button[data-controller='dropdown']").click


### PR DESCRIPTION
#### :tophat: What? Why?

After #14651 we don't have any way of knowing if a meeting is published or not in the admin, and that makes bugs like #15162. This PR fixes this by adding the column as we have in other resources (such as Processes, Assemblies, Conferences, etc).

Even though is in the fine line between a `type: fix` or a `type: feature`, I'm leaning to a `type: fix`, as it is practically the only consistent way of solving the bug. Mind that in v0.30 or v0.29 is not that problematic as the change of the icon is a kind of design affordance for this problem (see the screenshot that I provided at #15162). 

#### :pushpin: Related Issues 

- Fixes #15162 

#### Testing

1. Sign in as admin
2. Unpublish a meeting

### :camera: Screenshots

#### Before

<img width="1668" height="812" alt="image" src="https://github.com/user-attachments/assets/a771111b-3876-48dd-bf71-89c7ca5bb645" />

#### After

<img width="1653" height="813" alt="image" src="https://github.com/user-attachments/assets/fa01e385-c8c3-4c8a-bc90-158c1cc247fd" />


:hearts: Thank you!
