### PR TITLE
Backport 'Show badges next to user nicknames' to v0.30

### DIFF
--- a/.erb_lint.yml
+++ b/.erb_lint.yml
@@ -124,7 +124,6 @@ linters:
           - author-data__extra
           - author-data__main
           - author__avatar--small
-          - author__badge
           - author__date
           - author__name--container
           - author__nickname

--- a/decidim-core/app/cells/decidim/author/badge.erb
+++ b/decidim-core/app/cells/decidim/author/badge.erb
@@ -1,0 +1,6 @@
+<% if show_badge? %>
+  <span class="author__badge">
+    <%= icon "star-s-fill" %>
+    <span class="sr-only"><%= officialization_text %></span>
+  </span>
+<% end %>

--- a/decidim-core/app/cells/decidim/author/show.erb
+++ b/decidim-core/app/cells/decidim/author/show.erb
@@ -6,7 +6,10 @@
       <%= render :avatar %>
 
       <span>
-        <%= render :name %>
+        <span class="flex gap-2">
+          <%= render :name %>
+          <%= render :badge %>
+        </span>
 
         <% context_actions.each do |action| %>
           <%= render action %>
@@ -17,6 +20,7 @@
     <% else %>
       <%= render :avatar %>
       <%= render :name %>
+      <%= render :badge %>
     <% end %>
   <% end %>
 

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -186,5 +186,15 @@ module Decidim
 
       model.has_tooltip?
     end
+
+    def show_badge?
+      return false unless model.respond_to? :officialized?
+
+      model.officialized?
+    end
+
+    def officialization_text
+      translated_attribute(model.officialized_as).presence || t("decidim.profiles.show.officialized")
+    end
   end
 end

--- a/decidim-core/app/cells/decidim/profile/avatar.erb
+++ b/decidim-core/app/cells/decidim/profile/avatar.erb
@@ -2,6 +2,4 @@
   <div class="profile__avatar">
     <%= image_tag avatar_url, alt: t("decidim.author.avatar", name: decidim_sanitize(presented_profile.name)) %>
   </div>
-
-  <%= render :badge if show_badge? %>
 </div>

--- a/decidim-core/app/cells/decidim/profile/badge.erb
+++ b/decidim-core/app/cells/decidim/profile/badge.erb
@@ -1,4 +1,4 @@
-<div class="profile__avatar-badge">
+<span class="profile__details-badge">
   <%= icon "star-s-fill" %>
-  <span class="sr-only"><%= officialization_text %></span>
-</div>
+  <%= officialization_text %>
+</span>

--- a/decidim-core/app/cells/decidim/profile/details.erb
+++ b/decidim-core/app/cells/decidim/profile/details.erb
@@ -1,7 +1,8 @@
 <div class="profile__details">
-  <h1 class="h3">
+  <h1 class="h3 flex gap-2">
     <%= presented_profile.name %>
     <span class="sr-only"><%= tab_items.find { |tab_item| is_active_link?(tab_item[:path]) }&.dig(:text) %> (<%= presented_profile.name %>)</span>
+    <%= render :badge if show_badge? %>
   </h1>
   <div class="profile__details-data">
     <% details_items.each do |detail| %>

--- a/decidim-core/app/packs/stylesheets/decidim/_author.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_author.scss
@@ -29,6 +29,10 @@
     @apply text-secondary font-semibold;
   }
 
+  &__badge svg {
+    @apply grid overflow-hidden place-items-center bg-primary rounded-full w-4 h-4 text-white fill-current;
+  }
+
   &__metadata {
     @apply flex items-center gap-1 text-gray-2 text-sm;
 

--- a/decidim-core/app/packs/stylesheets/decidim/_profile.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_profile.scss
@@ -9,18 +9,18 @@
     &-container {
       @apply w-24 h-24 relative;
     }
-
-    &-badge {
-      @apply absolute top-full right-0 -translate-y-full grid place-items-center w-6 h-6 rounded-full overflow-hidden bg-primary border border-white;
-
-      svg {
-        @apply w-4 h-4 text-white fill-current;
-      }
-    }
   }
 
   &__details {
     @apply pb-3 space-y-2;
+
+    &-badge {
+      @apply flex items-center gap-1 text-sm text-gray-2;
+
+      svg {
+        @apply w-4 h-4 inline-block bg-primary rounded-full text-white fill-current;
+      }
+    }
 
     &-data {
       @apply flex flex-wrap gap-x-6 gap-y-4;

--- a/decidim-core/spec/cells/decidim/author_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/author_cell_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::AuthorCell, type: :cell do
   controller Decidim::PagesController
 
   let(:my_cell) { cell("decidim/author", model) }
-  let!(:organization) { create(:organization) }
+  let!(:organization) { build(:organization) }
   let(:user) { create(:user, :confirmed, organization:) }
   let(:user_group) { create(:user_group, :verified) }
   let(:model) { Decidim::UserPresenter.new(user) }
@@ -16,6 +16,14 @@ describe Decidim::AuthorCell, type: :cell do
   context "when rendering a user" do
     it "renders a User author card" do
       expect(subject).to have_css("[data-author]")
+    end
+
+    context "and when this user is officialized" do
+      let(:user) { create(:user, :confirmed, :officialized, organization:) }
+
+      it "shows the officialization badge" do
+        expect(subject).to have_xpath("//svg/use[contains(@href, 'ri-star-s-fill')]")
+      end
     end
   end
 

--- a/decidim-core/spec/cells/decidim/profile_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/profile_cell_spec.rb
@@ -6,9 +6,9 @@ describe Decidim::ProfileCell, type: :cell do
   controller Decidim::ProfilesController
   subject { my_cell.call }
 
-  let(:organization) { create(:organization, user_groups_enabled: true) }
-  let(:user) { create(:user, :managed, organization:, blocked: false) }
-  let(:context) { { content_cell: "decidim/user_conversations", conversations: [] } }
+  let(:organization) { build(:organization, user_groups_enabled: true) }
+  let(:user) { build(:user, :managed, organization:, blocked: false) }
+  let(:context) { { content_cell: "decidim/badges" } }
   let(:my_cell) { cell("decidim/profile", user, context:) }
 
   context "when show is rendered" do
@@ -19,7 +19,7 @@ describe Decidim::ProfileCell, type: :cell do
 
   context "when the user displayed is blocked" do
     context "and is an admin" do
-      let(:user) { create(:user, :managed, organization:, blocked: true, admin: true) }
+      let(:user) { build(:user, :managed, organization:, blocked: true, admin: true) }
 
       it "shows the user profile" do
         expect(subject).to have_no_text("This profile is inaccessible due to terms of service violation!")
@@ -27,11 +27,23 @@ describe Decidim::ProfileCell, type: :cell do
     end
 
     context "and is not an admin" do
-      let(:user) { create(:user, :managed, organization:, blocked: true, admin: false) }
+      let(:user) { build(:user, :managed, organization:, blocked: true, admin: false) }
 
       it "shows the inaccessible profile alert" do
         expect(subject).to have_text("This profile is inaccessible due to terms of service violation!")
       end
+    end
+  end
+
+  context "when the user displayed is officialized" do
+    let(:user) { build(:user, :officialized, organization:) }
+
+    it "shows the officialization badge" do
+      expect(subject).to have_xpath("//svg/use[contains(@href, 'ri-star-s-fill')]")
+    end
+
+    it "shows the officialization name" do
+      expect(subject).to have_content(decidim_sanitize_translated(user.officialized_as))
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15315 to v0.30
<img width="555" height="180" alt="image" src="https://github.com/user-attachments/assets/54fd6de0-ca66-486b-8147-fc41839407ed" />

<img width="1002" height="221" alt="image" src="https://github.com/user-attachments/assets/8579712b-c167-4696-92fb-b695add48371" />

:hearts: Thank you!