### PR TITLE
Fix factories generation issues

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -1036,7 +1036,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     reminder { create(:reminder, skip_injection:) }
-    remindable { build(:dummy_resource, skip_injection:) }
+    remindable { build(:dummy_resource, organization: reminder.user.organization, skip_injection:) }
 
     Decidim::ReminderRecord::STATES.keys.each do |defined_state|
       trait defined_state do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -623,8 +623,11 @@ FactoryBot.define do
   end
 
   factory :taxonomization, class: "Decidim::Taxonomization" do
+    transient do
+      skip_injection { false }
+    end
     taxonomy { association(:taxonomy, :with_parent) }
-    taxonomizable { association(:dummy_resource) }
+    taxonomizable { association(:dummy_resource, organization: taxonomy.organization, skip_injection:) }
   end
 
   factory :taxonomy_filter, class: "Decidim::TaxonomyFilter" do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -772,8 +772,8 @@ FactoryBot.define do
       skip_injection { false }
     end
 
-    originator { build(:user, skip_injection:) }
-    interlocutors { [build(:user, skip_injection:)] }
+    originator { build(:user, organization: user.organization, skip_injection:) }
+    interlocutors { [build(:user, organization: originator.organization, skip_injection:)] }
     body { Faker::Lorem.sentence }
     user
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -647,7 +647,7 @@ FactoryBot.define do
 
   factory :taxonomy_filter_item, class: "Decidim::TaxonomyFilterItem" do
     taxonomy_filter
-    taxonomy_item { association(:taxonomy, parent: taxonomy_filter.root_taxonomy) }
+    taxonomy_item { association(:taxonomy, organization: taxonomy_filter.root_taxonomy.organization, parent: taxonomy_filter.root_taxonomy) }
   end
 
   factory :coauthorship, class: "Decidim::Coauthorship" do

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -936,9 +936,10 @@ FactoryBot.define do
   factory :amendment, class: "Decidim::Amendment" do
     transient do
       skip_injection { false }
+      organization { create(:organization, skip_injection:) }
     end
-    amendable { build(:dummy_resource, skip_injection:) }
-    emendation { build(:dummy_resource, skip_injection:) }
+    amendable { build(:dummy_resource, organization:, skip_injection:) }
+    emendation { build(:dummy_resource, organization:, skip_injection:) }
     amender { emendation.try(:creator_author) || emendation.try(:author) }
     state { "evaluating" }
 

--- a/decidim-core/spec/factory_bot_spec.rb
+++ b/decidim-core/spec/factory_bot_spec.rb
@@ -13,9 +13,11 @@ describe FactoryBot do
         expect { create(factory.name) }.to change(Decidim::Organization, :count).by(1)
       end
 
-      factory.defined_traits.each do |trait|
-        it "generates a single organization when using :#{trait} name" do
-          expect { create(factory.name, trait) }.to change(Decidim::Organization, :count).by(1)
+      context "when using a trait" do
+        factory.defined_traits.collect(&:name).each do |trait|
+          it ":#{trait}" do
+            expect { create(factory.name, trait.to_sym) }.to change(Decidim::Organization, :count).by(1)
+          end
         end
       end
     end

--- a/decidim-core/spec/factory_bot_spec.rb
+++ b/decidim-core/spec/factory_bot_spec.rb
@@ -6,4 +6,18 @@ describe FactoryBot do
   it "has 100% valid factories" do
     expect { described_class.lint(traits: true) }.not_to raise_error
   end
+
+  described_class.factories.sort_by(&:name).each do |factory|
+    context "when using the #{factory.name} factory" do
+      it "generates a single organization" do
+        expect { create(factory.name) }.to change(Decidim::Organization, :count).by(1)
+      end
+
+      factory.defined_traits.each do |trait|
+        it "generates a single organization when using :#{trait} name" do
+          expect { create(factory.name, trait) }.to change(Decidim::Organization, :count).by(1)
+        end
+      end
+    end
+  end
 end

--- a/decidim-core/spec/factory_bot_spec.rb
+++ b/decidim-core/spec/factory_bot_spec.rb
@@ -10,8 +10,8 @@ describe FactoryBot do
   described_class.factories.each do |factory|
     context "when using the #{factory.name} factory" do
       # There are some factories that should not create an organization.
-      # We have this as a exclusion list from our expectation.
-      let(:increment) { %w(admin).include?(factory.name.to_s) ? 0 : 1 }
+      # We have this as an exclusion list from our expectation.
+      let(:increment) { %w(admin blob).include?(factory.name.to_s) ? 0 : 1 }
 
       it "generates a single organization" do
         expect { create(factory.name) }.to change(Decidim::Organization, :count).by(increment)

--- a/decidim-core/spec/factory_bot_spec.rb
+++ b/decidim-core/spec/factory_bot_spec.rb
@@ -7,16 +7,20 @@ describe FactoryBot do
     expect { described_class.lint(traits: true) }.not_to raise_error
   end
 
-  described_class.factories.sort_by(&:name).each do |factory|
+  described_class.factories.each do |factory|
     context "when using the #{factory.name} factory" do
+      # There are some factories that should not create an organization.
+      # We have this as a exclusion list from our expectation.
+      let(:increment) { %w(admin).include?(factory.name.to_s) ? 0 : 1 }
+
       it "generates a single organization" do
-        expect { create(factory.name) }.to change(Decidim::Organization, :count).by(1)
+        expect { create(factory.name) }.to change(Decidim::Organization, :count).by(increment)
       end
 
       context "when using a trait" do
         factory.defined_traits.collect(&:name).each do |trait|
           it ":#{trait}" do
-            expect { create(factory.name, trait.to_sym) }.to change(Decidim::Organization, :count).by(1)
+            expect { create(factory.name, trait.to_sym) }.to change(Decidim::Organization, :count).by(increment)
           end
         end
       end

--- a/decidim-dev/lib/decidim/dev/test/factories.rb
+++ b/decidim-dev/lib/decidim/dev/test/factories.rb
@@ -15,9 +15,10 @@ FactoryBot.define do
     transient do
       skip_injection { false }
       users { nil }
+      organization { create(:organization, skip_injection:) }
     end
     title { generate_localized_title(:dummy_resource_title, skip_injection:) }
-    component { create(:dummy_component, skip_injection:) }
+    component { create(:dummy_component, organization: , skip_injection:) }
     author { create(:user, :confirmed, organization: component.organization, skip_injection:) }
     scope { create(:scope, organization: component.organization, skip_injection:) }
 

--- a/decidim-dev/lib/decidim/dev/test/factories.rb
+++ b/decidim-dev/lib/decidim/dev/test/factories.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       organization { create(:organization, skip_injection:) }
     end
     title { generate_localized_title(:dummy_resource_title, skip_injection:) }
-    component { create(:dummy_component, organization: , skip_injection:) }
+    component { create(:dummy_component, organization:, skip_injection:) }
     author { create(:user, :confirmed, organization: component.organization, skip_injection:) }
     scope { create(:scope, organization: component.organization, skip_injection:) }
 

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -118,16 +118,16 @@ FactoryBot.define do
 
     trait :with_response_options do
       after(:build) do |question, evaluator|
-        question.response_options do
-          Array.new(3).collect { build(:response_option, question: , skip_injection: evaluator.skip_injection) }
+        question.response_options = Array.new(3).collect do
+          build(:response_option, question:, skip_injection: evaluator.skip_injection)
         end
       end
     end
 
     trait :conditioned do
       after(:build) do |question, evaluator|
-        question.display_conditions do
-          Array.new(3).collect { build(:display_condition, question:, skip_injection: evaluator.skip_injection) }
+        question.display_conditions = Array.new(3).collect do
+          build(:display_condition, question:, skip_injection: evaluator.skip_injection)
         end
       end
     end

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -117,14 +117,18 @@ FactoryBot.define do
     end
 
     trait :with_response_options do
-      response_options do
-        Array.new(3).collect { build(:response_option, skip_injection:) }
+      after(:build) do |question, evaluator|
+        question.response_options do
+          Array.new(3).collect { build(:response_option, question: , skip_injection: evaluator.skip_injection) }
+        end
       end
     end
 
     trait :conditioned do
-      display_conditions do
-        Array.new(3).collect { build(:display_condition, skip_injection:) }
+      after(:build) do |question, evaluator|
+        question.display_conditions do
+          Array.new(3).collect { build(:display_condition, question:, skip_injection: evaluator.skip_injection) }
+        end
       end
     end
 
@@ -195,7 +199,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     condition_question { create(:questionnaire_question, skip_injection:) }
-    question { create(:questionnaire_question, position: 1, skip_injection:) }
+    question { create(:questionnaire_question, position: 1, questionnaire: condition_question.questionnaire, skip_injection:) }
     condition_type { :responded }
     mandatory { true }
 

--- a/decidim-forms/lib/decidim/forms/test/factories.rb
+++ b/decidim-forms/lib/decidim/forms/test/factories.rb
@@ -198,8 +198,8 @@ FactoryBot.define do
     transient do
       skip_injection { false }
     end
-    condition_question { create(:questionnaire_question, skip_injection:) }
-    question { create(:questionnaire_question, position: 1, questionnaire: condition_question.questionnaire, skip_injection:) }
+    condition_question { create(:questionnaire_question, questionnaire: question.questionnaire, skip_injection:) }
+    question { create(:questionnaire_question, position: 1, skip_injection:) }
     condition_type { :responded }
     mandatory { true }
 

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -182,7 +182,7 @@ FactoryBot.define do
 
   factory :meeting_link, class: "Decidim::Meetings::MeetingLink" do
     meeting
-    component
+    component { meeting.component }
   end
 
   factory :registration, class: "Decidim::Meetings::Registration" do

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -236,7 +236,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     meeting
-    user
+    user { create(:user, :confirmed, organization: meeting.component.organization, skip_injection:) }
     sent_at { 1.day.ago }
     accepted_at { nil }
     rejected_at { nil }

--- a/decidim-meetings/lib/decidim/meetings/test/factories.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/factories.rb
@@ -190,7 +190,7 @@ FactoryBot.define do
       skip_injection { false }
     end
     meeting
-    user
+    user { create(:user, :confirmed, organization: meeting.component.organization, skip_injection:) }
   end
 
   factory :agenda, class: "Decidim::Meetings::Agenda" do

--- a/decidim-meetings/spec/models/decidim/meetings/invite_spec.rb
+++ b/decidim-meetings/spec/models/decidim/meetings/invite_spec.rb
@@ -20,7 +20,8 @@ module Decidim
       end
 
       context "without a meeting" do
-        let(:invite) { build(:invite, meeting: nil) }
+        let!(:user) { create(:user, :confirmed) }
+        let(:invite) { build(:invite, meeting: nil, user:) }
 
         it { is_expected.not_to be_valid }
       end

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     transient do
       skip_injection { false }
     end
-    questionnaire { build(:questionnaire, :with_questions, questionnaire_for: component.participatory_space, skip_injection:) }
+    questionnaire { build(:questionnaire, :with_questions, questionnaire_for: component.try(:participatory_space), skip_injection:) }
     component { build(:surveys_component, skip_injection:) }
 
     trait :published do

--- a/decidim-surveys/lib/decidim/surveys/test/factories.rb
+++ b/decidim-surveys/lib/decidim/surveys/test/factories.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
     transient do
       skip_injection { false }
     end
-    questionnaire { build(:questionnaire, :with_questions, skip_injection:) }
+    questionnaire { build(:questionnaire, :with_questions, questionnaire_for: component.participatory_space, skip_injection:) }
     component { build(:surveys_component, skip_injection:) }
 
     trait :published do

--- a/decidim-surveys/spec/system/private_space_survey_spec.rb
+++ b/decidim-surveys/spec/system/private_space_survey_spec.rb
@@ -54,7 +54,7 @@ describe "Private Space Respond a survey" do
 
         expect(page).to have_i18n_content(questionnaire.title)
         expect(page).to have_i18n_content(questionnaire.description)
-        
+
         expect(page).to have_no_css(".form.response-questionnaire")
 
         within ".response-questionnaire__step" do

--- a/decidim-surveys/spec/system/private_space_survey_spec.rb
+++ b/decidim-surveys/spec/system/private_space_survey_spec.rb
@@ -54,10 +54,10 @@ describe "Private Space Respond a survey" do
 
         expect(page).to have_i18n_content(questionnaire.title)
         expect(page).to have_i18n_content(questionnaire.description)
-
+        
         expect(page).to have_no_css(".form.response-questionnaire")
 
-        within "[data-question-readonly]" do
+        within ".response-questionnaire__step" do
           expect(page).to have_i18n_content(question.body)
           expect(page).not_to have_i18n_content(question_conditioned.body)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on a plugin regarding the sitemaps, i have noticed that the factories are generating way too many organizations than it should. 

This PR fixes that, and fixes any failing the specs

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Fetch the specs i have added from `decidim-core/spec/factory_bot_spec.rb`
2. Run it against the develop branch
3. See there are some specs failing 
4. Apply the patch
5. Run the spec again
6. See there are no errors.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
