### PR TITLE
Add short flags and document --component flags on generator

### DIFF
--- a/decidim-generators/exe/decidim
+++ b/decidim-generators/exe/decidim
@@ -48,6 +48,10 @@ App generation extra options (ignored if the --component flag is on):
   --seed_db [true|false]   Seed the database: generate demo data for each participatory space and component
   --recreate_db            Recreate the database after installing Decidim
 
+Component generation extra options (ignored ifthe --component flag is not defined)
+  --external               To create a new module external to the main decidim repository
+  --destination-folder     IF you want to point to an existing folder or give it a custom name
+
 Examples:
   decidim my-application
   decidim --storage=s3 my-application
@@ -55,6 +59,9 @@ Examples:
   decidim --locales=en,ca,es,fr my-application
   decidim --queue sidekiq my-application
   decidim --queue sidekiq --storage s3 my-application
+
+  decidim --component --external my_component
+  decidim --component --external my_component --destination-folder my-comp
 "
 else
   require "decidim/generators/app_generator"

--- a/decidim-generators/exe/decidim
+++ b/decidim-generators/exe/decidim
@@ -48,7 +48,7 @@ App generation extra options (ignored if the --component flag is on):
   --seed_db [true|false]   Seed the database: generate demo data for each participatory space and component
   --recreate_db            Recreate the database after installing Decidim
 
-Component generation extra options (ignored ifthe --component flag is not defined)
+Component generation extra options (ignored if the --component flag is not defined)
   --external               To create a new module external to the main decidim repository
   --destination-folder     IF you want to point to an existing folder or give it a custom name
 

--- a/decidim-generators/exe/decidim
+++ b/decidim-generators/exe/decidim
@@ -9,25 +9,25 @@ if File.exist?(File.expand_path("../../.git", __dir__))
 end
 
 case ARGV[0]
-when "--component"
+when "--component", "-c"
   ARGV.replace(["component", *ARGV[1..-1]])
 
   require "decidim/generators/component_generator"
 
   Decidim::Generators::ComponentGenerator.start
-when "--version"
+when "--version", "-v"
   require "decidim/core/version"
   puts Decidim::Core.version
-when "--help"
+when "--help", "-h"
   require "decidim/core/version"
   puts "Decidim #{Decidim::Core.version}
 Syntax: decidim [options] [App or Module name]
 https://decidim.org
 
 Options:
-  --help                   display this help and exit
-  --version                output version information and exit
-  --component [name]       creates a component for Decidim
+  -h, --help                   display this help and exit
+  -v, --version                output version information and exit
+  -c, --component [name]       creates a component for Decidim
   [name]                   creates an application based on Decidim
 
 App generation extra options (ignored if the --component flag is on):


### PR DESCRIPTION
#### :tophat: What? Why?

While working on  #15297, I noticed two things:

- we have some undocumented flags on the generator for component
- we could have an easy improvement of DX by also having the short version flags (standarized with other UNIX tools, such as -h and -v)

This PR fixes these two issues. 

#### :pushpin: Related Issues
 
- Related to #15297
 
#### Testing

./decidim-generators/exe/decidim  -v
./decidim-generators/exe/decidim  -h 

:hearts: Thank you!
