### PR TITLE
Add deprecation notices for Polls, Sortitions, and Collaborative Drafts

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -459,6 +459,7 @@ Jeet
 Jenae
 Jfcm
 jfif
+Jitsi
 jkl
 JKR
 joannadoe

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -47,7 +47,7 @@ As part of our ongoing efforts to improve and make simpler Decidim, the followin
 
 #### Collaborative Drafts and Participatory Texts
 
-The Collaborative Drafts and Participatory Texts features in the Proposals module (`decidim-proposals`) will be removed in v0.32. These features allowed participants to collaboratively edit texts within proposals. Organizations using this feature should plan to migrate to the `decidim-collaborative_texts` module.
+The Collaborative Drafts feature in the Proposals module (`decidim-proposals`) will be removed in v0.32. Organizations using this feature can switch to the new proposal co-authorship feature.
 
 #### Sortitions (decidim-sortitions)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -45,7 +45,7 @@ bin/rails db:migrate
 
 As part of our ongoing efforts to improve and make simpler Decidim, the following modules will be **deprecated** in this version (v0.31) and **removed** in the next major version (v0.32):
 
-#### Collaborative Drafts and Participatory Texts
+#### Collaborative Drafts
 
 The Collaborative Drafts feature in the Proposals module (`decidim-proposals`) will be removed in v0.32. Organizations using this feature can switch to the new proposal co-authorship feature.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,22 @@ bin/rails db:migrate
 
 ## 2. General notes
 
+### 2.1. Module deprecations
+
+As part of our ongoing efforts to improve and make simpler Decidim, the following modules will be **deprecated** in this version (v0.31) and **removed** in the next major version (v0.32):
+
+#### Collaborative Drafts and Participatory Texts
+
+The Collaborative Drafts and Participatory Texts features in the Proposals module (`decidim-proposals`) will be removed in v0.32. These features allowed participants to collaboratively edit texts within proposals. Organizations using this feature should plan to migrate to the `decidim-collaborative_texts` module.
+
+#### Sortitions (decidim-sortitions)
+
+The Sortitions module (`decidim-sortitions`) will be removed in v0.32. This module provided functionality to randomly select participants or proposals. Organizations relying on this feature should consider implementing alternative selection mechanisms.
+
+#### Polls in Meetings (decidim-meetings polls functionality)
+
+The Polls feature within the Meetings module (`decidim-meetings`) will be removed in a future version (to be determined). This feature allowed meeting organizers to create polls during meetings. Organizations using meeting polls should plan to use external polling tools (for instance, through Jitsi) or migrate to other voting mechanisms available in Decidim, such as the new Elections module (`decidim-elections`).
+
 ## 3. One time actions
 
 These are one time actions that need to be done after the code is updated in the production database.

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/edit.html.erb
@@ -12,6 +12,8 @@
   </h1>
 </div>
 
+<div class="flash warning"><%= t("deprecation_warning_polls_html", scope: "decidim.meetings.admin") %></div>
+
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
     <%= decidim_form_for(@form, url: update_url, method: :put, html: { class: "form-defaults form edit_questionnaire" }) do |form| %>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -330,6 +330,7 @@ en:
           update:
             invalid: There was a problem updating this agenda.
             success: Agenda successfully updated.
+        deprecation_warning_polls_html: "⚠️ <b>Deprecation Notice.</b> The Polls feature will be removed in a future version (bo be determined). Organizations using meeting polls should plan to use external polling tools (for instance, through Jitsi) or migrate to other voting mechanisms available in Decidim, such as the new Elections module (`decidim-elections`)."
         exports:
           meeting_comments: Comments
           meetings: Meetings

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -330,7 +330,7 @@ en:
           update:
             invalid: There was a problem updating this agenda.
             success: Agenda successfully updated.
-        deprecation_warning_polls_html: "⚠️ <b>Deprecation Notice.</b> The Polls feature will be removed in a future version (bo be determined). Organizations using meeting polls should plan to use external polling tools (for instance, through Jitsi) or migrate to other voting mechanisms available in Decidim, such as the new Elections module (`decidim-elections`)."
+        deprecation_warning_polls_html: "⚠️ <b>Deprecation Notice.</b> The Polls feature will be removed in a future version (to be determined). Organizations using meeting polls should plan to use external polling tools (for instance, through Jitsi) or migrate to other voting mechanisms available in Decidim, such as the new Elections module (`decidim-elections`)."
         exports:
           meeting_comments: Comments
           meetings: Meetings

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -22,6 +22,15 @@
     <%= render partial: "decidim/proposals/admin/proposals/bulk_actions/unassign_from_evaluator" %>
   </div>
   <%= admin_filter_selector(filter_prefix_key) %>
+
+  <% if component_settings.participatory_texts_enabled? %>
+    <div class="flash warning"><%= t("deprecation_warning_participatory_texts_html", scope: "decidim.proposals.admin") %></div>
+  <% end %>
+
+  <% if component_settings.collaborative_drafts_enabled? %>
+    <div class="flash warning"><%= t("deprecation_warning_collaborative_drafts_html", scope: "decidim.proposals.admin") %></div>
+  <% end %>
+
   <div class="table-stacked mt-8">
     <table class="table-list">
       <%= render partial: "proposals-thead" %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/index.html.erb
@@ -23,10 +23,6 @@
   </div>
   <%= admin_filter_selector(filter_prefix_key) %>
 
-  <% if component_settings.participatory_texts_enabled? %>
-    <div class="flash warning"><%= t("deprecation_warning_participatory_texts_html", scope: "decidim.proposals.admin") %></div>
-  <% end %>
-
   <% if component_settings.collaborative_drafts_enabled? %>
     <div class="flash warning"><%= t("deprecation_warning_collaborative_drafts_html", scope: "decidim.proposals.admin") %></div>
   <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -177,7 +177,7 @@ en:
             can_accumulate_votes_beyond_threshold: Can accumulate votes beyond threshold
             clear_all: Clear all
             collaborative_drafts_enabled: Collaborative drafts enabled
-            collaborative_drafts_enabled_help: The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the "decidim-collaborative_texts" module.
+            collaborative_drafts_enabled_help: The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using it can switch to the new proposal co-authorship feature.
             comments_enabled: Comments enabled
             comments_max_length: Comments max length (Leave 0 for default value)
             default_sort_order: Default proposal sorting

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -205,7 +205,7 @@ en:
             no_taxonomy_filters_found: No taxonomy filters found.
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
-            participatory_texts_enabled_readonly: The Participatory Texts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the "decidim-collaborative_texts" module. Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
+            participatory_texts_enabled_readonly: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
             proposal_answering_enabled: Proposal answering enabled
             proposal_edit_time: Proposal editing
             proposal_edit_time_choices:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -495,7 +495,6 @@ en:
           deleted_proposals_info: Deleted proposals can be restored from the trash.
           preview: Preview
           view_deleted_proposals: View deleted proposals
-        deprecation_warning_participatory_texts_html: "⚠️ <b>Deprecation Notice.</b> The Participatory Texts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the \"decidim-collaborative_texts\" module."
         deprecation_warning_collaborative_drafts_html: "⚠️ <b>Deprecation Notice.</b> The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the \"decidim-collaborative_texts\" module."
         evaluation_assignments:
           create:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -495,7 +495,7 @@ en:
           deleted_proposals_info: Deleted proposals can be restored from the trash.
           preview: Preview
           view_deleted_proposals: View deleted proposals
-        deprecation_warning_collaborative_drafts_html: "⚠️ <b>Deprecation Notice.</b> The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the \"decidim-collaborative_texts\" module."
+        deprecation_warning_collaborative_drafts_html: "⚠️ <b>Deprecation Notice.</b> The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using it can switch to the new proposal co-authorship feature."
         evaluation_assignments:
           create:
             invalid: There was a problem assigning proposals to a evaluator.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -177,6 +177,7 @@ en:
             can_accumulate_votes_beyond_threshold: Can accumulate votes beyond threshold
             clear_all: Clear all
             collaborative_drafts_enabled: Collaborative drafts enabled
+            collaborative_drafts_enabled_help: The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the "decidim-collaborative_texts" module.
             comments_enabled: Comments enabled
             comments_max_length: Comments max length (Leave 0 for default value)
             default_sort_order: Default proposal sorting
@@ -204,7 +205,7 @@ en:
             no_taxonomy_filters_found: No taxonomy filters found.
             official_proposals_enabled: Official proposals enabled
             participatory_texts_enabled: Participatory texts enabled
-            participatory_texts_enabled_readonly: Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
+            participatory_texts_enabled_readonly: The Participatory Texts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the "decidim-collaborative_texts" module. Cannot interact with this setting if there are existing proposals. Please, create a new `Proposals component` if you want to enable this feature or discard all imported proposals in the `Participatory Texts` menu if you want to disable it.
             proposal_answering_enabled: Proposal answering enabled
             proposal_edit_time: Proposal editing
             proposal_edit_time_choices:
@@ -494,6 +495,8 @@ en:
           deleted_proposals_info: Deleted proposals can be restored from the trash.
           preview: Preview
           view_deleted_proposals: View deleted proposals
+        deprecation_warning_participatory_texts_html: "⚠️ <b>Deprecation Notice.</b> The Participatory Texts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the \"decidim-collaborative_texts\" module."
+        deprecation_warning_collaborative_drafts_html: "⚠️ <b>Deprecation Notice.</b> The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using this feature should plan to migrate to the \"decidim-collaborative_texts\" module."
         evaluation_assignments:
           create:
             invalid: There was a problem assigning proposals to a evaluator.

--- a/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
+++ b/decidim-sortitions/app/views/decidim/sortitions/admin/sortitions/index.html.erb
@@ -9,6 +9,9 @@
       <%= render partial: "decidim/admin/components/resource_action" %>
     </h1>
   </div>
+
+  <div class="flash warning"><%= t("deprecation_warning_html", scope: "decidim.sortitions.admin") %></div>
+
   <div class="table-stacked">
     <table class="table-list">
       <thead>

--- a/decidim-sortitions/config/locales/en.yml
+++ b/decidim-sortitions/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
           new_sortition: New sortition
           show: Sortition details
           title: Actions
+        deprecation_warning_html: "⚠️ <b>Deprecation Notice.</b> The Sortitions module will be removed in Decidim v0.32. Please plan accordingly and consider alternative solutions for participant or proposal selection."
         models:
           sortition:
             fields:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds releases notes for deprecated modules. 

As these deprecations will go to v0.31, and they will be removed in v0.32, the PRs workflow will be like this:

1. Merge this PR in develop (v0.32.0.dev). 
2. Backport the PR to the stable branch of v0.31 so these notices are released to v0.31.0
3. Start new PRs, each for each feature

#### :pushpin: Related Issues
 
- Fixes #15177
 
#### Testing
 
Checking these features should have these callouts

### :camera: Screenshots

<img width="1494" height="625" alt="image" src="https://github.com/user-attachments/assets/3023208e-2eec-4cd3-9f5d-86db3e6e1b39" />
<img width="1693" height="584" alt="image" src="https://github.com/user-attachments/assets/16d9c6c8-d134-4509-a49a-879386f3557a" />
<img width="1594" height="602" alt="image" src="https://github.com/user-attachments/assets/15dbb43a-762c-4486-bee8-586c94790925" />
<img width="1641" height="660" alt="image" src="https://github.com/user-attachments/assets/90f3b3ad-facc-4d0c-9b23-2904e10e6663" />

:hearts: Thank you!
