### PR TITLE
Bump Linkify to v4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5198,7 +5198,7 @@
       "version": "2.1.13",
       "license": "MIT",
       "dependencies": {
-        "linkifyjs": "^4.1.0"
+        "linkifyjs": "^4.3.2"
       },
       "funding": {
         "type": "github",


### PR DESCRIPTION
#### :tophat: What? Why?
Bumps Linkify to the next version.

#### :pushpin: Related Issues

#### Testing
run `npm install`. 

### :camera: Screenshots


:hearts: Thank you!
