### PR TITLE
Start election sticky button 

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/dashboard/_calendar.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/dashboard/_calendar.html.erb
@@ -24,8 +24,8 @@
     </div>
   </div>
 </div>
-<div class="fixed bottom-0 left-0 w-full bg-[rgb(62,76,92)] z-50">
-  <div class="flex justify-end p-4">
+<div class="item__edit-sticky">
+  <div class="item__edit-sticky-container">
     <% if (action_data = election_status_action_data(election)) %>
       <%= form_with url: update_status_election_path(election), method: :put, local: true do %>
         <%= hidden_field_tag :status_action, action_data[:status_action] %>

--- a/decidim-elections/app/views/decidim/elections/admin/dashboard/_calendar.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/dashboard/_calendar.html.erb
@@ -2,12 +2,6 @@
   <div class="card-divider">
     <h2 class="card-title justify-between">
         <span class="text-black font-bold"><%= t("decidim.elections.admin.dashboard.calendar.title") %></span>
-      <% if (action_data = election_status_action_data(election)) %>
-        <%= form_with url: update_status_election_path(election), method: :put, local: true do %>
-          <%= hidden_field_tag :status_action, action_data[:status_action] %>
-          <%= button_tag action_data[:label], class: "button button__xs button__secondary small" %>
-        <% end %>
-      <% end %>
     </h2>
   </div>
 
@@ -28,5 +22,15 @@
         </div>
       <% end %>
     </div>
+  </div>
+</div>
+<div class="fixed bottom-0 left-0 w-full bg-[rgb(62,76,92)] z-50">
+  <div class="flex justify-end p-4">
+    <% if (action_data = election_status_action_data(election)) %>
+      <%= form_with url: update_status_election_path(election), method: :put, local: true do %>
+        <%= hidden_field_tag :status_action, action_data[:status_action] %>
+        <%= button_tag action_data[:label], class: "button button__sm button__secondary" %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -33,7 +33,8 @@
     <%= render partial: "decidim/elections/admin/dashboard/questions" %>
     <%= render partial: "decidim/elections/admin/dashboard/census" %>
   <% end %>
-
+</div>
+<% unless election.published? %>
   <div class="item__edit-sticky">
     <div class="item__edit-sticky-container">
       <% if allowed_to?(:publish, :election, election:) %>
@@ -47,4 +48,4 @@
       <% end %>
     </div>
   </div>
-</div>
+<% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
This PR allows the start election button when configured to manual start, to be a sticky button on the page.

#### :pushpin: Related Issues
- Fixes #15357 

#### Testing
1. Login
2. Head to Admin
3. Find a process with elections configured
4. Create an election with a manual start and follow steps till dashboard tab
5. Publish election
6. See the start election button is now sticky

### :camera: Screenshots

<img width="197" height="167" alt="image" src="https://github.com/user-attachments/assets/99ca5880-f73c-41d3-b2db-4638590ad02b" />

MOBILE
<img width="588" height="581" alt="image" src="https://github.com/user-attachments/assets/7783c41e-684b-4669-b9cb-46f982915f23" />



:hearts: Thank you!
