### PR TITLE
Fix for process admins accessing some components

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -103,11 +103,11 @@ module Decidim
       ransacker_i18n_multi :search_text, [:title, :description]
 
       def self.ransackable_attributes(auth_object = nil)
-        base = %w(search_text title description)
+        base = %w(id_string id search_text title description)
 
         return base unless auth_object&.admin?
 
-        base + %w(id_string created_at id progress)
+        base + %w(created_at progress)
       end
 
       def self.ransackable_associations(auth_object = nil)

--- a/decidim-accountability/spec/system/admin/admin_access_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "accountability" }
+  let!(:result) { create(:result, component:) }
+  let(:title) { "Results" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-admin/lib/decidim/admin/test/admin_participatory_space_component_access_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_participatory_space_component_access_examples.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+shared_examples "accessing the component in a participatory space" do
+  context "when the user is a visitor" do
+    let(:user) { nil }
+
+    it "shows the unauthenticated message" do
+      expect(page).to have_content "You need to log in or create an account before continuing."
+    end
+  end
+
+  context "when the user is a normal user" do
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:unauthorized_path) { "/" }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it_behaves_like "a 404 page" do
+      let(:target_path) { manage_component_path(component) }
+    end
+  end
+
+  context "when the user is a process admin" do
+    let(:user) { create(:process_admin, :confirmed, organization:, participatory_process:) }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it "access the index page" do
+      expect(page).to have_content(title)
+    end
+  end
+end

--- a/decidim-blogs/spec/system/admin_access_spec.rb
+++ b/decidim-blogs/spec/system/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "blogs" }
+  let!(:post) { create(:post, component:, title: { en: "Blog post title" }) }
+  let(:title) { "Posts" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-budgets/app/models/decidim/budgets/project.rb
+++ b/decidim-budgets/app/models/decidim/budgets/project.rb
@@ -151,11 +151,11 @@ module Decidim
       end
 
       def self.ransackable_attributes(auth_object = nil)
-        base = %w(search_text description title)
+        base = %w(id_string id search_text description title)
 
         return base unless auth_object&.admin?
 
-        base + %w(id_string id selected selected_at confirmed_orders_count)
+        base + %w(selected selected_at confirmed_orders_count)
       end
 
       def self.ransackable_associations(_auth_object = nil)

--- a/decidim-budgets/spec/system/admin_access_spec.rb
+++ b/decidim-budgets/spec/system/admin_access_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "budgets" }
+  let(:budget) { create(:budget, component:) }
+  let!(:project) { create(:project, budget:) }
+  let(:title) { "Budgets" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-budgets/spec/system/admin_access_spec.rb
+++ b/decidim-budgets/spec/system/admin_access_spec.rb
@@ -12,4 +12,19 @@ describe "AdminAccess" do
 
   include_context "when managing a component as an admin"
   include_examples "accessing the component in a participatory space"
+
+  describe "when accessing projects" do
+    context "when the user is a process admin" do
+      let(:user) { create(:process_admin, :confirmed, organization:, participatory_process:) }
+
+      before do
+        login_as user, scope: :user
+      end
+
+      it "access the projects' index page" do
+        click_on(translated(budget.title))
+        expect(page).to have_content(translated(project.title))
+      end
+    end
+  end
 end

--- a/decidim-collaborative_texts/spec/system/admin/admin_access_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "collaborative_texts" }
+  let!(:document) { create(:collaborative_text_document, :published, component:) }
+  let(:title) { "Collaborative texts" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-debates/spec/system/admin_access_spec.rb
+++ b/decidim-debates/spec/system/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "debates" }
+  let!(:debate) { create(:debate, component:) }
+  let(:title) { "Debates" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-elections/spec/system/admin/admin_access_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "elections" }
+  let!(:election) { create(:election, :with_token_csv_census, :published, component:) }
+  let(:title) { "Elections" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-meetings/spec/system/admin/admin_access_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "meetings" }
+  let!(:meeting) { create(:meeting, :published, component:) }
+  let(:title) { "Meetings" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-pages/spec/system/admin_access_spec.rb
+++ b/decidim-pages/spec/system/admin_access_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "pages" }
+  let(:title) { "Edit page" }
+
+  # This does not work for pages
+  # 
+  # let!(:page) { create(:page, component:) }
+  # 
+  # So, we need to do a workaround
+  before do
+    create(:page, component:)
+  end
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-pages/spec/system/admin_access_spec.rb
+++ b/decidim-pages/spec/system/admin_access_spec.rb
@@ -9,9 +9,9 @@ describe "AdminAccess" do
   let(:title) { "Edit page" }
 
   # This does not work for pages
-  # 
+  #
   # let!(:page) { create(:page, component:) }
-  # 
+  #
   # So, we need to do a workaround
   before do
     create(:page, component:)

--- a/decidim-proposals/spec/system/admin/admin_access_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "proposals" }
+  let!(:proposal) { create(:proposal, :official, component:) }
+  let(:title) { "Proposals" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end

--- a/decidim-surveys/spec/system/admin_access_spec.rb
+++ b/decidim-surveys/spec/system/admin_access_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "decidim/admin/test/admin_participatory_space_component_access_examples"
+
+describe "AdminAccess" do
+  let(:manifest_name) { "surveys" }
+  let!(:survey) { create(:survey, :published, :clean_after_publish, component:) }
+  let(:title) { "Surveys" }
+
+  include_context "when managing a component as an admin"
+  include_examples "accessing the component in a participatory space"
+end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the bug where process admins can't access components. As far as I see this only happens with accountability. 

As this should have been detected by testing, I'm adding a "canary in the coal mine" for accessing the listing page of all the components as process admins. 

This didn't happen in v0.29 as it was introduced by https://github.com/decidim/decidim/pull/13196 

#### :pushpin: Related Issues
 
- Fixes #15502 

#### Testing

1. On develop branch, start the server and login with `participatory_process_1_admin@example.org`
2. Navigate to admin panel / approve tos 
3. visit the process / components / accountability 
4. (Without the patch) See the error
5. (With the patch) See the index page 

:hearts: Thank you!
