### PR TITLE
Add pages field to static page topic

### DIFF
--- a/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
+++ b/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
@@ -8,6 +8,7 @@ module Decidim
 
       field :description, Decidim::Core::TranslatedFieldType, "The description of this static page topic", null: false
       field :id, GraphQL::Types::ID, "Internal ID of this static page topic", null: false
+      field :pages, [Decidim::Core::StaticPageType, { null: true }], "The pages associated to this static page topic", null: true
       field :show_in_footer, GraphQL::Types::Boolean, "Whether this static page topic should be shown in the footer", null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title of this static page topic", null: false
     end

--- a/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
+++ b/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
@@ -9,7 +9,7 @@ module Decidim
       field :description, Decidim::Core::TranslatedFieldType, "The description of this static page topic", null: false
       field :id, GraphQL::Types::ID, "Internal ID of this static page topic", null: false
       field :show_in_footer, GraphQL::Types::Boolean, "Whether this static page topic should be shown in the footer", null: false
-      field :static_pages, [Decidim::Core::StaticPageType, { null: true }], "The static pages associated to this static page topic", null: true
+      field :static_pages, [Decidim::Core::StaticPageType, { null: true }], "The static pages associated to this static page topic", null: true, method: :pages
       field :title, Decidim::Core::TranslatedFieldType, "The title of this static page topic", null: false
     end
   end

--- a/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
+++ b/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
@@ -8,7 +8,7 @@ module Decidim
 
       field :description, Decidim::Core::TranslatedFieldType, "The description of this static page topic", null: false
       field :id, GraphQL::Types::ID, "Internal ID of this static page topic", null: false
-      field :pages, [Decidim::Core::StaticPageType, { null: true }], "The pages associated to this static page topic", null: true
+      field :static_pages, [Decidim::Core::StaticPageType, { null: true }], "The static pages associated to this static page topic", null: true
       field :show_in_footer, GraphQL::Types::Boolean, "Whether this static page topic should be shown in the footer", null: false
       field :title, Decidim::Core::TranslatedFieldType, "The title of this static page topic", null: false
     end

--- a/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
+++ b/decidim-core/lib/decidim/api/types/static_page_topic_type.rb
@@ -8,8 +8,8 @@ module Decidim
 
       field :description, Decidim::Core::TranslatedFieldType, "The description of this static page topic", null: false
       field :id, GraphQL::Types::ID, "Internal ID of this static page topic", null: false
-      field :static_pages, [Decidim::Core::StaticPageType, { null: true }], "The static pages associated to this static page topic", null: true
       field :show_in_footer, GraphQL::Types::Boolean, "Whether this static page topic should be shown in the footer", null: false
+      field :static_pages, [Decidim::Core::StaticPageType, { null: true }], "The static pages associated to this static page topic", null: true
       field :title, Decidim::Core::TranslatedFieldType, "The title of this static page topic", null: false
     end
   end

--- a/decidim-core/spec/types/static_page_topic_type_spec.rb
+++ b/decidim-core/spec/types/static_page_topic_type_spec.rb
@@ -42,20 +42,20 @@ module Decidim
         end
       end
 
-      describe "pages" do
-        let(:query) { "{ pages { id } }" }
+      describe "static_pages" do
+        let(:query) { "{ static_pages { id } }" }
 
-        context "when the topic has no pages" do
-          it "returns the pages object" do
-            expect(response["pages"]).to eq([])
+        context "when the topic has no static pages" do
+          it "returns the static pages object" do
+            expect(response["static_pages"]).to eq([])
           end
         end
 
-        context "when the topic has pages" do
-          let!(:page) { create(:static_page, topic: model) }
+        context "when the topic has static pages" do
+          let!(:static_page) { create(:static_page, topic: model) }
 
           it "returns the pages object" do
-            expect(response["pages"]).to eq([{ "id" => page.id.to_s }])
+            expect(response["static_pages"]).to eq([{ "id" => static_page.id.to_s }])
           end
         end
       end

--- a/decidim-core/spec/types/static_page_topic_type_spec.rb
+++ b/decidim-core/spec/types/static_page_topic_type_spec.rb
@@ -41,6 +41,24 @@ module Decidim
           expect(response["showInFooter"]).to be_truthy
         end
       end
+
+      describe "pages" do
+        let(:query) { "{ pages { id } }" }
+
+        context "when the topic has no pages" do
+          it "returns the pages object" do
+            expect(response["pages"]).to eq([])
+          end
+        end
+
+        context "when the topic has pages" do
+          let!(:page) { create(:static_page, topic: model) }
+
+          it "returns the pages object" do
+            expect(response["pages"]).to eq([{ "id" => page.id.to_s }])
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/types/static_page_topic_type_spec.rb
+++ b/decidim-core/spec/types/static_page_topic_type_spec.rb
@@ -43,11 +43,11 @@ module Decidim
       end
 
       describe "static_pages" do
-        let(:query) { "{ static_pages { id } }" }
+        let(:query) { "{ staticPages { id } }" }
 
         context "when the topic has no static pages" do
           it "returns the static pages object" do
-            expect(response["static_pages"]).to eq([])
+            expect(response["staticPages"]).to eq([])
           end
         end
 
@@ -55,7 +55,7 @@ module Decidim
           let!(:static_page) { create(:static_page, topic: model) }
 
           it "returns the pages object" do
-            expect(response["static_pages"]).to eq([{ "id" => static_page.id.to_s }])
+            expect(response["staticPages"]).to eq([{ "id" => static_page.id.to_s }])
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the request of @andreslucena from this [review](https://github.com/decidim/decidim/pull/15485/files/77d2b029df5837e55f86158777741826284f3d0e#r2514206523):
When requesting the page topic, you should have also the associated pages of that topic. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15485

#### Testing
1. Login as admin , create a Topic, create some pages belonging to that topic. 
2. Visit the api, request the page toipic object, see there are pages

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
