### PR TITLE
UI adjustments for Elections part 2

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -26,9 +26,8 @@
       <%= render partial: election.census.admin_form_partial, locals: { form: f } %>
     <% end %>
   <% end %>
-  <div class="border-t border-gray-3 my-4">
-    <%= render partial: "decidim/elections/admin/census/preview", locals: { election: } if preview_users(election).present? %>
-  </div>
+
+  <%= render partial: "decidim/elections/admin/census/preview", locals: { election: } if preview_users(election).present? %>
 </div>
 
 <div class="item__edit-sticky">

--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="item_show__header form-defaults border-none">
   <h1 class="item_show__header-title">
-    <%= t(".title") %>
+    <%= t("decidim.elections.actions.edit") %>
   </h1>
   <%= select_tag "census_manifest",
                  options_for_select(census_manifests.to_h { |manifest| [manifest.label, manifest.name] }, selected: election.census&.name),

--- a/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/census/edit.html.erb
@@ -4,22 +4,25 @@
   <h1 class="item_show__header-title">
     <%= t("decidim.elections.actions.edit") %>
   </h1>
-  <%= select_tag "census_manifest",
-                 options_for_select(census_manifests.to_h { |manifest| [manifest.label, manifest.name] }, selected: election.census&.name),
-                 include_blank: t(".choose_census"),
-                 id: "census-manifest-selector" %>
-
 </div>
 
 <%= render "decidim/elections/admin/elections/tabs_menu" %>
 
-  <% if election.census_ready? %>
-   <%
-    census_ready = t("decidim.elections.censuses.census_ready_html", election_title: decidim_sanitize_translated(election.title))
-    census_count = t("decidim.elections.censuses.census_size_html", count: census_count(election))
-   %>
+<div class="form-defaults my-8 flex justify-end">
+  <%= select_tag "census_manifest",
+                 options_for_select(census_manifests.to_h { |manifest| [manifest.label, manifest.name] }, selected: election.census&.name),
+                 include_blank: t(".choose_census"),
+                 id: "census-manifest-selector" %>
+</div>
+
+<% if election.census_ready? %>
+    <%
+      census_ready = t("decidim.elections.censuses.census_ready_html", election_title: decidim_sanitize_translated(election.title))
+      census_count = t("decidim.elections.censuses.census_size_html", count: census_count(election))
+    %>
     <%= cell "decidim/announcement", "#{census_ready}<br>#{census_count}", callout_class: "success" %>
-   <% end %>
+<% end %>
+
 <div class="card-section census-form form-defaults 2xl:mr-80">
   <% if @form && election.census&.admin_form_partial %>
     <%= decidim_form_for(@form, url: election_census_path(election, manifest: election.census&.name), method: :patch, multipart: true, html: { id: "census-election-form" }) do |f| %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -5,7 +5,7 @@
 
 <div class="item_show__header" style="border-bottom: none;">
   <h1 class="item_show__header-title">
-    <%= t(".title") %>
+    <%= t("decidim.elections.actions.edit") %>
   </h1>
 
   <div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -9,10 +9,7 @@
   </h1>
 
   <div>
-    <%= link_to resource_locator(election).path,
-            class: "button button__xs button__transparent-secondary flex flex-row items-center gap-2",
-            target: :blank,
-            data: { "external-link": false } do %>
+    <%= link_to resource_locator(election).path, class: "button button__xs button__transparent-secondary flex flex-row items-center gap-2", target: :blank, data: { "external-link": false } do %>
       <%= icon "eye-line", class: "inline-block" %>
       <%# i18n-tasks-use t("decidim.elections.actions.view") %>
       <%# i18n-tasks-use t("decidim.elections.actions.preview") %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/dashboard.html.erb
@@ -9,11 +9,14 @@
   </h1>
 
   <div>
-    <%= link_to resource_locator(election).path, class: "button button__xs button__transparent-secondary", target: :blank, data: { "external-link": false } do %>
-      <%= icon "eye-line" %>
+    <%= link_to resource_locator(election).path,
+            class: "button button__xs button__transparent-secondary flex flex-row items-center gap-2",
+            target: :blank,
+            data: { "external-link": false } do %>
+      <%= icon "eye-line", class: "inline-block" %>
       <%# i18n-tasks-use t("decidim.elections.actions.view") %>
       <%# i18n-tasks-use t("decidim.elections.actions.preview") %>
-      <%= t(election.published? ? "view" : "preview", scope: "decidim.elections.actions") %>
+      <span class="whitespace-nowrap"><%= t(election.published? ? "view" : "preview", scope: "decidim.elections.actions") %></span>
     <% end %>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/new.html.erb
@@ -3,7 +3,7 @@
 <% append_javascript_pack_tag "decidim_elections_admin" %>
 <% append_stylesheet_pack_tag "decidim_elections_admin" %>
 
-<div class="item_show__header">
+<div class="item_show__header border-none">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
   </h1>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -4,7 +4,6 @@
   <div class="item_show__header" style="border-bottom: none;">
     <h1 class="item_show__header-title">
         <%= t("decidim.elections.actions.edit") %>
-      <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
     </h1>
   </div>
 
@@ -26,5 +25,6 @@
         </div>
       </div>
     </div>
+    <button class="button button__sm button__transparent-secondary add-question mt-1"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
   </div>
 </div>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/edit_questions.html.erb
@@ -3,7 +3,7 @@
 <div class="questionnaire-questions">
   <div class="item_show__header" style="border-bottom: none;">
     <h1 class="item_show__header-title">
-      <%= t(".title") %>
+        <%= t("decidim.elections.actions.edit") %>
       <button class="button button__sm button__transparent-secondary add-question"><%= t("add_question", scope: "decidim.forms.admin.questionnaires.form") %></button>
     </h1>
   </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -45,7 +45,6 @@ en:
             choose_census: Choose the census type you want to use for this election
             created_at: Created at
             identifier: User identifier
-            title: Census type
           preview:
             title:
               one: The preview list is limited to %{count} record.

--- a/decidim-elections/spec/system/admin/admin_manages_election_census_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_census_spec.rb
@@ -18,7 +18,7 @@ describe "Admin manages election census" do
   end
 
   it "opens the census tab" do
-    expect(page).to have_content("Census type")
+    expect(page).to have_content("Edit election")
   end
 
   context "when the admin selects unregistered participants with tokens" do


### PR DESCRIPTION
#### :tophat: What? Why?
UI adjustments for the Election module which continues from https://github.com/decidim/decidim/issues/15261. These improvements include:

- [x] "Edit election" on all tabs within a newly created election
- [x] Underline removed from under the title in `new` election
- [x] "Add question" moved to the bottom of the form in the Questions tab
- [x] Cenus options moved to under the tabs within the Cenus tab 


Not in scope but fixed #15353. Schedule and publish an election to see change.
- [x] See election preview button (last images of before & after)

#### :pushpin: Related Issues
- Fixes #15360 
- Fixes #15353

#### Testing
1. Login
2. Head to edit admin area
3. Find whatever space you want
4. Configure an election module
5. Play around and see the improvements

### :camera: Screenshots
CENUS & TITLE CHANGE:
<img width="683" height="243" alt="image" src="https://github.com/user-attachments/assets/abe33c3f-0898-4cdb-b7db-22ef873d92f1" />

TITLE CHANGE & QUESTIONS BUTTON:
<img width="688" height="363" alt="image" src="https://github.com/user-attachments/assets/6a75520b-19a9-4ca2-9561-893f8348e5c8" />

SEE ELECTION PREVIEW
Before
<img width="280" height="213" alt="image" src="https://github.com/user-attachments/assets/00f4781d-134d-4898-85bb-9c5ab416c116" />

After
<img width="354" height="279" alt="image" src="https://github.com/user-attachments/assets/341066ec-46c8-4cea-bdd7-51fa1cbcc383" />



:hearts: Thank you!
