### PR TITLE
Fix exception in search with budgets' projects

### DIFF
--- a/decidim-budgets/app/cells/decidim/budgets/project_metadata_cell.rb
+++ b/decidim-budgets/app/cells/decidim/budgets/project_metadata_cell.rb
@@ -7,7 +7,7 @@ module Decidim
       include Decidim::Budgets::ProjectsHelper
 
       delegate :selected?, to: :model
-      delegate :show_votes_count?, :resource_added?, to: :controller
+      delegate :resource_added?, to: :controller
 
       alias project model
 
@@ -18,6 +18,10 @@ module Decidim
       end
 
       private
+
+      def show_votes_count?
+        model.component.current_settings.show_votes?
+      end
 
       def project_items
         [status_item] + taxonomy_items + [budget_amount]

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -262,6 +262,17 @@ describe "Explore projects", :slow do
     end
   end
 
+  describe "search" do
+    before do
+      switch_to_host(organization.host)
+      visit decidim.search_path
+    end
+
+    it "shows the project" do
+      expect(page).to have_content(translated_attribute(projects.last.title))
+    end
+  end
+
   private
 
   def decidim_budgets


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #14903 we have added the following part, that is actually causing errors in search page: 

This PR is fixing the error. 

<img width="1073" height="559" alt="image" src="https://github.com/user-attachments/assets/1354ef4c-a1ef-44f6-b513-c21c53d32f6c" />


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14903
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
