### PR TITLE
Show children assemblies in breadcrumb with components

### DIFF
--- a/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
+++ b/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
@@ -10,6 +10,7 @@ module Decidim
 
       def current_participatory_space_breadcrumb_item
         return {} if current_participatory_space.blank?
+        return {} unless current_participatory_space.is_a?(Decidim::Assembly)
 
         dropdown_cell = current_participatory_space_manifest.breadcrumb_cell
 

--- a/decidim-assemblies/lib/decidim/assemblies/engine.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/engine.rb
@@ -112,6 +112,13 @@ module Decidim
       initializer "decidim_assemblies.shakapacker.assets_path" do
         Decidim.register_assets_path File.expand_path("app/packs", root)
       end
+
+      initializer "decidim_assemblies.extend_component_controllers" do
+        config.to_prepare do
+          # Extend component controllers with assembly breadcrumb when mounted under assemblies
+          Decidim::Components::BaseController.include(Decidim::Assemblies::AssemblyBreadcrumb)
+        end
+      end
     end
   end
 end

--- a/decidim-assemblies/spec/system/assembly_breadcrumb_spec.rb
+++ b/decidim-assemblies/spec/system/assembly_breadcrumb_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Assembly Breadcrumb" do
+  let(:organization) { create(:organization) }
+  let(:parent_assembly) { create(:assembly, :published, organization:) }
+  let(:child_assembly) { create(:assembly, :published, organization:, parent: parent_assembly) }
+  let(:component) { create(:proposal_component, :published, participatory_space: child_assembly) }
+  let(:router) { Decidim::EngineRouter.main_proxy(component) }
+  let!(:proposal) { create(:proposal, :published, component:) }
+
+  before do
+    switch_to_host(organization.host)
+    child_assembly.update!(parent: parent_assembly)
+  end
+
+  context "when viewing a child assembly page" do
+    scenario "shows breadcrumb with parent assembly and child assembly" do
+      visit decidim_assemblies.assembly_path(child_assembly)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(parent_assembly.title))
+        expect(page).to have_content(translated(child_assembly.title))
+      end
+    end
+  end
+
+  context "when viewing a component page within a child assembly" do
+    scenario "shows breadcrumb with parent assembly, child assembly, and component" do
+      visit router.root_path
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(parent_assembly.title))
+        expect(page).to have_content(translated(child_assembly.title))
+        expect(page).to have_content(translated(component.name))
+      end
+    end
+
+    scenario "shows breadcrumb with parent assembly, child assembly, and component on component sub-pages" do
+      visit router.proposal_path(proposal)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(parent_assembly.title))
+        expect(page).to have_content(translated(child_assembly.title))
+        expect(page).to have_content(translated(component.name))
+      end
+    end
+  end
+
+  context "when viewing a parent assembly page" do
+    scenario "shows breadcrumb with only parent assembly" do
+      visit decidim_assemblies.assembly_path(parent_assembly)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(parent_assembly.title))
+        expect(page).to have_no_content(translated(child_assembly.title))
+      end
+    end
+  end
+
+  context "when viewing a component page within a parent assembly" do
+    let(:component) { create(:component, manifest_name: "proposals", participatory_space: parent_assembly) }
+    let!(:proposal) { create(:proposal, component:) }
+
+    scenario "shows breadcrumb with parent assembly and component" do
+      visit router.root_path
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(parent_assembly.title))
+        expect(page).to have_content(translated(component.name))
+        expect(page).to have_no_content(translated(child_assembly.title))
+      end
+    end
+  end
+
+  context "when viewing an assembly without parent" do
+    let(:standalone_assembly) { create(:assembly, :published, organization:) }
+    let(:component) { create(:component, manifest_name: "proposals", participatory_space: standalone_assembly) }
+
+    scenario "shows breadcrumb with only assembly" do
+      visit decidim_assemblies.assembly_path(standalone_assembly)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(standalone_assembly.title))
+        expect(page).to have_no_content(translated(parent_assembly.title))
+      end
+    end
+
+    scenario "shows breadcrumb with assembly and component" do
+      visit router.root_path
+
+      within ".menu-bar" do
+        expect(page).to have_content("Assemblies")
+        expect(page).to have_content(translated(standalone_assembly.title))
+        expect(page).to have_content(translated(component.name))
+        expect(page).to have_no_content(translated(parent_assembly.title))
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with Assemblies that have a Parent, I noticed a bug, where the 

#### :pushpin: Related Issues
 
- Related to #14980 
- Related to #15507

#### Testing

1. Go to an assembly that has a parent
2. See that the breadcrumb is correctly shown
<img width="1400" height="840" alt="image" src="https://github.com/user-attachments/assets/929c5716-433b-407d-9fae-98d8f5163b81" />

3. Go to any component of the this space, for instance Meetings 
4. (Bug!) see that the parent assembly disappears from the breadcrumb

### :camera: Screenshots

#### Before

<img width="1401" height="830" alt="image" src="https://github.com/user-attachments/assets/0d9da805-09de-418f-a630-ccb4ec5f6e95" />

#### After 

<img width="1409" height="885" alt="image" src="https://github.com/user-attachments/assets/e9bc7d01-d0ac-4f5a-b9f9-a648213ac9fe" />

:hearts: Thank you!
