### PR TITLE
Disable hidden fields for all forms

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
@@ -181,7 +181,7 @@ class DynamicFieldsComponent {
 
       $removedField.addClass("hidden");
       $removedField.hide();
-      $removedField.attr("disabled", true);
+      $removedField.prop("disabled", true);
     } else {
       $removedField.remove();
     }

--- a/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/dynamic_fields.component.js
@@ -181,6 +181,7 @@ class DynamicFieldsComponent {
 
       $removedField.addClass("hidden");
       $removedField.hide();
+      $removedField.attr("disabled", true);
     } else {
       $removedField.remove();
     }

--- a/decidim-admin/app/packs/src/decidim/admin/scope_picker_enabler.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/scope_picker_enabler.component.js
@@ -5,8 +5,8 @@ $(() => {
   if ($(".edit_component, .new_component").length > 0) {
     $ComponentScopeEnabled.on("change", (event) => {
       const checked = event.target.checked;
-      $ComponentScopeId.attr("disabled", !checked);
+      $ComponentScopeId.prop("disabled", !checked);
     })
-    $ComponentScopeId.attr("disabled", !$ComponentScopeEnabled.prop("checked"));
+    $ComponentScopeId.prop("disabled", !$ComponentScopeEnabled.prop("checked"));
   }
 });

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assemblies.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assemblies.js
@@ -5,9 +5,9 @@ $(() => {
   if ($(".edit_assembly, .new_assembly").length > 0) {
     $assemblyScopeEnabled.on("change", (event) => {
       const checked = event.target.checked;
-      $assemblyScopeId.attr("disabled", !checked);
+      $assemblyScopeId.prop("disabled", !checked);
     })
-    $assemblyScopeId.attr("disabled", !$assemblyScopeEnabled.prop("checked"));
+    $assemblyScopeId.prop("disabled", !$assemblyScopeEnabled.prop("checked"));
   }
 
   const $form = $(".assembly_form_admin");

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assemblies.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/admin/assemblies.js
@@ -21,11 +21,11 @@ $(() => {
 
     const toggleDisabledHiddenFields = () => {
       const enabledPrivateSpace = $privateSpace.find("input[type='checkbox']").prop("checked");
-      $isTransparent.find("input[type='checkbox']").attr("disabled", "disabled");
+      $isTransparent.find("input[type='checkbox']").prop("disabled", true);
       $specialFeatures.hide();
 
       if (enabledPrivateSpace) {
-        $isTransparent.find("input[type='checkbox']").attr("disabled", !enabledPrivateSpace);
+        $isTransparent.find("input[type='checkbox']").prop("disabled", !enabledPrivateSpace);
         $specialFeatures.show();
       }
     };

--- a/decidim-budgets/app/packs/src/decidim/budgets/projects.js
+++ b/decidim-budgets/app/packs/src/decidim/budgets/projects.js
@@ -21,7 +21,7 @@ $(() => {
     const $currentTarget = $(event.currentTarget);
     const projectAllocation = parseInt($currentTarget.attr("data-allocation"), 10);
 
-    if ($currentTarget.attr("disabled")) {
+    if ($currentTarget.prop("disabled")) {
       cancelEvent(event);
     } else if (($currentTarget.attr("data-add") === "true") && ((currentAllocation + projectAllocation) > totalAllocation)) {
       window.Decidim.currentDialogs["budget-excess"].toggle()

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -128,7 +128,7 @@ export default class CommentsComponent {
       $form.on("submit.decidim-comments", () => {
         const $submit = $("button[type='submit']", $form);
 
-        $submit.attr("disabled", "disabled");
+        $submit.prop("disabled", true);
         this._stopPolling();
       });
 
@@ -312,9 +312,9 @@ export default class CommentsComponent {
     const $submit = $("button[type='submit']", $form);
 
     if ($text.val().length > 0) {
-      $submit.removeAttr("disabled");
+      $submit.prop("disabled", false);
     } else {
-      $submit.attr("disabled", "disabled");
+      $submit.prop("disabled", true);
     }
   }
 }

--- a/decidim-conferences/app/packs/src/decidim/conferences/admin/conferences.js
+++ b/decidim-conferences/app/packs/src/decidim/conferences/admin/conferences.js
@@ -6,16 +6,16 @@ $(() => {
   if ($form.length > 0) {
     $conferenceScopeEnabled.on("change", (event) => {
       const checked = event.target.checked;
-      $conferenceScopeId.attr("disabled", !checked);
+      $conferenceScopeId.prop("disabled", !checked);
     })
-    $conferenceScopeId.attr("disabled", !$conferenceScopeEnabled.prop("checked"));
+    $conferenceScopeId.prop("disabled", !$conferenceScopeEnabled.prop("checked"));
 
     const $registrationsEnabled = $form.find("#conference_registrations_enabled");
     const $availableSlots = $form.find("#conference_available_slots");
     const $registrationTerms = $form.find("#conference_registrations_terms");
     const toggleDisabledFields = () => {
       const enabled = $registrationsEnabled.prop("checked");
-      $availableSlots.attr("disabled", !enabled);
+      $availableSlots.prop("disabled", !enabled);
 
       $registrationTerms[0].querySelectorAll(".editor-container .ProseMirror").forEach((node) => {
         node.editor.setOptions({ editable: enabled });

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
@@ -191,7 +191,7 @@ class DisplayConditionsComponent {
       this.wrapperField.hide();
     }
 
-    this.wrapperField.find("input, textarea").prop("disabled", "disabled");
+    this.wrapperField.find("input, textarea").prop("disabled", true);
   }
 }
 

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -37,6 +37,7 @@ $(() => {
 
     if (inputDeleted === "true") {
       $target.addClass("hidden");
+      $target.prop("disabled", true);
       $target.hide();
     }
   };
@@ -89,10 +90,10 @@ $(() => {
 
     const toggleDisabledHiddenFields = () => {
       const enabledPrivateSpace = $privateMeeting.find("input[type='checkbox']").prop("checked");
-      $transparent.find("input[type='checkbox']").attr("disabled", "disabled");
+      $transparent.find("input[type='checkbox']").prop("disabled", true);
 
       if (enabledPrivateSpace) {
-        $transparent.find("input[type='checkbox']").attr("disabled", !enabledPrivateSpace);
+        $transparent.find("input[type='checkbox']").prop("disabled", !enabledPrivateSpace);
       }
     };
 
@@ -125,14 +126,14 @@ $(() => {
     const toggleTypeDependsOnSelect = ($target, $showDiv, type) => {
       const value = $target.val();
       if (value === "hybrid") {
-        $showDiv.find("input").attr("disabled", false);
+        $showDiv.find("input").prop("disabled", false);
         $showDiv.show();
 
       } else {
-        $showDiv.find("input").attr("disabled", true);
+        $showDiv.find("input").prop("disabled", true);
         $showDiv.hide();
         if (value === type) {
-          $showDiv.find("input").attr("disabled", false);
+          $showDiv.find("input").prop("disabled", false);
           $showDiv.show();
         }
       }
@@ -145,7 +146,7 @@ $(() => {
       toggleTypeDependsOnSelect($target, $meetingOnlineFields, "online");
       toggleTypeDependsOnSelect($target, $meetingInPersonFields, "in_person");
       if (embedTypeValue === "none") {
-        $meetingOnlineAccessLevelFields.find("input").attr("disabled", true);
+        $meetingOnlineAccessLevelFields.find("input").prop("disabled", true);
         $meetingOnlineAccessLevelFields.hide();
       } else {
         toggleTypeDependsOnSelect($target, $meetingOnlineAccessLevelFields, "online");

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -125,10 +125,14 @@ $(() => {
     const toggleTypeDependsOnSelect = ($target, $showDiv, type) => {
       const value = $target.val();
       if (value === "hybrid") {
+        $showDiv.find("input").attr("disabled", false);
         $showDiv.show();
+
       } else {
+        $showDiv.find("input").attr("disabled", true);
         $showDiv.hide();
         if (value === type) {
+          $showDiv.find("input").attr("disabled", false);
           $showDiv.show();
         }
       }
@@ -141,6 +145,7 @@ $(() => {
       toggleTypeDependsOnSelect($target, $meetingOnlineFields, "online");
       toggleTypeDependsOnSelect($target, $meetingInPersonFields, "in_person");
       if (embedTypeValue === "none") {
+        $meetingOnlineAccessLevelFields.find("input").attr("disabled", true);
         $meetingOnlineAccessLevelFields.hide();
       } else {
         toggleTypeDependsOnSelect($target, $meetingOnlineAccessLevelFields, "online");

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/meetings_form.js
@@ -108,6 +108,7 @@ $(() => {
     const toggleDependsOnSelect = ($target, $showDiv, type) => {
       const value = $target.val();
       $showDiv.toggle(value === type);
+      $showDiv.find("input").prop("disabled", value !== type);
     };
 
     $meetingRegistrationType.on("change", (ev) => {

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/registrations_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/registrations_form.js
@@ -18,9 +18,9 @@ $(() => {
 
     const toggleDisabledFields = () => {
       const enabled = $registrationsEnabled.prop("checked");
-      $availableSlots.attr("disabled", !enabled);
-      $reservedSlots.attr("disabled", !enabled);
-      $customizeRegistrationEmail.attr("disabled", !enabled);
+      $availableSlots.prop("disabled", !enabled);
+      $reservedSlots.prop("disabled", !enabled);
+      $customizeRegistrationEmail.prop("disabled", !enabled);
 
       $form[0].querySelectorAll(".editor-container .ProseMirror").forEach((node) => {
         node.editor.setOptions({ editable: enabled });

--- a/decidim-meetings/app/packs/src/decidim/meetings/meetings_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/meetings_form.js
@@ -18,10 +18,13 @@ $(() => {
     const toggleDependsOnSelect = ($target, $showDiv, type) => {
       const value = $target.val();
       if (value === "hybrid") {
+        $showDiv.find("input").prop("disabled", false);
         $showDiv.show();
       } else {
+        $showDiv.find("input").prop("disabled", true);
         $showDiv.hide();
         if (value === type) {
+          $showDiv.find("input").prop("disabled", false);
           $showDiv.show();
         }
       }

--- a/decidim-participatory_processes/app/packs/src/decidim/participatory_processes/admin/participatory_processes.js
+++ b/decidim-participatory_processes/app/packs/src/decidim/participatory_processes/admin/participatory_processes.js
@@ -6,13 +6,9 @@ $(() => {
   if ($(".edit_participatory_process, .new_participatory_process").length > 0) {
     $participatoryProcessScopeEnabled.on("change", (event) => {
       const checked = event.target.checked;
-      $participatoryProcessScopeId.attr("disabled", !checked);
-      if (checked === true) {
-        $participatoryProcessScopeTypeId.removeAttr("disabled");
-      } else {
-        $participatoryProcessScopeTypeId.attr("disabled", true)
-      }
-      $participatoryProcessScopeId.attr("disabled", !$participatoryProcessScopeEnabled.prop("checked"));
+      $participatoryProcessScopeId.prop("disabled", !checked);
+      $participatoryProcessScopeTypeId.prop("disabled", !checked)
+      $participatoryProcessScopeId.prop("disabled", !$participatoryProcessScopeEnabled.prop("checked"));
     })
   }
 });

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals_form.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals_form.js
@@ -9,7 +9,7 @@ $(() => {
 
     const toggleDisabledHiddenFields = () => {
       const enabledMeeting = $proposalCreatedInMeeting.prop("checked");
-      $proposalMeeting.find("select").attr("disabled", "disabled");
+      $proposalMeeting.find("select").prop("disabled", true);
       $proposalMeeting.hide();
 
       if (enabledMeeting) {

--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals_form.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/proposals_form.js
@@ -13,7 +13,7 @@ $(() => {
       $proposalMeeting.hide();
 
       if (enabledMeeting) {
-        $proposalMeeting.find("select").attr("disabled", !enabledMeeting);
+        $proposalMeeting.find("select").prop("disabled", !enabledMeeting);
         $proposalMeeting.show();
       }
     };

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/_form.html.erb
@@ -37,6 +37,7 @@
           <%= form.radio_button :bg_color, color_values[:background],
                                 label: color_values[:name],
                                 style: "display: none;",
+                                disabled: true,
                                 data: {
                                   "sync-radio-buttons-value-target" => color_key,
                                   "css-preview" => true,

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/_form.html.erb
@@ -37,7 +37,6 @@
           <%= form.radio_button :bg_color, color_values[:background],
                                 label: color_values[:name],
                                 style: "display: none;",
-                                disabled: true,
                                 data: {
                                   "sync-radio-buttons-value-target" => color_key,
                                   "css-preview" => true,


### PR DESCRIPTION
#### :tophat: What? Why?

This PR add the "disabled" property to a few hidden fields in some specific forms.
The goal is to have 100% uniformity in the codebase: if the field of a form is hidden, then it is disabled. See the issue for why I think it's important.

#### :pushpin: Related Issues

- Fixes #15464 

#### Testing

1. Go to admin
2. Create a new participatory process
3. Create a new "metting" event
4. click on Type -> In person
5. inspect the page
The input element "online_meeting_url should be hidden but not disabled.
If you refresh the page, the element "meeting_registration_url" should be disabled to

All the other forms should work in the same way as before.


### :camera: Screenshots

N/A

### Note

I implemented this PR on the 0.29 branch because the dev environment was easier to setup for me on this branch.
I think it can be fast-forwared pretty-easily with the develop branch.

:hearts: Thank you!
