### PR TITLE
Remove legacy images from ActiveStorage migration

### DIFF
--- a/decidim-assemblies/db/migrate/20251112114736_remove_legacy_images_from_assemblies_module.rb
+++ b/decidim-assemblies/db/migrate/20251112114736_remove_legacy_images_from_assemblies_module.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveLegacyImagesFromAssembliesModule < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_assemblies, :hero_image, :string
+    remove_column :decidim_assemblies, :banner_image, :string
+  end
+end

--- a/decidim-conferences/db/migrate/20251112114826_remove_legacy_images_from_conferences_module.rb
+++ b/decidim-conferences/db/migrate/20251112114826_remove_legacy_images_from_conferences_module.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveLegacyImagesFromConferencesModule < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_conferences, :hero_image, :string
+    remove_column :decidim_conferences, :banner_image, :string
+    remove_column :decidim_conferences, :main_logo, :string
+    remove_column :decidim_conferences, :signature, :string
+
+    remove_column :decidim_conference_speakers, :avatar, :string
+    remove_column :decidim_conferences_partners, :logo, :string
+  end
+end

--- a/decidim-core/db/migrate/20251030132959_remove_legacy_images_from_core_module.rb
+++ b/decidim-core/db/migrate/20251030132959_remove_legacy_images_from_core_module.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+ 
+class RemoveLegacyImagesFromCoreModule< ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_organizations, :logo, :string
+    remove_column :decidim_organizations, :official_img_footer, :string
+    remove_column :decidim_organizations, :favicon, :string
+
+    remove_column :oauth_applications, :organization_logo, :string
+
+    remove_column :decidim_authorizations, :verification_attachment, :string
+
+    remove_column :decidim_attachments, :file, :string
+
+    remove_column :decidim_users, :avatar, :string
+
+    remove_column :decidim_private_exports, :file, :string
+  end
+end

--- a/decidim-core/db/migrate/20251112132305_remove_legacy_images_from_core_module.rb
+++ b/decidim-core/db/migrate/20251112132305_remove_legacy_images_from_core_module.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
  
-class RemoveLegacyImagesFromCoreModule< ActiveRecord::Migration[7.2]
+class RemoveLegacyImagesFromCoreModule < ActiveRecord::Migration[7.2]
   def change
     remove_column :decidim_organizations, :logo, :string
     remove_column :decidim_organizations, :official_img_footer, :string
@@ -10,7 +10,12 @@ class RemoveLegacyImagesFromCoreModule< ActiveRecord::Migration[7.2]
 
     remove_column :decidim_authorizations, :verification_attachment, :string
 
-    remove_column :decidim_attachments, :file, :string
+    # The original decidim_attachments table creation was in decidim-participatory_processes
+    # at decidim-participatory_processes/db/migrate/20161116115156_create_attachments.rb
+    #
+    # We need to workaround this issue as when creating new application this table may not exist
+    # when this migration is run
+    remove_column :decidim_attachments, :file, :string if table_exists?(:decidim_attachments)
 
     remove_column :decidim_users, :avatar, :string
 

--- a/decidim-core/db/migrate/20251112132305_remove_legacy_images_from_core_module.rb
+++ b/decidim-core/db/migrate/20251112132305_remove_legacy_images_from_core_module.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
- 
+
 class RemoveLegacyImagesFromCoreModule < ActiveRecord::Migration[7.2]
   def change
     remove_column :decidim_organizations, :logo, :string

--- a/decidim-debates/db/migrate/20251114092453_remove_legacy_images_from_debates_module.rb
+++ b/decidim-debates/db/migrate/20251114092453_remove_legacy_images_from_debates_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveLegacyImagesFromDebatesModule < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_debates_debates, :image, :string
+  end
+end

--- a/decidim-debates/lib/decidim/api/debate_type.rb
+++ b/decidim-debates/lib/decidim/api/debate_type.rb
@@ -21,7 +21,6 @@ module Decidim
       field :description, Decidim::Core::TranslatedFieldType, "The description for this debate", null: true
       field :end_time, Decidim::Core::DateTimeType, "The end time for this debate", null: true
       field :id, GraphQL::Types::ID, "The internal ID for this debate", null: false
-      field :image, GraphQL::Types::String, "The image of this debate", null: true
       field :information_updates, Decidim::Core::TranslatedFieldType, "The information updates for this debate", null: true
       field :instructions, Decidim::Core::TranslatedFieldType, "The instructions for this debate", null: true
       field :last_comment_at, Decidim::Core::DateTimeType, "The last comment time for this debate", null: true

--- a/decidim-debates/spec/types/integration_schema_spec.rb
+++ b/decidim-debates/spec/types/integration_schema_spec.rb
@@ -33,7 +33,6 @@ describe "Decidim::Api::QueryType" do
           followsCount
           hasComments
           id
-          image
           informationUpdates {
             translation(locale: "#{locale}")
           }
@@ -94,7 +93,6 @@ describe "Decidim::Api::QueryType" do
       "followsCount" => 3,
       "hasComments" => debate.comment_threads.size.positive?,
       "id" => debate.id.to_s,
-      "image" => nil,
       "informationUpdates" => { "translation" => debate.information_updates[locale] },
       "instructions" => { "translation" => debate.instructions[locale] },
       "lastCommentAt" => debate.last_comment_at.to_time.iso8601,
@@ -179,7 +177,6 @@ describe "Decidim::Api::QueryType" do
               followsCount
               hasComments
               id
-              image
               informationUpdates {
                 translation(locale: "#{locale}")
               }

--- a/decidim-initiatives/db/migrate/20251112114520_remove_legacy_images_from_initiatives_module.rb
+++ b/decidim-initiatives/db/migrate/20251112114520_remove_legacy_images_from_initiatives_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveLegacyImagesFromInitiativesModule < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_initiatives_types, :banner_image, :string
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
+++ b/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+ 
+class RemoveLegacyImagesFromParticipatoryProcessesModule < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_participatory_processes, :hero_image, :string
+
+    remove_column :decidim_participatory_process_groups, :hero_image, :string
+  end
+end

--- a/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
+++ b/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
- 
 class RemoveLegacyImagesFromParticipatoryProcessesModule < ActiveRecord::Migration[7.2]
   def change
     remove_column :decidim_participatory_processes, :hero_image, :string

--- a/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
+++ b/decidim-participatory_processes/db/migrate/20251112113613_remove_legacy_images_from_participatory_processes_module.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class RemoveLegacyImagesFromParticipatoryProcessesModule < ActiveRecord::Migration[7.2]
   def change
     remove_column :decidim_participatory_processes, :hero_image, :string


### PR DESCRIPTION
#### :tophat: What? Why?

While working with images, I noticed that we have legacy fields in lots of tables that are from before the ActiveStorage migration. 

This PR removes them.  

I found them by grepping `has_one_attached` 

```bash
rg has_one_attached decidim*/app/models/
decidim-conferences/app/models/decidim/conferences/partner.rb
17:      has_one_attached :logo

decidim-conferences/app/models/decidim/conference.rb
62:    has_one_attached :hero_image
65:    has_one_attached :banner_image
68:    has_one_attached :main_logo
71:    has_one_attached :signature

decidim-conferences/app/models/decidim/conference_speaker.rb
23:    has_one_attached :avatar

decidim-participatory_processes/app/models/decidim/participatory_process.rb
74:    has_one_attached :hero_image

decidim-participatory_processes/app/models/decidim/participatory_process_group.rb
24:    has_one_attached :hero_image

decidim-initiatives/app/models/decidim/initiatives_type.rb
31:    has_one_attached :banner_image

decidim-core/app/models/decidim/attachment.rb
18:    has_one_attached :file

decidim-core/app/models/decidim/user_base_entity.rb
26:    has_one_attached :avatar

decidim-core/app/models/decidim/private_export.rb
7:    has_one_attached :file

decidim-core/app/models/decidim/user.rb
50:    has_one_attached :download_your_data_file

decidim-core/app/models/decidim/oauth_application.rb
11:    has_one_attached :organization_logo

decidim-core/app/models/decidim/organization.rb
49:    has_one_attached :official_img_footer
52:    has_one_attached :logo
55:    has_one_attached :favicon

decidim-core/app/models/decidim/authorization.rb
21:    has_one_attached :verification_attachment

decidim-core/app/models/decidim/editor_image.rb
11:    has_one_attached :file

decidim-core/app/models/decidim/content_block_attachment.rb
11:    has_one_attached :file

decidim-assemblies/app/models/decidim/assembly.rb
71:    has_one_attached :hero_image
74:    has_one_attached :banner_image
```

And actually checking out if these columns still existed in `development_app/db/schema.rb`

Mind that these columns were leftovers from [v0.25.0](https://rubygems.org/gems/decidim/versions/0.25.0) - that was released at October 07, 2021 (more than 4 years ago), and we're in the process of releasing v0.31.0, so I think that we could say that it's safe to delete these. 

#### :pushpin: Related Issues
 
- Related to #7598 and #7902

#### Testing

1. (Before applying this patch) Go to the admin
2. Upload images in the organizations form (or whatever other form from the models that are referred on this PR)
3. See that everything works
4. Apply this patch
5. See that everything works the same without any difference
 
:hearts: Thank you!
