### PR TITLE
Prevent shakapacker related flakys in CI

### DIFF
--- a/decidim-core/lib/decidim/shakapacker/configuration.rb
+++ b/decidim-core/lib/decidim/shakapacker/configuration.rb
@@ -64,11 +64,7 @@ module Decidim
       end
 
       def configuration_file_path
-        @configuration_file_path ||= if ENV["CI"]
-                                       File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
-                                     else
-                                       File.join(app_path, "tmp/shakapacker_runtime.yml")
-                                     end
+        @configuration_file_path ||= File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
       end
 
       def original_configuration_file_path

--- a/decidim-core/lib/decidim/shakapacker/configuration.rb
+++ b/decidim-core/lib/decidim/shakapacker/configuration.rb
@@ -64,7 +64,13 @@ module Decidim
       end
 
       def configuration_file_path
-        @configuration_file_path ||= File.join(app_path, "tmp/shakapacker_runtime.yml")
+        @configuration_file_path ||= begin
+                                       if ENV["CI"]
+                                         File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
+                                       else
+                                         File.join(app_path, "tmp/shakapacker_runtime.yml")
+                                       end
+                                     end
       end
 
       def original_configuration_file_path

--- a/decidim-core/lib/decidim/shakapacker/configuration.rb
+++ b/decidim-core/lib/decidim/shakapacker/configuration.rb
@@ -64,13 +64,11 @@ module Decidim
       end
 
       def configuration_file_path
-        @configuration_file_path ||= begin
-				  if defined?(Rails) && Rails.env.test?
-				    File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
-				  else
-				    File.join(app_path, "tmp/shakapacker_runtime.yml")
-				  end
-				end
+        @configuration_file_path ||= if defined?(Rails) && Rails.env.test?
+                                       File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
+                                     else
+                                       File.join(app_path, "tmp/shakapacker_runtime.yml")
+                                     end
       end
 
       def original_configuration_file_path

--- a/decidim-core/lib/decidim/shakapacker/configuration.rb
+++ b/decidim-core/lib/decidim/shakapacker/configuration.rb
@@ -64,12 +64,10 @@ module Decidim
       end
 
       def configuration_file_path
-        @configuration_file_path ||= begin
-                                       if ENV["CI"]
-                                         File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
-                                       else
-                                         File.join(app_path, "tmp/shakapacker_runtime.yml")
-                                       end
+        @configuration_file_path ||= if ENV["CI"]
+                                       File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
+                                     else
+                                       File.join(app_path, "tmp/shakapacker_runtime.yml")
                                      end
       end
 

--- a/decidim-core/lib/decidim/shakapacker/configuration.rb
+++ b/decidim-core/lib/decidim/shakapacker/configuration.rb
@@ -64,7 +64,13 @@ module Decidim
       end
 
       def configuration_file_path
-        @configuration_file_path ||= File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
+        @configuration_file_path ||= begin
+				  if defined?(Rails) && Rails.env.test?
+				    File.join(app_path, "tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml")
+				  else
+				    File.join(app_path, "tmp/shakapacker_runtime.yml")
+				  end
+				end
       end
 
       def original_configuration_file_path

--- a/decidim-core/spec/lib/shakapacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/shakapacker/configuration_spec.rb
@@ -14,7 +14,7 @@ module Decidim
 
       describe "#configuration_file" do
         let(:runtime_config_path) do
-          Rails.application.root.join("tmp/shakapacker_runtime.yml")
+          Rails.application.root.join("tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml").to_s
         end
         let(:runtime_config) { YAML.load_file(runtime_config_path, aliases: true) }
         let(:core_path) do

--- a/decidim-core/spec/lib/shakapacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/shakapacker/configuration_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         let!(:config_file) { subject.configuration_file }
 
         it "returns the runtime configuration path" do
-          expect(config_file).to eq(Rails.application.root.join("tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml").to_s)
+          expect(config_file).to eq(runtime_config_path.to_s)
         end
 
         it "adds the core additional paths to the shakapacker runtime configuration" do

--- a/decidim-core/spec/lib/shakapacker/configuration_spec.rb
+++ b/decidim-core/spec/lib/shakapacker/configuration_spec.rb
@@ -24,7 +24,7 @@ module Decidim
         let!(:config_file) { subject.configuration_file }
 
         it "returns the runtime configuration path" do
-          expect(config_file).to eq(runtime_config_path.to_s)
+          expect(config_file).to eq(Rails.application.root.join("tmp/shakapacker_runtime#{ENV.fetch("TEST_ENV_NUMBER", "")}.yml").to_s)
         end
 
         it "adds the core additional paths to the shakapacker runtime configuration" do


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15349  @andreslucena tried to fix the the shakapacker related flaky specs. I have seen the approach, and considered we could have a simpler approach. I am opening the PR on @andreslucena 's request from [here](https://github.com/decidim/decidim/pull/15349#issuecomment-3521049440)

While investigating this, i have realized there is a problem between `parallel_tests`, `shakapacker` and our overrides on the config. This PR simplifies the whole stack by assigning a runtime config for each one of the test threads. 

Surpassing https://github.com/decidim/decidim/pull/15349

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15349
- Fixes #?

#### Testing
1. Run the pipeline several times using `git commit --allow-empty -m "Retry the full CI (empty commit)"`
2. You should not see any shakapacker related issues. 


### :camera: Screenshots

<img width="1700" height="918" alt="image" src="https://github.com/user-attachments/assets/bec2547f-8606-4733-8c2b-acd12e8ba366" />

### Stacktrace

```
An error occurred while loading ./spec/system/admin/admin_manages_meetings_polls_spec.rb.
Failure/Error: require "decidim/dev/test/base_spec_helper"

ArgumentError:
  The parameter passed to #in? must respond to #include?
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/core_ext/object/inclusion.rb:23:in `rescue in in?'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/core_ext/object/inclusion.rb:15:in `in?'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/core_ext/object/inclusion.rb:35:in `presence_in'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/env.rb:19:in `current'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/env.rb:13:in `inquire'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/env.rb:5:in `inquire'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/instance.rb:14:in `env'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/instance.rb:21:in `config'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker.rb:36:in `config'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/version_checker.rb:21:in `raise_if_gem_and_node_package_versions_differ'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/shakapacker-8.3.0/lib/shakapacker/railtie.rb:14:in `block in <class:Engine>'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/railties-7.2.2.2/lib/rails/initializable.rb:32:in `instance_exec'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/railties-7.2.2.2/lib/rails/initializable.rb:32:in `run'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/railties-7.2.2.2/lib/rails/initializable.rb:61:in `block in run_initializers'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/railties-7.2.2.2/lib/rails/initializable.rb:60:in `run_initializers'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/railties-7.2.2.2/lib/rails/application.rb:435:in `initialize!'
# /home/runner/work/decidim/decidim/spec/decidim_dummy_app/config/environment.rb:5:in `<top (required)>'
# /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.7.3/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
# /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb:30:in `<top (required)>'
# ./spec/spec_helper.rb:9:in `<top (required)>'
# ./spec/system/admin/admin_manages_meetings_polls_spec.rb:3:in `<top (required)>'
# ------------------
# --- Caused by: ---
# NoMethodError:
#   undefined method `include?' for nil
#   /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.3.0/gems/activesupport-7.2.2.2/lib/active_support/core_ext/object/inclusion.rb:20:in `in?'
No examples found.
``` 

:hearts: Thank you!
