### PR TITLE
Do not update the weight when updating the component form

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_component.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_component.rb
@@ -37,7 +37,6 @@ module Decidim
       def update_component
         @previous_settings = @component.attributes["settings"].with_indifferent_access
         @component.name = form.name
-        @component.weight = form.weight
 
         restore_readonly_settings!
 

--- a/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
@@ -53,7 +53,6 @@ module Decidim::Admin
         end.to broadcast(:ok)
 
         expect(component["name"]["en"]).to eq("My component")
-        expect(component.weight).to eq(3)
         expect(component.settings.dummy_global_attribute1).to be(true)
         expect(component.settings.dummy_global_attribute2).to be(false)
         expect(component.settings.readonly_attribute).to be(true)
@@ -62,6 +61,14 @@ module Decidim::Admin
         expect(step_settings.dummy_step_attribute1).to be(true)
         expect(step_settings.dummy_step_attribute2).to be(false)
         expect(step_settings.readonly_step_attribute).to be(true)
+      end
+
+      it "broadcats :ok and does not update the weight" do
+        expect do
+          described_class.call(form, component)
+        end.to broadcast(:ok)
+
+        expect(component.weight).to eq(0)
       end
 
       it "fires the hooks" do

--- a/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
@@ -63,7 +63,7 @@ module Decidim::Admin
         expect(step_settings.readonly_step_attribute).to be(true)
       end
 
-      it "broadcats :ok and does not update the weight" do
+      it "broadcasts :ok and does not update the weight" do
         expect do
           described_class.call(form, component)
         end.to broadcast(:ok)


### PR DESCRIPTION
#### :tophat: What? Why?

With the introduction of Components order UI in admin (see #13074), we have detected that this weight is reset when editing the Component form. This PR fixes this behavior.

The only place to update weights/orders of Components is the index/table page. 

#### :pushpin: Related Issues
 
- Fixes #15449 

#### Testing

1. Go to the admin panel and go to a participatory space with several components.
2. Set the order of components using the drag-and-drop functionality.
3. Edit and update one of the components (e.g., change its name or settings).
4. (Before) Observe that the updated component moves to the top of the list automatically.
5. (After) Observe that the updated component keeps its place in the list. 

:hearts: Thank you!
