### PR TITLE
Lock graphql-ws to stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11358,7 +11358,9 @@
       }
     },
     "node_modules/graphql-ws": {
-      "version": "5.14.3",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -20874,7 +20876,7 @@
         "emojibase": "^6.1.0",
         "foundation-sites": "^6.7.0",
         "graphiql": "^3.0.10",
-        "graphql-ws": ">= 4.5.0",
+        "graphql-ws": "^5.16.2",
         "html5sortable": "0.10.0",
         "identity-obj-proxy": "^3.0.0",
         "jquery": "^3.2.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "emojibase": "^6.1.0",
     "foundation-sites": "^6.7.0",
     "graphiql": "^3.0.10",
-    "graphql-ws": ">= 4.5.0",
+    "graphql-ws": "^5.16.2",
     "html5sortable": "0.10.0",
     "identity-obj-proxy": "^3.0.0",
     "jquery": "^3.2.1",


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we are locking the `graphql-ws` version to 5.x so that any of the Decidim supported version could work.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15451
- Fixes #14769

#### Testing
When performing a clean install of decidim 0.29 / 0.30, on a clean linux box there should not be compiling errors.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
