### PR TITLE
Order posts by publication date

### DIFF
--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -91,9 +91,9 @@ module Decidim
 
       def posts
         @posts ||= if current_user&.admin?
-                     Post.where(component: current_component)
+                     Post.where(component: current_component).published_at_desc
                    else
-                     Post.published.where(component: current_component)
+                     Post.published.where(component: current_component).published_at_desc
                    end
       end
 
@@ -101,7 +101,7 @@ module Decidim
       def posts_most_commented
         @posts_most_commented ||= posts.joins(:comments).group(:id)
                                        .select("count(decidim_comments_comments.id) as counter")
-                                       .select("decidim_blogs_posts.*").order("counter DESC").created_at_desc.limit(7)
+                                       .select("decidim_blogs_posts.*").order("counter DESC").published_at_desc.limit(7)
       end
     end
   end

--- a/decidim-blogs/app/models/decidim/blogs/post.rb
+++ b/decidim-blogs/app/models/decidim/blogs/post.rb
@@ -29,6 +29,7 @@ module Decidim
       validates :title, presence: true
 
       scope :created_at_desc, -> { order(arel_table[:created_at].desc) }
+      scope :published_at_desc, -> { order(arel_table[:published_at].desc) }
       scope :published, -> { where(published_at: ..Time.current) }
 
       searchable_fields({

--- a/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
+++ b/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
@@ -12,12 +12,18 @@ module Decidim
           let!(:post_component) { create(:post_component, participatory_space: participatory_process) }
           let!(:unpublished) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.from_now) }
           let!(:published) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.ago) }
+          let!(:another_published) { create(:post, component: post_component, created_at: 3.days.ago, published_at: 1.day.ago) }
           let!(:current_user) { create(:user, :admin, :confirmed, organization:) }
 
           before do
             request.env["decidim.current_organization"] = organization
             request.env["decidim.current_component"] = post_component
             request.env["decidim.current_participatory_space"] = participatory_process
+          end
+
+          it "lists only published posts" do
+            get :index
+            expect(controller.helpers.posts).to eq([another_published, published])
           end
 
           it "shows published posts" do


### PR DESCRIPTION
#### :tophat: What? Why?

We've realized that posts are not ordered by publication date anywhere, there just ordered by whatever Postgres decides (usually the ID).

This PR corrects this and ensure that the publication date has meaning.

We also thing that this should be backported.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Write some posts in the blog component, assign different publication dates, see that they are not ordered.

### :camera: Screenshots
Before:
<img width="1894" height="1388" alt="imatge" src="https://github.com/user-attachments/assets/5a991528-f812-4241-bcdb-883d4d8fc65c" />

After
<img width="1894" height="1388" alt="imatge" src="https://github.com/user-attachments/assets/c37b278e-fa7b-4e42-bbb1-9dc265deb524" />

:hearts: Thank you!
