### PR TITLE
Display the description of each question in the voting booth

### DIFF
--- a/decidim-elections/app/helpers/decidim/elections/application_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/application_helper.rb
@@ -43,6 +43,15 @@ module Decidim
         end
       end
 
+      def question_description(question, tag = :p, **options)
+        description = translated_attribute(question.description)
+        return if description.blank?
+
+        content_tag(tag, **options) do
+          decidim_sanitize(description)
+        end
+      end
+
       def selected_response_option_id(question)
         session.dig(:votes_buffer, question.id.to_s, "response_option_id")&.to_i
       end

--- a/decidim-elections/app/helpers/decidim/elections/application_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/application_helper.rb
@@ -37,18 +37,21 @@ module Decidim
         (defined?(current_component) && translated_attribute(current_component&.name).presence) || t("decidim.components.elections.name")
       end
 
-      def question_title(question, tag = :h3, **options)
+      def question_title(question, tag, **options)
         content_tag(tag, **options) do
           translated_attribute(question.body)
         end
       end
 
-      def question_description(question, tag = :p, **options)
+      def render_question_description(question)
         description = translated_attribute(question.description)
         return if description.blank?
 
-        content_tag(tag, **options) do
-          decidim_sanitize(description)
+        sanitized = decidim_sanitize_admin(description)
+        if rich_text_editor_in_public_views?
+          Decidim::ContentProcessor.render_without_format(sanitized).html_safe
+        else
+          Decidim::ContentProcessor.render(sanitized, "div")
         end
       end
 

--- a/decidim-elections/app/helpers/decidim/elections/application_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/application_helper.rb
@@ -37,7 +37,7 @@ module Decidim
         (defined?(current_component) && translated_attribute(current_component&.name).presence) || t("decidim.components.elections.name")
       end
 
-      def question_title(question, tag, **options)
+      def question_title(question, tag = :h3, **options)
         content_tag(tag, **options) do
           translated_attribute(question.body)
         end

--- a/decidim-elections/app/packs/stylesheets/decidim/elections/elections.scss
+++ b/decidim-elections/app/packs/stylesheets/decidim/elections/elections.scss
@@ -89,3 +89,7 @@
     }
   }
 }
+
+.vote_booth-question_title {
+  @apply h3 mb-4;
+}

--- a/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions.html.erb
@@ -19,6 +19,7 @@
                 <%= translated_attribute(question.body) %>
                 <small class="font-normal ml-4"><%= t("decidim.forms.question_types.#{question.question_type}") %></small>
               </h3>
+              <div><%= decidim_sanitize_admin translated_attribute(question.description) %></div>
               <h3 class="h6 mt-4 mb-2"><%= t("decidim.elections.admin.dashboard.questions.labels.answers") %>:</h3>
               <ul>
                 <% question.response_options.each_with_index do |option, opt_index| %>

--- a/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions_with_results.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions_with_results.html.erb
@@ -15,6 +15,7 @@
             </div>
           <% end %>
         </h3>
+        <div><%= decidim_sanitize_admin translated_attribute(question.description) %></div>
       </div>
       <div class="row column">
         <div class="table-scroll mb-4">

--- a/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h3, class: "vote_booth-question_title") %>
+  <%= question_title(question, :h1, class: "vote_booth-question_title") %>
   <div class="editor-content">
     <%= render_question_description(question) %>
   </div>

--- a/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
@@ -1,5 +1,6 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h1, class: "h4 mb-8") %>
+  <%= question_title(question, :h1, class: "h4 mb-4") %>
+  <%= question_description(question, :p, class: "mb-8") %>
 
   <div class="question__response-options mt-4 flex flex-col gap-4">
     <% question.response_options.each do |option| %>

--- a/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/per_question_votes/show.html.erb
@@ -1,6 +1,8 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h1, class: "h4 mb-4") %>
-  <%= question_description(question, :p, class: "mb-8") %>
+  <%= question_title(question, :h3, class: "vote_booth-question_title") %>
+  <div class="editor-content">
+    <%= render_question_description(question) %>
+  </div>
 
   <div class="question__response-options mt-4 flex flex-col gap-4">
     <% question.response_options.each do |option| %>

--- a/decidim-elections/app/views/decidim/elections/votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/show.html.erb
@@ -1,5 +1,5 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h3, class: "vote_booth-question_title") %>
+  <%= question_title(question, :h1, class: "vote_booth-question_title") %>
   <div class="editor-content">
     <%= render_question_description(question) %>
   </div>

--- a/decidim-elections/app/views/decidim/elections/votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/show.html.erb
@@ -1,5 +1,6 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h1, class: "h4 mb-8") %>
+  <%= question_title(question, :h1, class: "h4 mb-4") %>
+  <%= question_description(question, :p, class: "mb-8") %>
 
   <div class="question__response-options mt-4 flex flex-col gap-4">
     <% question.response_options.each do |option| %>

--- a/decidim-elections/app/views/decidim/elections/votes/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/show.html.erb
@@ -1,6 +1,8 @@
 <%= form_with url: url_for(action: :show, id: question), method: :patch, local: true do %>
-  <%= question_title(question, :h1, class: "h4 mb-4") %>
-  <%= question_description(question, :p, class: "mb-8") %>
+  <%= question_title(question, :h3, class: "vote_booth-question_title") %>
+  <div class="editor-content">
+    <%= render_question_description(question) %>
+  </div>
 
   <div class="question__response-options mt-4 flex flex-col gap-4">
     <% question.response_options.each do |option| %>

--- a/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
@@ -10,6 +10,7 @@ shared_examples "a csv token per question votable election" do
     click_on "Access"
     expect(page).to have_current_path(election_vote_path(question1))
     expect(page).to have_content(translated_attribute(question1.body))
+    expect(page).to have_content(strip_tags(translated_attribute(question1.description)))
     choose translated_attribute(question1.response_options.first.body)
     click_on "Cast vote"
     expect(page).to have_content("Your vote has been successfully cast.")
@@ -18,6 +19,7 @@ shared_examples "a csv token per question votable election" do
     # wait for javascript to update the page
     sleep 2
     expect(page).to have_current_path(election_vote_path(question2))
+    expect(page).to have_content(strip_tags(translated_attribute(question2.description)))
     click_on "Cast vote"
     expect(page).to have_content("There was a problem casting your vote.")
     check translated_attribute(question2.response_options.first.body)
@@ -52,6 +54,7 @@ shared_examples "a per question votable election" do
     expect(page).to have_content(translated_attribute(question1.body))
     expect(page).to have_content(translated_attribute(question2.body))
     click_on "Vote"
+    expect(page).to have_content(strip_tags(translated_attribute(question1.description)))
     choose translated_attribute(question1.response_options.first.body)
     click_on "Cast vote"
     expect(page).to have_current_path(waiting_election_votes_path)
@@ -61,6 +64,7 @@ shared_examples "a per question votable election" do
     # wait for javascript to update the page
     sleep 2
     expect(page).to have_current_path(election_vote_path(question2))
+    expect(page).to have_content(strip_tags(translated_attribute(question2.description)))
     check translated_attribute(question2.response_options.first.body)
     click_on "Cast vote"
     expect(page).to have_current_path(receipt_election_votes_path)
@@ -101,6 +105,7 @@ shared_examples "a per question votable election with published results" do
     # wait for javascript to update the page
     sleep 2
     expect(page).to have_current_path(election_vote_path(question2))
+    expect(page).to have_content(strip_tags(translated_attribute(question2.description)))
     check translated_attribute(question2.response_options.first.body)
     click_on "Cast vote"
     expect(page).to have_current_path(receipt_election_votes_path)
@@ -137,6 +142,7 @@ shared_examples "a per question votable election with already voted questions" d
     expect(page).to have_content(translated_attribute(question2.body))
     expect(page).to have_content(translated_attribute(question3.body))
     click_on "Vote"
+    expect(page).to have_content(strip_tags(translated_attribute(question1.description)))
     choose translated_attribute(question1.response_options.first.body)
     click_on "Cast vote"
     check translated_attribute(question2.response_options.first.body)
@@ -144,10 +150,12 @@ shared_examples "a per question votable election with already voted questions" d
     expect(page).to have_current_path(waiting_election_votes_path)
     click_on "Edit your vote"
     expect(page).to have_current_path(election_vote_path(question1))
+    expect(page).to have_content(strip_tags(translated_attribute(question1.description)))
     expect(find("input[value='#{question1.response_options.first.id}']")).to be_checked
     choose translated_attribute(question1.response_options.second.body)
     click_on "Cast vote"
     expect(page).to have_current_path(election_vote_path(question2))
+    expect(page).to have_content(strip_tags(translated_attribute(question2.description)))
     expect(find("input[value='#{question2.response_options.first.id}']")).to be_checked
     expect(find("input[value='#{question2.response_options.second.id}']")).not_to be_checked
     check translated_attribute(question2.response_options.second.body)
@@ -156,6 +164,7 @@ shared_examples "a per question votable election with already voted questions" d
     question1.update!(published_results_at: Time.current)
     click_on "Edit your vote"
     expect(page).to have_current_path(election_vote_path(question2))
+    expect(page).to have_content(strip_tags(translated_attribute(question2.description)))
     question2.update!(published_results_at: Time.current)
     click_on "Cast vote"
     expect(page).to have_current_path(waiting_election_votes_path)

--- a/decidim-elections/lib/decidim/elections/test/vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/vote_examples.rb
@@ -22,10 +22,12 @@ end
 def fill_in_votes
   expect(page).to have_current_path(election_vote_path(election.questions.first))
   expect(page).to have_content(translated_attribute(election.questions.first.body))
+  expect(page).to have_content(strip_tags(translated_attribute(election.questions.first.description)))
   choose translated_attribute(election.questions.first.response_options.first.body)
   click_on "Next"
   expect(page).to have_current_path(election_vote_path(election.questions.second))
   expect(page).to have_content(translated_attribute(election.questions.second.body))
+  expect(page).to have_content(strip_tags(translated_attribute(election.questions.second.description)))
   check translated_attribute(election.questions.second.response_options.first.body)
   check translated_attribute(election.questions.second.response_options.second.body)
   click_on "Next"

--- a/decidim-elections/spec/helpers/decidim/elections/application_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/application_helper_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Elections
+    describe ApplicationHelper do
+      describe "#question_description" do
+        subject(:rendered_description) { helper.question_description(question, :span, class: "question__description") }
+
+        context "when the description is blank" do
+          let(:question) { build(:election_question, description: { "en" => "" }) }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "when the description has plain text" do
+          let(:question) { create(:election_question, description: { "en" => "More info" }) }
+
+          it { is_expected.to eq('<span class="question__description">More info</span>') }
+        end
+
+        context "when the description includes markup" do
+          let(:question) { build(:election_question, description: { "en" => "<strong>Intro</strong>" }) }
+
+          it "keeps the allowed tags" do
+            expect(rendered_description).to eq('<span class="question__description"><strong>Intro</strong></span>')
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-elections/spec/helpers/decidim/elections/application_helper_spec.rb
+++ b/decidim-elections/spec/helpers/decidim/elections/application_helper_spec.rb
@@ -5,8 +5,15 @@ require "spec_helper"
 module Decidim
   module Elections
     describe ApplicationHelper do
+      let(:organization) { create(:organization) }
+
+      before do
+        allow(helper).to receive(:current_organization).and_return(organization)
+        allow(helper).to receive(:rich_text_editor_in_public_views?).and_return(true)
+      end
+
       describe "#question_description" do
-        subject(:rendered_description) { helper.question_description(question, :span, class: "question__description") }
+        subject(:rendered_description) { helper.render_question_description(question) }
 
         context "when the description is blank" do
           let(:question) { build(:election_question, description: { "en" => "" }) }
@@ -17,14 +24,24 @@ module Decidim
         context "when the description has plain text" do
           let(:question) { create(:election_question, description: { "en" => "More info" }) }
 
-          it { is_expected.to eq('<span class="question__description">More info</span>') }
+          it { is_expected.to eq("More info") }
         end
 
         context "when the description includes markup" do
           let(:question) { build(:election_question, description: { "en" => "<strong>Intro</strong>" }) }
 
           it "keeps the allowed tags" do
-            expect(rendered_description).to eq('<span class="question__description"><strong>Intro</strong></span>')
+            expect(rendered_description).to eq("<strong>Intro</strong>")
+          end
+        end
+
+        context "when the description includes images" do
+          let(:question) { build(:election_question, description: { "en" => '<p>Check this image:</p><img src="image.jpg" alt="Example">' }) }
+
+          it "keeps the image tags" do
+            expect(rendered_description).to include("<img")
+            expect(rendered_description).to include('src="image.jpg"')
+            expect(rendered_description).to include('alt="Example"')
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
 Display election question descriptions inside the voting booth.

#### :pushpin: Related Issues
- Fixes #15307

#### Testing
  1. Create an election with at least one question that has a non-empty description.
  2. Open the voting booth for that election.
  3. Confirm the description renders under the question title in the booth.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
