### PR TITLE
Fix ActiveRecord::AssociationTypeMismatch in AddDemocraticQualityStaticPage

### DIFF
--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/create_democratic_quality_indicators_page.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/create_democratic_quality_indicators_page.rb
@@ -5,9 +5,9 @@ module Decidim
     class CreateDemocraticQualityIndicatorsPage < Decidim::Command
       # Public: Initializes the command.
       #
-      # @param organization [Decidim::Organization] a Decidim::Organization instance
-      def initialize(organization)
-        @organization = organization
+      # @param organization_id [Integer] an id to fetch a Decidim::Organization instance
+      def initialize(organization_id)
+        @organization = Decidim::Organization.find(organization_id)
       end
 
       # Executes the command that creates the required static page or returns it if it already exists.

--- a/decidim-participatory_processes/db/migrate/20250403110052_add_democratic_quality_static_page.rb
+++ b/decidim-participatory_processes/db/migrate/20250403110052_add_democratic_quality_static_page.rb
@@ -11,7 +11,7 @@ class AddDemocraticQualityStaticPage < ActiveRecord::Migration[7.0]
 
   def up
     Organization.find_each do |organization|
-      Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(organization)
+      Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(organization.id)
     end
   end
 end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -110,7 +110,7 @@ module Decidim
       initializer "decidim_participatory_processes.static_pages" do
         config.to_prepare do
           Decidim::EventsManager.subscribe("decidim.system.create_organization:after") do |_event_name, data|
-            Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(data[:organization])
+            Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(data[:organization].id)
           end
         end
       end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/seeds.rb
@@ -7,7 +7,7 @@ module Decidim
   module ParticipatoryProcesses
     class Seeds < Decidim::Seeds
       def call
-        Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(organization)
+        Decidim::ParticipatoryProcesses::CreateDemocraticQualityIndicatorsPage.call(organization.id)
 
         create_content_block!
 

--- a/decidim-participatory_processes/spec/commands/decidim/participatory_processes/create_democratic_quality_indicators_page_spec.rb
+++ b/decidim-participatory_processes/spec/commands/decidim/participatory_processes/create_democratic_quality_indicators_page_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   module ParticipatoryProcesses
     describe CreateDemocraticQualityIndicatorsPage do
-      subject { described_class.new(organization1) }
+      subject { described_class.new(organization1.id) }
       let!(:organization1) { create(:organization, create_static_pages: false) }
       let!(:organization2) { create(:organization, create_static_pages: false) }
 
@@ -14,15 +14,15 @@ module Decidim
       end
 
       it "creates the indicators page for all the organizations" do
-        described_class.new(organization1).call
-        described_class.new(organization2).call
+        described_class.new(organization1.id).call
+        described_class.new(organization2.id).call
 
         expect(organization1.static_pages.count).to eq(1)
         expect(organization2.static_pages.count).to eq(1)
       end
 
       it "sets the content with translatable title" do
-        described_class.new(organization1).call
+        described_class.new(organization1.id).call
 
         organization1.static_pages.each do |page|
           expect(page.title["en"]).to include(I18n.t("title", scope: "decidim.participatory_processes.static_pages.democratic_quality_indicators"))
@@ -32,7 +32,7 @@ module Decidim
       it "sets the content with each locale" do
         allow(Decidim).to receive(:available_locales).and_return [:en, :ca]
 
-        described_class.new(organization1).call
+        described_class.new(organization1.id).call
         organization1.static_pages.each do |page|
           expect(page.title["en"]).not_to be_nil
           expect(page.title["ca"]).not_to be_nil


### PR DESCRIPTION
#### :tophat: What? Why?
We are changing the way we are fetching the organization in `CreateDemocraticQualityIndicatorsPage` to avoid having the `ActiveRecord::AssociationTypeMismatch` Error

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15157
- Fixes #15398

#### Testing
To replicate the error:
```
git checkout release/0.30-stable
git pull origin release/0.30-stable 
bundle exec rake development_app
git checkout develop
cd development_app

# secrets API deprecations
rm config/initializers/decidim.rb config/environments/production.rb
cp ../decidim-generators/lib/decidim/generators/app_templates/storage.yml config/

bin/rails decidim:upgrade
bin/rails db:migrate
```

Observe the error 

```
cd development_app/
rm db/migrate/*_add_democratic_quality_static_page.decidim_participatory_processes.rb 
bin/rails decidim:upgrade
bin/rails db:migrate
```
Observe the error is not there 


### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
