### PR TITLE
Increase the timeout for the meeting flaky spec

### DIFF
--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -195,7 +195,7 @@ describe "Meeting", download: true do
       it "timeouts user normally" do
         visit_meeting
         travel 1.minute
-        expect(page).to have_content("You were inactive for too long")
+        expect(page).to have_content("You were inactive for too long", wait: 10)
       end
 
       context "when comments are enabled" do

--- a/decidim-meetings/spec/system/meeting_spec.rb
+++ b/decidim-meetings/spec/system/meeting_spec.rb
@@ -195,7 +195,7 @@ describe "Meeting", download: true do
       it "timeouts user normally" do
         visit_meeting
         travel 1.minute
-        expect(page).to have_content("You were inactive for too long", wait: 10)
+        expect(page).to have_content("You were inactive for too long", wait: 30)
       end
 
       context "when comments are enabled" do


### PR DESCRIPTION
#### :tophat: What? Why?

This is another spin to solving the flaky spec from #15524

🤞🏽 🤞🏽 🤞🏽 

#### Testing

As it is a flaky that only happens in CI, we don't have an easy way of actually reproducing the race condition that is generating this failure. What we do in these cases is to retry the full test suite execution at least 5 times (each of these having green in the "Meetings - System tests" workflow). 

:hearts: Thank you!
