### PR TITLE
Fix meeting frontend menu items entries

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
@@ -1,5 +1,5 @@
 <% if allowed_to?(:update, :meeting, meeting: meeting) %>
-  <li role="menuitem">
+  <li class="dropdown__item" role="menuitem">
     <%= link_to edit_meeting_path(meeting), class: "dropdown__button"  do %>
       <span><%= t("edit_meeting", scope: "decidim.meetings.meetings.meeting") %></span>
       <%= icon "pencil-line" %>
@@ -9,7 +9,7 @@
 
 <% if allowed_to?(:close, :meeting, meeting: meeting) %>
   <% caption = meeting.closed? ? t("edit_close_meeting", scope: "decidim.meetings.meetings.meeting") : t("close_meeting", scope: "decidim.meetings.meetings.meeting") %>
-  <li role="menuitem">
+  <li class="dropdown__item" role="menuitem">
     <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "dropdown__button"  do %>
       <span><%= caption %></span>
       <%= icon "lock-line" %>
@@ -18,7 +18,7 @@
 <% end %>
 
 <% if meeting.withdrawable_by?(current_user) %>
-  <li role="menuitem">
+  <li class="dropdown__item" role="menuitem">
     <%= action_authorized_link_to(
           :withdraw,
           withdraw_meeting_path(meeting),


### PR DESCRIPTION
#### :tophat: What? Why?
I am trying to fix action menu items on the meetings page. 

Since there is only a css issue there is no code involved

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14713 ( not 100% ) 
- Fixes #?

#### Testing
1. Visit a meeting component admin interface 
2. Edit and allow participants to create meetings 
3. Visit frontend, create a meeting
4. See new buttons 
5. Apply patch
6. See fix

### :camera: Screenshots

**Before:** 
<img width="195" height="209" alt="image" src="https://github.com/user-attachments/assets/3834d600-14ed-4591-af67-ccd30e4ca029" />

**After:** 
<img width="195" height="209" alt="image" src="https://github.com/user-attachments/assets/eff80a1c-decb-4658-a967-8300c1aab3a6" />


:hearts: Thank you!
