### PR TITLE
Fix saving geocoding data when present in proposals

### DIFF
--- a/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
+++ b/decidim-proposals/app/commands/decidim/proposals/create_proposal.rb
@@ -83,7 +83,11 @@ module Decidim
 
             proposal.taxonomizations = form.taxonomizations if form.taxonomizations.present?
             proposal.documents = form.documents if form.documents.present?
-            proposal.address = form.address if form.has_address? && !form.geocoded?
+            if form.geocoded?
+              proposal.latitude = form.latitude
+              proposal.longitude = form.longitude
+            end
+            proposal.address = form.address if form.has_address?
             proposal.add_coauthor(@current_user)
             proposal.save!
             @attached_to = proposal

--- a/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -142,6 +142,28 @@ module Decidim
             end
           end
         end
+
+        describe "when geocoding is enabled" do
+          let(:component) { create(:proposal_component, :with_geocoding_enabled) }
+          let(:form_params) do
+            {
+              title: "A reasonable proposal title",
+              body: "A reasonable proposal body",
+              address: "Carrer de Balmes, 132, Barcelona",
+              latitude: 41.394897,
+              longitude: 2.153088
+            }
+          end
+
+          it "saves geocoding data" do
+            expect { command.call }.to broadcast(:ok)
+            proposal = Decidim::Proposals::Proposal.last
+
+            expect(proposal.address).to eq(form_params[:address])
+            expect(proposal.latitude).to eq(form_params[:latitude])
+            expect(proposal.longitude).to eq(form_params[:longitude])
+          end
+        end
       end
     end
   end

--- a/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
+++ b/decidim-proposals/spec/commands/decidim/proposals/create_proposal_spec.rb
@@ -149,7 +149,7 @@ module Decidim
             {
               title: "A reasonable proposal title",
               body: "A reasonable proposal body",
-              address: "Carrer de Balmes, 132, Barcelona",
+              address: "Barcelona",
               latitude: 41.394897,
               longitude: 2.153088
             }


### PR DESCRIPTION
#### :tophat: What? Why?

Geolocation data is not saved when creating (it is when updating) a proposal.

This ensures a proper detection of the geocoding status

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?


#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
