### PR TITLE
Fix duplicated participatory spaces in open data exports

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -46,10 +46,9 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   end
 
   participatory_space.exports :assemblies do |export|
-    export.collection do
-      Decidim::Assembly
-        .public_spaces
-        .includes(:attachment_collections)
+    export.collection do |participatory_space, _user|
+      query = Decidim::Assembly.public_spaces.includes(:attachment_collections)
+      participatory_space ? query.where(id: participatory_space) : query
     end
 
     export.include_in_open_data = true

--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -47,8 +47,7 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
 
   participatory_space.exports :assemblies do |export|
     export.collection do |participatory_space, _user|
-      query = Decidim::Assembly.public_spaces.includes(:attachment_collections)
-      participatory_space ? query.where(id: participatory_space) : query
+      Decidim::Assembly.public_spaces.includes(:attachment_collections).where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -51,10 +51,9 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
   end
 
   participatory_space.exports :conferences do |export|
-    export.collection do
-      Decidim::Conference
-        .public_spaces
-        .includes(:taxonomies, :attachment_collections)
+    export.collection do |participatory_space, _user|
+      query = Decidim::Conference.public_spaces.includes(:taxonomies, :attachment_collections)
+      participatory_space ? query.where(id: participatory_space) : query
     end
 
     export.include_in_open_data = true

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -52,8 +52,7 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
 
   participatory_space.exports :conferences do |export|
     export.collection do |participatory_space, _user|
-      query = Decidim::Conference.public_spaces.includes(:taxonomies, :attachment_collections)
-      participatory_space ? query.where(id: participatory_space) : query
+      Decidim::Conference.public_spaces.includes(:taxonomies, :attachment_collections).where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -117,9 +117,10 @@ module Decidim
     end
 
     def data_for_participatory_space(export_manifest)
-      collection = participatory_spaces.flat_map do |participatory_space|
+      collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
         export_manifest.collection.call(participatory_space)
       end
+
       serializer = export_manifest.open_data_serializer.nil? ? export_manifest.serializer : export_manifest.open_data_serializer
       exporter = Decidim::Exporters::CSV.new(collection, serializer)
       get_help_definition(:spaces, exporter, export_manifest, collection.count) unless collection.empty?

--- a/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
@@ -179,6 +179,13 @@ describe Decidim::OpenDataExporter do
         end
       end
 
+      it "includes only one reference por participatory space" do
+        csv_data = zip_contents.glob("*open-data-participatory_processes.csv").first.get_input_stream.read
+        expect(csv_data).to include(participatory_process.title["en"].gsub(/"/, '""')).once
+        csv_data = zip_contents.glob("*open-data-assemblies.csv").first.get_input_stream.read
+        expect(csv_data).to include(assembly.title["en"].gsub(/"/, '""')).once
+      end
+
       describe "README content" do
         let(:file_data) { zip_contents.glob("README.md").first.get_input_stream.read }
 
@@ -189,8 +196,8 @@ describe Decidim::OpenDataExporter do
           expect(file_data).to include("## results (1 resource)")
           expect(file_data).to include("## meetings (1 resource)")
           expect(file_data).to include("## meeting_comments (1 resource)")
-          expect(file_data).to include("## participatory_processes (30 resources)")
-          expect(file_data).to include("## assemblies (6 resources)")
+          expect(file_data).to include("## participatory_processes (5 resources)")
+          expect(file_data).to include("## assemblies (1 resource)")
         end
 
         it "does not have any missing translation" do

--- a/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-core/spec/services/decidim/open_data_exporter_spec.rb
@@ -162,6 +162,8 @@ describe Decidim::OpenDataExporter do
       let!(:participatory_process) { create(:participatory_process, :published, organization:) }
       let!(:assembly) { create(:assembly, :published, organization:) }
 
+      let!(:another_tenant_process) { create(:participatory_process, :published) }
+
       before do
         subject.export
       end
@@ -184,6 +186,12 @@ describe Decidim::OpenDataExporter do
         expect(csv_data).to include(participatory_process.title["en"].gsub(/"/, '""')).once
         csv_data = zip_contents.glob("*open-data-assemblies.csv").first.get_input_stream.read
         expect(csv_data).to include(assembly.title["en"].gsub(/"/, '""')).once
+      end
+
+      it "does not include data from other tenants" do
+        csv_data = zip_contents.glob("*open-data-participatory_processes.csv").first.get_input_stream.read
+        expect(csv_data).not_to include(another_tenant_process.title["en"].gsub(/"/, '""'))
+        expect(csv_data).to include(participatory_process.title["en"].gsub(/"/, '""')).once
       end
 
       describe "README content" do

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -57,8 +57,9 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
   ]
 
   participatory_space.exports :initiatives do |export|
-    export.collection do
-      Decidim::Initiative.public_spaces
+    export.collection do |participatory_space, _user|
+      query = Decidim::Initiative.public_spaces
+      participatory_space ? query.where(id: participatory_space) : query
     end
 
     export.include_in_open_data = true

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -58,8 +58,7 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
 
   participatory_space.exports :initiatives do |export|
     export.collection do |participatory_space, _user|
-      query = Decidim::Initiative.public_spaces
-      participatory_space ? query.where(id: participatory_space) : query
+      Decidim::Initiative.public_spaces.where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -42,8 +42,9 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   end
 
   participatory_space.exports :participatory_processes do |export|
-    export.collection do
-      Decidim::ParticipatoryProcess.public_spaces
+    export.collection do |participatory_space, _user|
+      query = Decidim::ParticipatoryProcess.public_spaces
+      participatory_space ? query.where(id: participatory_space) : query
     end
 
     export.include_in_open_data = true

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -43,8 +43,7 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
 
   participatory_space.exports :participatory_processes do |export|
     export.collection do |participatory_space, _user|
-      query = Decidim::ParticipatoryProcess.public_spaces
-      participatory_space ? query.where(id: participatory_space) : query
+      Decidim::ParticipatoryProcess.public_spaces.where(id: participatory_space)
     end
 
     export.include_in_open_data = true


### PR DESCRIPTION
#### :tophat: What? Why?
If you open the generated CSV for any participatory space in open data exports. you will see that the info is multiplied many times. This number of duplications depens on the number of participatory spaces and the registered manifests and leads to quickly increase the size of the CSV (which I guess will cause memory problems on some servers).

Try for instance the latest export for metadecidim:
https://meta.decidim.org/open-data/download/assemblies?locale=ca
<img width="1690" height="1272" alt="imatge" src="https://github.com/user-attachments/assets/9ca49806-334f-4344-9f8c-9ffb4210c385" />

This is cause by this line:

https://github.com/decidim/decidim/blob/81e861e2059f467a330e53122fb9dc3e6cf99196/decidim-core/app/services/decidim/open_data_exporter.rb#L120-L122

The main problem is that we are sending a parameter to the exporter but this is not used.
I've added a where clause to limit the export to the participatory space in case is defined (not sure this is the best solution but it follows the current original purpose for that parameter).

This should be backported as it is behaving like this for more than 4 years now.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Check your open data export for a participatory space, see the information is repeated several times, more if you have more content.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
