### PR TITLE
Survey responses open-data export

### DIFF
--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -57,8 +57,8 @@ en:
           id: Unique identifier for the survey response
           ip_hash: Hashed IP address of the respondent for privacy
           question: The question that was Responded
-          registered: Registered survey participants
-          unregistered: Unregistered survey participants
+          registered: Registered participant
+          unregistered: Unregistered participant
           user_status: Status of the user who submitted the response
     statistics:
       responses: 'Responses:'

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -49,6 +49,15 @@ en:
           email_outro: You have received this notification because you are following %{participatory_space_title}. You can stop receiving notifications following the previous link.
           email_subject: A new survey in %{participatory_space_title}
           notification_title: The survey <a href="%{resource_path}">%{resource_title}</a> in <a href="%{participatory_space_url}">%{participatory_space_title}</a> is now open.
+    open_data:
+      help:
+        published_survey_user_responses:
+          body: The content of the response
+          created_at: Timestamp when the response was created
+          id: Unique identifier for the survey response
+          ip_hash: Hashed IP address of the respondent for privacy
+          question: The question that was Responded
+          user_status: Status of the user who submitted the response (e.g., registered, unregistered)
     statistics:
       responses: 'Responses:'
       responses_count: Responses

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -57,7 +57,9 @@ en:
           id: Unique identifier for the survey response
           ip_hash: Hashed IP address of the respondent for privacy
           question: The question that was Responded
-          user_status: Status of the user who submitted the response (e.g., registered, unregistered)
+          registered: Registered survey participants
+          unregistered: Unregistered survey participants
+          user_status: Status of the user who submitted the response
     statistics:
       responses: 'Responses:'
       responses_count: Responses

--- a/decidim-surveys/lib/decidim/surveys.rb
+++ b/decidim-surveys/lib/decidim/surveys.rb
@@ -10,5 +10,6 @@ module Decidim
   # This namespace holds the logic of the `Surveys` component. This component
   # allows users to create surveys in a participatory process.
   module Surveys
+    autoload :UserResponsesSerializer, "decidim/surveys/user_responses_serializer"
   end
 end

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -71,6 +71,23 @@ Decidim.register_component(:surveys) do |component|
     exports.serializer Decidim::Forms::UserResponsesSerializer
   end
 
+  component.exports :published_survey_user_responses do |exports|
+    exports.collection do |component|
+      survey = Decidim::Surveys::Survey.find_by(component: component)
+
+      Decidim::Forms::Response
+        .joins(:question)
+        .where(questionnaire: survey.questionnaire)
+        .where.not(decidim_forms_questions: { question_type: %w(separator title_and_description) })
+        .where.not(decidim_forms_questions: { survey_responses_published_at: nil })
+        .includes(:question, :choices, :user)
+    end
+
+    exports.formats []
+    exports.include_in_open_data = true
+    exports.serializer Decidim::Surveys::UserResponsesSerializer
+  end
+
   component.seeds do |participatory_space|
     require "decidim/surveys/seeds"
 

--- a/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
@@ -41,10 +41,14 @@ module Decidim
 
       def translated_attribute(attribute)
         if attribute.is_a?(Hash)
-          attribute[I18n.locale.to_s] || attribute["en"] || attribute.values.first
+          attribute[I18n.locale.to_s] || attribute[organization.default_locale] || attribute.values.first
         else
           attribute.to_s
         end
+      end
+
+      def organization
+        resource.questionnaire.questionnaire_for.organization
       end
     end
   end

--- a/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Surveys
+    class UserResponsesSerializer < Decidim::Exporters::Serializer
+      include Decidim::TranslationsHelper
+
+      # Public: Exports a hash with the serialized data for the user response.
+      def serialize
+        # Returns a csv export of surveys responses only if they have been published.
+        response = resource
+        {
+          id: response.session_token,
+          created_at: response.created_at,
+          ip_hash: response.ip_hash,
+          user_status: (response.decidim_user_id.present? ? "Registered" : "Unregistered"),
+          question: question_text(response),
+          body: normalize_body(response)
+        }
+      end
+
+      private
+
+      def question_text(response)
+        if response.question.present?
+          "#{response.question.position}. #{translated_attribute(response.question.body)}"
+        else
+          ""
+        end
+      end
+
+      def normalize_body(response)
+        return response.body if response.body.present?
+
+        normalize_choices(response.choices)
+      end
+
+      def normalize_choices(choices)
+        choices.map { |choice| translated_attribute(choice.try(:body)) }.compact.join(", ")
+      end
+
+      def translated_attribute(attribute)
+        if attribute.is_a?(Hash)
+          attribute[I18n.locale.to_s] || attribute["en"] || attribute.values.first
+        else
+          attribute.to_s
+        end
+      end
+    end
+  end
+end

--- a/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
@@ -13,7 +13,7 @@ module Decidim
           id: response.session_token,
           created_at: response.created_at,
           ip_hash: response.ip_hash,
-          user_status: translated_attribute(response.decidim_user_id.present? ? "Registered" : "Unregistered"),
+          user_status: I18n.t(response.decidim_user_id.present? ? "registered" : "unregistered", scope: "decidim.open_data.help.published_survey_user_responses"),
           question: question_text(response),
           body: normalize_body(response)
         }

--- a/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
+++ b/decidim-surveys/lib/decidim/surveys/user_responses_serializer.rb
@@ -13,7 +13,7 @@ module Decidim
           id: response.session_token,
           created_at: response.created_at,
           ip_hash: response.ip_hash,
-          user_status: (response.decidim_user_id.present? ? "Registered" : "Unregistered"),
+          user_status: translated_attribute(response.decidim_user_id.present? ? "Registered" : "Unregistered"),
           question: question_text(response),
           body: normalize_body(response)
         }

--- a/decidim-surveys/spec/services/open_data_exporter_spec.rb
+++ b/decidim-surveys/spec/services/open_data_exporter_spec.rb
@@ -1,40 +1,45 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "csv"
 
-require "decidim/core/test/shared_examples/open_data_exporter_examples"
-
-describe Decidim::OpenDataExporter do
+describe Decidim::OpenDataExporter do # rubocop:disable RSpec/SpecFilePathFormat
   subject { described_class.new(organization, path) }
 
   let(:organization) { create(:organization) }
   let(:path) { Rails.root.join("tmp/open-data-export") }
 
   describe "published survey user responses" do
-    let(:resource_file_name) { "published-survey-user-responses" }
-    let(:participatory_process) { create(:participatory_process, organization:) }
+    let(:component) { create(:surveys_component, organization:, published_at: Time.current) }
+    let(:questionnaire) { create(:questionnaire) }
+    let(:questions) { create(:questionnaire_question, survey_responses_published_at: Time.current) }
 
-    let(:component) do
-      create(:surveys_component, participatory_space: participatory_process, published_at: Time.current)
-    end
-    let!(:published_survey) { create(:survey, :published, component:) }
-    let!(:published_question) { create(:questionnaire_question, questionnaire: published_survey.questionnaire) }
-    let!(:published_responses) do
-      3.times.map do
-        create(:response, questionnaire: published_survey.questionnaire, question: published_question)
+    context "when no responses are published" do
+      before do
+        questions.update(survey_responses_published_at: nil)
+      end
+
+      it "does not export unpublished responses" do
+        subject.export
+
+        csv_file = Dir.glob(path.join("*published-survey-user-responses*.csv")).first
+
+        expect(CSV.read(csv_file, headers: true).count).to eq(0) if csv_file
       end
     end
 
-    let(:unpublished_component) do
-      create(:surveys_component, participatory_space: participatory_process, published_at: nil)
-    end
-    let!(:unpublished_survey) { create(:survey, component: unpublished_component) }
+    context "when survey component is unpublished" do
+      before do
+        component.update(published_at: nil)
+        questions.update(survey_responses_published_at: nil)
+      end
 
-    before do
-      published_question.update(survey_responses_published_at: Time.current)
-    end
+      it "does not export responses from unpublished responses" do
+        subject.export
 
-    it_behaves_like "open data exporter"
+        csv_file = Dir.glob(path.join("*published-survey-user-responses*.csv")).first
+
+        expect(CSV.read(csv_file, headers: true).count).to eq(0) if csv_file
+      end
+    end
   end
 end

--- a/decidim-surveys/spec/services/open_data_exporter_spec.rb
+++ b/decidim-surveys/spec/services/open_data_exporter_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "csv"
+
+require "decidim/core/test/shared_examples/open_data_exporter_examples"
+
+describe Decidim::OpenDataExporter do
+  subject { described_class.new(organization, path) }
+
+  let(:organization) { create(:organization) }
+  let(:path) { Rails.root.join("tmp/open-data-export") }
+
+  describe "published survey user responses" do
+    let(:resource_file_name) { "published-survey-user-responses" }
+    let(:participatory_process) { create(:participatory_process, organization:) }
+
+    let(:component) do
+      create(:surveys_component, participatory_space: participatory_process, published_at: Time.current)
+    end
+    let!(:published_survey) { create(:survey, :published, component:) }
+    let!(:published_question) { create(:questionnaire_question, questionnaire: published_survey.questionnaire) }
+    let!(:published_responses) do
+      3.times.map do
+        create(:response, questionnaire: published_survey.questionnaire, question: published_question)
+      end
+    end
+
+    let(:unpublished_component) do
+      create(:surveys_component, participatory_space: participatory_process, published_at: nil)
+    end
+    let!(:unpublished_survey) { create(:survey, component: unpublished_component) }
+
+    before do
+      published_question.update(survey_responses_published_at: Time.current)
+    end
+
+    it_behaves_like "open data exporter"
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This makes the available the publication of survey responses through Open Data exports. 

Exports published would only before from being included in the Open Data export thanks to a new component created within Surveys.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/13694

#### Testing
(Before testing make sure you have responses available via seeds in a survey component via any space)

1. Head to a Decidim application 
2. Head to a space with a Survey component active (make sure that survey has responses)
3. Head to the settings tab and make sure "Allow responses" button is unticked.
4. Head back to responses and press the "Publish responses" button 
5. Click a response to a question and make it publish it
6. Head back to the front end home page of the application
7. Scroll down to the footer and click "Open Data"
8. See "published_survey_user_responses" link
9. Click it
10. See export working with the published responses you set in the admin.

(Click the export button again, if you get an export Open Data job error first time)

#### Further Testing

Since the Open Data job in development caches each export, publishing  more responses won't change the contents of the export. 

Head back to the admin where you have responses in the survey component you're testing and set to publish one more set. Kill the server and run the `rails console` with the following commands:

```Decidim::Organization.first.open_data_files.each(&:purge)```

followed by

```Decidim::OpenDataJob.perform_now(Decidim::Organization.first)```

If successful, will purge any open-data files cached and perform any pending open-data jobs. 

Close the `rails console` then run the server (`bin/dev`). Go to the footer and repeat steps 6, 7, 8 and 9. See the CSV export with new publications of responses (or unpublished if you performed that action).
 
### :camera: Screenshots

Export in footer: 
<img width="377" height="409" alt="Screenshot 2025-11-05 at 14 11 01" src="https://github.com/user-attachments/assets/29d7c92a-0bc1-4cf0-a6e8-c6eabef892a9" />

Published responses (eg first set:  "Soluta voluptatem quis. Accusamus consequatur numquam. Quisquam sapiente quos."):

<img width="2664" height="1488" alt="image" src="https://github.com/user-attachments/assets/da17cc7d-c6c3-44d7-9af6-35e5cc217e4b" />

Export CSV:

<img width="2850" height="665" alt="image" src="https://github.com/user-attachments/assets/c1bf17f2-c639-4c9d-824e-6831373b8110" />

:hearts: Thank you!