### PR TITLE
Fix w3c validator CI pipeline (NuValidator json errors)

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -53,7 +53,7 @@ jobs:
       DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
     services:
       validator:
-        image: ghcr.io/validator/validator:latest
+        image: ghcr.io/validator/validator@sha256:28bd490412bb5abf1cf23eae0e3c197e9fbbda43cb9d23239b9ce859dc585db0
         ports: ["8888:8888"]
       postgres:
         image: postgres:14


### PR DESCRIPTION
#### :tophat: What? Why?
In the last versions of NU validator, there is a Json error, which is causing issues. 
The problem happens in github pipeline, but also locally, indicating that the probem occurs in the validator service. 
In this PR i am locking the NU validator service to a stable release from a month ago that has some a relevant number of downloads.

If you visit the page: https://validator.w3.org/nu/about.html
You will see a link named "Check serialized DOM of current page (results as JSON)" 
Once clicked you should be able to see a JSON error. 
<img width="1175" height="215" alt="image" src="https://github.com/user-attachments/assets/45d62e69-2258-4244-a6a9-1c261f8acab6" />

#### Testing
Our pipeline should be green, as currently all the target branches are failing ( develop, release/0.31-stable, release/0.30-stable, release/0.29-stable ) 

:hearts: Thank you!
