### PR TITLE
Backport 'Remove user data left behind by `Decidim::DestroyAccount`' to v0.31

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -19,6 +19,15 @@ module Decidim
         destroy_user_account!
         destroy_user_identities
         destroy_follows
+        destroy_user_versions
+        destroy_user_private_exports
+        destroy_user_access_grants
+        destroy_user_access_tokens
+        destroy_user_reminders
+        destroy_user_notifications
+        destroy_user_badges
+        destroy_user_likes
+        destroy_user_reports
         destroy_participatory_space_private_user
         delegate_destroy_to_participatory_spaces
       end
@@ -47,17 +56,53 @@ module Decidim
       current_user.save!
     end
 
+    def destroy_user_badges
+      Decidim::Gamification::BadgeScore.where(user: current_user).find_each(&:destroy)
+    end
+
+    def destroy_user_reports
+      Decidim::UserModeration.where(user: current_user).find_each(&:destroy)
+    end
+
+    def destroy_user_likes
+      Decidim::Like.where(author: current_user).find_each(&:destroy)
+    end
+
     def destroy_user_identities
-      current_user.identities.destroy_all
+      current_user.identities.find_each(&:destroy)
+    end
+
+    def destroy_user_versions
+      current_user.versions.find_each(&:destroy)
+    end
+
+    def destroy_user_private_exports
+      current_user.private_exports.find_each(&:destroy)
+    end
+
+    def destroy_user_access_grants
+      current_user.access_grants.find_each(&:destroy)
+    end
+
+    def destroy_user_access_tokens
+      current_user.access_tokens.find_each(&:destroy)
+    end
+
+    def destroy_user_reminders
+      current_user.reminders.find_each(&:destroy)
+    end
+
+    def destroy_user_notifications
+      current_user.notifications.find_each(&:destroy)
     end
 
     def destroy_follows
-      Decidim::Follow.where(followable: current_user).destroy_all
-      Decidim::Follow.where(user: current_user).destroy_all
+      Decidim::Follow.where(followable: current_user).find_each(&:destroy)
+      Decidim::Follow.where(user: current_user).find_each(&:destroy)
     end
 
     def destroy_participatory_space_private_user
-      Decidim::ParticipatorySpacePrivateUser.where(user: current_user).destroy_all
+      Decidim::ParticipatorySpacePrivateUser.where(user: current_user).find_each(&:destroy)
     end
 
     def delegate_destroy_to_participatory_spaces

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -864,6 +864,18 @@ FactoryBot.define do
     scopes { "profile" }
   end
 
+  factory :oauth_access_grant, class: "Doorkeeper::AccessGrant" do
+    transient do
+      skip_injection { false }
+      organization { create(:organization) }
+    end
+    resource_owner_id { create(:user, organization: application.organization, skip_injection:).id }
+    application { create(:oauth_application, organization:, skip_injection:) }
+    redirect_uri { "https://app.com/callback" }
+    expires_in { 100 }
+    scopes { "public write" }
+  end
+
   factory :private_export, class: "Decidim::PrivateExport" do
     transient do
       skip_injection { false }

--- a/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :upgrade do
+    desc "Removes deleted users left behind data"
+    task remove_deleted_users_left_data: :environment do
+      logger.info("=== Removing left behind data by 'Decidim::DestroyAccount'")
+      Decidim::User.where.not(deleted_at: nil).find_each do |deleted_user|
+        Decidim::Follow.where(followable: deleted_user).find_each(&:destroy)
+        Decidim::Follow.where(user: deleted_user).find_each(&:destroy)
+        Decidim::ParticipatorySpacePrivateUser.where(user: deleted_user).find_each(&:destroy)
+        Decidim::Gamification::BadgeScore.where(user: deleted_user).find_each(&:destroy)
+        Decidim::UserModeration.where(user: deleted_user).find_each(&:destroy)
+        Decidim::Like.where(author: deleted_user).find_each(&:destroy)
+
+        Decidim.participatory_space_manifests.each do |space_manifest|
+          space_manifest.invoke_on_destroy_account(deleted_user)
+        end
+
+        deleted_user.identities.find_each(&:destroy)
+        deleted_user.versions.find_each(&:destroy)
+        deleted_user.private_exports.find_each(&:destroy)
+        deleted_user.access_grants.find_each(&:destroy)
+        deleted_user.access_tokens.find_each(&:destroy)
+        deleted_user.reminders.find_each(&:destroy)
+        deleted_user.notifications.find_each(&:destroy)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:remove_deleted_users_left_data", type: :task, versioning: true do
+  let!(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed) }
+  let(:other_user) { create(:user, :confirmed) }
+  let(:deleted_user) { create(:user, :confirmed, :deleted) }
+
+  before do
+    create(:oauth_access_token, resource_owner_id: deleted_user.id)
+    create(:oauth_access_grant, organization: user.organization, resource_owner_id: deleted_user.id)
+    create(:notification, user: deleted_user)
+    create(:reminder, user: deleted_user)
+    create(:private_export, attached_to: deleted_user)
+    create(:identity, user: deleted_user)
+    create(:follow, followable: deleted_user, user: user)
+    create(:follow, followable: user, user: deleted_user)
+    create(:participatory_space_private_user, user: deleted_user)
+
+    create(:oauth_access_token, resource_owner_id: user.id)
+    create(:identity, user:)
+    create(:follow, followable: user, user: other_user)
+    create(:follow, followable: other_user, user:)
+    create(:private_export, attached_to: user)
+  end
+
+  context "when the task is performed" do
+    it "deletes the access tokens of deleted user" do
+      expect { task.execute }.to change(Doorkeeper::AccessToken, :count).by(-1)
+    end
+
+    it "deletes the follows of the deleted user" do
+      expect { task.execute }.to change(Decidim::Follow, :count).by(-2)
+    end
+
+    it "deletes the access grants of deleted user" do
+      expect { task.execute }.to change(Doorkeeper::AccessGrant, :count).by(-1)
+    end
+
+    it "deletes the notifications of deleted user" do
+      expect { task.execute }.to change(Decidim::Notification, :count).by(-1)
+    end
+
+    it "deletes the reminders of deleted user" do
+      expect { task.execute }.to change(Decidim::Reminder, :count).by(-1)
+    end
+
+    it "deletes the authorizations of deleted user" do
+      expect { task.execute }.not_to change(Decidim::Authorization, :count)
+    end
+
+    it "deletes the versions of deleted user" do
+      task.execute
+      expect(deleted_user.reload.versions.count).to eq(0)
+    end
+
+    it "deletes the private exports of deleted user" do
+      expect { task.execute }.to change(Decidim::PrivateExport, :count).by(-1)
+    end
+
+    it "deletes the identities of deleted user" do
+      expect { task.execute }.to change(Decidim::Identity, :count).by(-1)
+    end
+
+    it "deletes the participatory space private user of deleted user" do
+      expect { task.execute }.to change(Decidim::ParticipatorySpacePrivateUser, :count).by(-1)
+    end
+
+    it "deletes the badges of deleted user" do
+      Decidim::Gamification::BadgeScore.find_or_create_by(user: deleted_user, badge_name: :followers)
+
+      expect { task.execute }.to change(Decidim::Gamification::BadgeScore, :count).by(-1)
+    end
+
+    it "deletes user's reports status" do
+      form_params = {
+        reason: "spam",
+        details: "some details about the report"
+      }
+      form = Decidim::ReportForm.from_params(form_params).with_context(current_user: deleted_user)
+      Decidim::CreateUserReport.call(form, deleted_user)
+
+      expect { task.execute }.to change(Decidim::UserModeration, :count).by(-1)
+    end
+
+    it "deletes user likes" do
+      component = create(:dummy_component, organization: deleted_user.organization)
+      resource = create(:dummy_resource, component:)
+      create(:like, author: deleted_user, resource:)
+
+      expect { task.execute }.to change(Decidim::Like, :count).by(-1)
+    end
+  end
+
+  context "when task is performed for not deleted users" do
+    it "does not affects the user records" do
+      expect { task.execute }.not_to(change { user.reload.versions.count })
+      expect { task.execute }.not_to(change { user.reload.access_tokens.count })
+      expect { task.execute }.not_to(change { user.reload.identities.count })
+      expect { task.execute }.not_to(change { user.reload.follows.count })
+      expect { task.execute }.not_to(change { user.reload.private_exports.count })
+      expect { task.execute }.not_to change(Decidim::Authorization, :count)
+      expect { task.execute }.not_to change(Decidim::UserModeration, :count)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14731 to v0.31

:hearts: Thank you!