### PR TITLE
Fix for editing an organization on system with 5 locales

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -416,6 +416,7 @@ inviteduser
 isbn
 iseq
 isready
+Italiano
 ivan
 Jaskolski
 Jaume

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -77,6 +77,10 @@ describe "Admin manages organization" do
         I18n.available_locales = available_locales
         Decidim.available_locales = available_locales
         I18n.backend.reload!
+
+        Decidim::Admin.send(:remove_const, :OrganizationForm)
+        load "#{Decidim::Admin::Engine.root}/app/forms/decidim/admin/organization_form.rb"
+
         organization.update!(available_locales:, name: organization_names)
       end
 
@@ -84,6 +88,9 @@ describe "Admin manages organization" do
         I18n.available_locales = %w(en ca es)
         Decidim.available_locales = %w(en ca es)
         I18n.backend.reload!
+
+        Decidim::Admin.send(:remove_const, :OrganizationForm)
+        load "#{Decidim::Admin::Engine.root}/app/forms/decidim/admin/organization_form.rb"
       end
 
       it "renders a dropdown for the language selector and switches between languages" do

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -61,6 +61,57 @@ describe "Admin manages organization" do
       expect(page).to have_content("There is an error in this field.")
     end
 
+    context "when there are more than 4 locales in the organization" do
+      let(:available_locales) { %w(en ca es fr it) }
+      let(:organization_names) do
+        {
+          en: "English Organization Name",
+          ca: "Nom de l'organització en català",
+          es: "Nombre de la organización en español",
+          fr: "Nom de l'organisation en français",
+          it: "Nome dell'organizzazione in italiano"
+        }
+      end
+
+      before do
+        I18n.available_locales = available_locales
+        Decidim.available_locales = available_locales
+        I18n.backend.reload!
+        organization.update!(available_locales:, name: organization_names)
+      end
+
+      after do
+        I18n.available_locales = %w(en ca es)
+        Decidim.available_locales = %w(en ca es)
+        I18n.backend.reload!
+      end
+
+      it "renders a dropdown for the language selector and switches between languages" do
+        visit decidim_admin.edit_organization_path
+
+        expect(page).to have_select("organization-name-tabs")
+
+        expect(page).to have_css("#organization_name_en", visible: :visible)
+        expect(page).to have_field("organization_name_en", with: organization_names[:en])
+
+        select "Català", from: "organization-name-tabs"
+        expect(page).to have_css("#organization_name_ca", visible: :visible)
+        expect(page).to have_field("organization_name_ca", with: organization_names[:ca])
+
+        select "Français", from: "organization-name-tabs"
+        expect(page).to have_css("#organization_name_fr", visible: :visible)
+        expect(page).to have_field("organization_name_fr", with: organization_names[:fr])
+
+        select "Italiano", from: "organization-name-tabs"
+        expect(page).to have_css("#organization_name_it", visible: :visible)
+        expect(page).to have_field("organization_name_it", with: organization_names[:it])
+
+        select "Castellano", from: "organization-name-tabs"
+        expect(page).to have_css("#organization_name_es", visible: :visible)
+        expect(page).to have_field("organization_name_es", with: organization_names[:es])
+      end
+    end
+
     context "when using the rich text editor" do
       before do
         visit decidim_admin.edit_organization_path

--- a/decidim-system/app/views/layouts/decidim/system/_header.html.erb
+++ b/decidim-system/app/views/layouts/decidim/system/_header.html.erb
@@ -2,4 +2,4 @@
 <%= csrf_meta_tags %>
 <%= append_stylesheet_pack_tag "decidim_system_overrides", media: "all" %>
 <%= stylesheet_pack_tag "decidim_core", "decidim_system", media: "all" %>
-<%= javascript_pack_tag "decidim_core", "decidim_system", defer: false %>
+<%= javascript_pack_tag "decidim_core", "decidim_admin", "decidim_system", defer: false %>

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -228,6 +228,73 @@ describe "Organizations" do
           expect(page).to have_no_field(:update_organization_header_snippets)
         end
       end
+
+      context "when there are more than 4 locales available" do
+        let(:available_locales) { %w(en ca es fr it) }
+        let(:organization_names) do
+          {
+            en: "English Organization Name",
+            ca: "Nom de l'organització en català",
+            es: "Nombre de la organización en español",
+            fr: "Nom de l'organisation en français",
+            it: "Nome dell'organizzazione in italiano"
+          }
+        end
+
+        before do
+          I18n.available_locales = available_locales
+          Decidim.available_locales = available_locales
+          I18n.backend.reload!
+
+          Decidim::System.send(:remove_const, :BaseOrganizationForm)
+          Decidim::System.send(:remove_const, :UpdateOrganizationForm)
+          load "#{Decidim::System::Engine.root}/app/forms/decidim/system/base_organization_form.rb"
+          load "#{Decidim::System::Engine.root}/app/forms/decidim/system/update_organization_form.rb"
+
+          organization.update!(available_locales:, name: organization_names)
+        end
+
+        before do
+          click_on "Organizations"
+          within "table tbody" do
+            first("tr").click_on "Edit"
+          end
+        end
+
+        after do
+          I18n.available_locales = %w(en ca es)
+          Decidim.available_locales = %w(en ca es)
+          I18n.backend.reload!
+
+          Decidim::System.send(:remove_const, :BaseOrganizationForm)
+          Decidim::System.send(:remove_const, :UpdateOrganizationForm)
+          load "#{Decidim::System::Engine.root}/app/forms/decidim/system/base_organization_form.rb"
+          load "#{Decidim::System::Engine.root}/app/forms/decidim/system/update_organization_form.rb"
+        end
+
+        it "renders a dropdown for the language selector and switches between languages" do
+          expect(page).to have_select("update_organization-name-tabs")
+
+          expect(page).to have_css("#update_organization_name_en", visible: :visible)
+          expect(page).to have_field("update_organization_name_en", with: organization_names[:en])
+
+          select "Català", from: "update_organization-name-tabs"
+          expect(page).to have_css("#update_organization_name_ca", visible: :visible)
+          expect(page).to have_field("update_organization_name_ca", with: organization_names[:ca])
+
+          select "Français", from: "update_organization-name-tabs"
+          expect(page).to have_css("#update_organization_name_fr", visible: :visible)
+          expect(page).to have_field("update_organization_name_fr", with: organization_names[:fr])
+
+          select "Italiano", from: "update_organization-name-tabs"
+          expect(page).to have_css("#update_organization_name_it", visible: :visible)
+          expect(page).to have_field("update_organization_name_it", with: organization_names[:it])
+
+          select "Castellano", from: "update_organization-name-tabs"
+          expect(page).to have_css("#update_organization_name_es", visible: :visible)
+          expect(page).to have_field("update_organization_name_es", with: organization_names[:es])
+        end
+      end
     end
 
     describe "editing an organization with disabled OmniAuth provider" do

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -252,9 +252,6 @@ describe "Organizations" do
           load "#{Decidim::System::Engine.root}/app/forms/decidim/system/update_organization_form.rb"
 
           organization.update!(available_locales:, name: organization_names)
-        end
-
-        before do
           click_on "Organizations"
           within "table tbody" do
             first("tr").click_on "Edit"


### PR DESCRIPTION
#### :tophat: What? Why?

While working with the system panel, I noticed that we have a bug with the current i18n switcher dropdown in system panel. 

This PR fixes it. 

I also added a spec for admin panel as I couldn't find it.

My theory is that this dropdown in system was already broken since #12681, but we didn't noticed because the default configuration was to only have a few languages enabled in the organizations, and we've been changing this default lately. 

#### :pushpin: Related Issues
 
- Fixes #15619 

#### Testing

1. Sign in as a system admin at http://localhost:3000/system/
2. Create an organization with 10 languages
3. Edit this organization (go to http://localhost:3000/system/organizations/2/edit) 
4. Change the selector for the locale in the "Name" field, for instance to Spanish
5. (Before) see that it doesn't change 
6. (After) see that it changes

### :camera: Screenshots

<img width="1794" height="627" alt="image" src="https://github.com/user-attachments/assets/863938d9-78aa-46f4-b299-98e34ed0b963" />
 
:hearts: Thank you!
