### PR TITLE
Make the WYSIWYG editor vertical resizable

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/editor.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/editor.scss
@@ -84,7 +84,9 @@
     }
 
     .ProseMirror {
-      @apply relative p-2.5 outline-0 min-h-full prose max-w-none prose-headings:first:mt-0 prose-p:first:mt-0 prose-ul:first:mt-0 prose-ol:first:mt-0 prose-blockquote:first:mt-0 prose-pre:first:mt-0;
+      @apply relative p-2.5 outline-0 resize-y overflow-hidden prose max-w-none prose-headings:first:mt-0 prose-p:first:mt-0 prose-ul:first:mt-0 prose-ol:first:mt-0 prose-blockquote:first:mt-0 prose-pre:first:mt-0;
+
+      min-height: inherit;
 
       &.ProseMirror-focused,
       &.dialog-open {

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -204,7 +204,7 @@ module Decidim
             disabled: options[:disabled],
             options: editor_options[:editor]
           }
-        ) { content_tag(:div, nil, class: "editor-input", style: "height: #{lines}rem") }
+        ) { content_tag(:div, nil, class: "editor-input", style: "min-height: #{lines}rem") }
         template += error_for(name, options) if error?(name)
         template += editor_upload(editor_image, editor_options[:upload])
         template.html_safe


### PR DESCRIPTION
#### :tophat: What? Why?

After the introduction of the TipTap Editor (see #10082), participants have lost the possibility of resizing the area where they're writing, as they no longer have the "resize handler": 

<img width="234" height="110" alt="image" src="https://github.com/user-attachments/assets/f061d2d8-ff72-4309-9b65-5c4b6b402ef3" />

This PR fixes this behavior by letting participants change the vertical resizing of these areas. 

Mind that I didn't use `min-height-inherit` because Tailwind doesn't have it (see https://github.com/tailwindlabs/tailwindcss/discussions/1361)

#### :pushpin: Related Issues
 
- Related to #10082 
 

#### Testing

1. Sign in as admin
2. Go to a form with a WYSIWYG
3. (Before) see that you can't resize it
4. (After) see that you can resize it vertically 

### :camera: Screenshots
 
[Kooha-2025-10-16-10-38-44.webm](https://github.com/user-attachments/assets/50bd9b13-eefd-4bc2-916b-45e2463366f9)

:hearts: Thank you!
