### PR TITLE
Add published/unpublished state in the Surveys' admin index page

### DIFF
--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -71,7 +71,7 @@
                   <% if allowed_to?(:update, :questionnaire) %>
                     <% if survey.published? %>
                       <li class="dropdown__item">
-                        <%= link_to unpublish_survey_path(survey), method: :put, class: "dropdown__button" do %>
+                        <%= link_to unpublish_survey_path(survey), method: :put, data: { confirm: t("actions.confirm_unpublish_survey", scope: "decidim.admin") }, class: "dropdown__button" do %>
                           <%= icon "close-circle-line" %>
                           <%= t("actions.unpublish", scope: "decidim.admin") %>
                         <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -15,6 +15,7 @@
           <th><%= t("models.survey.fields.questions", scope: "decidim.surveys") %></th>
           <th><%= t("models.survey.fields.responses", scope: "decidim.surveys") %></th>
           <th><%= t("models.survey.fields.status", scope: "decidim.surveys") %></th>
+          <th><%= t("models.survey.fields.published", scope: "decidim.surveys") %></th>
           <th><%= t("actions.title", scope: "decidim.surveys") %></th>
         </tr>
       </thead>
@@ -32,6 +33,17 @@
             </td>
             <td data-label="<%= t("models.survey.fields.status", scope: "decidim.surveys") %>">
               <%= survey.open? ? t("models.survey.status.open", scope: "decidim.surveys") : t("models.survey.status.closed", scope: "decidim.surveys") %>
+            </td>
+            <td data-label="<%= t("models.survey.fields.published", scope: "decidim.surveys") %>">
+              <% if survey.published? %>
+                <span class="label success !text-sm">
+                  <%= t("models.survey.published.published", scope: "decidim.surveys") %>
+                </span>
+              <% else %>
+                <span class="label alert !text-sm">
+                  <%= t("models.survey.published.unpublished", scope: "decidim.surveys") %>
+                </span>
+              <% end %>
             </td>
             <td data-label="<%= t("actions.title", scope: "decidim.surveys") %>" class="table-list__actions">
               <button type="button" data-controller="dropdown" data-target="actions-survey-<%= survey.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: survey.title) %>">

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -23,7 +23,7 @@
         <% surveys.each do |survey| %>
           <tr>
             <td data-label="<%= t("models.survey.fields.title", scope: "decidim.surveys") %>">
-              <%= decidim_sanitize_translated(survey.title) %>
+              <%= link_to decidim_sanitize_translated(survey.title), edit_survey_path(survey) %>
             </td>
             <td data-label="<%= t("models.survey.fields.questions", scope: "decidim.surveys") %>">
               <%= survey.questionnaire.questions.size %>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -130,8 +130,8 @@ en:
       models:
         survey:
           fields:
-            questions: Questions
             published: Published
+            questions: Questions
             responses: Responses
             status: Status
             title: Title

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -130,9 +130,13 @@ en:
         survey:
           fields:
             questions: Questions
+            published: Published
             responses: Responses
             status: Status
             title: Title
+          published:
+            published: Published
+            unpublished: Unpublished
           status:
             closed: Closed
             open: Open

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
   decidim:
     admin:
       actions:
+        confirm_unpublish_survey: Are you sure you want to unpublish this survey?
         see_survey: See survey
       admin_log:
         changeset:

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -146,7 +146,7 @@ describe "Admin manages surveys" do
 
               within "tr", text: decidim_sanitize_translated(survey.title) do
                 find("button[data-controller='dropdown']").click
-                click_on "Unpublish"
+                accept_confirm { click_on "Unpublish" }
               end
 
               within "tr", text: decidim_sanitize_translated(survey.title) do

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -79,6 +79,14 @@ describe "Admin manages surveys" do
         expect(page).to have_no_selector("#questions_questions_#{question.id}_body_en[disabled]")
       end
 
+      it "shows the unpublish modal" do
+        within "tr", text: decidim_sanitize_translated(survey.title) do
+          find("button[data-controller='dropdown']").click
+          click_on "Unpublish"
+          expect(accept_confirm).to eq("Are you sure you want to unpublish this survey?")
+        end
+      end
+
       it "deletes responses after published" do
         within "tr", text: decidim_sanitize_translated(survey.title) do
           find("button[data-controller='dropdown']").click
@@ -96,7 +104,7 @@ describe "Admin manages surveys" do
 
         within "tr", text: decidim_sanitize_translated(survey.title) do
           find("button[data-controller='dropdown']").click
-          click_on "Unpublish"
+          accept_confirm { click_on "Unpublish" }
         end
 
         expect(page).to have_admin_callout "Survey successfully unpublished"

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -98,13 +98,23 @@ describe "Admin manages surveys" do
           find("button[data-controller='dropdown']").click
           click_on "Unpublish"
         end
+
         expect(page).to have_admin_callout "Survey successfully unpublished"
+
+        within "tr", text: decidim_sanitize_translated(survey.title) do
+          expect(page).to have_content "Unpublished"
+        end
 
         within "tr", text: decidim_sanitize_translated(survey.title) do
           find("button[data-controller='dropdown']").click
           accept_confirm { click_on("Publish") }
         end
+
         expect(page).to have_admin_callout "Survey successfully published"
+
+        within "tr", text: decidim_sanitize_translated(survey.title) do
+          expect(page).to have_content "Published"
+        end
         expect(questionnaire.responses).to be_empty
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #15256, I checked out which other resources this might be happening and found the same problem with Surveys. 

This PR fixes it. 

It also implements the modal confirmation that we have on #15254 

While working on these issues, @carolromero mentioned that this page doesn't have the link to the surveys' edit form as the other resources, and that it should be there because of consistency (see #9496 - i think it was a leftover and it should be there)

#### :pushpin: Related Issues
 
- Related to #15256 
- Related to #15254 

#### Testing

1. Sign in as admin
2. Unpublish a survey

### :camera: Screenshots

#### Before

<img width="1206" height="573" alt="image" src="https://github.com/user-attachments/assets/9f264411-42f5-485e-8229-6dad398f926d" />

#### After

<img width="1303" height="624" alt="image" src="https://github.com/user-attachments/assets/5f80a05f-c745-4a12-a445-575adc8da0c1" />

<img width="1105" height="518" alt="image" src="https://github.com/user-attachments/assets/cfd54921-ac34-4940-8be5-3b2b92615b85" />


:hearts: Thank you!
