### PR TITLE
Patch user groups that have invalid emails

### DIFF
--- a/decidim-core/app/mailers/decidim/user_group_mailer.rb
+++ b/decidim-core/app/mailers/decidim/user_group_mailer.rb
@@ -2,6 +2,9 @@
 
 module Decidim
   class UserGroupMailer < ApplicationMailer
+    # This is a mailer that aids migration from the old user_groups to the new user group system
+    # This should be used only in the scope of the migration process
+    # @deprecated This mailer will be removed in decidim v0.32.0
     def notify_deprecation_to_owner(group)
       with_user(group) do
         @group_name = group.name
@@ -13,6 +16,9 @@ module Decidim
       end
     end
 
+    # This is a mailer that aids migration from the old user_groups to the new user group system
+    # This should be used only in the scope of the migration process
+    # @deprecated This mailer will be removed in decidim v0.32.0
     def notify_deprecation_to_member(user, group_name, group_email)
       with_user(user) do
         @user = user
@@ -21,6 +27,21 @@ module Decidim
         @organization = user.organization
 
         subject = I18n.t("notify_deprecation_to_member.subject", scope: "decidim.user_group_mailer")
+        mail(to: user.email, subject:)
+      end
+    end
+
+    # This is a mailer that aids migration from the old user_groups to the new user group system
+    # This should be used only in the scope of the migration process
+    # @deprecated This mailer will be removed in decidim v0.32.0
+    def notify_user_group_patched(group, user, password)
+      with_user(user) do
+        @group = group
+        @user = user
+        @password = password
+        @organization = user.organization
+
+        subject = I18n.t("notify_user_group_patched.subject", scope: "decidim.user_group_mailer")
         mail(to: user.email, subject:)
       end
     end

--- a/decidim-core/app/views/decidim/user_group_mailer/notify_user_group_patched.html.erb
+++ b/decidim-core/app/views/decidim/user_group_mailer/notify_user_group_patched.html.erb
@@ -1,0 +1,21 @@
+<p class="email-greeting"><%= t(".greeting", name: @user.name) %></p>
+
+<p class="email-instructions"><%= t(".body_1_html", organization_name: organization_name(@organization)) %></p>
+
+<p class="email-instructions"><%= t(".body_2_html", name: @group.name) %></p>
+
+<p class="email-instructions"><%= t(".body_3_html") %></p>
+
+<p class="email-instructions"><%= t(".instructions_title_html") %></p>
+
+<ul class="list-decimal">
+  <li>
+    <%= t(".instructions_1_html", email: @group.email, password: @password) %>
+  </li>
+  <li>
+    <%= t(".instructions_2_html") %>
+  </li>
+  <li>
+    <%= t(".instructions_3_html") %>
+  </li>
+</ul>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1750,7 +1750,7 @@ en:
         body_2_html: As part of our efforts to simplify and improve the experience for organizations like yours, we are deprecating the "User Groups" feature. Your Group, <strong>%{name}</strong>, has been converted into a regular account.
         body_3_html: To continue accessing your account and share access, we need you to set a new email and password. Please note that each member of your group will receive this email. To ensure continued access, you will need to agree internally on the shared credentials (email and password) that everyone will use.
         greeting: Dear %{name},
-        instructions_1_html: 'Use the following temporary credentials to log in: <br><br> Username: <strong>%{email}</strong> <br> Password: <strong>%{password}</strong> <br><br>'
+        instructions_1_html: 'Use the following temporary credentials to log in: <br><br> Username: <strong>%{email}</strong> <br> Password: <strong>%{password}</strong><br><br>'
         instructions_2_html: Set a new email address and password.
         instructions_3_html: Share the chosen login credentials with your colleagues so the entire group can continue accessing the account.
         instructions_title_html: "<strong>What You Need to Do</strong>"

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1745,6 +1745,16 @@ en:
         instructions_title: "<strong>What You Need to Do</strong>"
         set_password: Start Password Setting Process
         subject: User group important update
+      notify_user_group_patched:
+        body_1_html: We are reaching out to inform you about an important update regarding your Group profile on %{organization_name}.
+        body_2_html: As part of our efforts to simplify and improve the experience for organizations like yours, we are deprecating the "User Groups" feature. Your Group, <strong>%{name}</strong>, has been converted into a regular account.
+        body_3_html: To continue accessing your account and share access, we need you to set a new email and password. Please note that each member of your group will receive this email. To ensure continued access, you will need to agree internally on the shared credentials (email and password) that everyone will use.
+        greeting: Dear %{name},
+        instructions_1_html: 'Use the following temporary credentials to log in: <br><br> Username: <strong>%{email}</strong> <br> Password: <strong>%{password}</strong> <br><br>'
+        instructions_2_html: Set a new email address and password.
+        instructions_3_html: Share the chosen login credentials with your colleagues so the entire group can continue accessing the account.
+        instructions_title_html: "<strong>What You Need to Do</strong>"
+        subject: Important update regarding your Group profile
     user_report_mailer:
       notify:
         body_1: User %{user} has been reported by %{token}

--- a/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
+++ b/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
@@ -2,6 +2,8 @@
 
 class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
   class User < ApplicationRecord
+    belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+
     self.table_name = "decidim_users"
     self.inheritance_column = nil
 
@@ -14,6 +16,8 @@ class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
   end
 
   class UserGroup < ApplicationRecord
+    belongs_to :organization, foreign_key: "decidim_organization_id", class_name: "Decidim::Organization"
+
     self.table_name = "decidim_users"
     self.inheritance_column = nil
   end

--- a/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
+++ b/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
@@ -18,9 +18,23 @@ class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
     self.inheritance_column = nil
   end
 
+  # Identify if there is another user with the same email in the same organization
+  # @param [User] group
+  # @return [Boolean]
+  def another_user_with_same_email_in_organization?(group)
+    User.where.not(id: group.id).exists?(decidim_organization_id: group.decidim_organization_id, email: group.email)
+  end
+
   # rubocop:disable Rails/SkipsModelValidations
   def up
     User.old_group.find_each do |group|
+      if group.email.blank? || another_user_with_same_email_in_organization?(group)
+        group.update_attribute(:email, "user_group_#{group.id}@#{group.organization.host}.invalid")
+        group.update_attribute(:extended_data, (group.extended_data || {}).merge("patched" => true, "previous_email" => group.email))
+
+        group.reload
+      end
+
       group.update_attribute(:extended_data, (group.extended_data || {}).merge("group" => true))
       group.update_attribute(:type, "Decidim::User")
       group.update_attribute(:officialized_at, group.verified_at) if group.verified_at.present?

--- a/decidim-core/lib/tasks/upgrade/user_groups_migration.rake
+++ b/decidim-core/lib/tasks/upgrade/user_groups_migration.rake
@@ -5,12 +5,43 @@ namespace :decidim do
     namespace :user_groups do
       desc "Main task to notify users and change references to groups"
       task remove: [
+        :"decidim:upgrade:user_groups:perform_patches_on_emails",
         :"decidim:upgrade:user_groups:send_reset_password_instructions",
         :"decidim:upgrade:user_groups:send_user_group_changes_notification_to_members",
         :"decidim:upgrade:user_groups:transfer_user_groups_authorships",
         :"decidim:upgrade:user_groups:fix_user_groups_action_logs",
         :"decidim:upgrade:user_groups:remove_groups_notifications"
       ]
+
+      desc "Patch users migrated from user groups with invalid emails"
+      task perform_patches_on_emails: :environment do
+        class UserGroupMembership < ApplicationRecord
+          self.table_name = "decidim_user_group_memberships"
+
+          belongs_to :user, class_name: "Decidim::User", foreign_key: :decidim_user_id
+          belongs_to :group, class_name: "Decidim::User", foreign_key: :decidim_user_group_id
+
+          scope :member, -> { where(role: %w(creator admin member)) }
+        end
+
+        Decidim::User.where("extended_data @> ?", { group: true, patched: true }.to_json).where(encrypted_password: "").find_each do |group|
+          next if group.blocked?
+
+          password = Random.alphanumeric(15)
+
+          group.skip_password_change_notification!
+          group.password = password
+          group.extended_data = (group.extended_data || {}).merge("patched" => false)
+          group.save!
+
+          UserGroupMembership.where(group:).member.find_each do |membership|
+            user = membership.user
+            next if user.deleted? || user.blocked? || !user.confirmed?
+
+            Decidim::UserGroupMailer.notify_user_group_patched(group, user, password).deliver_later
+          end
+        end
+      end
 
       desc "Send reset password instructions to groups"
       task send_reset_password_instructions: :environment do
@@ -104,6 +135,8 @@ namespace :decidim do
           # rubocop:enable Rails/SkipsModelValidations
 
           puts "Transferred authorship in #{a[:model]} with id #{a[:id]} and gid #{a[:gid]} from #{a[:author_type]} with id #{a[:author_id]} to user with id #{a[:group_id]}"
+        rescue NameError
+          puts "Error on #{a[:id]}"
         end
         puts "===== Transfer finished."
       end

--- a/decidim-core/spec/mailers/previews/user_group_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/user_group_mailer_preview.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Decidim
+  class UserGroupMailerPreview < ActionMailer::Preview
+    def notify_deprecation_to_owner
+      UserGroupMailer.notify_deprecation_to_owner(group)
+    end
+
+    def notify_deprecation_to_member
+      UserGroupMailer.notify_deprecation_to_member(user, group.name, group.email)
+    end
+
+    def notify_user_group_patched
+      UserGroupMailer.notify_user_group_patched(group, user, password)
+    end
+
+    private
+
+    def user
+      @user ||= Decidim::User.new(name: "John Doe", email: "john.doe@example.org", organization:)
+    end
+
+    def group
+      @group ||= Decidim::User.new(name: "Demo Group", email: "group@example.org", organization:, extended_data: { group: true })
+    end
+
+    def password
+      Random.alphanumeric(15)
+    end
+
+    def organization
+      @organization ||= Decidim::Organization.first
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am trying to fix the issue reported in #15281. 

At migration level, i am assessing if the user group needs to be updated, and if the email is empty or the email exists on other user, i am setting new email an some additional extended data. 

Additionally, in the task, i am creating the password, i am skipping email notification
And then i am sending the email 


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

<img width="679" height="799" alt="image" src="https://github.com/user-attachments/assets/30cebf48-99ea-408b-bab9-685a687d2b85" />

:hearts: Thank you!
