### PR TITLE
Elections admin layout update

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -1,9 +1,5 @@
 <%= append_javascript_pack_tag "decidim_elections_admin" %>
 
-<%= render "decidim/elections/admin/elections/tabs_menu" do %>
-  <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button #{"hide" unless election.census}", form: "census-election-form" %>
-<% end %>
-
 <div class="item_show__header form-defaults">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
@@ -14,6 +10,9 @@
                  id: "census-manifest-selector" %>
 
 </div>
+
+<%= render "decidim/elections/admin/elections/tabs_menu" %>
+
   <% if election.census_ready? %>
    <%
     census_ready = t("decidim.elections.censuses.census_ready_html", election_title: decidim_sanitize_translated(election.title))
@@ -29,5 +28,11 @@
   <% end %>
   <div class="border-t border-gray-3 my-4">
     <%= render partial: "decidim/elections/admin/census/preview", locals: { election: } if preview_users(election).present? %>
+  </div>
+</div>
+
+<div class="item__edit-sticky">
+  <div class="item__edit-sticky-container">
+    <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary #{"hide" unless election.census}", form: "census-election-form" %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -20,7 +20,7 @@
    %>
     <%= cell "decidim/announcement", "#{census_ready}<br>#{census_count}", callout_class: "success" %>
    <% end %>
-<div class="card-section census-form form-defaults">
+<div class="card-section census-form form-defaults 2xl:mr-80">
   <% if @form && election.census&.admin_form_partial %>
     <%= decidim_form_for(@form, url: election_census_path(election, manifest: election.census&.name), method: :patch, multipart: true, html: { id: "census-election-form" }) do |f| %>
       <%= render partial: election.census.admin_form_partial, locals: { form: f } %>

--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -1,6 +1,6 @@
 <%= append_javascript_pack_tag "decidim_elections_admin" %>
 
-<div class="item_show__header form-defaults">
+<div class="item_show__header form-defaults border-none">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
   </h1>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -29,7 +29,7 @@
 
 <%= render "decidim/elections/admin/elections/tabs_menu" %>
 
-<div class="item__edit-form">
+<div class="item__edit-form 2xl:mr-80">
   <% if election.published? %>
     <div class="flex flex-col md:flex-row gap-4 w-full mb-10">
       <div class="flex-1"><%= render partial: "decidim/elections/admin/dashboard/status" %></div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -3,7 +3,11 @@
 <% append_javascript_pack_tag "decidim_elections_admin" %>
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
-<%= render "decidim/elections/admin/elections/tabs_menu" do %>
+<div class="item_show__header" style="border-bottom: none;">
+  <h1 class="item_show__header-title">
+    <%= t(".title") %>
+  </h1>
+
   <div>
     <% if allowed_to?(:publish, :election, election:) %>
       <%= link_to publish_election_path(election),
@@ -21,7 +25,9 @@
       <%= t(election.published? ? "view" : "preview", scope: "decidim.elections.actions") %>
     <% end %>
   </div>
-<% end %>
+</div>
+
+  <%= render "decidim/elections/admin/elections/tabs_menu" %>
 
 <div class="item__edit-form">
   <% if election.published? %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -27,7 +27,7 @@
   </div>
 </div>
 
-  <%= render "decidim/elections/admin/elections/tabs_menu" %>
+<%= render "decidim/elections/admin/elections/tabs_menu" %>
 
 <div class="item__edit-form">
   <% if election.published? %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -9,15 +9,6 @@
   </h1>
 
   <div>
-    <% if allowed_to?(:publish, :election, election:) %>
-      <%= link_to publish_election_path(election),
-                  method: :put,
-                  class: "button button__xs button__secondary",
-                  data: { confirm: t("publish_confirm", scope: "decidim.elections.admin.dashboard") } do %>
-                  <%= icon "check-line" %>
-                  <%= t("publish", scope: "decidim.elections.admin.elections.form") %>
-      <% end %>
-    <% end %>
     <%= link_to resource_locator(election).path, class: "button button__xs button__transparent-secondary", target: :blank, data: { "external-link": false } do %>
       <%= icon "eye-line" %>
       <%# i18n-tasks-use t("decidim.elections.actions.view") %>
@@ -42,4 +33,18 @@
     <%= render partial: "decidim/elections/admin/dashboard/questions" %>
     <%= render partial: "decidim/elections/admin/dashboard/census" %>
   <% end %>
+
+  <div class="item__edit-sticky">
+    <div class="item__edit-sticky-container">
+      <% if allowed_to?(:publish, :election, election:) %>
+        <%= link_to publish_election_path(election),
+                    method: :put,
+                    class: "button button__sm button__secondary",
+                    data: { confirm: t("publish_confirm", scope: "decidim.elections.admin.dashboard") } do %>
+                    <%= icon "check-line" %>
+                    <%= t("publish", scope: "decidim.elections.admin.elections.form") %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
@@ -3,8 +3,7 @@
 <% append_javascript_pack_tag "decidim_elections_admin" %>
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
-<%= render "decidim/elections/admin/elections/tabs_menu" do %>
-<% end %>
+<%= render "decidim/elections/admin/elections/tabs_menu" %>
 
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">

--- a/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
@@ -3,6 +3,12 @@
 <% append_javascript_pack_tag "decidim_elections_admin" %>
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
+<div class="item_show__header" style="border-bottom: none;">
+    <h1 class="item_show__header-title">
+      <%= t(".title") %>
+    </h1>
+</div>
+
 <%= render "decidim/elections/admin/elections/tabs_menu" %>
 
 <div class="item__edit item__edit-1col">

--- a/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
@@ -4,7 +4,6 @@
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
 <%= render "decidim/elections/admin/elections/tabs_menu" do %>
-  <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "basic-election-form-edit" %>
 <% end %>
 
 <div class="item__edit item__edit-1col">
@@ -13,4 +12,10 @@
       <%= render partial: "form", object: f %>
     <% end %>
   </div>
+
+  <div class="item__edit-sticky">
+      <div class="item__edit-sticky-container">
+        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "basic-election-form-edit" %>
+      </div>
+    </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/edit.html.erb
@@ -20,7 +20,7 @@
 
   <div class="item__edit-sticky">
       <div class="item__edit-sticky-container">
-        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "basic-election-form-edit" %>
+        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary", form: "basic-election-form-edit" %>
       </div>
     </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
@@ -3,19 +3,24 @@
 <% append_javascript_pack_tag "decidim_elections_admin" %>
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
-<%= render "decidim/elections/admin/elections/tabs_menu" do %>
-  <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "basic-election-form-new" %>
-<% end %>
-
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
   </h1>
 </div>
+
+<%= render "decidim/elections/admin/elections/tabs_menu" %>
+
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, html: { id: "basic-election-form-new", class: "form-defaults form new_election" }) do |f| %>
       <%= render partial: "form", object: f %>
     <% end %>
+
+    <div class="item__edit-sticky">
+      <div class="item__edit-sticky-container">
+        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary", form: "basic-election-form-new" %>
+      </div>
+    </div>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -1,26 +1,31 @@
 <% add_decidim_page_title(t(".title")) %>
 
-<%= render "decidim/elections/admin/elections/tabs_menu" do %>
-<% end %>
-
 <div class="questionnaire-questions">
-  <div class="row column">
-    <%= cell "decidim/announcement", t("decidim.elections.admin.questions.form.form_description") %>
+  <div class="item_show__header" style="border-bottom: none;">
+    <h1 class="item_show__header-title">
+      <%= t(".title") %>
+      <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
+    </h1>
   </div>
 
-    <div class="grid-cols-1">
-      <div class="item__edit-form">
-      <%= decidim_form_for(@form, url: update_url, method: :put, html: { id: "questions-election-form", class: "form-defaults form edit_questions" }) do |form| %>
-        <%= render partial: "decidim/elections/admin/questions/form", object: form %>
-      <% end %>
+  <div class="row column">
+      <%= cell "decidim/announcement", t("decidim.elections.admin.questions.form.form_description") %>
+  </div>
 
-      <div class="mt-2">
-        <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
-      </div>
-      <div class="item__edit-sticky">
-        <div class="item__edit-sticky-container">
-          <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>
-        </div>
+  <%= render "decidim/elections/admin/elections/tabs_menu" %>
+
+  <div class="grid-cols-1 2xl:mr-80">
+    <div class="item__edit-form">
+    <%= decidim_form_for(@form, url: update_url, method: :put, html: { id: "questions-election-form", class: "form-defaults form edit_questions" }) do |form| %>
+      <%= render partial: "decidim/elections/admin/questions/form", object: form %>
+    <% end %>
+
+    <div class="mt-2">
+      <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
+    </div>
+    <div class="item__edit-sticky">
+      <div class="item__edit-sticky-container">
+        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>
       </div>
     </div>
   </div>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="row column">
-      <%= cell "decidim/announcement", t("decidim.elections.admin.questions.form.form_description") %>
+    <%= cell "decidim/announcement", t("decidim.elections.admin.questions.form.form_description") %>
   </div>
 
   <%= render "decidim/elections/admin/elections/tabs_menu" %>
@@ -20,9 +20,6 @@
       <%= render partial: "decidim/elections/admin/questions/form", object: form %>
     <% end %>
 
-    <div class="mt-2">
-      <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
-    </div>
     <div class="item__edit-sticky">
       <div class="item__edit-sticky-container">
         <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -1,7 +1,6 @@
 <% add_decidim_page_title(t(".title")) %>
 
 <%= render "decidim/elections/admin/elections/tabs_menu" do %>
-  <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>
 <% end %>
 
 <div class="questionnaire-questions">
@@ -17,6 +16,11 @@
 
       <div class="mt-2">
         <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
+      </div>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>
+        </div>
       </div>
     </div>
   </div>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -22,7 +22,7 @@
 
     <div class="item__edit-sticky">
       <div class="item__edit-sticky-container">
-        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "main-tabs-menu__cta-button", form: "questions-election-form" %>
+        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary", form: "questions-election-form" %>
       </div>
     </div>
   </div>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -16,13 +16,14 @@
 
   <div class="grid-cols-1 2xl:mr-80">
     <div class="item__edit-form">
-    <%= decidim_form_for(@form, url: update_url, method: :put, html: { id: "questions-election-form", class: "form-defaults form edit_questions" }) do |form| %>
-      <%= render partial: "decidim/elections/admin/questions/form", object: form %>
-    <% end %>
+      <%= decidim_form_for(@form, url: update_url, method: :put, html: { id: "questions-election-form", class: "form-defaults form edit_questions" }) do |form| %>
+        <%= render partial: "decidim/elections/admin/questions/form", object: form %>
+      <% end %>
 
-    <div class="item__edit-sticky">
-      <div class="item__edit-sticky-container">
-        <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary", form: "questions-election-form" %>
+      <div class="item__edit-sticky">
+        <div class="item__edit-sticky-container">
+          <%= button_tag t("save", scope: "decidim.elections.admin.elections.form"), class: "button button__sm button__secondary", form: "questions-election-form" %>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### :tophat: What? Why?
Updates to improve the layout of the elections component within admin. These should resemble recent changes made to Surveys within the admin area.

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/15261

#### Testing
1. Login to a decidim application
2. Head to a space with elections configured
3. Create an election 
4. See the following changes on each tab within the module:

- [x]  See the save and continue sticky button on each required tab
- [x] Position of title before tabs and alignment of buttons
- [x]  See title added to each tab
- [x]  Margin to right of each tab


### :camera: Screenshots
MOBILE:

<img width="1193" height="1414" alt="image" src="https://github.com/user-attachments/assets/2181be9d-889d-4f20-901c-e160a9326950" />

DESKTOP:

<img width="2348" height="1461" alt="image" src="https://github.com/user-attachments/assets/778b0a53-b9a4-402c-920b-56492a956882" />


:hearts: Thank you!
