### PR TITLE
Fix proposal evaluation migration

### DIFF
--- a/decidim-proposals/db/migrate/20250121110904_rename_valuation_assignments_count_to_evaluation_assignments_count.rb
+++ b/decidim-proposals/db/migrate/20250121110904_rename_valuation_assignments_count_to_evaluation_assignments_count.rb
@@ -8,7 +8,7 @@ class RenameValuationAssignmentsCountToEvaluationAssignmentsCount < ActiveRecord
       dir.up do
         Decidim::Proposals::Proposal.reset_column_information
         Decidim::Proposals::Proposal.unscoped.find_each do |record|
-          Decidim::Proposals::Proposal.reset_counters(record.id, :evaluation_assignments)
+          Decidim::Proposals::Proposal.unscoped.reset_counters(record.id, :evaluation_assignments)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?
In some cases when the proposal would be soft deleted, the migration would fail, as the `find_each` is unscoped, yet the update statement would be default_scoped.  

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13684

#### Testing
1. Go to admin, create a proposal ( could be draft as well ) 
2. delete it 
3. Run the initial file from develop
4. See is failing 
5. Apply patch, rerun the file 
6. See there is no error 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
