### PR TITLE
Change user links in Comments and Debates

### DIFF
--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -175,7 +175,7 @@
     }
 
     &-author-name {
-      @apply text-secondary font-semibold;
+      @apply text-gray-2 font-semibold;
     }
 
     &-author-selected {

--- a/decidim-debates/app/views/decidim/debates/debates/show.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/show.html.erb
@@ -38,7 +38,7 @@ edit_link(
     <div class="layout-author <%= "has_status" if debate.closed? %>">
       <div class="relative flex items-center justify-center w-full">
         <div class="w-10/12 flex items-center gap-4">
-          <%= cell "decidim/author", debate_presenter.author, skip_profile_link: true %>
+          <%= cell "decidim/author", debate_presenter.author %>
         </div>
         <%= render "decidim/shared/resource_actions", resource: debate do %>
           <%= render "decidim/debates/debates/debate_actions" %>


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #15315, I found two minor bugs:

1. There's a missing link to the author profile in the Debate's author
2. There's a text that seems a link in the Comment textarea 

This PR fixes both of these. 

#### Testing

1. SIgn in 
2. Create a debate
3. View this page

### :camera: Screenshots

#### Before

<img width="1254" height="818" alt="image" src="https://github.com/user-attachments/assets/8e9904b8-8f47-4dd0-acdf-9f6a50a86647" />

#### After

<img width="1337" height="821" alt="image" src="https://github.com/user-attachments/assets/1e200cec-b66a-4c69-8913-e0a5ab61ecd7" />

:hearts: Thank you!
