### PR TITLE
Fix styles for registration modal in conferences

### DIFF
--- a/decidim-conferences/app/cells/decidim/conferences/registration_type/registration_confirm.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type/registration_confirm.erb
@@ -4,7 +4,7 @@
     <div class="font-semibold text-black text-2xl" id="dialog-title-conference-registration-confirm-<%= model.id %>"><%= I18n.t("registration", scope: "decidim.conferences.conference.show") %></div>
   </div>
 
-  <div id="dialog-desc-conference-registration-confirm-<%= model.id %>" class="text-gray-2 text-xl mt-9">
+  <div id="dialog-desc-conference-registration-confirm-<%= model.id %>" class="text-gray-2 text-xl mt-9 prose">
     <%= decidim_sanitize_editor translated_attribute(conference.registration_terms) %>
   </div>
 


### PR DESCRIPTION
#### :tophat: What? Why?

There's an styling problem in the conferences' registration modal. This PR fixes it. 

#### :pushpin: Related Issues 

- Fixes #13925

#### Testing

1. Go to a Conference with registrations enabled and seeded registration types
2. Go in the "About this Conference" form 
3. Add a link in the "Registration terms" field
4. On the user interface, click the Register button 
5. (Before) See that the link in modal is not underlined
5. (After) See that the link in modal is not underlined

### :camera: Screenshots

#### Before

<img width="832" height="652" alt="image" src="https://github.com/user-attachments/assets/83d8d780-7760-418f-afa5-6e21daf0d701" />

#### After

<img width="828" height="665" alt="image" src="https://github.com/user-attachments/assets/9df6bcaf-a9fa-408f-a593-a6a832a2c470" />

:hearts: Thank you!
