### PR TITLE
Add published status in collaborative texts in admin

### DIFF
--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_document-tr.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_document-tr.html.erb
@@ -9,6 +9,13 @@
   <td data-label="<%= t("models.collaborative_text.fields.suggestions", scope: "decidim.collaborative_texts") %>">
     <%= t("booleans.#{document.accepting_suggestions}") %>
   </td>
+  <td data-label="<%= t("models.collaborative_text.fields.published", scope: "decidim.collaborative_texts") %>">
+    <% if document.published? %>
+      <span class="label success !text-sm"><%= t("admin.index.published", scope: "decidim.collaborative_texts") %></span>
+    <% else %>
+      <span class="label alert !text-sm"><%= t("admin.index.unpublished", scope: "decidim.collaborative_texts") %></span>
+    <% end %>
+  </td>
   <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.collaborative_texts") %>">
     <%= render partial: "decidim/collaborative_texts/admin/documents/actions", locals: { document:, view: } %>
   </td>

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_documents-thead.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/_documents-thead.html.erb
@@ -2,6 +2,7 @@
   <tr>
     <th><%= t("models.collaborative_text.fields.title", scope: "decidim.collaborative_texts") %></th>
     <th><%= t("models.collaborative_text.fields.suggestions", scope: "decidim.collaborative_texts") %></th>
+    <th><%= t("models.collaborative_text.fields.published", scope: "decidim.collaborative_texts") %></th>
     <th><%= t("actions.title", scope: "decidim.collaborative_texts") %></th>
   </tr>
 </thead>

--- a/decidim-collaborative_texts/config/locales/en.yml
+++ b/decidim-collaborative_texts/config/locales/en.yml
@@ -74,6 +74,9 @@ en:
           update_settings:
             invalid: There was a problem updating the document.
             success: Document successfully updated.
+        index:
+          published: Published
+          unpublished: Unpublished
       admin_log:
         document:
           create: "%{user_name} created the %{resource_name} collaborative text in %{space_name}"
@@ -122,6 +125,7 @@ en:
       models:
         collaborative_text:
           fields:
+            published: Published
             suggestions: Accept suggestions
             title: Title
       suggestion:

--- a/decidim-collaborative_texts/spec/system/admin/admin_publishes_and_unpublishes_document_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_publishes_and_unpublishes_document_spec.rb
@@ -24,12 +24,14 @@ describe "Admin publish and unpublish documents" do
     expect(page).to have_content("Configure")
 
     within "tr", text: title do
+      expect(page).to have_content("Unpublished")
       find("button[data-controller='dropdown']").click
       click_on "Publish"
     end
     expect(page).to have_admin_callout "Document successfully published"
 
     within "tr", text: title do
+      expect(page).to have_content("Published")
       find("button[data-controller='dropdown']").click
       click_on "Unpublish"
     end


### PR DESCRIPTION
#### :tophat: What? Why?
As in #15256 we are adding the published state, to the Collaborative Texts. 

As it originates from the issue revealed by #15256, I am leaning as well to categorize as a `type: fix`. 
The issue should be backported only to 0.31

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15256
- Related to #14013

#### Testing
1. As admin login, and check the collaborative texts component
2. You should see a new column with Publish / Unpublish
3. Compare with Nightly where you do not have the field.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1478" height="274" alt="image" src="https://github.com/user-attachments/assets/9191fa3d-f1ca-4533-8911-9566871e897d" />

:hearts: Thank you!
