### PR TITLE
Fix production alert error for deprecated js components

### DIFF
--- a/decidim-core/app/packs/src/decidim/index.js
+++ b/decidim-core/app/packs/src/decidim/index.js
@@ -70,16 +70,21 @@ const deprecate = (element, targetController, oldSyntax) => {
     return;
   }
 
-  console.warn(element)
   console.warn(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - data-controller="${targetController}" - ${window.location.href}`)
-  // eslint-disable-next-line no-alert
-  alert(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - data-controller="${targetController}"`)
+
+  if (typeof window.Decidim.dev !== "undefined" && window.Decidim.dev === true) {
+    // eslint-disable-next-line no-alert
+    alert(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - data-controller="${targetController}"`)
+  }
 }
 
 const deprecationMessage = (element, oldSyntax, newSyntax) => {
   console.warn(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - ${newSyntax}`)
-  // eslint-disable-next-line no-alert
-  alert(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - ${newSyntax}`)
+
+  if (typeof window.Decidim.dev !== "undefined" && window.Decidim.dev === true) {
+    // eslint-disable-next-line no-alert
+    alert(`[Decidim] ${oldSyntax} is deprecated. Please use the new version of this component - ${newSyntax}`)
+  }
 }
 
 window.deprecate = deprecate;

--- a/decidim-dev/app/packs/entrypoints/decidim_dev.js
+++ b/decidim-dev/app/packs/entrypoints/decidim_dev.js
@@ -3,5 +3,7 @@ require.context("../images", true)
 
 // CSS
 import "entrypoints/decidim_dev.scss";
-
 import "src/decidim/dev/accessibility";
+
+window.Decidim = window.Decidim || {};
+window.Decidim.dev = true;


### PR DESCRIPTION
#### :tophat: What? Why?
Back in [#15091](https://github.com/decidim/decidim/pull/15091) we have added an alert message to the javascript files to make the test environment break when we migrate to stimulus. This has actually reached production and is a bad thing. 
The current PR fixes the issue. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #15494

#### Testing
1. On your development environment, edit a file from the layout folder 
2. I have edited the `decidim-core/app/views/layouts/decidim/_application.html.erb`
3. On a tag, add a deprecated element syntax like `data-sticky-buttons` 
4. Refresh your browser
5. See alert
6. Switch to this branch
7. Refresh your browser 
8. See there is no error 
9. Play with the `decidim-dev/app/packs/entrypoints/decidim_dev.js` and `window.Decidim.dev` variable to set on true / false 
10. Refresh the page to see the alert is being toggled depending on the `dev` variable value ( when dev is true, the alert should be displayed, when is false, the alert should disapear) 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
