### PR TITLE
Fix missing shared context "with a graphql type and authenticated user"

### DIFF
--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -2,6 +2,7 @@
 
 require "spec_helper"
 require "decidim/api/test"
+require "decidim/api/test/mutation_context"
 
 module Decidim
   module Core
@@ -137,10 +138,22 @@ module Decidim
       end
 
       describe "participant_details" do
-        include_context "with a graphql type and authenticated user"
+        include_context "with a graphql class type"
 
         let!(:participant) { create(:user, :confirmed, organization: current_organization) }
         let(:query) { %({ participantDetails(id: #{participant.id}){email name nickname}} ) }
+        let(:user_type) { :user }
+
+        let!(:current_user) do
+          case user_type
+          when :admin
+            create(:user, :admin, :confirmed, organization: current_organization)
+          when :api_user
+            create(:api_user, organization: current_organization)
+          else
+            create(:user, :confirmed, organization: current_organization)
+          end
+        end
 
         context "with unauthorized user" do
           it "does not show participant details" do

--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -2,7 +2,6 @@
 
 require "spec_helper"
 require "decidim/api/test"
-require "decidim/api/test/mutation_context"
 
 module Decidim
   module Core


### PR DESCRIPTION
#### :tophat: What? Why?
After I have merged #14885, i have noticed the pipeline is failing. This PR fixes it. 

#### :pushpin: Related Issues
- Related to #14885

#### Testing
The pipeline `[CI] Core / Lib specs / Test (push)` has to be green, without no errors like: 

<img width="872" height="230" alt="image" src="https://github.com/user-attachments/assets/e2feb67e-a408-4564-adab-eb05405b4c1e" />

:hearts: Thank you!
