### PR TITLE
Process page announcement bug fix with system test

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/index.js
+++ b/decidim-core/app/packs/src/decidim/editor/index.js
@@ -82,7 +82,9 @@ export default function createEditor(container) {
   container.insertBefore(toolbar, editorContainer);
 
   editor.on("update", () => {
-    input.value = editor.isEmpty ? "" : editor.getHTML();
+    input.value = editor.isEmpty
+      ? ""
+      : editor.getHTML();
   });
 
   return editor;

--- a/decidim-core/app/packs/src/decidim/editor/index.js
+++ b/decidim-core/app/packs/src/decidim/editor/index.js
@@ -82,7 +82,7 @@ export default function createEditor(container) {
   container.insertBefore(toolbar, editorContainer);
 
   editor.on("update", () => {
-    input.value = editor.isEmpty ? '' : editor.getHTML();
+    input.value = editor.isEmpty ? "" : editor.getHTML();
   });
 
   return editor;

--- a/decidim-core/app/packs/src/decidim/editor/index.js
+++ b/decidim-core/app/packs/src/decidim/editor/index.js
@@ -81,7 +81,9 @@ export default function createEditor(container) {
   const toolbar = createEditorToolbar(editor);
   container.insertBefore(toolbar, editorContainer);
 
-  editor.on("update", () => (input.value = editor.getHTML()));
+  editor.on("update", () => {
+    input.value = editor.isEmpty ? '' : editor.getHTML();
+  });
 
   return editor;
 }

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -40,7 +40,7 @@ shared_examples "manage processes announcements" do
     end
   end
 
-  it "remove announcement element if annoucement body is empty" do
+  it "remove announcement element if announcement body is empty" do
     within "tr", text: translated(participatory_process.title) do
       click_on translated(participatory_process.title)
     end

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples "manage processes announcements" do
-  let!(:participatory_process) { create(:participatory_process, :with_content_blocks, organization:, blocks_manifests: [:announcement]) }
+  let!(:participatory_process) { create(:participatory_process, :with_content_blocks, organization:, blocks_manifests: [:announcement], announcement: {}) }
 
   it "can customize a general announcement for the process" do
     within "tr", text: translated(participatory_process.title) do
@@ -37,6 +37,41 @@ shared_examples "manage processes announcements" do
 
     page.within_window(new_window) do
       expect(page).to have_content("An important announcement")
+    end
+  end
+
+  it "remove announcement element if annoucement body is empty" do
+    within "tr", text: translated(participatory_process.title) do
+      click_on translated(participatory_process.title)
+    end
+
+    within_admin_sidebar_menu do
+      click_on "About this process"
+    end
+
+    find_by_id("participatory_process-announcement-tabs").click
+    send_keys("T")
+    send_keys(:backspace)
+
+    within ".edit_participatory_process" do
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_admin_callout("successfully")
+
+    visit decidim_admin_participatory_processes.participatory_processes_path
+
+    new_window = window_opened_by do
+      within("tr", text: translated(participatory_process.title)) do
+        find("button[data-controller='dropdown']").click
+        click_on "Preview"
+      end
+    end
+
+    page.within_window(new_window) do
+      expect(page).to have_no_css(".flash")
+      expect(page).to have_no_css(".flash__message")
+      expect(page).to have_no_css(".announcement")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When updating the process announcement, the editor would leave a break point in the array which resulted in an empty announcement tab , which looked un-professional.

#### :pushpin: Related Issues
#15569 

#### Testing
Update the process announcement with edit, then preview the process and the tab is not there.


:hearts: Thank you!
