### PR TITLE
Remove github directory in newly generated apps

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -99,6 +99,10 @@ module Decidim
         remove_dir("app/javascript")
       end
 
+      def remove_old_github_files
+        remove_dir(".github")
+      end
+
       def remove_sprockets_requirement
         gsub_file "config/application.rb", %r{require ['"]rails/all['"]\R}, <<~RUBY
           require "decidim/rails"


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15460 @davidbeig reported that the rails template is adding a `.github/workflows/ci.yml` which is breaking the pipeline on a newly created application. This PR removes this file. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #15460

#### Testing
- create a test app using develop branch 
- see there is a `.github/workflows/ci.yml` file 
- apply patch 
- regenerate the application 
- see there is no file

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
