### PR TITLE
Fix Regex expression in Etiquette Validator

### DIFF
--- a/decidim-core/app/validators/etiquette_validator.rb
+++ b/decidim-core/app/validators/etiquette_validator.rb
@@ -31,7 +31,7 @@ class EtiquetteValidator < ActiveModel::EachValidator
   end
 
   def validate_caps(record, attribute, value)
-    number_of_caps = value.scan(/[A-Z]/).length
+    number_of_caps = value.scan(/[[:upper:]]/).length
     return if number_of_caps.zero? || number_of_caps < value.length / 2 # 50%
 
     record.errors.add(attribute, options[:message] || :too_much_caps)
@@ -44,7 +44,7 @@ class EtiquetteValidator < ActiveModel::EachValidator
   end
 
   def validate_caps_first(record, attribute, value)
-    return if value.scan(/\A[a-z]{1}/).empty?
+    return if value.scan(/\A[[:lower:]]{1}/).empty?
 
     record.errors.add(attribute, options[:message] || :must_start_with_caps)
   end

--- a/decidim-core/spec/validators/etiquette_validator_spec.rb
+++ b/decidim-core/spec/validators/etiquette_validator_spec.rb
@@ -24,7 +24,8 @@ describe EtiquetteValidator do
     [
       %(I am a very reasonable body, ain't I? I have the right length, the right style, the right words. Yup.),
       %("Validate bodies", they said. "It is gonna be fun!", they said.),
-      %(I contain special characters because I am à la mode.)
+      %(I contain special characters because I am à la mode.),
+      %(À la mode, I want to contain special characters.)
     ].each do |a_body|
       describe "like \"#{a_body}\"" do
         let(:body) { a_body }
@@ -48,6 +49,12 @@ describe EtiquetteValidator do
     end
 
     context "when etiquette_validator is enabled" do
+      it { is_expected.to be_invalid }
+    end
+
+    context "when the text has non-ascii uppercase characters" do
+      let(:body) { "À ÑÓ ÂÊ" }
+
       it { is_expected.to be_invalid }
     end
   end
@@ -81,6 +88,12 @@ describe EtiquetteValidator do
   context "when the text is written starting in downcase" do
     context "with a single line body" do
       let(:body) { "i no care about grammar" }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "with non ascii characters" do
+      let(:body) { "à la mode, we start with a non-ascii character in downcase." }
 
       it { is_expected.to be_invalid }
     end


### PR DESCRIPTION
#### :tophat: What? Why?

The current EtiquetteValidator use very naive Regex Expressions for check if a phrase starts with CAPS or if it contain to many of them inside. It does not take into account non-asci chars leading to phrase incorrectly detected as wrong.

This is a very simple fix but the bug is here from the very beggining of Decidim so it can be backported pretty much everywhere.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
