### PR TITLE
Show unpublished meetings in the Meetings' admin sidebar counter

### DIFF
--- a/decidim-meetings/app/queries/decidim/meetings/filtered_meetings.rb
+++ b/decidim-meetings/app/queries/decidim/meetings/filtered_meetings.rb
@@ -27,7 +27,7 @@ module Decidim
       # Finds the Projects scoped to an array of components and filtered
       # by a range of dates.
       def query
-        meetings = Decidim::Meetings::Meeting.not_hidden.published.where(component: @components)
+        meetings = Decidim::Meetings::Meeting.not_hidden.where(component: @components)
         meetings = meetings.where(created_at: @start_at..) if @start_at.present?
         meetings = meetings.where(created_at: ..@end_at) if @end_at.present?
         meetings

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -28,11 +28,17 @@ Decidim.register_component(:meetings) do |component|
   end
 
   component.register_stat :meetings_count,
-                          primary: true,
                           admin: false,
                           priority: Decidim::StatsRegistry::HIGH_PRIORITY,
                           icon_name: "map-pin-line",
                           tooltip_key: "meetings_count_tooltip" do |components, start_at, end_at|
+    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).published.not_withdrawn
+    meetings.count
+  end
+
+  component.register_stat :admin_meetings_count,
+                          primary: true,
+                          admin: false do |components, start_at, end_at|
     meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).not_withdrawn
     meetings.count
   end
@@ -41,7 +47,7 @@ Decidim.register_component(:meetings) do |component|
                           priority: Decidim::StatsRegistry::MEDIUM_PRIORITY,
                           icon_name: "map-pin-line",
                           tooltip_key: "meetings_count_tooltip" do |components, start_at, end_at|
-    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).not_withdrawn
+    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).published.not_withdrawn
     meetings.count
   end
 
@@ -50,7 +56,7 @@ Decidim.register_component(:meetings) do |component|
                           icon_name: "user-follow-line",
                           tooltip_key: "followers_count_tooltip",
                           priority: Decidim::StatsRegistry::MEDIUM_PRIORITY do |components, start_at, end_at|
-    meetings_ids = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).pluck(:id)
+    meetings_ids = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).published.pluck(:id)
     Decidim::Follow.where(decidim_followable_type: "Decidim::Meetings::Meeting", decidim_followable_id: meetings_ids).count
   end
 
@@ -59,7 +65,7 @@ Decidim.register_component(:meetings) do |component|
                           icon_name: "chat-1-line",
                           tooltip_key: "comments_count",
                           tag: :comments do |components, start_at, end_at|
-    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).not_hidden
+    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).published.not_hidden
     meetings.sum(:comments_count)
   end
 

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -39,7 +39,7 @@ Decidim.register_component(:meetings) do |component|
   component.register_stat :admin_meetings_count,
                           primary: true,
                           admin: false do |components, start_at, end_at|
-    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at).not_withdrawn
+    meetings = Decidim::Meetings::FilteredMeetings.for(components, start_at, end_at)
     meetings.count
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's a non-intuitive logic in the Meetings' admin sidebar counter, where it doesn't counts the non-published meetings.

This PR fixes it.

#### :pushpin: Related Issues

- Fixes #15164 

#### Testing

1. Create a new meeting as an admin
2. See that the counter changes (with a +1) 

### :camera: Screenshots

<img width="353" height="653" alt="image" src="https://github.com/user-attachments/assets/005640a0-2fc5-4a33-90e6-93c201cb1369" />


:hearts: Thank you!
