### PR TITLE
Add warning regarding a User Group activity bug

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -266,6 +266,9 @@ You can read more about this change on PR [#14940](https://github.com/decidim/de
 
 ### 3.6. User Groups removal
 
+> [!WARNING]
+> We have detected a bug related to the authorship of the UserGroups activity. This was already happening in versions before v0.31.0, and we plan on fixing this for v0.31.1. See [#15448](https://github.com/decidim/decidim/issues/15448) for more details.
+
 As part of our efforts to simplify the experience for organizations, the "User Groups" feature has been deprecated. All previously existing User Groups has been converted into regular participants able to sign in providing the email and a password. The users with access to the email associated with the User Group will be able to set a password.
 
 There are some tasks to notify users affected by the changes, transfer authorships and remove deprecated references to groups. All of them can be executed in a main task:


### PR DESCRIPTION
#### :tophat: What? Why?

This PR adds a warning for the v0.31 release notes, regarding the bug #15448.

We will not fix it for v0.31.0, but we wanted to give a heads-up to implementers just in case it's a blocker for them. 

#### :pushpin: Related Issues
 
- Related to #15448 

#### Testing

Reading this in the GH UI should look fine 

### :camera: Screenshots

<img width="1338" height="701" alt="image" src="https://github.com/user-attachments/assets/ed577cb5-7bfa-435b-ba6f-130969a8d7a3" />

:hearts: Thank you!
