### PR TITLE
Fix active record scope on Decidim::User 

### DIFF
--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -66,8 +66,8 @@ module Decidim
     scope :active_after_notification, lambda {
       where("current_sign_in_at > (extended_data->'inactivity_notification'->>'sent_at')::timestamp")
     }
-    scope :user_group, -> { where("#{arel_table.name}.extended_data @> ?", Arel.sql({ group: true }.to_json)) }
-    scope :not_user_group, -> { where.not("#{arel_table.name}.extended_data @> ?", Arel.sql({ group: true }.to_json)) }
+    scope :user_group, -> { where("#{arel_table.name}.extended_data @> ?", { group: true }.to_json) }
+    scope :not_user_group, -> { where.not("#{arel_table.name}.extended_data @> ?", { group: true }.to_json) }
 
     attr_accessor :newsletter_notifications
 

--- a/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
+++ b/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
@@ -5,7 +5,7 @@ class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
     self.table_name = "decidim_users"
     self.inheritance_column = nil
 
-    scope :new_group, -> { where("extended_data @> ?", Arel.sql({ group: true }.to_json)) }
+    scope :new_group, -> { where("extended_data @> ?", { group: true }.to_json) }
     scope :old_group, -> { where(type: "Decidim::UserGroup") }
 
     def verified_at

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -206,6 +206,27 @@ module Decidim
       end
     end
 
+    describe "scopes" do
+      let!(:user_group) { create(:user, organization:, extended_data: { group: true }) }
+      let!(:user_group_not_set) { create(:user, organization:, extended_data: { group: false }) }
+      let!(:not_set_user) { create(:user, organization:, extended_data: {}) }
+
+      describe ".user_group" do
+        it "finds the user group" do
+          expect(described_class.user_group).to eq([user_group])
+          expect(described_class.user_group.length).to eq(1)
+        end
+      end
+
+      describe ".not_user_group" do
+        it "finds the required users" do
+          expect(described_class.not_user_group).to include(user_group_not_set)
+          expect(described_class.not_user_group).to include(not_set_user)
+          expect(described_class.not_user_group).not_to include(user_group)
+        end
+      end
+    end
+
     describe "search" do
       subject { described_class.ransack(search_params, context_params).result }
 


### PR DESCRIPTION
#### :tophat: What? Why?
While migrating to 0.31, we have noticed there is an error when we call "Decidim::User.user_group" 

Due to fact that we have that `Arel.sql`, in place, the json does not converted to string, and postgres will throw an error, as ActiveRecord will not escape the json bit. 

What we get: 
```
SELECT 
  "decidim_users".* 
FROM 
  "decidim_users" 
WHERE 
  "decidim_users"."type" = $1 AND 
  (decidim_users.extended_data @> {"group":true})  /* THIS IS OUR CULPRIT */
LIMIT $2
```

What we should get: 
```
SELECT 
  "decidim_users".* 
FROM 
  "decidim_users" 
WHERE 
  "decidim_users"."type" = $1 AND 
  (decidim_users.extended_data @> '{"group":true}')  /* THIS IS OUR CULPRIT; note the quotes */
LIMIT $2
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. On develop branch, open a console, and type in: 
2. `Decidim::User.user_group.count`
3. You should get an error
4. Apply patch, reload the console 
5. type: `Decidim::User.user_group.count` 
6. See there is a non error output 

### :camera: Screenshots
<img width="1499" height="570" alt="image" src="https://github.com/user-attachments/assets/dfbf8735-24c4-45f5-a224-e7fbef507113" />

:hearts: Thank you!
