### PR TITLE
Fix strong tags color in footer organization description

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_footer.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_footer.scss
@@ -5,7 +5,8 @@ footer {
     &__top {
       @apply hidden lg:flex flex-row gap-8 container py-10;
 
-      .prose a {
+      .prose a,
+      .prose strong {
         @apply text-white;
       }
     }


### PR DESCRIPTION
#### :tophat: What? Why?
This is a follow up to #15536 which only resolved the color issue for the links. This one fixes the color of bold text (using `<strong>` tags).
It could be backported until 0.29 IMHO.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #15174 

:hearts: Thank you!
