### PR TITLE
Fix validation for start/end dates in processes

### DIFF
--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -50,6 +50,9 @@ module Decidim
 
         validates :weight, presence: true
 
+        validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
+        validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
+
         alias organization current_organization
 
         def map_model(model)

--- a/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
@@ -44,6 +44,8 @@ module Decidim
             ca: "Descripció curta"
           }
         end
+        let(:start_date) { 1.month.ago }
+        let(:end_date) { 1.month.from_now }
         let(:slug) { "slug" }
         let(:attachment) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")) }
         let(:attributes) do
@@ -62,6 +64,8 @@ module Decidim
               "short_description_en" => short_description[:en],
               "short_description_es" => short_description[:es],
               "short_description_ca" => short_description[:ca],
+              "start_date" => start_date,
+              "end_date" => end_date,
               "hero_image" => attachment,
               "slug" => slug,
               "taxonomies" => [taxonomies.first.id, taxonomies.second.id]
@@ -175,6 +179,45 @@ module Decidim
               expect(subject).to be_valid
             end
           end
+        end
+
+        context "when the start_date is later than end_date" do
+          let(:start_date) { 1.month.from_now }
+          let(:end_date) { 2.months.ago }
+
+          it { is_expected.to be_invalid }
+
+          it "has an error" do
+            subject.valid?
+
+            expect(subject.errors).not_to be_empty
+            expect(subject.errors[:end_date]).not_to be_empty
+            expect(subject.errors[:start_date]).not_to be_empty
+          end
+        end
+
+        context "when start_date is present" do
+          let(:start_date) { 3.months.ago }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when end_date is present" do
+          let(:end_date) { 2.months.from_now }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when start_date is not present" do
+          let(:start_date) { nil }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when end_date is not present" do
+          let(:end_date) { nil }
+
+          it { is_expected.to be_valid }
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

@marcocerdelli detected that we have a bug related to the validations in the start and end dates in the process form: you can configure a process that ends before it starts 🤯 

This PR fixes it by implementing the same validations and specs that we have in `ParticipatoryProcessStepForm`, so it is easy-peasy. 

#### :pushpin: Related Issues

- Fixes #15539

#### Testing

1. Edit a process
2. Put a process with a end date before the start date
3. Save it
4. (Before) see that you can save it
5. (After) see that you have a validation error 

### :camera: Screenshots

<img width="1105" height="634" alt="image" src="https://github.com/user-attachments/assets/09565b90-a6ab-4c47-b2f9-e9e358cf92eb" />

:hearts: Thank you!
