### PR TITLE
Fix accountability results filtering

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -111,8 +111,6 @@ module Decidim
       end
 
       def self.ransackable_associations(auth_object = nil)
-        return [] unless auth_object&.admin?
-
         %w(taxonomies status)
       end
 

--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -110,7 +110,7 @@ module Decidim
         base + %w(created_at progress)
       end
 
-      def self.ransackable_associations(auth_object = nil)
+      def self.ransackable_associations(_auth_object = nil)
         %w(taxonomies status)
       end
 

--- a/decidim-accountability/spec/requests/result_search_spec.rb
+++ b/decidim-accountability/spec/requests/result_search_spec.rb
@@ -113,5 +113,23 @@ RSpec.describe "Result search" do
         expect(subject).to contain_exactly(result1, result2)
       end
     end
+
+    context "when filtering by taxonomy" do
+      context "when filtering by taxonomy1" do
+        let(:filter_params) { { taxonomies_part_of_contains: taxonomy1.id } }
+
+        it "returns results with that taxonomy directly assigned" do
+          expect(subject).to contain_exactly(result1)
+        end
+      end
+
+      context "when filtering by taxonomy2" do
+        let(:filter_params) { { taxonomies_part_of_contains: taxonomy2.id } }
+
+        it "returns results with that taxonomy and results with its child taxonomies" do
+          expect(subject).to contain_exactly(result2, result4)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes accountability results filtering bug, to allow any user to filter results by taxonomies.

#### :pushpin: Related Issues
- Fixes #15470

#### Testing
On a development app, go to an Accountability component with results and some taxonomies configured. You should be able to filter now the results by taxonomies, independently to being logged as an admin or not. 

### :camera: Screenshots
https://github.com/user-attachments/assets/fcc27ec1-eae0-41aa-8d8d-68c95f4fff91

:hearts: Thank you!
