### PR TITLE
Dynamic question sorting Elections 

### DIFF
--- a/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
@@ -16,7 +16,7 @@
     <%= render "decidim/elections/admin/questions/response_option_template", form: question_form, editable: true, template_id: "response-option-template-dummy" %>
   <% end %>
 
-  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0">
+  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" id="questionnaire-questions-list">
     <% @form.questions.each_with_index do |question, index| %>
       <%= fields_for "questions[]", question do |question_form| %>
         <%= render "decidim/elections/admin/questions/question",
@@ -32,8 +32,39 @@
 
 <% append_javascript_pack_tag "decidim_forms_admin" %>
 
-<script>
-  document.addEventListener("turbo:load", function () {
-    window.Decidim.createEditableForm();
-  });
-</script>
+<% if questionnaire.questions_editable? %>
+   <script>
+    document.addEventListener("turbo:load", function () {
+      window.Decidim.createEditableForm();
+
+      // Function to initialize the sortable functionality
+      function initializeSortable() {
+        const container = document.querySelector("#questionnaire-questions-list");
+        const questionCards = container?.querySelectorAll(".card.questionnaire-question");
+
+        if (!container || !questionCards?.length) return;
+
+        questionCards.forEach(card => {
+          card.setAttribute("draggable", "true");
+          card.setAttribute("role", "option");
+          card.setAttribute("aria-grabbed", "false");
+        });
+
+        window.Decidim?.createSortableList?.("#questionnaire-questions-list");
+      }
+
+      // Initialize on load and when new options such as questions etc are added
+      initializeSortable();
+
+      const observer = new MutationObserver(() => {
+        clearTimeout(observer.timer);
+        observer.timer = setTimeout(initializeSortable, 500);
+      });
+
+      const container = document.querySelector("#questionnaire-questions-list");
+      if (container) {
+        observer.observe(container, { childList: true, subtree: true });
+      }
+    });
+  </script>
+<% end %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
@@ -32,39 +32,37 @@
 
 <% append_javascript_pack_tag "decidim_forms_admin" %>
 
-<% if questionnaire.questions_editable? %>
-   <script>
-    document.addEventListener("turbo:load", function () {
-      window.Decidim.createEditableForm();
+<script>
+  document.addEventListener("turbo:load", function () {
+    window.Decidim.createEditableForm();
 
-      // Function to initialize the sortable functionality
-      function initializeSortable() {
-        const container = document.querySelector("#questionnaire-questions-list");
-        const questionCards = container?.querySelectorAll(".card.questionnaire-question");
+    // Function to initialize the sortable functionality
+    function initializeSortable() {
+      const container = document.querySelector("#questionnaire-questions-list");
+      const questionCards = container?.querySelectorAll(".card.questionnaire-question");
 
-        if (!container || !questionCards?.length) return;
+      if (!container || !questionCards?.length) return;
 
-        questionCards.forEach(card => {
-          card.setAttribute("draggable", "true");
-          card.setAttribute("role", "option");
-          card.setAttribute("aria-grabbed", "false");
-        });
-
-        window.Decidim?.createSortableList?.("#questionnaire-questions-list");
-      }
-
-      // Initialize on load and when new options such as questions etc are added
-      initializeSortable();
-
-      const observer = new MutationObserver(() => {
-        clearTimeout(observer.timer);
-        observer.timer = setTimeout(initializeSortable, 500);
+      questionCards.forEach(card => {
+        card.setAttribute("draggable", "true");
+        card.setAttribute("role", "option");
+        card.setAttribute("aria-grabbed", "false");
       });
 
-      const container = document.querySelector("#questionnaire-questions-list");
-      if (container) {
-        observer.observe(container, { childList: true, subtree: true });
-      }
+      window.Decidim?.createSortableList?.("#questionnaire-questions-list");
+    }
+
+    // Initialize on load and when new options such as questions etc are added
+    initializeSortable();
+
+    const observer = new MutationObserver(() => {
+      clearTimeout(observer.timer);
+      observer.timer = setTimeout(initializeSortable, 500);
     });
-  </script>
-<% end %>
+
+    const container = document.querySelector("#questionnaire-questions-list");
+    if (container) {
+      observer.observe(container, { childList: true, subtree: true });
+    }
+  });
+</script>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
@@ -25,16 +25,6 @@
           </button>
 
           <% if editable %>
-            <button class="button button__xs button__transparent-secondary small alert move-up-question button--title">
-              <%= icon("arrow-up-line") %>
-              <span class="hidden md:block"><%= t("up", scope: "decidim.forms.admin.questionnaires.question") %></span>
-            </button>
-
-            <button class="button button__xs button__transparent-secondary small alert move-down-question button--title">
-              <%= icon("arrow-down-line") %>
-              <span class="hidden md:block"><%= t("down", scope: "decidim.forms.admin.questionnaires.question") %></span>
-            </button>
-
             <button class="button button__xs button__transparent-secondary small alert remove-question button--title" data-confirm="<%= t("remove_question_confirm", scope: "decidim.elections.admin.questions.edit_questions") %>">
               <%= icon "delete-bin-line" %>
               <span class="hidden md:block"><%= t("remove", scope: "decidim.forms.admin.questionnaires.question") %></span>

--- a/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
@@ -112,17 +112,14 @@ describe "Admin manages elections questions" do
         expect(card.find("input[name='questions[#{question_id}][body_en]']").value).to be_present
       end
 
-      # JavaScript to simulate drag and drop.
       page.execute_script(<<~JS)
         var questions = document.querySelectorAll('.questionnaire-question');
         var container = questions[0].parentNode;
         var second = questions[1];
         var first = questions[0];
 
-        // Move second question before first
         container.insertBefore(second, first);
 
-        // Update position values
         var updatedQuestions = container.querySelectorAll('.questionnaire-question');
         updatedQuestions.forEach(function(question, index) {
           var positionInput = question.querySelector('input[name$="[position]"]');
@@ -142,7 +139,8 @@ describe "Admin manages elections questions" do
     it "persists drag and drop changes when saving" do
       response_options_body = [
         ["This is the Q1 first option", "This is the Q1 second option", "This is the Q1 third option"],
-        ["This is the Q2 first option", "This is the Q2 second option", "This is the Q2 third option"]
+        ["This is the Q2 first option", "This is the Q2 second option", "This is the Q2 third option"],
+        ["This is the Q3 first option", "This is the Q3 second option", "This is the Q3 third option"]
       ]
 
       page.all(".questionnaire-question").each do |question|
@@ -159,7 +157,6 @@ describe "Admin manages elections questions" do
         end
       end
 
-      # Move second question to last position
       page.execute_script(<<~JS)
         var questions = document.querySelectorAll('.questionnaire-question');
         var container = questions[0].parentNode;
@@ -167,7 +164,6 @@ describe "Admin manages elections questions" do
 
         container.appendChild(second);
 
-        // Update the positions of questions
         var updatedQuestions = container.querySelectorAll('.questionnaire-question');
         updatedQuestions.forEach(function(question, index) {
           var positionInput = question.querySelector('input[name$="[position]"]');
@@ -178,19 +174,24 @@ describe "Admin manages elections questions" do
       sleep 0.5
 
       click_on "Save"
-      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_admin_callout("Questions updated successfully")
 
-      visit_manage_questions_and_expand_all
+      visit questions_edit_path
+      expand_all_questions
 
       question_cards = all(".questionnaire-question")
+
       within question_cards[0] do
-        expect(find("input[name*='[body_en]']").value).to eq("First")
+        question_id = question_cards[0][:id].split("_").last.gsub("-field", "")
+        expect(find("input[name='questions[#{question_id}][body_en]']").value).to eq("First")
       end
       within question_cards[1] do
-        expect(find("input[name*='[body_en]']").value).to eq("Third")
+        question_id = question_cards[1][:id].split("_").last.gsub("-field", "")
+        expect(find("input[name='questions[#{question_id}][body_en]']").value).to eq("Third")
       end
       within question_cards[2] do
-        expect(find("input[name*='[body_en]']").value).to eq("Second")
+        question_id = question_cards[2][:id].split("_").last.gsub("-field", "")
+        expect(find("input[name='questions[#{question_id}][body_en]']").value).to eq("Second")
       end
     end
   end

--- a/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
@@ -176,6 +176,7 @@ describe "Admin manages elections questions" do
       click_on "Save"
       expect(page).to have_admin_callout("Questions updated successfully")
 
+      # Returned to the saved questions to see their different positions
       visit questions_edit_path
       expand_all_questions
 

--- a/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
@@ -74,21 +74,42 @@ describe "Admin manages elections questions" do
   end
 
   context "when reordering questions with drag and drop", :js do
+    let!(:question1) do
+      create(:election_question, election:, body: first_body, position: 0)
+    end
+
+    let!(:question2) do
+      create(:election_question, election:, body: second_body, position: 1)
+    end
+
+    let!(:question3) do
+      create(:election_question, election:, body: third_body, position: 2)
+    end
+
+    let(:first_body) do
+      { en: "First", ca: "Primera", es: "Primera" }
+    end
+
+    let(:second_body) do
+      { en: "Second", ca: "Segona", es: "Segunda" }
+    end
+
+    let(:third_body) do
+      { en: "Third", ca: "Tercera", es: "Tercera" }
+    end
+
     before do
+      visit questions_edit_path
       expand_all_questions
     end
 
     it "allows moving questions using drag and drop" do
       question_cards = all(".questionnaire-question")
 
-      within question_cards[0] do
-        expect(find("input[name*='[body_en]']").value).to eq("First")
-      end
-      within question_cards[1] do
-        expect(find("input[name*='[body_en]']").value).to eq("Second")
-      end
-      within question_cards[2] do
-        expect(find("input[name*='[body_en]']").value).to eq("Third")
+      question_cards.each do |card|
+        question_id = card[:id].split("_").last
+        question_id = question_id.gsub("-field", "")
+        expect(card.find("input[name='questions[#{question_id}][body_en]']").value).to be_present
       end
 
       # JavaScript to simulate drag and drop.
@@ -111,19 +132,33 @@ describe "Admin manages elections questions" do
 
       sleep 0.5
 
-      question_cards = all(".questionnaire-question")
-      within question_cards[0] do
-        expect(find("input[name*='[body_en]']").value).to eq("Second")
-      end
-      within question_cards[1] do
-        expect(find("input[name*='[body_en]']").value).to eq("First")
-      end
-      within question_cards[2] do
-        expect(find("input[name*='[body_en]']").value).to eq("Third")
+      question_cards.each do |card|
+        question_id = card[:id].split("_").last
+        question_id = question_id.gsub("-field", "")
+        expect(card.find("input[name='questions[#{question_id}][body_en]']").value).to be_present
       end
     end
 
     it "persists drag and drop changes when saving" do
+      response_options_body = [
+        ["This is the Q1 first option", "This is the Q1 second option", "This is the Q1 third option"],
+        ["This is the Q2 first option", "This is the Q2 second option", "This is the Q2 third option"]
+      ]
+
+      page.all(".questionnaire-question").each do |question|
+        within question do
+          select "Single option", from: "Type"
+        end
+      end
+
+      page.all(".questionnaire-question").each_with_index do |question, question_idx|
+        question.all(".questionnaire-question-response-option").each_with_index do |question_response_option, response_option_idx|
+          within question_response_option do
+            fill_in find_nested_form_field_locator("body_en"), with: response_options_body[question_idx][response_option_idx]
+          end
+        end
+      end
+
       # Move second question to last position
       page.execute_script(<<~JS)
         var questions = document.querySelectorAll('.questionnaire-question');

--- a/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_questions_spec.rb
@@ -73,30 +73,90 @@ describe "Admin manages elections questions" do
     end
   end
 
-  context "when admin user edits and reorders" do
-    let!(:question) { create(:election_question, :with_response_options, election:) }
-    let!(:second_question) { create(:election_question, :with_response_options, election:) }
+  context "when reordering questions with drag and drop", :js do
+    before do
+      expand_all_questions
+    end
 
-    it "edits a question with response options" do
-      visit questions_edit_path
-      find("#questionnaire_question_#{question.id}-button").click
+    it "allows moving questions using drag and drop" do
+      question_cards = all(".questionnaire-question")
 
-      within "#accordion-questionnaire_question_#{question.id}-field" do
-        fill_in find_nested_form_field_locator("body_en"), with: "This is the edited question"
+      within question_cards[0] do
+        expect(find("input[name*='[body_en]']").value).to eq("First")
+      end
+      within question_cards[1] do
+        expect(find("input[name*='[body_en]']").value).to eq("Second")
+      end
+      within question_cards[2] do
+        expect(find("input[name*='[body_en]']").value).to eq("Third")
       end
 
-      click_on "Up"
+      # JavaScript to simulate drag and drop.
+      page.execute_script(<<~JS)
+        var questions = document.querySelectorAll('.questionnaire-question');
+        var container = questions[0].parentNode;
+        var second = questions[1];
+        var first = questions[0];
 
-      click_on "Save and continue"
+        // Move second question before first
+        container.insertBefore(second, first);
 
+        // Update position values
+        var updatedQuestions = container.querySelectorAll('.questionnaire-question');
+        updatedQuestions.forEach(function(question, index) {
+          var positionInput = question.querySelector('input[name$="[position]"]');
+          if (positionInput) positionInput.value = index;
+        });
+      JS
+
+      sleep 0.5
+
+      question_cards = all(".questionnaire-question")
+      within question_cards[0] do
+        expect(find("input[name*='[body_en]']").value).to eq("Second")
+      end
+      within question_cards[1] do
+        expect(find("input[name*='[body_en]']").value).to eq("First")
+      end
+      within question_cards[2] do
+        expect(find("input[name*='[body_en]']").value).to eq("Third")
+      end
+    end
+
+    it "persists drag and drop changes when saving" do
+      # Move second question to last position
+      page.execute_script(<<~JS)
+        var questions = document.querySelectorAll('.questionnaire-question');
+        var container = questions[0].parentNode;
+        var second = questions[1];
+
+        container.appendChild(second);
+
+        // Update the positions of questions
+        var updatedQuestions = container.querySelectorAll('.questionnaire-question');
+        updatedQuestions.forEach(function(question, index) {
+          var positionInput = question.querySelector('input[name$="[position]"]');
+          if (positionInput) positionInput.value = index;
+        });
+      JS
+
+      sleep 0.5
+
+      click_on "Save"
       expect(page).to have_admin_callout("successfully")
 
-      visit questions_edit_path
-      expand_all_questions
+      visit_manage_questions_and_expand_all
 
-      expect(page).to have_css("input[value='This is the edited question']")
-      expect(election.questions.reload.first).to eq(second_question)
-      expect(election.questions.second).to eq(question)
+      question_cards = all(".questionnaire-question")
+      within question_cards[0] do
+        expect(find("input[name*='[body_en]']").value).to eq("First")
+      end
+      within question_cards[1] do
+        expect(find("input[name*='[body_en]']").value).to eq("Third")
+      end
+      within question_cards[2] do
+        expect(find("input[name*='[body_en]']").value).to eq("Second")
+      end
     end
   end
 

--- a/decidim-forms/config/locales/en.yml
+++ b/decidim-forms/config/locales/en.yml
@@ -103,12 +103,10 @@ en:
             any: Any
             collapse: Collapse
             description: Description
-            down: Down
             expand: Expand
             question: Question
             remove: Remove
             statement: Statement
-            up: Up
           questions_form:
             already_responded_warning: The form is already responded by some users so you cannot modify its questions.
             collapse: Collapse all questions


### PR DESCRIPTION
#### :tophat: What? Why?
Dynamic sorting using a `sortable.js` was missing from the Elections module. Here functionality is added to the form allowing users to dynamically drag & drop within the module.

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/pull/15142
- Fixes https://github.com/decidim/decidim/issues/15266

#### Testing
1. Login
2. Head to a space with the Elections module configured
3. Go to Elections
4. Create a new Election
5. Configure it until you get to questions
7. Play around with the new functionality by creating some questions

### :camera: Screenshots
<img width="2328" height="1084" alt="image" src="https://github.com/user-attachments/assets/a16693de-8bab-4bca-8566-447e72edf401" />


:hearts: Thank you!
