### PR TITLE
Add format validation for name and nickname in UserGroupForm

### DIFF
--- a/decidim-core/app/forms/decidim/user_group_form.rb
+++ b/decidim-core/app/forms/decidim/user_group_form.rb
@@ -16,10 +16,12 @@ module Decidim
     attribute :phone
 
     validates :name, presence: true
+    validates :name, format: { with: Decidim::UserBaseEntity::REGEXP_NAME }
     validates :email, presence: true, "valid_email_2/email": { disposable: true }
     validates :nickname, presence: true
 
     validates :nickname, length: { maximum: Decidim::User.nickname_max_length, allow_blank: true }
+    validates :nickname, format: { with: Decidim::UserBaseEntity::REGEXP_NICKNAME }
     validates :avatar, passthru: { to: Decidim::UserGroup }
 
     validate :unique_document_number

--- a/decidim-core/spec/system/user_group_creation_spec.rb
+++ b/decidim-core/spec/system/user_group_creation_spec.rb
@@ -36,4 +36,40 @@ describe "User group creation" do
       expect(page).to have_content(user.name)
     end
   end
+
+  context "when nickname has invalid format" do
+    it "shows validation error in the form instead of raising exception" do
+      click_on "Create group"
+
+      fill_in "Name", with: "Valid Group Name"
+      fill_in "Nickname", with: "Invalid Nickname"
+      fill_in "Email", with: "user_group@decidim.org"
+      fill_in "Document number", with: "12345678X"
+      fill_in "Phone", with: "12345678"
+
+      click_on "Create group"
+
+      expect(page).to have_content("There was a problem creating the group")
+      expect(page).to have_css("small.form-error.is-visible", text: "is invalid")
+      expect(page).to have_css(".is-invalid-input#group_nickname")
+    end
+  end
+
+  context "when name has invalid format" do
+    it "shows validation error in the form instead of raising exception" do
+      click_on "Create group"
+
+      fill_in "Name", with: "<Invalid Name>"
+      fill_in "Nickname", with: "valid_nickname"
+      fill_in "Email", with: "user_group@decidim.org"
+      fill_in "Document number", with: "12345678X"
+      fill_in "Phone", with: "12345678"
+
+      click_on "Create group"
+
+      expect(page).to have_content("There was a problem creating the group")
+      expect(page).to have_css("small.form-error.is-visible", text: "is invalid")
+      expect(page).to have_css(".is-invalid-input#group_name")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When creating or updating a user group, if the **_name_** or **_nickname_** fields contained invalid characters, the validation would fail at the model level (_UserGroup_/_UserBaseEntity_) instead of at the form level (_UserGroupForm_).

Since the _CreateUserGroup_ command uses _UserGroup.create!_ (with bang), this caused an _ActiveRecord::RecordInvalid_ exception to be raised, resulting in Rails' error page (red screen) instead of showing validation errors in the form.

#### :pushpin: Related Issues
- Related to #14271 

#### Testing

1. Try creating a user group with invalid **_name_** (e.g., "<Test Group>")
2. Try creating a user group with invalid **_nickname_** (e.g., "My Group" with spaces or uppercase)
3. Verify that validation errors are shown in the form instead of raising exceptions
