### PR TITLE
Change the 'Edit' button link to the 'Edit layouts' pages

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -6,7 +6,7 @@
 
 <%
 edit_link(
-  resource_locator(current_participatory_space).edit,
+  decidim_admin_assemblies.edit_assembly_landing_page_path(current_participatory_space),
   :update,
   :assembly,
   assembly: current_participatory_space

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -16,7 +16,12 @@ describe "AdminAccess" do
     let(:participatory_space_path) { decidim_assemblies.assembly_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
-    it_behaves_like "admin participatory space edit button"
+
+    describe "edit button" do
+      let(:target_path) { decidim_admin_assemblies.edit_assembly_landing_page_path(participatory_space) }
+
+      it_behaves_like "admin participatory space edit button"
+    end
   end
 
   context "with participatory space evaluator" do

--- a/decidim-core/app/views/decidim/homepage/show.html.erb
+++ b/decidim-core/app/views/decidim/homepage/show.html.erb
@@ -1,6 +1,6 @@
 <%
   edit_link(
-    decidim_admin.edit_organization_path,
+    decidim_admin.edit_organization_homepage_path,
     :update,
     :organization,
     organization: current_organization

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -38,6 +38,25 @@ describe "Homepage" do
         visit decidim.root_path
       end
 
+      context "with an admin user" do
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+        before do
+          login_as user, scope: :user if user
+          visit current_path
+        end
+
+        describe "the edit button" do
+          let(:edit_path) { decidim_admin.edit_organization_homepage_path }
+
+          it "shows the admin bar with the Edit button" do
+            within "#admin-bar" do
+              expect(page).to have_link("Edit", href: edit_path)
+            end
+          end
+        end
+      end
+
       context "when having homepage anchors" do
         %w(hero sub_hero how_to_participate footer_sub_hero).each do |anchor|
           it { expect(page).to have_css("[id^=#{anchor}]", visible: :all) }
@@ -223,24 +242,6 @@ describe "Homepage" do
                 static_page_topic2_page2.title["en"],
                 href: "/pages/#{static_page_topic2_page2.slug}"
               )
-            end
-
-            context "with an admin user" do
-              let(:user) { create(:user, :admin, :confirmed, organization:) }
-
-              before do
-                login_as user, scope: :user if user
-              end
-
-              describe "the edit button" do
-                let(:edit_path) { decidim_admin.edit_organization_homepage_path }
-
-                it "shows the admin bar with the Edit button" do
-                  within "#admin-bar" do
-                    expect(page).to have_link("Edit", href: edit_path)
-                  end
-                end
-              end
             end
           end
         end

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -224,6 +224,24 @@ describe "Homepage" do
                 href: "/pages/#{static_page_topic2_page2.slug}"
               )
             end
+
+            context "with an admin user" do
+              let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+              before do
+                login_as user, scope: :user if user
+              end
+
+              describe "the edit button" do
+                let(:edit_path) { decidim_admin.edit_organization_homepage_path }
+
+                it "shows the admin bar with the Edit button" do
+                  within "#admin-bar" do
+                    expect(page).to have_link("Edit", href: edit_path)
+                  end
+                end
+              end
+            end
           end
         end
       end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -7,7 +7,7 @@
 
 <%
   edit_link(
-    resource_locator(current_participatory_space).edit,
+   decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(current_participatory_space),
     :update,
     :process,
     process: current_participatory_space

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -8,9 +8,9 @@
 <%
   edit_link(
    decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(current_participatory_space),
-    :update,
-    :process,
-    process: current_participatory_space
+   :update,
+   :process,
+   process: current_participatory_space
   )
 %>
 

--- a/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
@@ -16,7 +16,12 @@ describe "AdminAccess" do
     let(:participatory_space_path) { decidim_participatory_processes.participatory_process_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
-    it_behaves_like "admin participatory space edit button"
+
+    describe "edit button" do
+      let(:target_path) { decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(participatory_space) }
+
+      it_behaves_like "admin participatory space edit button"
+    end
   end
 
   context "with participatory space evaluator" do


### PR DESCRIPTION
#### :tophat: What? Why?

While working with the "Landing page layout" feature (aka Content Blocks inside of a Process or Assembly), I thought that it would make sense to have the "Edit" button link to this page.

I pitched the idea to @carolromero and she bought it 😄 

I'm also changing the Homepage button to the equivalent page, as it makes sense there too.


#### Testing

1. Sign in as admin 
2. Go to the homepage
3. Click on "Edit" button at the topbar
4. See that you go to the "Homepage layout" page in the Admin (http://localhost:3000/admin/organization/homepage/edit) 
2. Go to the landing page of a process
3. Click on "Edit" button at the topbar
4. See that you go to the "Landing page layout" page in the Admin (http://localhost:3000/admin/participatory_processes/defend-onion/landing_page/edit)

### :camera: Screenshots

<img width="1168" height="278" alt="image" src="https://github.com/user-attachments/assets/84513b20-8b59-4a24-a9bb-9a0c29e7d9cb" />

:hearts: Thank you!
