### PR TITLE
Add decidim-elections installation instructions to readme

### DIFF
--- a/decidim-elections/README.md
+++ b/decidim-elections/README.md
@@ -12,6 +12,14 @@ To install this module, run in your console:
 bundle add decidim-elections
 ```
 
+And then execute:
+
+```bash
+bundle
+bundle exec rails decidim_elections:install:migrations
+bundle exec rails db:migrate
+```
+
 ## Contributing
 
 See [Decidim](https://github.com/decidim/decidim).


### PR DESCRIPTION
#### :tophat: What? Why?
The README for the `decidim-elections` gem was missing the installation steps after adding the gem to the Gemfile.

#### Testing
I've ran the additional code block instructions in my instance to validate that it works. The code was copied from `decidim-conferences`.

:hearts: Thank you!
