### PR TITLE
Upgrade syntax on shakapacker.yml

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -143,7 +143,14 @@ bin/rails decidim:upgrade:fix_deleted_private_follows
 
 You can read more about this change on PR [#12878](https://github.com/decidim/decidim/pull/12878).
 
-### 3.4. [[TITLE OF THE ACTION]]
+### 3.4. webpack-dev-server upgrade
+
+Back in [#15534](https://github.com/decidim/decidim/pull/15534) we upgraded webpack-dev-server to version 5.2.2. In order to succesfully upgrade you need to edit your `config/shakapacker.yml` and remove the `https` option under `dev_server` key.
+
+You can read more about this change on PR [#15534](https://github.com/decidim/decidim/pull/15534).
+
+
+### 3.5. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -147,7 +147,7 @@ You can read more about this change on PR [#12878](https://github.com/decidim/de
 
 Back in [#15534](https://github.com/decidim/decidim/pull/15534) we upgraded webpack-dev-server to version 5.2.2. In order to succesfully upgrade you need to edit your `config/shakapacker.yml` and remove the `https` option under `dev_server` key.
 
-You can read more about this change on PR [#15534](https://github.com/decidim/decidim/pull/15534).
+You can read more about this change on PR [#15534](https://github.com/decidim/decidim/pull/15534), [#15674](https://github.com/decidim/decidim/pull/15674).
 
 
 ### 3.5. [[TITLE OF THE ACTION]]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -149,7 +149,6 @@ Back in [#15534](https://github.com/decidim/decidim/pull/15534) we upgraded webp
 
 You can read more about this change on PR [#15534](https://github.com/decidim/decidim/pull/15534), [#15674](https://github.com/decidim/decidim/pull/15674).
 
-
 ### 3.5. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -145,7 +145,7 @@ You can read more about this change on PR [#12878](https://github.com/decidim/de
 
 ### 3.4. webpack-dev-server upgrade
 
-Back in [#15534](https://github.com/decidim/decidim/pull/15534) we upgraded webpack-dev-server to version 5.2.2. In order to succesfully upgrade you need to edit your `config/shakapacker.yml` and remove the `https` option under `dev_server` key.
+Back in [#15534](https://github.com/decidim/decidim/pull/15534) we upgraded webpack-dev-server to version 5.2.2. In order to successfully upgrade you need to edit your `config/shakapacker.yml` and remove the `https` option under `dev_server` key.
 
 You can read more about this change on PR [#15534](https://github.com/decidim/decidim/pull/15534), [#15674](https://github.com/decidim/decidim/pull/15674).
 

--- a/decidim-core/lib/decidim/shakapacker/shakapacker.yml
+++ b/decidim-core/lib/decidim/shakapacker/shakapacker.yml
@@ -43,7 +43,6 @@ development:
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:
-    https: false
     host: localhost
     # Notice that we use a different port (to prevent blocking the default one) as
     # there will be at least two webpack servers running


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15534 we have upgraded webpack-dev-server. After that we have noticed that The shakapacker fails to start due to unknown parameter called https. 
Tracking the error, i noticed that shakapacker does not have that parameter, making me understand that we are overriding the config. 


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15534 
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
