### PR TITLE
Fix links in footer when using the organizations' description

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_footer.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_footer.scss
@@ -4,6 +4,10 @@ footer {
 
     &__top {
       @apply hidden lg:flex flex-row gap-8 container py-10;
+
+      .prose a {
+        @apply text-white;
+      }
     }
 
     &__down {


### PR DESCRIPTION
#### :tophat: What? Why?

If I change the description of the organization and add it a link, this is displayed in the footer, but the link is really difficult to actually read. It is an accessibility issue. 

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/15174 

#### Testing

1. Sign in as admin 
2. Go to http://localhost:3000/admin/organization/edit
3. Add a link in "Description" 
<img width="1149" height="561" alt="image" src="https://github.com/user-attachments/assets/2eb2a42a-93b4-459b-98de-abee7734b9d2" />
4. Go to the frontend and scroll to the footer
5. (Before) It isn't possible to read clearly
6. (After) It's possible to read clearly

### :camera: Screenshots 

#### Before

<img width="1582" height="454" alt="image" src="https://github.com/user-attachments/assets/43c41780-be7f-435b-8792-81be0fefd5b4" />

#### After

<img width="1624" height="472" alt="image" src="https://github.com/user-attachments/assets/0ba517a6-8fbc-4963-abb4-7398a28a1b23" />


:hearts: Thank you!
