### PR TITLE
Proposal index grid cards 

### DIFF
--- a/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
+++ b/decidim-proposals/app/packs/stylesheets/decidim/proposals/proposals.scss
@@ -217,7 +217,7 @@
     @apply md:gap-4;
 
     .card__proposals-item {
-      @apply flex flex-col justify-between border-solid border-[#D3D5D9] border rounded;
+      @apply flex flex-col mt-6 justify-between border-solid border-[#D3D5D9] border rounded;
 
       .card__grid {
         @apply mb-2.5 md:mb-0 flex-1 justify-between;


### PR DESCRIPTION
#### :tophat: What? Why?
Top margin is now added to the `.card__proposals-item` within the `__grid-grid` of the index in the module.

#### :pushpin: Related Issues
- Fixes #15572

#### Testing
1. Use the decidim application
2. Find a space with proposals published 
3. Go to the list of index proposals
4. See the margin on the index equal with the rest of the grid

### :camera: Screenshots
<img width="1172" height="734" alt="image" src="https://github.com/user-attachments/assets/9c7f98d7-bf89-4855-b730-486de501f767" />


:hearts: Thank you!
