### PR TITLE
Fix the color chooser selector with enter

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization/form/_colors.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_colors.html.erb
@@ -48,7 +48,7 @@
               <input id="preview-tertiary" type="hidden">
             </label>
 
-            <button id="set-colors" class="button button__sm button__secondary">
+            <button id="set-colors" type="button" class="button button__sm button__secondary">
               <%= t("update_suggested_colors", scope: "decidim.admin.organization.form.colors") %>
             </button>
           </fieldset>


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out #15190, I found another bug. Basically if you go to the "Edit organization" form and you submit with `Enter`, then the colors for the organization are changed to black.

This is because the button isn't a `type="button"`so the browser actually tries to submit the first button in the form. 

#### :pushpin: Related Issues
 
- Related to #10977 

#### Testing

To reproduce the bug: 

1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/edit 
3. Click in the first input ("Organization name")
4. Press the `Enter` key
5. See that nothing (visibly) happens
6. Click on the "Update" button
7. Go to the frontend 
8. See that the organization's colors are changed to black 

To reproduce the fix

0. Change the organization colors to something else
1. Sign in as admin
2. Go to http://localhost:3000/admin/organization/edit 
3. Click in the first input ("Organization name")
4. Press the `Enter` key
5. See that nothing (visibly) happens
6. Click on the "Update" button
7. Go to the frontend 
8. See that the organization's colors are unchanged

### :camera: Screenshots

<img width="1838" height="1531" alt="image" src="https://github.com/user-attachments/assets/20fde288-19b4-455c-a9fc-b000bcff8476" />

Typical black and white organization: 

<img width="1842" height="1438" alt="image" src="https://github.com/user-attachments/assets/627508cd-e6c0-4709-9ba0-12ec78133121" />

:hearts: Thank you!
