### PR TITLE
Conference admin seeing processes

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
@@ -75,3 +75,21 @@ shared_examples "admin participatory space access" do
     end
   end
 end
+
+shared_examples "admin menu shows only assigned space" do |space_name:, other_spaces: []|
+  before do
+    switch_to_host(organization.host)
+    login_as role, scope: :user
+    visit target_path
+  end
+
+  context "and doesn't show unassigned spaces" do
+    it "shows only the assigned space" do
+      expect(page).to have_content(space_name)
+
+      other_spaces.each do |other_space|
+        expect(page).to have_no_content(other_space)
+      end
+    end
+  end
+end

--- a/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_participatory_space_access_examples.rb
@@ -83,7 +83,7 @@ shared_examples "admin menu shows only assigned space" do |space_name:, other_sp
     visit target_path
   end
 
-  context "and doesn't show unassigned spaces" do
+  context "and does not show unassigned spaces" do
     it "shows only the assigned space" do
       expect(page).to have_content(space_name)
 

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -16,6 +16,9 @@ describe "AdminAccess" do
     let(:participatory_space_path) { decidim_assemblies.assembly_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
+    it_behaves_like "admin menu shows only assigned space",
+                    space_name: "Assemblies",
+                    other_spaces: %w(Processes Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_assemblies.edit_assembly_landing_page_path(participatory_space) }

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -18,7 +18,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Assemblies",
-                    other_spaces: %w(Processes Initiatives Conferences)
+                    other_spaces: %w(Processes Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_assemblies.edit_assembly_landing_page_path(participatory_space) }

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -18,7 +18,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Assemblies",
-                    other_spaces: %w(Processes Conferences)
+                    other_spaces: %w(Processes Initiatives Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_assemblies.edit_assembly_landing_page_path(participatory_space) }

--- a/decidim-conferences/spec/system/admin/admin_access_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_access_spec.rb
@@ -19,7 +19,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space edit button"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Conferences",
-                    other_spaces: %w(Processes Initiatives Assemblies)
+                    other_spaces: %w(Processes Assemblies)
   end
 
   context "with participatory space evaluator" do

--- a/decidim-conferences/spec/system/admin/admin_access_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_access_spec.rb
@@ -17,6 +17,9 @@ describe "AdminAccess" do
 
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin participatory space edit button"
+    it_behaves_like "admin menu shows only assigned space",
+                    space_name: "Conferences",
+                    other_spaces: %w(Processes Assemblies)
   end
 
   context "with participatory space evaluator" do

--- a/decidim-conferences/spec/system/admin/admin_access_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_access_spec.rb
@@ -19,7 +19,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space edit button"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Conferences",
-                    other_spaces: %w(Processes Assemblies)
+                    other_spaces: %w(Processes Initiatives Assemblies)
   end
 
   context "with participatory space evaluator" do

--- a/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
+++ b/decidim-participatory_processes/app/permissions/decidim/participatory_processes/permissions.rb
@@ -154,7 +154,7 @@ module Decidim
                       permission_action.subject == :space_area &&
                       context.fetch(:space_name, nil) == :processes
 
-        toggle_allow(user.admin? || user_has_any_role?(user, process, broad_check: true) || has_manageable_processes?)
+        toggle_allow(user.admin? || has_manageable_processes?)
       end
 
       # Only organization admins can manage process groups.

--- a/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
@@ -16,6 +16,9 @@ describe "AdminAccess" do
     let(:participatory_space_path) { decidim_participatory_processes.participatory_process_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
+    it_behaves_like "admin menu shows only assigned space",
+                    space_name: "Processes",
+                    other_spaces: %w(Assemblies Initiatives Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(participatory_space) }

--- a/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
@@ -18,7 +18,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Processes",
-                    other_spaces: %w(Assemblies Initiatives Conferences)
+                    other_spaces: %w(Assemblies Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(participatory_space) }

--- a/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_access_spec.rb
@@ -18,7 +18,7 @@ describe "AdminAccess" do
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin menu shows only assigned space",
                     space_name: "Processes",
-                    other_spaces: %w(Assemblies Conferences)
+                    other_spaces: %w(Assemblies Initiatives Conferences)
 
     describe "edit button" do
       let(:target_path) { decidim_admin_participatory_processes.edit_participatory_process_landing_page_path(participatory_space) }


### PR DESCRIPTION
#### :tophat: What? Why?
Removes a check in the participatory process permissions to allow admins within Conferences only to see the space they are designated to see. 

This was caused by a previous PR created by me: https://github.com/decidim/decidim/pull/14522. The functionality of this remains unchanged.

#### :pushpin: Related Issues
- Fixes #15529

#### Testing
1. Create a conference space admin within the conferences space
2.  Login as that conference admin 
3. Head to admin dashboard 
4. Visit conferences
5. See you can't see Participatory processes anymore

### :camera: Screenshots
<img width="566" height="791" alt="image" src="https://github.com/user-attachments/assets/acb440ed-e2eb-48df-bddd-7661393923e7" />


:hearts: Thank you!
