### PR TITLE
Add local `app/views` to `Cell::ViewModel` view paths

### DIFF
--- a/decidim-core/lib/decidim/core/engine.rb
+++ b/decidim-core/lib/decidim/core/engine.rb
@@ -488,6 +488,7 @@ module Decidim
       end
 
       initializer "decidim_core.add_cells_view_paths" do
+        Cell::ViewModel.view_paths << Rails.root.join("app/views") # for partials
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/cells/amendable")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Core::Engine.root}/app/views") # for partials


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds the local application's `app/views` directory to the `Cell::ViewModel` view paths, enabling cells to use partials and views from the decidim application.

Currently, `Cell::ViewModel` only searches for views in the engine's directories and local application's `app/cells` directories. But some cells use view files as partials.  This makes it difficult for applications to override or customize cell views locally without modifying the gem itself.

This PR adds `app/views` of local applications to the `Cell::ViewModel`'s view paths, making it easier to customize existing cells.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing

Manual testing:

1. Generate development_app
2. Add `development_app/app/views/decidim/application/_document.html.erb` and modify it
3. Add some attachments in admin panels
4. Confirm attachment panel is customized

### :camera: Screenshots

- `development_app/app/views/decidim/application/_document.html.erb`
```ruby
<div id="<%= dom_id(document) %>">
  !!!! CUSTOM TEMPLATE HERE !!!!
</div>
```

##### Before

<img width="750" height="416" alt="before-pr" src="https://github.com/user-attachments/assets/c5db1c5a-aae5-4bf2-9673-bee8e8f2fa42" />

##### After

<img width="750" height="377" alt="after-pr" src="https://github.com/user-attachments/assets/612d0242-038c-4e73-a1a5-924eb62ae4b0" />
