### PR TITLE
Drop the symbols compatibility for Decidim::AttributeObject::Model

### DIFF
--- a/decidim-core/lib/decidim/attribute_object/model.rb
+++ b/decidim-core/lib/decidim/attribute_object/model.rb
@@ -103,19 +103,6 @@ module Decidim
         assign_attributes(correct_attributes)
       end
 
-      # This provides backwards compatibility for accessing the attributes
-      # through symbols by calling `obj.attributes[:key]` or
-      # `obj.attributes.slice(:key1, :key2)`. In the legacy Virtus models, this
-      # returned a hash with symbol keys.
-      #
-      # Deprecated:
-      # Attributes access through symbols is deprecated and may be removed in
-      # future versions. Please refactor all your attributes calls to access the
-      # attributes through string keys.
-      def attributes
-        super.with_indifferent_access
-      end
-
       # Convenience method for accessing the attributes through
       # model[:attr_name] which is used in multiple places across the code.
       def [](attribute_name)
@@ -134,7 +121,7 @@ module Decidim
       end
 
       def to_h
-        hash = attributes.to_h.symbolize_keys
+        hash = attributes.transform_keys(&:to_sym)
         hash.delete(:id) if hash.has_key?(:id) && hash[:id].blank?
 
         hash


### PR DESCRIPTION
#### :tophat: What? Why?

In #8669, when we dropped the `virtus` gem, we introduced a backwards compatibility layer so we didn't break the modules and apps that depended on that. 

We talked that this should be removed in the future (v0.30.0) we said. Well, the future is now! 

#### :pushpin: Related Issues
 
- Fixes #8722 

#### Testing

Everything should be green 

:hearts: Thank you!
