### PR TITLE
Fix collapse not working in the filters

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/filter_assemblies_helper.rb
@@ -13,7 +13,7 @@ module Decidim
           items.append(method: "with_any_taxonomies[#{taxonomy_filter.root_taxonomy_id}]",
                        collection: filter_taxonomy_values_for(taxonomy_filter),
                        label: decidim_sanitize_translated(taxonomy_filter.name),
-                       id: "taxonomy")
+                       id: "taxonomy-#{taxonomy_filter.root_taxonomy_id}")
         end
 
         items.reject { |item| item[:collection].blank? }

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -20,6 +20,10 @@ describe "Filter Assemblies" do
     let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
     let!(:another_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: another_taxonomy) }
 
+    let!(:second_taxonomy) { create(:taxonomy, :with_parent, organization:, name: { en: "Another great taxonomy" }) }
+    let(:second_taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: second_taxonomy.parent, participatory_space_manifests:) }
+    let!(:second_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter: second_taxonomy_filter, taxonomy_item: second_taxonomy) }
+
     context "and choosing a taxonomy" do
       before do
         visit decidim_assemblies.assemblies_path(filter: { with_any_taxonomies: { taxonomy.parent_id => [taxonomy.id] } })
@@ -31,7 +35,8 @@ describe "Filter Assemblies" do
           expect(page).to have_no_content(translated(assembly_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
+          click_filter_item "A great taxonomy"
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -41,7 +46,7 @@ describe "Filter Assemblies" do
           expect(page).to have_no_content(translated(assembly_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -49,6 +54,27 @@ describe "Filter Assemblies" do
         within "#assemblies-grid" do
           expect(page).to have_content(translated(assembly_with_taxonomy.title))
           expect(page).to have_content(translated(assembly_without_taxonomy.title))
+        end
+      end
+
+      it "collapses the accordions on click" do
+        within "#panel-dropdown-menu-taxonomy-#{second_taxonomy_filter.root_taxonomy_id}" do
+          expect(page).to have_content "All"
+          expect(page).to have_content "Another great taxonomy"
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Another great taxonomy"
+          expect(page).to have_no_content "A great taxonomy"
+        end
+
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Another great taxonomy"
+          expect(page).to have_content "A great taxonomy"
         end
       end
     end

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -14,7 +14,11 @@ describe "Explore projects", :slow do
   let(:taxonomy) { create(:taxonomy, :with_parent, skip_injection: true, organization:) }
   let(:taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: taxonomy.parent) }
   let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
-  let(:taxonomy_filter_ids) { [taxonomy_filter.id] }
+
+  let(:second_taxonomy) { create(:taxonomy, :with_parent, skip_injection: true, organization:) }
+  let(:second_taxonomy_filter) { create(:taxonomy_filter, root_taxonomy: second_taxonomy.parent) }
+  let!(:second_taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter: second_taxonomy_filter, taxonomy_item: second_taxonomy) }
+  let(:taxonomy_filter_ids) { [taxonomy_filter.id, second_taxonomy_filter.id] }
 
   before do
     component_settings = component["settings"]["global"].merge!(taxonomy_filters: taxonomy_filter_ids)
@@ -160,6 +164,30 @@ describe "Explore projects", :slow do
 
         filter_params = CGI.parse(URI.parse(page.current_url).query)
         expect(filter_params["filter[search_text_cont]"]).to eq(["foobar"])
+      end
+
+      it "collapses the accordions on click" do
+        visit_budget
+
+        within "#panel-dropdown-menu-taxonomy-#{second_taxonomy_filter.root_taxonomy_id}" do
+          expect(page).to have_content "All"
+          expect(page).to have_content decidim_sanitize_translated(second_taxonomy.name)
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+        click_on decidim_sanitize_translated(taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content decidim_sanitize_translated(taxonomy.name)
+          expect(page).to have_no_content decidim_sanitize_translated(second_taxonomy.name)
+        end
+
+        click_on decidim_sanitize_translated(second_taxonomy_filter.root_taxonomy.name)
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content decidim_sanitize_translated(taxonomy.name)
+          expect(page).to have_content decidim_sanitize_translated(second_taxonomy.name)
+        end
       end
 
       it "allows filtering by taxonomy" do

--- a/decidim-core/app/packs/src/decidim/refactor/moved/check_boxes_tree.js
+++ b/decidim-core/app/packs/src/decidim/refactor/moved/check_boxes_tree.js
@@ -116,6 +116,7 @@ export default class CheckBoxesTree {
     const indeterminateSiblings = totalCheckSiblings.filter((checkbox) => checkbox.indeterminate)
 
     if (checkedSiblings.length === 0 && indeterminateSiblings.length === 0) {
+      parentCheck.checked = false;
       parentCheck.indeterminate = false;
     } else if (checkedSiblings.length === totalCheckSiblings.length && indeterminateSiblings.length === 0) {
       parentCheck.checked = true;

--- a/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_accordion.scss
@@ -1,13 +1,13 @@
-[data-controller="accordion"] [id*="panel"][aria-hidden="true"] {
+[data-controller*="accordion"] [id*="panel"][aria-hidden="true"] {
   display: none;
 }
 
-[data-controller="accordion"]
+[data-controller*="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="true"] {
   display: none;
 }
 
-[data-controller="accordion"]
+[data-controller*="accordion"]
   [id*="comment"][class="comment-reply"][aria-hidden="false"] {
   display: block;
 }
@@ -57,7 +57,7 @@
     @apply mr-4;
   }
 
-  &-section.content-block__description[data-controller="accordion"] {
+  &-section.content-block__description[data-controller*="accordion"] {
     @apply pb-4 mb-4 text-md;
 
     padding-left: 1.85rem;

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -2,7 +2,7 @@
   @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3 cursor-pointer;
 
   &[aria-hidden="true"] {
-    @apply hidden;
+    @apply hidden md:flex;
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -2,7 +2,7 @@
   @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3 cursor-pointer;
 
   &[aria-hidden="true"] {
-    @apply hidden md:flex;
+    @apply hidden;
   }
 }
 

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -262,6 +262,29 @@ describe "Explore debates" do
 
           expect(page).to have_css("a.card__list", count: 1)
         end
+
+        it "collapses the accordions on click" do
+          within ".layout-2col__aside" do
+            expect(page).to have_content "Ongoing"
+            expect(page).to have_content "Official"
+          end
+
+          click_on "Status"
+          click_on "The name for regular users"
+          click_on "Origin"
+
+          within ".layout-2col__aside" do
+            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_no_content "Official"
+          end
+
+          click_on "Origin"
+
+          within ".layout-2col__aside" do
+            expect(page).to have_no_content "Ongoing"
+            expect(page).to have_content "Official"
+          end
+        end
       end
     end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -414,6 +414,30 @@ describe "Explore meetings", :slow do
 
         expect(page).to have_css(meetings_selector, count: 1)
       end
+
+      it "collapses the accordions on click" do
+        visit_component
+
+        within ".layout-2col__aside" do
+          expect(page).to have_content "Upcoming"
+          expect(page).to have_content "Online"
+        end
+
+        click_on "Date"
+        click_on "Type"
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_no_content "Online"
+        end
+
+        click_on "Type"
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_content "Online"
+        end
+      end
     end
 
     context "when no upcoming meetings scheduled" do

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -91,7 +91,7 @@ module Decidim
           items.append(method: "with_any_taxonomies[#{taxonomy_filter.root_taxonomy_id}]",
                        collection: filter_taxonomy_values_for(taxonomy_filter),
                        label: decidim_sanitize_translated(taxonomy_filter.name),
-                       id: "taxonomy")
+                       id: "taxonomy-#{taxonomy_filter.root_taxonomy_id}")
         end
         items.reject { |item| item[:collection].blank? }
       end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -135,7 +135,8 @@ describe "Filter Participatory Processes" do
           expect(page).to have_no_content(translated(process_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
+          click_filter_item "A great taxonomy"
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -145,7 +146,7 @@ describe "Filter Participatory Processes" do
           expect(page).to have_no_content(translated(process_without_taxonomy.title))
         end
 
-        within "#panel-dropdown-menu-taxonomy" do
+        within "#panel-dropdown-menu-taxonomy-#{taxonomy_filter.root_taxonomy_id}" do
           click_filter_item "Another taxonomy"
           sleep 2
         end
@@ -169,7 +170,12 @@ describe "Filter Participatory Processes" do
           expect(page).to have_no_content "Upcoming"
           expect(page).to have_no_content "A great taxonomy"
         end
-        take_screenshot
+
+        click_on decidim_sanitize_translated taxonomy_filter.root_taxonomy.name
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_content "A great taxonomy"
+        end
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/filter_participatory_processes_spec.rb
@@ -155,6 +155,22 @@ describe "Filter Participatory Processes" do
           expect(page).to have_content(translated(process_without_taxonomy.title))
         end
       end
+
+      it "collapses the accordions on click" do
+        within ".layout-2col__aside" do
+          expect(page).to have_content "Upcoming"
+          expect(page).to have_content "A great taxonomy"
+        end
+
+        click_on "Date"
+        click_on decidim_sanitize_translated taxonomy_filter.root_taxonomy.name
+
+        within ".layout-2col__aside" do
+          expect(page).to have_no_content "Upcoming"
+          expect(page).to have_no_content "A great taxonomy"
+        end
+        take_screenshot
+      end
     end
   end
 end

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -113,6 +113,30 @@ describe "Filter Proposals", :slow do
     end
   end
 
+  it "collapses the accordions on click" do
+    visit_component
+
+    within ".layout-2col__aside" do
+      expect(page).to have_content "Not answered"
+      expect(page).to have_content "Official"
+    end
+
+    click_on "Status"
+    click_on "Origin"
+
+    within ".layout-2col__aside" do
+      expect(page).to have_no_content "Not answered"
+      expect(page).to have_no_content "Official"
+    end
+
+    click_on "Origin"
+
+    within ".layout-2col__aside" do
+      expect(page).to have_no_content "Not answered"
+      expect(page).to have_content "Official"
+    end
+  end
+
   context "when filtering proposals by TAXONOMY" do
     let!(:taxonomy2) { create(:taxonomy, skip_injection: true, name: { en: "Taxonomy name" }, parent: root_taxonomy, organization:) }
     let!(:taxonomy_filter_item2) { create(:taxonomy_filter_item, taxonomy_item: taxonomy2, taxonomy_filter:) }


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am fixing a bug introduced by https://github.com/decidim/decidim/pull/15091 , in which the filters do not collapse when clicking on category header. 
Please note, that in some cases, there is a category header like: "Filter and search" in which i could not "fix" as the potential fix is impacting conferences.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15091
- Fixes #15253

#### Testing
1. Visit any public page that has a filter (Proposal, Spaces etc)
2. Click on the filter title 
3. See it collapses or expands as expected

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
