### PR TITLE
Update Ruby version from 3.1.1 to 3.3.4 in v0.30 docs

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -4,7 +4,7 @@ In order to develop on decidim, you will need:
 
 * *Git* 2.34+
 * *PostgreSQL* 17.4+
-* *Ruby* 3.1.1
+* *Ruby* 3.3.4
 * *NodeJS* 18.17.x
 * *Npm* 10.9.x
 * *ImageMagick*
@@ -33,8 +33,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 3.1.1
-rbenv global 3.1.1
+rbenv install 3.3.4
+rbenv global 3.3.4
 ----
 
 == 2. Installing PostgreSQL


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing old versions, I noticed that we went from ruby 3.2.2 in Decidim v0.29 docs to 3.1.1 in v0.30 docs.

This PR fixes it. 

:hearts: Thank you!
