### PR TITLE
Fix incorrectly named initialize methods in `decidim-verifications`

### DIFF
--- a/decidim-verifications/lib/decidim/verifications/adapter.rb
+++ b/decidim-verifications/lib/decidim/verifications/adapter.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Verifications
     class InvalidVerificationRoute < StandardError
-      def new(route:)
+      def initialize(route:)
         msg = <<~MSG
           You specified a direct handler but you are trying to use `#{route}`
           which is only available for multi-step authorization workflows. Change
@@ -15,7 +15,7 @@ module Decidim
     end
 
     class MissingVerificationRoute < StandardError
-      def new(handler:, route:, action:)
+      def initialize(handler:, route:, action:)
         msg = <<~MSG
           The authorization handler `#{handler}` does not define the route
           `#{route}`. If you want to enable `#{action}` for `#{handler}`, change
@@ -27,7 +27,7 @@ module Decidim
     end
 
     class MissingEngine < StandardError
-      def new(handler:, engine:)
+      def initialize(handler:, engine:)
         msg = <<~MSG
           The authorization handler `#{handler}` does not define the `#{engine}`
           engine. Please define the engine in the workflow configuration.


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these `initialize` methods incorrectly named while working on [another improvement](https://github.com/decidim/decidim/pull/15287).

These methods do not currently have any effect but will have after this change.

#### :pushpin: Related Issues
- Related to #15287

#### Testing
Try to initialize one of those errors through the rails console and see the message:

```irb
> # Autoload the adapter class
> Decidim::Verifications::Adapter
> # Test the exceptions
>  [
  Decidim::Verifications::InvalidVerificationRoute.new(route: "foobar"),
  Decidim::Verifications::MissingVerificationRoute.new(handler: "foobar", route: "foobar", action: "foobar"),
  Decidim::Verifications::MissingEngine.new(handler: "foobar", engine: "foobar")
  ].each do |err|
    puts err.message
    puts "==="
  end ; nil
```