### PR TITLE
Change spec on decidim-api that removes the views directory

### DIFF
--- a/decidim-api/spec/tasks/decidim_api_generate_docs_spec.rb
+++ b/decidim-api/spec/tasks/decidim_api_generate_docs_spec.rb
@@ -2,15 +2,21 @@
 
 require "spec_helper"
 
-# describe "rake decidim_api:generate_docs", type: :task do
-#   it "creates the static docs files" do
-#     static = Rails.root.join("app/views/static/api/docs")
-#     FileUtils.rm_rf(static)
+describe "rake decidim_api:generate_docs", type: :task do
+  it "creates the static docs files" do
+    static = Rails.root.join("app/views/static/api/docs")
 
-#     task.execute
+    # We do not actually remove the files and execute this command, as this generates
+    # flaky specs with other tasks that are  checking out the documentation.
+    #
+    # This task is already executed during the test dummy app generation so there is
+    # not need to check after removing the files.
+    #
+    # FileUtils.rm_rf(static)
+    # task.execute
 
-#     index = File.read("#{static}/index.html")
-#     expect(index).to include("About the GraphQL API")
-#     expect(index).to include("GraphQL Reference")
-#   end
-# end
+    index = File.read("#{static}/index.html")
+    expect(index).to include("About the GraphQL API")
+    expect(index).to include("GraphQL Reference")
+  end
+end

--- a/decidim-api/spec/tasks/decidim_api_generate_docs_spec.rb
+++ b/decidim-api/spec/tasks/decidim_api_generate_docs_spec.rb
@@ -2,15 +2,15 @@
 
 require "spec_helper"
 
-describe "rake decidim_api:generate_docs", type: :task do
-  it "creates the static docs files" do
-    static = Rails.root.join("app/views/static/api/docs")
-    FileUtils.rm_rf(static)
+# describe "rake decidim_api:generate_docs", type: :task do
+#   it "creates the static docs files" do
+#     static = Rails.root.join("app/views/static/api/docs")
+#     FileUtils.rm_rf(static)
 
-    task.execute
+#     task.execute
 
-    index = File.read("#{static}/index.html")
-    expect(index).to include("About the GraphQL API")
-    expect(index).to include("GraphQL Reference")
-  end
-end
+#     index = File.read("#{static}/index.html")
+#     expect(index).to include("About the GraphQL API")
+#     expect(index).to include("GraphQL Reference")
+#   end
+# end


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out [#15349](https://github.com/decidim/decidim/pull/15349), I found another flaky spec. This is the one that happens only in `decidim-api`.

My hypothesis is that this is happening because we have a spec that checks for the files to exist and another that actually removes these files, so that doesn't plays nice with parallelization of the tests (i.e. `parallel_specs`)

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/18937789787/job/54068812328?pr=15349 (this will get lost when GH Actions does its housekeeping removing old logs)

#### Testing

1. Pipeline should be green, specially for the  "[CI] Api / Tests / Test (pull_request)" 

### :camera: Screenshots

<img width="1615" height="956" alt="image" src="https://github.com/user-attachments/assets/29dd114c-a240-47ee-b2b0-c3a7fe0bc1fa" />


```
.
1st Try error in ./spec/system/documentation_spec.rb:18:
Missing template static/api/docs/index with {:locale=>[:en], :formats=>[:html], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby]}.

Searched in:
  * "/home/runner/work/decidim/decidim/spec/decidim_dummy_app/app/views"
  * "/home/runner/work/decidim/decidim/decidim-templates/app/views"
  * "/home/runner/work/decidim/decidim/decidim-templates/app/views"
  * "/home/runner/work/decidim/decidim/decidim-initiatives/app/views"
  * "/home/runner/work/decidim/decidim/decidim-initiatives/app/views"
  * "/home/runner/work/decidim/decidim/decidim-elections/app/views"
  * "/home/runner/work/decidim/decidim/decidim-elections/app/views"
  * "/home/runner/work/decidim/decidim/decidim-design/app/views"
  * "/home/runner/work/decidim/decidim/decidim-demographics/app/views"
  * "/home/runner/work/decidim/decidim/decidim-demographics/app/views"
  * "/home/runner/work/decidim/decidim/decidim-conferences/app/views"
  * "/home/runner/work/decidim/decidim/decidim-conferences/app/views"
  * "/home/runner/work/decidim/decidim/decidim-collaborative_texts/app/views"
  * "/home/runner/work/decidim/decidim/decidim-collaborative_texts/app/views"
  * "/home/runner/work/decidim/decidim/decidim-blogs/app/views"
  * "/home/runner/work/decidim/decidim/decidim-blogs/app/views"
  * "/home/runner/work/decidim/decidim/decidim-sortitions/app/views"
  * "/home/runner/work/decidim/decidim/decidim-sortitions/app/views"
  * "/home/runner/work/decidim/decidim/decidim-debates/app/views"
  * "/home/runner/work/decidim/decidim/decidim-debates/app/views"
  * "/home/runner/work/decidim/decidim/decidim-accountability/app/views"
  * "/home/runner/work/decidim/decidim/decidim-accountability/app/views"
  * "/home/runner/work/decidim/decidim/decidim-surveys/app/views"
  * "/home/runner/work/decidim/decidim/decidim-surveys/app/views"
  * "/home/runner/work/decidim/decidim/decidim-budgets/app/views"
  * "/home/runner/work/decidim/decidim/decidim-budgets/app/views"
  * "/home/runner/work/decidim/decidim/decidim-meetings/app/views"
  * "/home/runner/work/decidim/decidim/decidim-meetings/app/views"
  * "/home/runner/work/decidim/decidim/decidim-meetings/app/views"
  * "/home/runner/work/decidim/decidim/decidim-proposals/app/views"
  * "/home/runner/work/decidim/decidim/decidim-proposals/app/views"
  * "/home/runner/work/decidim/decidim/decidim-pages/app/views"
  * "/home/runner/work/decidim/decidim/decidim-pages/app/views"
  * "/home/runner/work/decidim/decidim/decidim-assemblies/app/views"
  * "/home/runner/work/decidim/decidim/decidim-assemblies/app/views"
  * "/home/runner/work/decidim/decidim/decidim-participatory_processes/app/views"
  * "/home/runner/work/decidim/decidim/decidim-participatory_processes/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-verifications/app/views"
  * "/home/runner/work/decidim/decidim/decidim-forms/app/views"
  * "/home/runner/work/decidim/decidim/decidim-forms/app/views"
  * "/home/runner/work/decidim/decidim/decidim-admin/app/views"
  * "/home/runner/work/decidim/decidim/decidim-system/app/views"
  * "/home/runner/work/decidim/decidim/decidim-dev/app/views"
  * "/home/runner/work/decidim/decidim/decidim-comments/app/views"
  * "/home/runner/work/decidim/decidim/decidim-comments/app/views"
  * "/home/runner/work/decidim/decidim/decidim-core/app/views"
  * "/home/runner/work/decidim/decidim/decidim-api/app/views"
  * "/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/doorkeeper-5.8.2/app/views"
  * "/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/kaminari-core-1.2.2/app/views"
  * "/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/devise_invitable-2.0.11/app/views"
  * "/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/devise-i18n-1.12.1/app/views"
  * "/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/devise-4.9.4/app/views"
  * "/home/runner/work/decidim/decidim/decidim-dev/app/views"
  * "/home/runner/work/decidim/decidim/decidim-dev/app/views"
  * "/home/runner/work/decidim/decidim/decidim-dev/app/views"


RSpec::Retry: 2nd try ./spec/system/documentation_spec.rb:18
```

:hearts: Thank you!
