### PR TITLE
Fix markers displayed in meeting page

### DIFF
--- a/decidim-core/app/packs/src/decidim/map/controller/markers.js
+++ b/decidim-core/app/packs/src/decidim/map/controller/markers.js
@@ -67,7 +67,9 @@ export default class MapMarkersController extends MapController {
   }
 
   clearMarkers() {
-    this.map.removeLayer(this.markerClusters);
+    if (this.markerClusters !== null) {
+      this.map.removeLayer(this.markerClusters);
+    }
     this.markerClusters = new L.MarkerClusterGroup();
     this.map.addLayer(this.markerClusters);
   }


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes a js error when on /meeting page, and there is no upcoming meetings, and you select "All" in the date filters, the markers were not displayed on the map due to a js error, and you had to refresh the page to get them.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/15462

#### Testing

1. As an admin, ensure that there is no upcoming meetings
2. Go in the FO to /meetings and see that there is no upcoming meetings
3. Select "All" in the Date filter, and see that the meeting's markers are immediately displayed on the map, without refreshing it

:hearts: Thank you!
