### PR TITLE
Fix alignment on survey responses

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -35,7 +35,7 @@ module Decidim
             }
           end
 
-          return choice(choices.first) if response.question.question_type == "single_option"
+          return content_tag(:ul) { choice(choices.first) } if response.question.question_type == "single_option"
 
           content_tag(:ul) do
             safe_join(choices.map { |c| choice(c) })

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -34,7 +34,7 @@ module Decidim
               choice_body: body_or_custom_body(choice)
             }
           end
-          
+
           content_tag(:ul) do
             if response.question.question_type == "single_option"
               choice(choices.first)

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -34,11 +34,13 @@ module Decidim
               choice_body: body_or_custom_body(choice)
             }
           end
-
-          return content_tag(:ul) { choice(choices.first) } if response.question.question_type == "single_option"
-
+          
           content_tag(:ul) do
-            safe_join(choices.map { |c| choice(c) })
+            if response.question.question_type == "single_option"
+              choice(choices.first)
+            else
+              safe_join(choices.map { |c| choice(c) })
+            end
           end
         end
 

--- a/decidim-forms/spec/presenters/decidim/admin/questionnaire_response_presenter_spec.rb
+++ b/decidim-forms/spec/presenters/decidim/admin/questionnaire_response_presenter_spec.rb
@@ -40,7 +40,7 @@ module Decidim
 
         context "when it is a single_option question" do
           it "Returns the choice's body" do
-            expect(subject.body).to eq("<li>#{response_choice.body}</li>")
+            expect(subject.body).to eq("<ul><li>#{response_choice.body}</li></ul>")
           end
         end
 


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #15633 i noticed the questions are not aligned as they should. This PR fixes that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Have a test app with surveys configured within a space and responses in `develop`.
2. Login
3. Find that space with surveys and responses
4. Click on the responses tab.
5. Click on a questionnaire.
6. See the alignment issue
7. Apply patch 
8. See no alignment issue

Run the test created in this branch `decidim-forms/spec/presenters/decidim/admin/questionnaire_response_presenter_spec.rb` aganist `develop` for a failing environment.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
#### Before 
<img width="709" height="566" alt="image" src="https://github.com/user-attachments/assets/94222922-09c8-48bf-953f-c8466a974996" />


#### After: 
<img width="670" height="566" alt="image" src="https://github.com/user-attachments/assets/33838d7f-9982-49d7-87fb-8565aba8d624" />


:hearts: Thank you!
