### PR TITLE
Fix display conditions on survey seeds

### DIFF
--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -96,7 +96,7 @@ module Decidim
 
           # Files type questions do not support being conditionals for another questions
           files_question = questionnaire.questions.where(question_type: "files")
-          possible_condition_questions = questionnaire.questions.excluding(files_question)
+          possible_condition_questions = questionnaire.questions.excluding(question, files_question)
 
           question.display_conditions.create!(
             condition_question: possible_condition_questions.sample,


### PR DESCRIPTION
#### :tophat: What? Why?
while reviewing #15492, i have noticed that sometimes only for responses were exported. On a closer look on the question that has not been exported, i have noticed that it had 0 answers. digging deeper, i have seen that the question had itself as display condition. something like "You need to answer the question before displaying it", which caused issues. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15492 
- Fixes #?

#### Testing
1. Create a development application on the develop branch 
2. Go to edit questionnaire in admin ... 
3. Investigate if this applies to your forms. 
4. Apply the patch, repeat 1, 2 
5. See that the form is fixed.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
