### PR TITLE
Back to responses button in surveys

### DIFF
--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -55,7 +55,7 @@ en:
             tos: Terms of service
         questionnaires:
           actions:
-            back: Back to questions
+            back: Back to responses
             publish_responses: Publish responses
             show: Responses
           display_condition:

--- a/decidim-surveys/app/views/decidim/surveys/admin/publish_responses/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/publish_responses/index.html.erb
@@ -4,7 +4,7 @@
   <div class="w-full">
     <h1 class="item_show__header-title">
       <%= t(".title") %>
-      <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires"), questionnaire_url, class: "button button__sm button__secondary new" %>
+      <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires"), survey_responses_path, class: "button button__sm button__secondary new" %>
     </h1>
   </div>
 </div>


### PR DESCRIPTION
#### :tophat: What? Why?
This fixes an issue with the "Back to questions" button upon publishing responses within surveys had the incorrect label and URL path.

#### :pushpin: Related Issues
- Fixes #15358

#### Testing
1. Login
2. Head to admin
3. Find a space with the surveys component being used with an active survey and responses
4. Click on that survey
5. In settings make sure "Allow responses" is NOT checked (otherwise you can't publish any responses ;)
6. Head to the responses tab 
7. Click publish responses 
8. Click the button "Back to responses"
9. See you're redirected to a more appropriate url 

### :camera: Screenshots
<img width="532" height="611" alt="image" src="https://github.com/user-attachments/assets/8a55cdbe-6cc6-48f8-8b70-6f1d1a95a38c" />

:hearts: Thank you!
