### PR TITLE
Fix adjacent links in the related documents/attachments links

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -59,7 +59,11 @@
     }
 
     &-title {
-      @apply h4 text-secondary;
+      @apply h4;
+    }
+
+    a &-title {
+      @apply text-secondary;
 
       overflow: hidden;
       display: -webkit-box;

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -1,8 +1,8 @@
 <div id="<%= dom_id(document) %>">
   <div class="card__list-content">
-    <%= link_to document.url, target: "_blank", rel: "noopener noreferrer", class: "card__list-title", title: t("decidim.application.document.download") do %>
+    <span class="card__list-title">
       <%= h attachment_title(document) %>
-    <% end %>
+    </span>
     <% if document.description.present? %>
       <div class="card__list-text"><%= decidim_escape_translated(document.description) %></div>
     <% end %>

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -123,7 +123,7 @@ shared_examples "proposals wizards" do |options|
 
           click_on "Documents"
           within "#panel-documents" do
-            expect(find("a.card__list-title")["innerHTML"]).to include("&lt;svg onload=alert('ALERT')&gt;.pdf")
+            expect(find(".card__list-title")["innerHTML"]).to include("&lt;svg onload=alert('ALERT')&gt;.pdf")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

There's an accessibility problem with the current Related Documents sections, where there are two adjacent links that point to the same resource: the link to the attached document itself.

This PR fixes it by removing the link on the title.

Mind that we don't have this problem in the Collections (Folder), as the button is one big clickable element. 

#### :pushpin: Related Issues

- Fixes #11883 
- WCAG 2.1: 1.1.1, 2.4.4, 2.4.9

#### Testing

1. Go to a page with related documents (for instance a Process with the "Related documents" content block)
2. Tab on these elements
3. Apply this patch
4. See that the focus is correct and you only have one link

### :camera: Screenshots

#### Before

<img width="1337" height="645" alt="image" src="https://github.com/user-attachments/assets/753b2337-1ef4-49c4-b221-c9c2cb01236f" />


#### After

<img width="1315" height="741" alt="image" src="https://github.com/user-attachments/assets/127b90e0-8717-4410-8349-0cfc9e84bdea" />

<img width="1436" height="574" alt="image" src="https://github.com/user-attachments/assets/2fb0ef30-5545-4afa-b035-3aec5a005b6f" />


:hearts: Thank you!
