### PR TITLE
Improve the error message in case of an unregistered verification

### DIFF
--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -38,6 +38,17 @@ module Decidim
     end
 
     class UnregisteredVerificationManifest < StandardError
+      def initialize(name:)
+        msg = <<~MSG.squish
+          The verification workflow manifest `#{name}` is not defined. Please
+          verify your verification configuration and check your initializers to
+          ensure that the workflow is configured. Note that in some occasions a
+          successful configuration may require configuring some environment
+          variables.
+        MSG
+
+        super(msg)
+      end
     end
 
     #
@@ -54,7 +65,7 @@ module Decidim
       def self.from_element(element)
         manifest = Verifications.find_workflow_manifest(element)
 
-        raise UnregisteredVerificationManifest unless manifest
+        raise UnregisteredVerificationManifest.new(name: element) unless manifest
 
         new(manifest)
       end

--- a/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
+++ b/decidim-verifications/spec/lib/decidim/verifications/adapter_spec.rb
@@ -29,6 +29,17 @@ describe Decidim::Verifications::Adapter do
         expect(wrapper.renew_path).to eq("/dummy_authorization_workflow/renew_authorization")
       end
     end
+
+    context "with an unexisting verification workflow name" do
+      let(:wrapper) { described_class.from_element("unexisting_foobar") }
+
+      it "throws an exception" do
+        expect { wrapper }.to raise_error(
+          Decidim::Verifications::UnregisteredVerificationManifest,
+          /`unexisting_foobar`/
+        )
+      end
+    end
   end
 
   describe ".from_collection", with_authorization_workflows: %w(dummy_authorization_handler dummy_authorization_workflow) do


### PR DESCRIPTION
#### :tophat: What? Why?
There are cases when the verification method can be configured for the organization but the workflow is not correctly configured e.g. due to some missing ENV variables.

I've faced this issue before and just helped to solve this issue, so I believe adding the workflow name to the exception would be helpful in solving the problem.

#### Testing
Within the Rails console, do the following:
```irb
> org = Decidim::Organization.find(1)
> org.available_authorizations = (org.available_authorizations || []) + ["foobar"]
> org.save!
```

After this, go to edit the permissions of any component and see the exception with the string "foobar" included in it.

To revert the change:

``irb
> org.available_authorizations -= ["foobar"]
> org.save!
``

### :camera: Screenshots
<img width="1101" height="248" alt="Example exception that clarifies the situation" src="https://github.com/user-attachments/assets/e976c375-6384-4365-89f2-02f96028b10e" />