### PR TITLE
Remove CTA path and text in Processes' steps

### DIFF
--- a/decidim-dev/lib/decidim/dev/assets/participatory_processes.json
+++ b/decidim-dev/lib/decidim/dev/assets/participatory_processes.json
@@ -105,9 +105,6 @@
         },
         "start_date": "2019-09-02",
         "end_date": "2019-12-02",
-        "cta_path": null,
-        "cta_text": {
-        },
         "active": true,
         "position": 0
       }

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process_step.rb
@@ -6,7 +6,7 @@ module Decidim
       # A command with all the business logic when updating a participatory
       # process step in the system.
       class UpdateParticipatoryProcessStep < Decidim::Commands::UpdateResource
-        fetch_form_attributes :cta_path, :cta_text, :title, :start_date, :end_date, :description
+        fetch_form_attributes :title, :start_date, :end_date, :description
 
         private
 

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
@@ -17,10 +17,8 @@ module Decidim
 
         attribute :start_date, Decidim::Attributes::TimeWithZone
         attribute :end_date, Decidim::Attributes::TimeWithZone
-        attribute :cta_path, String
 
         validates :title, translatable_presence: true
-        validates :cta_path, format: { with: %r{\A[a-zA-Z]+[a-zA-Z0-9\-_/]+\z} }, allow_blank: true
 
         validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
         validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_step_form.rb
@@ -11,7 +11,6 @@ module Decidim
 
         translatable_attribute :title, String
         translatable_attribute :description, String
-        translatable_attribute :cta_text, String
 
         mimic :participatory_process_step
 

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -22,17 +22,6 @@ module Decidim
         dates.map { |date| date ? l(date.to_date, format: :decidim_short) : "?" }.join(" - ")
       end
 
-      # Public: Returns the path for the participatory process cta button
-      #
-      # Returns a String with path.
-      def participatory_process_cta_path(process)
-        return participatory_process_path(process) if process.active_step&.cta_path.blank?
-
-        path, params = participatory_process_path(process).split("?")
-
-        "#{path}/#{process.active_step.cta_path}" + (params.present? ? "?#{params}" : "")
-      end
-
       # Public: Returns the settings of a cta content block associated if
       # exists
       #

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
@@ -9,7 +9,7 @@ module Decidim
     include Traceable
     include Loggable
 
-    translatable_fields :title, :description, :cta_text
+    translatable_fields :title, :description
 
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess"
     has_one :organization, through: :participatory_process

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/step_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/step_presenter.rb
@@ -17,8 +17,6 @@ module Decidim
 
         def diff_fields_mapping
           {
-            cta_path: :string,
-            cta_text: :i18n,
             description: :i18n,
             title: :i18n
           }

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_serializer.rb
@@ -35,8 +35,6 @@ module Decidim
             description: step.try(:description),
             start_date: step.try(:start_date),
             end_date: step.try(:end_date),
-            cta_path: step.try(:cta_path),
-            cta_text: step.try(:cta_text),
             active: step.active,
             position: step.position
           }

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/_form.html.erb
@@ -16,15 +16,6 @@
       <div class="row column">
         <%= form.datetime_field :end_date %>
       </div>
-
-      <div class="row column" data-controller="slug">
-        <%= form.text_field :cta_path,
-                            help_text: t(".cta_path_help_html", url: decidim_form_slug_url("processes/" + current_participatory_process.slug, form.object.cta_path)) %>
-      </div>
-
-      <div class="row column">
-        <%= form.translated :text_field, :cta_text, help_text: t(".cta_text_help") %>
-      </div>
     </div>
   </div>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/edit.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_steps/edit.html.erb
@@ -8,11 +8,6 @@
 
 <div class="item__edit item__edit-1col">
   <div class="item__edit-form">
-    <%= cell "decidim/announcement", {
-          title: t("title", scope: "decidim.admin.participatory_process_steps.edit.cta_deprecated"),
-          body: t("body_html", scope: "decidim.admin.participatory_process_steps.edit.cta_deprecated")
-        }, callout_class: "warning" %>
-
     <%= decidim_form_for(@form, url: participatory_process_step_path(@participatory_process_step.participatory_process, @participatory_process_step), html: { class: "form form-defaults edit_participatory_process_step" }) do |f| %>
       <%= render partial: "form", object: f, locals: { title: t("participatory_process_steps.edit.title", scope: "decidim.admin") } %>
       <div class="item__edit-sticky">

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -501,10 +501,6 @@ en:
           form:
             document_legend: Add a document
             slug_help_html: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
-        participatory_process_steps:
-          form:
-            cta_path_help_html: 'Use partial paths, not full URLs here. Accepts letters, numbers, dashes and slashes, and must start with a letter. If not set, the button will not be shown. Example: %{url}'
-            cta_text_help: If not set, the button will not be shown.
         participatory_processes:
           form:
             announcement_help: The text you enter here will be shown to the user right below the process information.

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -206,13 +206,6 @@ en:
             last_step: Cannot delete the last phase of a process.
           success: Participatory process phase successfully deleted.
         edit:
-          cta_deprecated:
-            body_html: |-
-              Configuring the CTA through the Phase of the participatory process is deprecated with the new design.
-              Now this is done in the <b>Landing Page</b>, using the <b>Hero and image</b> content block.
-              We have left it here for you to migrate the CTAs that you need. The fields <i>Call to action path</i> and
-              <i>Call to action text</i> will be removed in the next version.
-            title: CTA deprecated
           title: Edit participatory process phase
           update: Update
         index:

--- a/decidim-participatory_processes/db/migrate/20251007094913_remove_cta_path_and_text_from_steps.rb
+++ b/decidim-participatory_processes/db/migrate/20251007094913_remove_cta_path_and_text_from_steps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveCtaPathAndTextFromSteps < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_participatory_process_steps, :cta_text, :jsonb
+    remove_column :decidim_participatory_process_steps, :cta_path, :string
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/api/participatory_process_step_type.rb
+++ b/decidim-participatory_processes/lib/decidim/api/participatory_process_step_type.rb
@@ -9,8 +9,6 @@ module Decidim
       implements Decidim::Core::TimestampsInterface
 
       field :active, GraphQL::Types::Boolean, "If this step is the active one", null: true
-      field :call_to_action_path, GraphQL::Types::String, "A call to action URL for this step", method: :cta_path, null: true
-      field :call_to_action_text, Decidim::Core::TranslatedFieldType, "The call to action text for this step", method: :cta_text, null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description of this step", null: true
       field :end_date, Decidim::Core::DateTimeType, "This step's end date", null: true
       field :id, GraphQL::Types::ID, "The unique ID of this step.", null: false

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -137,7 +137,6 @@ FactoryBot.define do
     end
     title { generate_localized_title(:participatory_process_step_title, skip_injection:) }
     description { generate_localized_description(:participatory_process_step_description, skip_injection:) }
-    cta_text { generate_localized_description(:participatory_process_step_cta_text, skip_injection:) }
     start_date { 1.month.ago }
     end_date { 2.months.from_now }
     position { nil }

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_step_spec.rb
@@ -13,8 +13,6 @@ module Decidim::ParticipatoryProcesses
       instance_double(
         Admin::ParticipatoryProcessStepForm,
         current_user: user,
-        cta_text: {},
-        cta_path: nil,
         title: { en: "new title" },
         description: { en: "new description" },
         start_date:,

--- a/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_step_form_spec.rb
@@ -24,11 +24,9 @@ module Decidim
         end
         let(:start_date) { nil }
         let(:end_date) { nil }
-        let(:cta_path) { nil }
         let(:attributes) do
           {
             "participatory_process_step" => {
-              "cta_path" => cta_path,
               "title_en" => title[:en],
               "title_es" => title[:es],
               "title_ca" => title[:ca],
@@ -62,18 +60,6 @@ module Decidim
         end
 
         context "when everything is OK" do
-          it { is_expected.to be_valid }
-        end
-
-        context "when cta_path is a full URL" do
-          let(:cta_path) { "http://example.org" }
-
-          it { is_expected.not_to be_valid }
-        end
-
-        context "when cta_path is a valid path" do
-          let(:cta_path) { "processes/my-process/" }
-
           it { is_expected.to be_valid }
         end
 

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
@@ -142,8 +142,6 @@ module Decidim::ParticipatoryProcesses
           expect(serialized_participatory_process_steps).to include(description: step.description)
           expect(serialized_participatory_process_steps).to include(start_date: step.start_date)
           expect(serialized_participatory_process_steps).to include(end_date: step.end_date)
-          expect(serialized_participatory_process_steps).to include(cta_path: step.cta_path)
-          expect(serialized_participatory_process_steps).to include(cta_text: step.cta_text)
           expect(serialized_participatory_process_steps).to include(active: step.active)
           expect(serialized_participatory_process_steps).to include(position: step.position)
         end

--- a/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_steps_examples.rb
@@ -37,7 +37,6 @@ shared_examples "manage process steps examples" do
       "#participatory_process_step-description-tabs",
       **attributes[:description].except("machine_translations")
     )
-    fill_in_i18n(:participatory_process_step_cta_text, "#participatory_process_step-cta_text-tabs", **attributes[:cta_text].except("machine_translations"))
 
     find_by_id("participatory_process_step_start_date_date").click
 
@@ -72,7 +71,6 @@ shared_examples "manage process steps examples" do
     within ".edit_participatory_process_step" do
       fill_in_i18n(:participatory_process_step_title, "#participatory_process_step-title-tabs", **attributes[:title].except("machine_translations"))
       fill_in_i18n_editor(:participatory_process_step_description, "#participatory_process_step-description-tabs", **attributes[:description].except("machine_translations"))
-      fill_in_i18n(:participatory_process_step_cta_text, "#participatory_process_step-cta_text-tabs", **attributes[:cta_text].except("machine_translations"))
 
       find("*[type=submit]").click
     end

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -221,8 +221,6 @@ describe "Decidim::Api::QueryType" do
       "steps" => [
         {
           "active" => participatory_process.steps.first.active,
-          "callToActionPath" => participatory_process.steps.first.cta_path,
-          "callToActionText" => { "translation" => participatory_process.steps.first.cta_text[locale] },
           "createdAt" => participatory_process.steps.first.created_at.to_time.iso8601,
           "description" => { "translation" => participatory_process.steps.first.description[locale] },
           "endDate" => participatory_process.steps.first.end_date&.to_time&.iso8601,

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -134,10 +134,6 @@ describe "Decidim::Api::QueryType" do
         startDate
         steps {
           active
-          callToActionPath
-          callToActionText{
-            translation(locale: "#{locale}")
-          }
           createdAt
           description{
             translation(locale: "#{locale}")

--- a/decidim-participatory_processes/spec/types/participatory_process_step_type_spec.rb
+++ b/decidim-participatory_processes/spec/types/participatory_process_step_type_spec.rb
@@ -13,7 +13,7 @@ module Decidim
       end
 
       let(:model) do
-        create(:participatory_process_step, participatory_process: process, cta_path: "#link1")
+        create(:participatory_process_step, participatory_process: process)
       end
 
       include_examples "timestamps interface"
@@ -67,23 +67,6 @@ module Decidim
 
         it "returns the step's end date" do
           expect(response["endDate"]).to eq(model.end_date.to_time.iso8601)
-        end
-      end
-
-      describe "call_to_action_path" do
-        let(:query) { "{ callToActionPath }" }
-
-        it "returns the step's call to action path" do
-          expect(response["callToActionPath"]).to eq("#link1")
-        end
-      end
-
-      describe "call_to_action_text" do
-        let(:query) { '{ callToActionText { locales translation(locale:"en") } }' }
-
-        it "returns the step's call to action text" do
-          expect(response["callToActionText"]["locales"]).to include(*model.cta_text.except("machine_translations").keys)
-          expect(response["callToActionText"]["translation"]).to eq(model.cta_text["en"])
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the Steps form in a @decidim/product meeting, we found the CTA path and CTA text fields here. 

As far as I see, this was used in the old design and with the Redesign isn't used anymore. We left a deprecation notice with #12198, so this PR removes the form fields, leftovers, and database fields. 

This PR removes them. 

#### :pushpin: Related Issues
 
- Related to #4184  
- Related to #12198

#### Testing

Search for `active_step.cta_path` or `active_step&.cta_path` being used. 
(The only usage that I found is a helper, `participatory_process_cta_path`, that isn't called anywhere) 

### :camera: Screenshots

The fields that I'm mentioning:

<img width="728" height="833" alt="image" src="https://github.com/user-attachments/assets/c2ea8ac0-494b-4b9c-a134-fe1f0aef2b50" />

The old design (😢):

<img width="1223" height="346" alt="image" src="https://github.com/user-attachments/assets/0bfe4866-2d56-4bbe-b792-cf42294f1625" />

:hearts: Thank you!
