### PR TITLE
Bring back comments to describe what `malicious.jpg` test file is

### DIFF
--- a/decidim-core/app/validators/uploader_image_dimensions_validator.rb
+++ b/decidim-core/app/validators/uploader_image_dimensions_validator.rb
@@ -29,7 +29,7 @@ class UploaderImageDimensionsValidator < ActiveModel::Validations::FileContentTy
     return if (image = extract_image(file)).blank?
 
     # A simple check to avoid DoS with maliciously crafted images, or just to
-    # avoid reckless users that upload gigapixels images.
+    # avoid reckless users that upload images with too many pixels.
     #
     # See https://hackerone.com/reports/390
     record.errors.add attribute, I18n.t("decidim.errors.files.file_resolution_too_large") if image.dimensions.any? { |dimension| dimension > uploader.max_image_height_or_width }

--- a/decidim-core/app/validators/uploader_image_dimensions_validator.rb
+++ b/decidim-core/app/validators/uploader_image_dimensions_validator.rb
@@ -28,6 +28,10 @@ class UploaderImageDimensionsValidator < ActiveModel::Validations::FileContentTy
     return unless uploader.validable_dimensions
     return if (image = extract_image(file)).blank?
 
+    # A simple check to avoid DoS with maliciously crafted images, or just to
+    # avoid reckless users that upload gigapixels images.
+    #
+    # See https://hackerone.com/reports/390
     record.errors.add attribute, I18n.t("decidim.errors.files.file_resolution_too_large") if image.dimensions.any? { |dimension| dimension > uploader.max_image_height_or_width }
   rescue MiniMagick::Error
     # The error may happen because of many reasons but most commonly the image

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -28,6 +28,7 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
+      # See UploaderImageDimensionsValidator#validate_image_size
       context "when the file is a malicious image" do
         subject do
           build(

--- a/decidim-core/spec/models/decidim/editor_image_spec.rb
+++ b/decidim-core/spec/models/decidim/editor_image_spec.rb
@@ -23,6 +23,7 @@ describe Decidim::EditorImage do
       it { is_expected.not_to be_valid }
     end
 
+    # See UploaderImageDimensionsValidator#validate_image_size
     context "when the file is a malicious image" do
       subject do
         build(

--- a/decidim-core/spec/models/decidim/user_spec.rb
+++ b/decidim-core/spec/models/decidim/user_spec.rb
@@ -151,6 +151,7 @@ module Decidim
         it { is_expected.not_to be_valid }
       end
 
+      # See UploaderImageDimensionsValidator#validate_image_size
       context "when the file is a malicious image" do
         let(:avatar_path) { Decidim::Dev.asset("malicious.jpg") }
         let(:user) do


### PR DESCRIPTION
#### :tophat: What? Why?
The `malicious.jpg` file shipped with the `decidim-dev` gem is considered a Trojan virus by some virus scanners. It originates from #258 and was moved to the current location at #371.

The comment for the reason why this file exists was lost from the codebase at some point. This PR revives the comment from the history to make a quicker judgement on why this file is in the codebase (had to do a bit of digging to find it out).

The file is the same as the `lottapixel.jpg` from this HackerOne report (produces the same SHA256 hash), so it was originally downloaded from there as stated in the original comment:
https://hackerone.com/reports/390

It is originally a 260x260 pixel JPEG image where the headers have been changed to report the file size as 64250x64250 pixels. The file exists to test that uploading such file to the system would not exhaust the system memory.

According to the report, you can crash Windows Image Viewer with this file, at least at the time of the report. Unsure if that is still the case but it could still crash some other image viewer applications which is why I guess it is flagged as a Trojan.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to
  * #258
  * #371

#### Testing
- Go to https://www.virustotal.com/
- Upload the file `malicious.jpg` from `decidim-dev/lib/decidim/dev/assets` to the service
- See the file flagged as a Trojan virus by many databases

### :camera: Screenshots

<img width="1350" height="2216" alt="Virus scanner results" src="https://github.com/user-attachments/assets/9ba7d938-442c-4c96-915f-8201f3d6d877" />
