### PR TITLE
Add moderations to GraphQL API

### DIFF
--- a/decidim-core/lib/decidim/api/types/moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/moderation_type.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # this type is used to represent a content moderation record
+    # This type represents a content moderation record
     class ModerationType < Decidim::Api::Types::BaseObject
       description "A moderation detail"
 
@@ -12,7 +12,7 @@ module Decidim
       field :id, GraphQL::Types::ID, "The ID of the moderation", null: false
       field :report_count, GraphQL::Types::Int, "The number of reports of this resource", null: true
       field :reported_content, GraphQL::Types::String, "The content that has been reported", null: true
-      field :reported_url, GraphQL::Types::String, "The url of the resource that was reported", null: true
+      field :reported_url, GraphQL::Types::String, "The URL of the resource that was reported", null: true
       field :reports, [Decidim::Core::ReportableType, { null: true }], "The reports of this resource", null: true
 
       def reported_url

--- a/decidim-core/lib/decidim/api/types/moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/moderation_type.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # this type is used to represent a content moderation record
+    class ModerationType < Decidim::Api::Types::BaseObject
+      description "A moderation detail"
+
+      implements Decidim::Core::TimestampsInterface
+
+      field :hidden_at, Decidim::Core::DateTimeType, "The date and time when the resource was hidden", null: true
+      field :id, GraphQL::Types::ID, "The ID of the moderation", null: false
+      field :report_count, GraphQL::Types::Int, "The number of reports of this resource", null: true
+      field :reported_content, GraphQL::Types::String, "The content that has been reported", null: true
+      field :reported_url, GraphQL::Types::String, "The url of the resource that was reported", null: true
+      field :reports, [Decidim::Core::ReportableType, { null: true }], "The reports of this resource", null: true
+
+      def reported_url
+        return "" unless object.reportable.respond_to?(:reported_content_url)
+
+        object.reportable.reported_content_url
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/types/reportable_type.rb
+++ b/decidim-core/lib/decidim/api/types/reportable_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # this type is used to represent a content report
+    class ReportableType < Decidim::Api::Types::BaseObject
+      description "A report object"
+
+      implements Decidim::Core::TimestampsInterface
+
+      field :details, GraphQL::Types::String, "The details of this report", null: false
+      field :id, GraphQL::Types::ID, "Internal ID of this reportable", null: false
+      field :locale, GraphQL::Types::String, "The locale of the reportable", null: false
+      field :reason, GraphQL::Types::String, "The reason of this report", null: false
+      field :user, UserType, "The author of this report", null: true
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/types/reportable_type.rb
+++ b/decidim-core/lib/decidim/api/types/reportable_type.rb
@@ -2,14 +2,14 @@
 
 module Decidim
   module Core
-    # this type is used to represent a content report
+    # This type represents a content report
     class ReportableType < Decidim::Api::Types::BaseObject
       description "A report object"
 
       implements Decidim::Core::TimestampsInterface
 
       field :details, GraphQL::Types::String, "The details of this report", null: false
-      field :id, GraphQL::Types::ID, "Internal ID of this reportable", null: false
+      field :id, GraphQL::Types::ID, "The ID of this reportable", null: false
       field :locale, GraphQL::Types::String, "The locale of the reportable", null: false
       field :reason, GraphQL::Types::String, "The reason of this report", null: false
       field :user, UserType, "The author of this report", null: true

--- a/decidim-core/lib/decidim/api/types/reportable_user_type.rb
+++ b/decidim-core/lib/decidim/api/types/reportable_user_type.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This type represents a User Report
+
+    class ReportableUserType < Decidim::Api::Types::BaseObject
+      description "An user report"
+
+      implements Decidim::Core::TimestampsInterface
+
+      field :details, GraphQL::Types::String, "The details of this report", null: false
+      field :id, GraphQL::Types::ID, "Internal ID of this report", null: false
+      field :reason, GraphQL::Types::String, "The reason of this report", null: false
+      field :user, UserType, "The author of this report", null: true
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/types/reportable_user_type.rb
+++ b/decidim-core/lib/decidim/api/types/reportable_user_type.rb
@@ -2,15 +2,14 @@
 
 module Decidim
   module Core
-    # This type represents a User Report
-
+    # This type represents an user report
     class ReportableUserType < Decidim::Api::Types::BaseObject
       description "An user report"
 
       implements Decidim::Core::TimestampsInterface
 
       field :details, GraphQL::Types::String, "The details of this report", null: false
-      field :id, GraphQL::Types::ID, "Internal ID of this report", null: false
+      field :id, GraphQL::Types::ID, "The ID of this report", null: false
       field :reason, GraphQL::Types::String, "The reason of this report", null: false
       field :user, UserType, "The author of this report", null: true
     end

--- a/decidim-core/lib/decidim/api/types/user_moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_moderation_type.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Core
+    # This type represents a User Moderation
+    class UserModerationType < Decidim::Api::Types::BaseObject
+      description "A moderated user detail"
+
+      implements Decidim::Core::TimestampsInterface
+
+      field :about, GraphQL::Types::String, "The about data of this user", null: true
+      field :block_reasons, GraphQL::Types::String, "The reasons why the user was blocked", null: true
+      field :blocked_at, Decidim::Core::DateTimeType, "The date at which the user was blocked", null: true
+      field :blocking_user, UserType, "The user who blocked the user", null: true
+      field :id, GraphQL::Types::ID, "The ID of the moderation", null: false
+      field :reports, [Decidim::Core::ReportableUserType, { null: true }], "The reports for this user", null: true
+      field :user_id, GraphQL::Types::ID, "The ID of this user'", null: false, method: :decidim_user_id
+
+      def about
+        object.user.presenter.about
+      end
+
+      def block_reasons
+        object.blocking.justification
+      end
+
+      def blocked_at
+        object.user.blocked_at
+      end
+
+      def blocking_user
+        object.blocking.blocking_user
+      end
+    end
+  end
+end

--- a/decidim-core/lib/decidim/api/types/user_moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_moderation_type.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module Core
-    # This type represents a User Moderation
+    # This type represents a user moderation
     class UserModerationType < Decidim::Api::Types::BaseObject
       description "A moderated user detail"
 

--- a/decidim-core/lib/decidim/core/api.rb
+++ b/decidim-core/lib/decidim/core/api.rb
@@ -37,6 +37,10 @@ module Decidim
     autoload :TraceVersionType, "decidim/api/types/trace_version_type"
     autoload :TranslatedFieldType, "decidim/api/types/translated_field_type"
     autoload :UserType, "decidim/api/types/user_type"
+    autoload :UserModerationType, "decidim/api/types/user_moderation_type"
+    autoload :ModerationType, "decidim/api/types/moderation_type"
+    autoload :ReportableUserType, "decidim/api/types/reportable_user_type"
+    autoload :ReportableType, "decidim/api/types/reportable_type"
     autoload :StaticPageType, "decidim/api/types/static_page_type"
     autoload :StaticPageTopicType, "decidim/api/types/static_page_topic_type"
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -706,7 +706,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     moderation
-    user { build(:user, organization: moderation.reportable.organization, skip_injection:) }
+    user { build(:user, :confirmed, organization: moderation.reportable.organization, skip_injection:) }
     reason { "spam" }
   end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -949,7 +949,7 @@ FactoryBot.define do
     end
     reason { "spam" }
     moderation { create(:user_moderation, user:, skip_injection:) }
-    user { build(:user) }
+    user { build(:user, :confirmed) }
   end
 
   factory :user_moderation, class: "Decidim::UserModeration" do

--- a/decidim-core/lib/decidim/query_extensions.rb
+++ b/decidim-core/lib/decidim/query_extensions.rb
@@ -44,6 +44,10 @@ module Decidim
                                 description: "The static pages for the current organization"
       type.field :static_page_topics, type: [Decidim::Core::StaticPageTopicType], null: true,
                                       description: "The static page topics for the current organization"
+      type.field :moderated_users, type: [Decidim::Core::UserModerationType], null: true,
+                                   description: "The moderated users for the current organization"
+      type.field :moderations, type: [Decidim::Core::ModerationType], null: true,
+                               description: "The moderation for the current organization"
     end
 
     def component(id: {})
@@ -94,6 +98,14 @@ module Decidim
 
     def static_page_topics
       static_pages.collect(&:topic).uniq.compact_blank
+    end
+
+    def moderated_users
+      Decidim::UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: context[:current_organization]&.id }).where.not(decidim_users: { blocked_at: nil })
+    end
+
+    def moderations
+      Decidim::Moderation.where(participatory_space: context[:current_organization].participatory_spaces).includes(:reports).hidden
     end
   end
 end

--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -73,6 +73,118 @@ module Decidim
         end
       end
 
+      describe "moderated_users" do
+        let(:user) { create(:user, :confirmed, :blocked, organization: current_organization) }
+        let(:reporter) { create(:user, :confirmed, organization: current_organization) }
+        let(:moderation) { create(:user_moderation, user:) }
+        let!(:user_block) { create(:user_block, user:, blocking_user: reporter) }
+        let!(:user_report) { create(:user_report, user: reporter, reason: "spam", details: "Lorem ipsum", moderation:) }
+
+        let(:query) do
+          %({
+            moderatedUsers{
+              about
+              blockReasons
+              blockedAt
+              blockingUser{
+                id
+              }
+              createdAt
+              id
+              reports{
+                createdAt
+                details
+                id
+                reason
+                updatedAt
+                user{
+                  id
+                }
+              }
+              updatedAt
+              userId
+            }
+          })
+        end
+
+        it "returns all the moderated users" do
+          expect(response["moderatedUsers"].last).to include(
+            "about" => user.about,
+            "blockReasons" => user_block.justification,
+            "blockedAt" => user.blocked_at.to_time.iso8601,
+            "blockingUser" => { "id" => user_block.blocking_user.id.to_s },
+            "createdAt" => moderation.created_at.to_time.iso8601,
+            "id" => moderation.id.to_s,
+            "reports" => [
+              {
+                "createdAt" => user_report.created_at.to_time.iso8601,
+                "details" => user_report.details,
+                "id" => user_report.id.to_s,
+                "reason" => user_report.reason,
+                "updatedAt" => user_report.updated_at.to_time.iso8601,
+                "user" => { "id" => user_report.user.id.to_s }
+              }
+            ],
+            "updatedAt" => moderation.updated_at.to_time.iso8601,
+            "userId" => user.id.to_s
+          )
+        end
+      end
+
+      describe "moderations" do
+        let(:participatory_space) { create(:assembly, :published, organization: current_organization) }
+        let(:component) { create(:dummy_component, :published, participatory_space:) }
+        let(:commentable) { create(:dummy_resource, :published, component:) }
+        let(:moderation) { create(:moderation, reportable: commentable, hidden_at: 2.days.ago, report_count: 1, reported_content: "This is the content") }
+        let!(:report) { create(:report, moderation:, details: "This is a report", locale: "en") }
+
+        let(:query) do
+          %({
+            moderations{
+              createdAt
+              hiddenAt
+              id
+              reportCount
+              reportedContent
+              reportedUrl
+              reports {
+                createdAt
+                details
+                id
+                locale
+                reason
+                updatedAt
+                user { id }
+              }
+              updatedAt
+            }
+          })
+        end
+
+        it "returns all the moderations" do
+          expect(response["moderations"].last).to include(
+            "createdAt" => moderation.created_at.to_time.iso8601,
+            "hiddenAt" => moderation.hidden_at.to_time.iso8601,
+            "id" => moderation.id.to_s,
+            "reportCount" => moderation.reports.count,
+            "reportedContent" => translated(moderation.reported_content),
+            "reportedUrl" => moderation.reportable.reported_content_url,
+            "reports" => [
+              {
+                "createdAt" => report.created_at.to_time.iso8601,
+                "details" => report.details,
+                "id" => report.id.to_s,
+                "locale" => report.locale,
+                "reason" => report.reason,
+                "updatedAt" => report.updated_at.to_time.iso8601,
+                "user" => { "id" => report.user.id.to_s }
+              }
+            ],
+            "updatedAt" => moderation.updated_at.to_time.iso8601
+          )
+        end
+      end
+
       describe "static_pages" do
         let!(:model) { create(:static_page, :with_topic, organization: current_organization) }
 

--- a/decidim-core/spec/lib/query_extensions_spec.rb
+++ b/decidim-core/spec/lib/query_extensions_spec.rb
@@ -82,22 +82,22 @@ module Decidim
 
         let(:query) do
           %({
-            moderatedUsers{
+            moderatedUsers {
               about
               blockReasons
               blockedAt
-              blockingUser{
+              blockingUser {
                 id
               }
               createdAt
               id
-              reports{
+              reports {
                 createdAt
                 details
                 id
                 reason
                 updatedAt
-                user{
+                user {
                   id
                 }
               }
@@ -140,7 +140,7 @@ module Decidim
 
         let(:query) do
           %({
-            moderations{
+            moderations {
               createdAt
               hiddenAt
               id

--- a/decidim-core/spec/types/moderation_type_spec.rb
+++ b/decidim-core/spec/types/moderation_type_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test"
+
+module Decidim
+  module Core
+    describe ModerationType do
+      include_context "with a graphql class type"
+
+      let(:model) { create(:moderation, :hidden, report_count: 1, reported_content: "This is the content") }
+      let!(:report) { create(:report, moderation: model) }
+
+      include_examples "timestamps interface"
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns the id field" do
+          expect(response).to eq("id" => model.id.to_s)
+        end
+      end
+
+      describe "hiddenAt" do
+        let(:query) { "{ hiddenAt }" }
+
+        it "returns the hidden at date field" do
+          expect(response).to eq("hiddenAt" => model.hidden_at.to_time.iso8601)
+        end
+      end
+
+      describe "reportCount" do
+        let(:query) { "{ reportCount }" }
+
+        it "returns the report count field" do
+          expect(response).to eq("reportCount" => 1)
+        end
+      end
+
+      describe "reportedContent" do
+        let(:query) { "{ reportedContent }" }
+
+        it "returns the reported content" do
+          expect(response).to eq("reportedContent" => translated(model.reported_content))
+        end
+      end
+
+      describe "reportedUrl" do
+        let(:query) { "{ reportedUrl }" }
+
+        it "returns the reported content url field" do
+          expect(response).to eq("reportedUrl" => model.reportable.reported_content_url)
+        end
+      end
+
+      describe "reports" do
+        let(:query) { "{ reports { id } }" }
+
+        it "returns the reports" do
+          expect(response["reports"].count).to eq(1)
+          expect(response["reports"].first["id"]).to eq(report.id.to_s)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/reportable_type_spec.rb
+++ b/decidim-core/spec/types/reportable_type_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test"
+
+module Decidim
+  module Core
+    describe ReportableType do
+      include_context "with a graphql class type"
+      let!(:model) { create(:report, details: "Testing reason", locale: "en") }
+
+      include_examples "timestamps interface"
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns the id field" do
+          expect(response).to eq("id" => model.id.to_s)
+        end
+      end
+
+      describe "reason" do
+        let(:query) { "{ reason }" }
+
+        it "returns the reason field" do
+          expect(response["reason"]).to eq(model.reason)
+        end
+      end
+
+      describe "details" do
+        let(:query) { "{ details }" }
+
+        it "returns the details field" do
+          expect(response["details"]).to eq(model.details)
+        end
+      end
+
+      describe "locale" do
+        let(:query) { "{ locale }" }
+
+        it "returns the locale field" do
+          expect(response["locale"]).to eq(model.locale)
+        end
+      end
+
+      describe "user" do
+        let(:query) { "{ user { id } }" }
+
+        it "returns the user object" do
+          expect(response["user"]["id"]).to eq(model.user.id.to_s)
+        end
+
+        context "when the user is anonymous" do
+          let(:moderation) { create(:moderation) }
+
+          context "when user reporting deleted his account" do
+            let!(:model) { create(:report, moderation:, user: create(:user, :confirmed, :deleted, organization: moderation.reportable.organization), details: "Testing reason", locale: "en") }
+
+            it "returns nil" do
+              expect(response["user"]).to be_nil
+            end
+          end
+
+          context "when user reporting got blocked" do
+            let!(:model) { create(:report, moderation:, user: create(:user, :confirmed, :blocked, organization: moderation.reportable.organization), details: "Testing reason", locale: "en") }
+
+            it "returns nil" do
+              expect(response["user"]).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/reportable_user_type_spec.rb
+++ b/decidim-core/spec/types/reportable_user_type_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test"
+
+module Decidim
+  module Core
+    describe ReportableUserType do
+      include_context "with a graphql class type"
+      let!(:model) { create(:user_report, details: "Testing reason") }
+
+      include_examples "timestamps interface"
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns the id field" do
+          expect(response).to eq("id" => model.id.to_s)
+        end
+      end
+
+      describe "reason" do
+        let(:query) { "{ reason }" }
+
+        it "returns the reason field" do
+          expect(response["reason"]).to eq(model.reason)
+        end
+      end
+
+      describe "details" do
+        let(:query) { "{ details }" }
+
+        it "returns the details field" do
+          expect(response["details"]).to eq(model.details)
+        end
+      end
+
+      describe "user" do
+        let(:query) { "{ user { id } }" }
+
+        it "returns the user object" do
+          expect(response["user"]["id"]).to eq(model.user.id.to_s)
+        end
+
+        context "when the user has an incidence (i.e. is deleted or blocked)" do
+          let(:moderation) { create(:user_moderation, user: create(:user)) }
+
+          let!(:model) { create(:user_report, moderation:, user: moderation.user, details: "Testing reason") }
+
+          it "returns nil" do
+            expect(response["user"]).to be_nil
+          end
+
+          context "when the user that made the report deleted their account" do
+            let(:moderation) { create(:user_moderation, user: create(:user, :confirmed, :deleted)) }
+
+            it "returns nil" do
+              expect(response["user"]).to be_nil
+            end
+          end
+
+          context "when the user that made the reporting got blocked" do
+            let(:moderation) { create(:user_moderation, user: create(:user, :confirmed, :blocked)) }
+
+            it "returns nil" do
+              expect(response["user"]).to be_nil
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/user_moderation_type_spec.rb
+++ b/decidim-core/spec/types/user_moderation_type_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test"
+
+module Decidim
+  module Core
+    describe UserModerationType do
+      include_context "with a graphql class type"
+
+      let(:current_organization) { create(:organization) }
+      let(:user) { create(:user, :confirmed, :blocked, organization: current_organization) }
+      let(:reporter) { create(:user, :confirmed, organization: current_organization) }
+      let(:moderation) { create(:user_moderation, user:) }
+      let!(:user_block) { create(:user_block, user:, blocking_user: reporter) }
+      let!(:user_report) { create(:user_report, user: reporter, reason: "spam", details: "Lorem ipsum", moderation:) }
+
+      let(:model) { moderation }
+
+      include_examples "timestamps interface"
+
+      describe "about" do
+        let(:query) { "{ about }" }
+
+        it "returns the about field" do
+          expect(response).to eq("about" => user.about)
+        end
+      end
+
+      describe "block_reasons" do
+        let(:query) { "{ blockReasons }" }
+
+        it "returns the block_reasons field" do
+          expect(response).to eq("blockReasons" => user_block.justification)
+        end
+      end
+
+      describe "blocked_at" do
+        let(:query) { "{ blockedAt }" }
+
+        it "returns the blocked at date field" do
+          expect(response).to eq("blockedAt" => user.blocked_at.to_time.iso8601)
+        end
+      end
+
+      describe "blocking_user" do
+        let(:query) { "{ blockingUser { id } }" }
+
+        it "returns the blocking user object" do
+          expect(response).to eq("blockingUser" => { "id" => user_block.blocking_user.id.to_s })
+        end
+      end
+
+      describe "reports" do
+        let(:query) { "{ reports { id } }" }
+
+        it "returns the reports field" do
+          expect(response["reports"]).to include({ "id" => user_report.id.to_s })
+        end
+      end
+
+      describe "id" do
+        let(:query) { "{ id }" }
+
+        it "returns the id field" do
+          expect(response).to eq("id" => moderation.id.to_s)
+        end
+      end
+
+      describe "user_id" do
+        let(:query) { "{ userId }" }
+
+        it "returns the blocked user id field" do
+          expect(response).to eq("userId" => moderation.user.id.to_s)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR we are adding moderated data to the GraphQL.  This is related to the work done in #14884 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14884

#### Testing
1. Boot up the dev environment 
2. Visit the api, and perform a request fetching the new fields 
3. See the fields are being properly displayed.

:hearts: Thank you!
