### PR TITLE
Revert "Fix w3c validator CI pipeline (#15342)" 

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -53,7 +53,7 @@ jobs:
       DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
     services:
       validator:
-        image: ghcr.io/validator/validator@sha256:28bd490412bb5abf1cf23eae0e3c197e9fbbda43cb9d23239b9ce859dc585db0
+        image: ghcr.io/validator/validator:latest
         ports: ["8888:8888"]
       postgres:
         image: postgres:14


### PR DESCRIPTION
#### :tophat: What? Why?
Seems like https://github.com/validator/validator/issues/1888  - so it is safe to return to the latest version in the CI. 

This reverts commit 2d87d33f81bee6a5298b6398c31701f87f87eada.

#### :pushpin: Related Issues
 
- Related to #15342 

#### Testing

Everything should be green  

To checking out the actual service:

1. Go to https://validator.w3.org/nu/about.html 
2. Click on "Check serialized DOM of current page (results as JSON)" 
3. See that the JSON is valid (in Firefox is parsed with pretty print)

#### 📷  Screenshot

<img width="885" height="315" alt="image" src="https://github.com/user-attachments/assets/d16a191c-96f3-4580-870e-c3cabc9b2d38" />


:hearts: Thank you!
