### PR TITLE
Backport 'Remove user data left behind by `Decidim::DestroyAccount`' to v0.30

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -88,7 +88,17 @@ bin/rails decidim:upgrade:fix_deleted_private_follows
 
 You can read more about this change on PR [#12878](https://github.com/decidim/decidim/pull/12878).
 
-### 3.4. [[TITLE OF THE ACTION]]
+### 3.4. Remove user data left behind by `Decidim::DestroyAccount`
+
+When a user deletes their account and the `Decidim::DestroyAccount` command is executed, certain related data such as authorizations, versions, private exports, access grants, access tokens, notifications, and reminders were left behind. To fix this issue, we've added a new rake task to clean up the leftover data for previously deleted users.
+
+```ruby
+bin/rails decidim:upgrade:remove_deleted_users_left_data
+```
+
+You can read more about this change on PR [#14731](https://github.com/decidim/decidim/pull/14731).
+
+### 3.5. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 

--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -27,7 +27,7 @@ module Decidim
         destroy_user_reminders
         destroy_user_notifications
         destroy_user_badges
-        destroy_user_likes
+        destroy_user_endorsements
         destroy_user_reports
         destroy_participatory_space_private_user
         delegate_destroy_to_participatory_spaces
@@ -65,8 +65,8 @@ module Decidim
       Decidim::UserModeration.where(user: current_user).find_each(&:destroy)
     end
 
-    def destroy_user_likes
-      Decidim::Like.where(author: current_user).find_each(&:destroy)
+    def destroy_user_endorsements
+      Decidim::Endorsement.where(author: current_user).find_each(&:destroy)
     end
 
     def destroy_user_identities

--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -20,6 +20,15 @@ module Decidim
         destroy_user_identities
         destroy_user_group_memberships
         destroy_follows
+        destroy_user_versions
+        destroy_user_private_exports
+        destroy_user_access_grants
+        destroy_user_access_tokens
+        destroy_user_reminders
+        destroy_user_notifications
+        destroy_user_badges
+        destroy_user_likes
+        destroy_user_reports
         destroy_participatory_space_private_user
         delegate_destroy_to_participatory_spaces
       end
@@ -48,8 +57,44 @@ module Decidim
       current_user.save!
     end
 
+    def destroy_user_badges
+      Decidim::Gamification::BadgeScore.where(user: current_user).find_each(&:destroy)
+    end
+
+    def destroy_user_reports
+      Decidim::UserModeration.where(user: current_user).find_each(&:destroy)
+    end
+
+    def destroy_user_likes
+      Decidim::Like.where(author: current_user).find_each(&:destroy)
+    end
+
     def destroy_user_identities
-      current_user.identities.destroy_all
+      current_user.identities.find_each(&:destroy)
+    end
+
+    def destroy_user_versions
+      current_user.versions.find_each(&:destroy)
+    end
+
+    def destroy_user_private_exports
+      current_user.private_exports.find_each(&:destroy)
+    end
+
+    def destroy_user_access_grants
+      current_user.access_grants.find_each(&:destroy)
+    end
+
+    def destroy_user_access_tokens
+      current_user.access_tokens.find_each(&:destroy)
+    end
+
+    def destroy_user_reminders
+      current_user.reminders.find_each(&:destroy)
+    end
+
+    def destroy_user_notifications
+      current_user.notifications.find_each(&:destroy)
     end
 
     def destroy_user_group_memberships
@@ -57,12 +102,12 @@ module Decidim
     end
 
     def destroy_follows
-      Decidim::Follow.where(followable: current_user).destroy_all
-      Decidim::Follow.where(user: current_user).destroy_all
+      Decidim::Follow.where(followable: current_user).find_each(&:destroy)
+      Decidim::Follow.where(user: current_user).find_each(&:destroy)
     end
 
     def destroy_participatory_space_private_user
-      Decidim::ParticipatorySpacePrivateUser.where(user: current_user).destroy_all
+      Decidim::ParticipatorySpacePrivateUser.where(user: current_user).find_each(&:destroy)
     end
 
     def delegate_destroy_to_participatory_spaces

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -932,6 +932,18 @@ FactoryBot.define do
     scopes { "public" }
   end
 
+  factory :oauth_access_grant, class: "Doorkeeper::AccessGrant" do
+    transient do
+      skip_injection { false }
+      organization { create(:organization) }
+    end
+    resource_owner_id { create(:user, organization: application.organization, skip_injection:).id }
+    application { create(:oauth_application, organization:, skip_injection:) }
+    redirect_uri { "https://app.com/callback" }
+    expires_in { 100 }
+    scopes { "public write" }
+  end
+
   factory :private_export, class: "Decidim::PrivateExport" do
     transient do
       skip_injection { false }

--- a/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  namespace :upgrade do
+    desc "Removes deleted users left behind data"
+    task remove_deleted_users_left_data: :environment do
+      logger.info("=== Removing left behind data by 'Decidim::DestroyAccount'")
+      Decidim::User.where.not(deleted_at: nil).find_each do |deleted_user|
+        Decidim::Follow.where(followable: deleted_user).find_each(&:destroy)
+        Decidim::Follow.where(user: deleted_user).find_each(&:destroy)
+        Decidim::ParticipatorySpacePrivateUser.where(user: deleted_user).find_each(&:destroy)
+        Decidim::Gamification::BadgeScore.where(user: deleted_user).find_each(&:destroy)
+        Decidim::UserModeration.where(user: deleted_user).find_each(&:destroy)
+        Decidim::Like.where(author: deleted_user).find_each(&:destroy)
+
+        Decidim.participatory_space_manifests.each do |space_manifest|
+          space_manifest.invoke_on_destroy_account(deleted_user)
+        end
+
+        deleted_user.identities.find_each(&:destroy)
+        deleted_user.versions.find_each(&:destroy)
+        deleted_user.private_exports.find_each(&:destroy)
+        deleted_user.access_grants.find_each(&:destroy)
+        deleted_user.access_tokens.find_each(&:destroy)
+        deleted_user.reminders.find_each(&:destroy)
+        deleted_user.notifications.find_each(&:destroy)
+      end
+    end
+  end
+end

--- a/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
+++ b/decidim-core/lib/tasks/upgrade/decidim_remove_deleted_users_left_data_tasks.rake
@@ -11,7 +11,7 @@ namespace :decidim do
         Decidim::ParticipatorySpacePrivateUser.where(user: deleted_user).find_each(&:destroy)
         Decidim::Gamification::BadgeScore.where(user: deleted_user).find_each(&:destroy)
         Decidim::UserModeration.where(user: deleted_user).find_each(&:destroy)
-        Decidim::Like.where(author: deleted_user).find_each(&:destroy)
+        Decidim::Endorsement.where(author: deleted_user).find_each(&:destroy)
 
         Decidim.participatory_space_manifests.each do |space_manifest|
           space_manifest.invoke_on_destroy_account(deleted_user)

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -145,7 +145,7 @@ module Decidim
           create(:like, author: user, resource:)
 
           expect(resource.likes.count).to eq(1)
-          expect { command.call }.to change(Like, :count).by(-1)
+          expect { command.call }.to change(Endorsement, :count).by(-1)
           expect(resource.likes.count).to eq(0)
         end
 

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -3,10 +3,9 @@
 require "spec_helper"
 
 module Decidim
-  describe DestroyAccount do
+  describe DestroyAccount, :versioning => true do
     let(:command) { described_class.new(form) }
     let(:user) { create(:user, :confirmed) }
-    let!(:identity) { create(:identity, user:) }
     let(:valid) { true }
     let(:data) do
       {
@@ -62,50 +61,109 @@ module Decidim
         expect(user.notifications_sending_frequency).to eq("none")
       end
 
-      it "destroys the current user avatar" do
-        command.call
-        expect(user.reload.avatar).not_to be_present
-      end
-
-      it "deletes user's identities" do
-        expect do
-          command.call
-        end.to change(Identity, :count).by(-1)
-      end
-
-      it "deletes user group memberships" do
-        user_group = create(:user_group)
-        create(:user_group_membership, user_group:, user:)
-
-        expect do
-          command.call
-        end.to change(UserGroupMembership, :count).by(-1)
-      end
-
-      it "deletes the follows" do
-        other_user = create(:user)
-        create(:follow, followable: user, user: other_user)
-        create(:follow, followable: other_user, user:)
-
-        expect do
-          command.call
-        end.to change(Follow, :count).by(-2)
-      end
-
-      it "deletes participatory space private user" do
-        create(:participatory_space_private_user, user:)
-
-        expect do
-          command.call
-        end.to change(ParticipatorySpacePrivateUser, :count).by(-1)
-      end
-
       context "when user is admin" do
         let(:user) { create(:user, :confirmed, :admin) }
 
         it "removes admin role" do
           command.call
           expect(user.reload.admin).to be_falsey
+        end
+      end
+
+      it "destroys the current user avatar" do
+        command.call
+        expect(user.reload.avatar).not_to be_present
+      end
+
+      context "when removing associated records" do
+        it "deletes user's access tokens" do
+          create(:oauth_access_token, resource_owner_id: user.id)
+
+          expect { command.call }.to change(::Doorkeeper::AccessToken, :count).by(-1)
+        end
+
+        it "deletes user's access grants" do
+          create(:oauth_access_grant, organization: user.organization, resource_owner_id: user.id)
+
+          expect { command.call }.to change(::Doorkeeper::AccessGrant, :count).by(-1)
+        end
+
+        it "deletes user's notifications" do
+          create(:notification, user:)
+
+          expect { command.call }.to change(Decidim::Notification, :count).by(-1)
+        end
+
+        it "deletes user's reminders" do
+          create(:reminder, user:)
+
+          expect { command.call }.to change(Decidim::Reminder, :count).by(-1)
+        end
+
+        it "deletes user's private exports" do
+          create(:private_export, attached_to: user)
+
+          expect { command.call }.to change(Decidim::PrivateExport, :count).by(-1)
+        end
+
+        it "deletes user's identities" do
+          create(:identity, user:)
+
+          expect { command.call }.to change(Decidim::Identity, :count).by(-1)
+        end
+
+        it "deletes user's versions" do
+          expect(user.reload.versions.count).to eq(1)
+          command.call
+          expect(user.reload.versions.count).to eq(0)
+        end
+
+        it "deletes the follows" do
+          other_user = create(:user)
+          create(:follow, followable: user, user: other_user)
+          create(:follow, followable: other_user, user:)
+
+          expect { command.call }.to change(Follow, :count).by(-2)
+        end
+
+        it "preserves the authorizations" do
+          create(:authorization, :granted, user:, unique_id: "12345678X")
+          create(:authorization, :granted, user:, unique_id: "A12345678")
+
+          expect { command.call }.not_to change(Decidim::Authorization, :count)
+        end
+
+        it "deletes participatory space private user" do
+          create(:participatory_space_private_user, user:)
+
+          expect { command.call }.to change(ParticipatorySpacePrivateUser, :count).by(-1)
+        end
+
+        it "deletes user likes" do
+          component = create(:dummy_component, organization: user.organization)
+          resource = create(:dummy_resource, component:)
+          create(:like, author: user, resource:)
+
+          expect(resource.likes.count).to eq(1)
+          expect { command.call }.to change(Like, :count).by(-1)
+          expect(resource.likes.count).to eq(0)
+        end
+
+        it "deletes user's badges" do
+          Decidim::Gamification::BadgeScore.find_or_create_by(user:, badge_name: :followers)
+
+          expect { command.call }.to change(Decidim::Gamification::BadgeScore, :count).by(-1)
+        end
+
+        it "deletes user's reports status" do
+          form_params = {
+            reason: "spam",
+            details: "some details about the report"
+          }
+          form = ReportForm.from_params(form_params).with_context(current_user: user)
+          Decidim::CreateUserReport.call(form, user)
+
+          expect { command.call }.to change(Decidim::UserModeration, :count).by(-1)
         end
       end
     end

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -139,14 +139,14 @@ module Decidim
           expect { command.call }.to change(ParticipatorySpacePrivateUser, :count).by(-1)
         end
 
-        it "deletes user likes" do
+        it "deletes user endorsements" do
           component = create(:dummy_component, organization: user.organization)
           resource = create(:dummy_resource, component:)
-          create(:like, author: user, resource:)
+          create(:endorsement, author: user, resource:)
 
-          expect(resource.likes.count).to eq(1)
+          expect(resource.endorsements.count).to eq(1)
           expect { command.call }.to change(Endorsement, :count).by(-1)
-          expect(resource.likes.count).to eq(0)
+          expect(resource.endorsements.count).to eq(0)
         end
 
         it "deletes user's badges" do

--- a/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:remove_deleted_users_left_data", type: :task, versioning: true do
+  let!(:organization) { create(:organization) }
+  let(:user) { create(:user, :confirmed) }
+  let(:other_user) { create(:user, :confirmed) }
+  let(:deleted_user) { create(:user, :confirmed, :deleted) }
+
+  before do
+    create(:oauth_access_token, resource_owner_id: deleted_user.id)
+    create(:oauth_access_grant, organization: user.organization, resource_owner_id: deleted_user.id)
+    create(:notification, user: deleted_user)
+    create(:reminder, user: deleted_user)
+    create(:private_export, attached_to: deleted_user)
+    create(:identity, user: deleted_user)
+    create(:follow, followable: deleted_user, user: user)
+    create(:follow, followable: user, user: deleted_user)
+    create(:participatory_space_private_user, user: deleted_user)
+
+    create(:oauth_access_token, resource_owner_id: user.id)
+    create(:identity, user:)
+    create(:follow, followable: user, user: other_user)
+    create(:follow, followable: other_user, user:)
+    create(:private_export, attached_to: user)
+  end
+
+  context "when the task is performed" do
+    it "deletes the access tokens of deleted user" do
+      expect { task.execute }.to change(Doorkeeper::AccessToken, :count).by(-1)
+    end
+
+    it "deletes the follows of the deleted user" do
+      expect { task.execute }.to change(Decidim::Follow, :count).by(-2)
+    end
+
+    it "deletes the access grants of deleted user" do
+      expect { task.execute }.to change(Doorkeeper::AccessGrant, :count).by(-1)
+    end
+
+    it "deletes the notifications of deleted user" do
+      expect { task.execute }.to change(Decidim::Notification, :count).by(-1)
+    end
+
+    it "deletes the reminders of deleted user" do
+      expect { task.execute }.to change(Decidim::Reminder, :count).by(-1)
+    end
+
+    it "deletes the authorizations of deleted user" do
+      expect { task.execute }.not_to change(Decidim::Authorization, :count)
+    end
+
+    it "deletes the versions of deleted user" do
+      task.execute
+      expect(deleted_user.reload.versions.count).to eq(0)
+    end
+
+    it "deletes the private exports of deleted user" do
+      expect { task.execute }.to change(Decidim::PrivateExport, :count).by(-1)
+    end
+
+    it "deletes the identities of deleted user" do
+      expect { task.execute }.to change(Decidim::Identity, :count).by(-1)
+    end
+
+    it "deletes the participatory space private user of deleted user" do
+      expect { task.execute }.to change(Decidim::ParticipatorySpacePrivateUser, :count).by(-1)
+    end
+
+    it "deletes the badges of deleted user" do
+      Decidim::Gamification::BadgeScore.find_or_create_by(user: deleted_user, badge_name: :followers)
+
+      expect { task.execute }.to change(Decidim::Gamification::BadgeScore, :count).by(-1)
+    end
+
+    it "deletes user's reports status" do
+      form_params = {
+        reason: "spam",
+        details: "some details about the report"
+      }
+      form = Decidim::ReportForm.from_params(form_params).with_context(current_user: deleted_user)
+      Decidim::CreateUserReport.call(form, deleted_user)
+
+      expect { task.execute }.to change(Decidim::UserModeration, :count).by(-1)
+    end
+
+    it "deletes user likes" do
+      component = create(:dummy_component, organization: deleted_user.organization)
+      resource = create(:dummy_resource, component:)
+      create(:like, author: deleted_user, resource:)
+
+      expect { task.execute }.to change(Decidim::Like, :count).by(-1)
+    end
+  end
+
+  context "when task is performed for not deleted users" do
+    it "does not affects the user records" do
+      expect { task.execute }.not_to(change { user.reload.versions.count })
+      expect { task.execute }.not_to(change { user.reload.access_tokens.count })
+      expect { task.execute }.not_to(change { user.reload.identities.count })
+      expect { task.execute }.not_to(change { user.reload.follows.count })
+      expect { task.execute }.not_to(change { user.reload.private_exports.count })
+      expect { task.execute }.not_to change(Decidim::Authorization, :count)
+      expect { task.execute }.not_to change(Decidim::UserModeration, :count)
+    end
+  end
+end

--- a/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
@@ -85,12 +85,12 @@ describe "rake decidim:upgrade:remove_deleted_users_left_data", type: :task, ver
       expect { task.execute }.to change(Decidim::UserModeration, :count).by(-1)
     end
 
-    it "deletes user likes" do
+    it "deletes user endorsements" do
       component = create(:dummy_component, organization: deleted_user.organization)
       resource = create(:dummy_resource, component:)
-      create(:like, author: deleted_user, resource:)
+      create(:endorsement, author: deleted_user, resource:)
 
-      expect { task.execute }.to change(Decidim::Like, :count).by(-1)
+      expect { task.execute }.to change(Decidim::Endorsement, :count).by(-1)
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14731 to v0.30

:hearts: Thank you!