### PR TITLE
Fix user group deprecation email messages

### DIFF
--- a/decidim-core/app/views/decidim/user_group_mailer/notify_deprecation_to_member.html.erb
+++ b/decidim-core/app/views/decidim/user_group_mailer/notify_deprecation_to_member.html.erb
@@ -6,10 +6,13 @@
 
 <p class="email-instructions"><%= t(".instructions_title").html_safe %></p>
 
-<p class="email-instructions"><%= t(".instructions_intro") %></p>
+<p class="email-instructions"><%= t(".instructions_intro", email: @group_email) %></p>
 
 <ul class="list-decimal">
   <li>
     <%= t(".instructions_1") %>
+  </li>
+  <li>
+    <%= t(".instructions_2") %>
   </li>
 </ul>

--- a/decidim-core/app/views/decidim/user_group_mailer/notify_deprecation_to_owner.html.erb
+++ b/decidim-core/app/views/decidim/user_group_mailer/notify_deprecation_to_owner.html.erb
@@ -14,9 +14,6 @@
     <p class="email-button email-button__cta"><%= link_to t(".set_password"), new_password_url(:user, host: @organization.host) %></p>
   </li>
   <li>
-    <%= t(".instructions_2") %>
-  </li>
-  <li>
-    <%= t(".instructions_3") %>
+    <%= t(".instructions_2", email: @group_email) %>
   </li>
 </ol>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1731,20 +1731,20 @@ en:
         body_2: As part of our efforts to simplify the experience for organizations, the "User Groups" feature is being deprecated. Your User Group profile has now been converted into a regular participant profile.
         greeting: Dear %{name},
         instructions_1: If you have access to that email account, please check your inbox for the instructions.
-        instructions_intro: We have sent instructions to the email associated with the account to set a new password for the profile.
+        instructions_2: If not, one of your colleagues who has access will need to set the password and share the login credentials with you.
+        instructions_intro: Group members will now share access to this profile using shared login credentials (email and password). We have sent instructions to %{email} to set a new password for the profile.
         instructions_title: "<strong>What This Means for You</strong>"
-        subject: User group you are member of important update
+        subject: Important update regarding your Group profile
       notify_deprecation_to_owner:
         body_1: We are reaching out to inform you about an important update regarding your Group profile on %{organization_name}.
         body_2: As part of our efforts to simplify and improve the experience for organizations like yours, we are deprecating the "User Groups" feature. Your Group, <strong>%{name}</strong>, has been converted into a regular account.
-        body_3: To continue accessing your account, we need you to set a password.
+        body_3: To continue accessing your account and share access, we need you to set a password. Once set, you can share the login credentials (email and password) with anyone.
         greeting: Dear %{name},
-        instructions_1: 'Click the link below to start the password setup process:'
-        instructions_2: On the form, enter the email address where you received this message and submit the request.
-        instructions_3: Check your inbox for an email with further instructions to set your new password.
+        instructions_1: 'Click the link below to set your password:'
+        instructions_2: 'Share the login credentials (email: %{email} and the new password) with your colleagues.'
         instructions_title: "<strong>What You Need to Do</strong>"
-        set_password: Start Password Setting Process
-        subject: User group important update
+        set_password: Set Your Password
+        subject: Important update regarding your Group profile
     user_report_mailer:
       notify:
         body_1: User %{user} has been reported by %{token}

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1733,7 +1733,7 @@ en:
         instructions_1: If you have access to that email account, please check your inbox for the instructions.
         instructions_2: If not, one of your colleagues who has access will need to set the password and share the login credentials with you.
         instructions_intro: Group members will now share access to this profile using shared login credentials (email and password). We have sent instructions to %{email} to set a new password for the profile.
-        instructions_title: "<strong>What This Means for You</strong>"
+        instructions_title: "<strong>What this means for you</strong>"
         subject: Important update regarding your Group profile
       notify_deprecation_to_owner:
         body_1: We are reaching out to inform you about an important update regarding your Group profile on %{organization_name}.
@@ -1742,7 +1742,7 @@ en:
         greeting: Dear %{name},
         instructions_1: 'Click the link below to set your password:'
         instructions_2: 'Share the login credentials (email: %{email} and the new password) with your colleagues.'
-        instructions_title: "<strong>What You Need to Do</strong>"
+        instructions_title: "<strong>What you need to do</strong>"
         set_password: Set Your Password
         subject: Important update regarding your Group profile
     user_report_mailer:

--- a/decidim-core/spec/mailers/previews/user_group_mailer_preview.rb
+++ b/decidim-core/spec/mailers/previews/user_group_mailer_preview.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  class UserGroupMailerPreview < ActionMailer::Preview
+    def notify_deprecation_to_owner
+      UserGroupMailer.notify_deprecation_to_owner(group)
+    end
+
+    def notify_deprecation_to_member
+      UserGroupMailer.notify_deprecation_to_member(user, group.name, group.email)
+    end
+
+    private
+
+    def user
+      @user ||= Decidim::User.new(name: "John Doe", email: "john.doe@example.org", organization:)
+    end
+
+    def group
+      @group ||= Decidim::User.new(name: "Demo Group", email: "group@example.org", organization:, extended_data: { group: true })
+    end
+
+    def password
+      Random.alphanumeric(15)
+    end
+
+    def organization
+      @organization ||= Decidim::Organization.first
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Yesterday @carolromero requested some changes to the emails texts we have implemented in #13969. This PR implements this. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15289
- Fixes #13969

#### Testing
1. Check the below texts
2. On local, checkout the branch 
3. Restart the application 
4. Access the following link to see the email templates http://localhost:3000/rails/mailers/decidim/user_group_mailer/

### :camera: Screenshots

#### Message sent to member:
<img width="1267" height="818" alt="image" src="https://github.com/user-attachments/assets/d0957aff-c76d-4f5e-a42d-52c0abb4bfbb" />

#### Message sent to owner:
<img width="1211" height="821" alt="image" src="https://github.com/user-attachments/assets/6e6d1787-2bc0-4d80-a4f7-6f0e1a46d80a" />


:hearts: Thank you!
