### PR TITLE
Survey seperator on metadata & display condtion

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/admin/display_condition_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/admin/display_condition_form.rb
@@ -39,7 +39,7 @@ module Decidim
         end
 
         def questions_for_select(questionnaire, id)
-          questionnaire.questions.map do |question|
+          questionnaire.questions.not_separator.map do |question|
             [
               question.translated_body,
               question.id,

--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -41,18 +41,15 @@ module Decidim
 
       # Public: Splits responses by step, keeping the separator.
       #
-      # Returns an array of steps. Each step is a list of the questions in that
-      # step, including the separator.
+      # Returns an array of steps. Splits responses at each separator.
+      # Allowing only steps with questions to be counted, excluding the separators.
       def responses_by_step
-        @responses_by_step ||=
-          begin
-            steps = responses.chunk_while do |a, b|
-              !a.question.separator? || b.question.separator?
-            end.to_a
-
-            steps = [[]] if steps == []
-            steps
+        @responses_by_step ||= begin
+          steps = responses.slice_before { |response| response.question.separator? }.map do |group|
+            group.reject { |response| response.question.separator? }
           end
+          steps.reject(&:empty?)
+        end
       end
 
       def total_steps

--- a/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
@@ -112,20 +112,32 @@ module Decidim
 
         describe "#questions_for_select" do
           let(:questions_for_select) { subject.questions_for_select(questionnaire, question.id) }
+          let!(:separator_question) { create(:questionnaire_question, questionnaire: questionnaire, question_type: "separator") }
 
           it "returns an array of arrays containing translated body, id, and a hash" do
-            expect(questions_for_select.first.first).to eq(questionnaire.questions.first.translated_body)
-            expect(questions_for_select.first.second).to eq(questionnaire.questions.first.id)
+            expect(questions_for_select.first.first).to eq(
+              questionnaire.questions.where.not(question_type: "separator").first.translated_body
+            )
+            expect(questions_for_select.first.second).to eq(
+              questionnaire.questions.where.not(question_type: "separator").first.id
+            )
             expect(questions_for_select.first.third).to be_a(Hash)
           end
 
           it "attaches a 'data-type' attribute to every question with its question_type" do
-            expect(questions_for_select.map { |q| q.last["data-type"] }).to match_array(questionnaire.questions.pluck(:question_type))
+            expect(questions_for_select.map { |q| q.last["data-type"] }).to match_array(
+              questionnaire.questions.where.not(question_type: "separator").pluck(:question_type)
+            )
           end
 
           it "disables current question" do
             this_question = questions_for_select.find { |q| q.second == decidim_question_id }
             expect(this_question.last["disabled"]).to be true
+          end
+
+          it "does not include separators as choices" do
+            ids = questions_for_select.map(&:second)
+            expect(ids).not_to include(separator_question.id)
           end
         end
 

--- a/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/questionnaire_form_spec.rb
@@ -54,7 +54,7 @@ module Decidim
 
           expect(result).to eq(
             [
-              [question.id.to_s, separator.id.to_s],
+              [question.id.to_s],
               [question2.id.to_s]
             ]
           )
@@ -68,7 +68,7 @@ module Decidim
           it "returns an empty spec" do
             result = subject.responses_by_step
 
-            expect(result).to eq([[]])
+            expect(result).to eq([])
           end
         end
       end

--- a/decidim-surveys/app/cells/decidim/surveys/survey_card_metadata_cell.rb
+++ b/decidim-surveys/app/cells/decidim/surveys/survey_card_metadata_cell.rb
@@ -31,7 +31,7 @@ module Decidim
       end
 
       def questions_count_item
-        text = "#{survey.questionnaire.questions.size} #{t("questions", scope: "decidim.surveys.surveys.show")}"
+        text = "#{survey.questionnaire.questions.not_separator.size} #{t("questions", scope: "decidim.surveys.surveys.show")}"
 
         {
           text:,

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -26,7 +26,7 @@
               <%= link_to decidim_sanitize_translated(survey.title), edit_survey_path(survey) %>
             </td>
             <td data-label="<%= t("models.survey.fields.questions", scope: "decidim.surveys") %>">
-              <%= survey.questionnaire.questions.size %>
+              <%= survey.questionnaire.questions.not_separator.size %>
             </td>
             <td data-label="<%= t("models.survey.fields.responses", scope: "decidim.surveys") %>">
               <%= survey.questionnaire.count_participants %>


### PR DESCRIPTION
#### :tophat: What? Why?
The `"seperator"` option within forms have caused a no. of issues within surveys. Some of these issues include the display condition being option within the form and the meta-data card counting the no. questions in the form including the separator, which is incorrect. 

This is partly due to the constant `SEPARATOR_TYPE = "separator"` defined as a string and not properly using the object `:not_separator` within the forms dependency. 

Aside for no crashing or rails errors while editing the form from the questionnaire, you can see a full set of issues detected in #15637

#### :pushpin: Related Issues
- Fixes #15627

#### Testing
1. Login
2. Go to a space, create the surveys (if not already) and create a new survey
3. Add a title and TOS. Click next.
4. On the questions tab, within the form add a separator, then click save.
5. Head to settings and click "Allow responses" and "Allow registered users to edit own survey responses"
6. Go back to the questions tab, add a question and give it a title
7. With that question add a display condition, close the accordion and try to save.
8. See the error in the question and try to add a display condition. 
9. See that the separator you added earlier doesn't show.
10. Head back to the survey index 
11. Publish that survey
12. Click see "see process" (or whatever space you're on)  and in the frontend find the surveys.
13. On that index in the front end see the surveys only count 1 question

### :camera: Screenshots
BUG 1 - Seperator 1st
<img width="1744" height="263" alt="image" src="https://github.com/user-attachments/assets/d993ff32-0b1c-419d-9a70-3cd360b389f4" />

BUG 1 - Question 2nd with display condition not including a separator.
<img width="1744" height="644" alt="image" src="https://github.com/user-attachments/assets/18df2e1c-4555-468e-9e32-112d191b4fc4" />
 
BUG 2 - See the survey index - only one question and not including the index
<img width="1017" height="483" alt="image" src="https://github.com/user-attachments/assets/6db67949-3618-4b07-a8f7-376cd959eff3" />

BUG 3 - See form without separator on pagination
<img width="1299" height="931" alt="image" src="https://github.com/user-attachments/assets/32b74f5e-8757-4a94-94b5-4acf7f4269f2" />

:hearts: Thank you!
