### PR TITLE
Search & filter in mobile responsive view

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_filters.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_filters.scss
@@ -129,7 +129,7 @@
 
 /* overwrite default dropdowns */
 [data-target="dropdown-menu-filters"] {
-  @apply px-0 justify-start [&>span]:text-gray-2;
+  @apply px-0 justify-start [&>span]:text-gray-2 md:hidden;
 
   > svg {
     @apply h-4 w-4 text-gray;


### PR DESCRIPTION
#### :tophat: What? Why?
This moves a search & filter component in core from desktop to be used only in mobile view. 

#### :pushpin: Related Issues
- Fixes #15163

#### Testing
1. Find yourself a space with a no. of components available and published on Desktop.
2. Head to a component like Proposals.
3. See there is no filter.
4. Repeat steps 1,2 and 3 on a mobile view to see the filter.

### :camera: Screenshots
DESKTOP:
<img width="522" height="1252" alt="image" src="https://github.com/user-attachments/assets/68fcbae4-029a-4ea0-ab5c-3791fefbfd5d" />

MOBILE:
<img width="895" height="1482" alt="image" src="https://github.com/user-attachments/assets/ffd39670-560b-4522-a49f-a27e3d28d8ae" />


:hearts: Thank you!
