### PR TITLE
Fix participants selection and list in conversations

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
@@ -16,11 +16,30 @@ export default class extends Controller {
 
     this.initializeEmptyFocusElement();
     this.initializeAutoComplete();
-    this.searchInput.addEventListener("selection", (event) => {
+    this.setupSelectionListener();
+  }
+
+  /**
+   * Setup the selection event listener
+   * @returns {void}
+   */
+  setupSelectionListener() {
+    this.selectionHandler = (event) => {
       const feedback = event.detail;
       const selection = feedback.selection;
       this.handleSelection(selection);
-    });
+    };
+    this.searchInput.addEventListener("selection", this.selectionHandler);
+  }
+
+  /*
+   * Remove event listener to prevent duplicates
+   * @returns {void}
+   */
+  disconnect() {
+    if (this.searchInput && this.selectionHandler) {
+      this.searchInput.removeEventListener("selection", this.selectionHandler);
+    }
   }
 
   /**
@@ -150,6 +169,10 @@ export default class extends Controller {
     this.addSelectedUser(selection, id);
     this.autoComplete.setInput("");
     this.selected.push(id);
+
+    if (this.autoComplete && this.autoComplete.autocomplete) {
+      this.autoComplete.autocomplete.close();
+    }
   }
 
   /**

--- a/decidim-core/app/packs/stylesheets/decidim/_conversations.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_conversations.scss
@@ -56,7 +56,7 @@
   }
 
   &__participants {
-    @apply bg-background rounded px-4 py-2 flex flex-col md:flex-row items-start md:items-center gap-2 md:gap-6 mb-14;
+    @apply bg-background rounded px-4 py-2 flex flex-wrap items-start md:items-center gap-2 md:gap-6 mb-14;
   }
 
   &__message {

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -294,6 +294,29 @@ describe "Conversations" do
           expect(page).to have_css("#autoComplete_list_1 li.disabled", wait: 5)
         end
       end
+
+      context "when selecting participants from autocomplete" do
+        let!(:user1) { create(:user, :confirmed, name: "Ana", organization:) }
+        let!(:user2) { create(:user, :confirmed, name: "Maria", organization:) }
+
+        it "does not insert element twice and closes dropdown", :slow do
+          visit_inbox
+          click_on "New conversation"
+          expect(page).to have_css("#add_conversation_users")
+
+          field = find_by_id("add_conversation_users")
+          field.native.send_keys "Mar"
+
+          expect(page).to have_css("#autoComplete_list_1 li", wait: 5)
+
+          find("#autoComplete_list_1 li").click
+
+          expect(page).to have_css(".conversation__modal-results li", count: 1)
+          expect(page).to have_content("Maria")
+          expect(page).to have_no_css("#autoComplete_list_1 li", wait: 2)
+          expect(field.value).to eq("")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes muiltiple bugs that I found on conversations:  

- When selecting a participant in the modal of "New conversation", the autocomplete list is still open 
- When selecting a participant in this modal, the participant is added two times (reported at #10109) 
- When there's a conversation with 9 participants, the list is broken and it breaks responsiveness  (reported at #13926)

#### :pushpin: Related Issues
 
- Fixes #10109 
- Fixes #13926 

#### Testing

1. Sign in as a participant 
2. Go to http://localhost:3000/conversations
3. Click in "New conversation"
4. Add a string with a couple characters (for instance "Arr") 
5. Click in any participant from the list
6. (First bug) See that the list is still open. Put more characters to close the list
7. (Second bug) See that you have duplicated participants in the list (See screenshot)
8. Keep adding participants until there are 9 participants
9. Click in the button "Next"
10. (Third bug) See that the list of participants is really long and breaks the responsiveness (See screenshot) 

### :camera: Screenshots

#### Before

<img width="848" height="461" alt="image" src="https://github.com/user-attachments/assets/ae18a5f9-262a-4e3f-a5c5-3e4cb5e5dc89" />
<img width="856" height="518" alt="image" src="https://github.com/user-attachments/assets/4b437c21-439f-4a2c-b742-f4d0f470c5cd" />


#### After

<img width="801" height="408" alt="image" src="https://github.com/user-attachments/assets/43bcb09f-2f09-409e-ae30-c5e638320e55" />
<img width="851" height="488" alt="image" src="https://github.com/user-attachments/assets/4cd7700c-a350-4124-9a0f-82c49e521f3c" />


:hearts: Thank you!
