### PR TITLE
Add missing i18n string in Conference program page

### DIFF
--- a/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
@@ -11,7 +11,7 @@
           <% categories.each do |category| %>
             <li>
               <div class="conference__program-category">
-                <%= category.present? ? translated_attribute(category.name) : t(".other_html") %>
+                <%= category.present? ? translated_attribute(category.name) : t(".other_category") %>
               </div>
             </li>
           <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
@@ -11,7 +11,7 @@
           <% categories.each do |category| %>
             <li>
               <div class="conference__program-category">
-                <%= category.present? ? translated_attribute(category.name) : t(".other") %>
+                <%= category.present? ? translated_attribute(category.name) : t(".other_html") %>
               </div>
             </li>
           <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_program/_program_item.html.erb
@@ -11,7 +11,7 @@
           <% categories.each do |category| %>
             <li>
               <div class="conference__program-category">
-                <%= category.present? ? translated_attribute(category.name) : "other" %>
+                <%= category.present? ? translated_attribute(category.name) : t(".other") %>
               </div>
             </li>
           <% end %>

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -444,7 +444,7 @@ en:
           registration: Registration
       conference_program:
         program_item:
-          other: Other
+          other_html: Other
         show:
           program: Program
       conference_registration_mailer:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -443,6 +443,8 @@ en:
           no_slots_available: No slots available
           registration: Registration
       conference_program:
+        program_item:
+          other: Other
         show:
           program: Program
       conference_registration_mailer:

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -444,7 +444,7 @@ en:
           registration: Registration
       conference_program:
         program_item:
-          other_html: Other
+          other_category: Other
         show:
           program: Program
       conference_registration_mailer:


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #15533, i noticed that we have a missing string. I have requested changes to that PR, but i realize this small change is going to be targeted to 0.29, 0.30, 0.31 and as well for develop, therefore a small PR was needed.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15533
- Related to #15272 

#### Testing
1. Visit the conferences / $NAME / Program page
2. See the "other" text
3. Play with the string from this PR, and see the change reflects in the page

### :camera: Screenshots
<img width="1449" height="262" alt="image" src="https://github.com/user-attachments/assets/631ba5c9-24d9-4bde-908d-f1f5573aee6d" />


:hearts: Thank you!
