### PR TITLE
Show processes groups in breadcrumb with components

### DIFF
--- a/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
+++ b/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
@@ -10,7 +10,7 @@ module Decidim
 
       def current_participatory_space_breadcrumb_item
         return {} if current_participatory_space.blank?
-        return {} unless current_participatory_space.is_a?(Decidim::Assembly)
+        return super unless current_participatory_space.is_a?(Decidim::Assembly)
 
         dropdown_cell = current_participatory_space_manifest.breadcrumb_cell
 

--- a/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
+++ b/decidim-assemblies/app/controllers/concerns/decidim/assemblies/assembly_breadcrumb.rb
@@ -24,13 +24,7 @@ module Decidim
           }
         end
 
-        items << {
-          label: current_participatory_space.title,
-          url: Decidim::ResourceLocatorPresenter.new(current_participatory_space).path,
-          active: true,
-          dropdown_cell:,
-          resource: current_participatory_space
-        }
+        items << super
       end
     end
   end

--- a/decidim-conferences/spec/system/conference_breadcrumb_spec.rb
+++ b/decidim-conferences/spec/system/conference_breadcrumb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Conference Breadcrumb" do
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:conference, :published, organization:) }
+  let(:component) { create(:proposal_component, :published, participatory_space:) }
+  let(:router) { Decidim::EngineRouter.main_proxy(component) }
+  let!(:proposal) { create(:proposal, :published, component:) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  scenario "shows breadcrumb with only conference" do
+    visit decidim_conferences.conference_path(participatory_space)
+
+    within ".menu-bar" do
+      expect(page).to have_content("Conferences")
+      expect(page).to have_content(translated(participatory_space.title))
+    end
+  end
+
+  scenario "shows breadcrumb with conference and component" do
+    visit router.root_path
+
+    within ".menu-bar" do
+      expect(page).to have_content("Conferences")
+      expect(page).to have_content(translated(participatory_space.title))
+      expect(page).to have_content(translated(component.name))
+    end
+  end
+end

--- a/decidim-initiatives/spec/system/initiative_breadcrumb_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_breadcrumb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Initiative Breadcrumb" do
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:initiative, :open, organization:) }
+  let(:component) { create(:meeting_component, :published, participatory_space:) }
+  let(:router) { Decidim::EngineRouter.main_proxy(component) }
+  let!(:meeting) { create(:meeting, :published, component:) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  scenario "shows breadcrumb with only initiative" do
+    visit decidim_initiatives.initiative_path(participatory_space)
+
+    within ".menu-bar" do
+      expect(page).to have_content("Initiatives")
+      expect(page).to have_content(translated(participatory_space.title))
+    end
+  end
+
+  scenario "shows breadcrumb with initiative and component" do
+    visit router.root_path
+
+    within ".menu-bar" do
+      expect(page).to have_content("Initiatives")
+      expect(page).to have_content(translated(participatory_space.title))
+      expect(page).to have_content(translated(component.name))
+    end
+  end
+end

--- a/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/participatory_process_breadcrumb.rb
+++ b/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/participatory_process_breadcrumb.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ParticipatoryProcesses
+    module ParticipatoryProcessBreadcrumb
+      extend ActiveSupport::Concern
+
+      private
+
+      def current_participatory_space_breadcrumb_item
+        return {} if current_participatory_space.blank?
+        return super unless current_participatory_space.is_a?(Decidim::ParticipatoryProcess)
+
+        items = []
+
+        if current_participatory_space.participatory_process_group.present?
+          items << {
+            label: translated_attribute(current_participatory_space.participatory_process_group.title),
+            active: false,
+            url: decidim_participatory_processes.participatory_process_group_path(current_participatory_space.participatory_process_group),
+            resource: current_participatory_space.participatory_process_group
+          }
+        end
+
+        items << super
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
@@ -6,7 +6,7 @@ module Decidim
       helper Decidim::SanitizeHelper
       helper_method :participatory_processes, :group, :active_content_blocks
 
-      before_action :set_group
+      before_action :set_group, :set_controller_breadcrumb
 
       def index
         enforce_permission_to :list, :process_group
@@ -46,6 +46,19 @@ module Decidim
       end
 
       attr_reader :group
+
+      def context_breadcrumb_items
+        @context_breadcrumb_items ||= []
+      end
+
+      def set_controller_breadcrumb
+        context_breadcrumb_items << {
+          label: translated_attribute(group.title),
+          url: participatory_process_group_path(group),
+          active: true,
+          resource: group
+        }
+      end
     end
   end
 end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_processes_controller.rb
@@ -9,6 +9,7 @@ module Decidim
       include FilterResource
       include Paginable
       include HasParticipatorySpaceContentBlocks
+      include ParticipatoryProcessBreadcrumb
 
       helper_method :collection,
                     :promoted_collection,

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -67,6 +67,13 @@ module Decidim
         Decidim::Api::QueryType.include Decidim::ParticipatoryProcesses::QueryExtensions
       end
 
+      initializer "decidim_participatory_processes.extend_component_controllers" do
+        config.to_prepare do
+          # Extend component controllers with assembly breadcrumb when mounted under assemblies
+          Decidim::Components::BaseController.include(Decidim::ParticipatoryProcesses::ParticipatoryProcessBreadcrumb)
+        end
+      end
+
       initializer "decidim_participatory_processes.add_cells_view_paths" do
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::ParticipatoryProcesses::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::ParticipatoryProcesses::Engine.root}/app/views") # for partials

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/engine.rb
@@ -69,7 +69,7 @@ module Decidim
 
       initializer "decidim_participatory_processes.extend_component_controllers" do
         config.to_prepare do
-          # Extend component controllers with assembly breadcrumb when mounted under assemblies
+          # Extend component controllers with participatory process breadcrumb when mounted under participatory processes
           Decidim::Components::BaseController.include(Decidim::ParticipatoryProcesses::ParticipatoryProcessBreadcrumb)
         end
       end

--- a/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
@@ -26,7 +26,7 @@ describe "Participatory Process Breadcrumb" do
       end
     end
 
-    scenario "shows breadcrumb with only participatory process" do
+    scenario "shows breadcrumb with participatory process group and participatory process" do
       visit decidim_participatory_processes.participatory_process_path(participatory_space)
 
       within ".menu-bar" do
@@ -36,7 +36,7 @@ describe "Participatory Process Breadcrumb" do
       end
     end
 
-    scenario "shows breadcrumb with participatory process and component" do
+    scenario "shows breadcrumb with participatory process group, participatory process and component" do
       visit router.root_path
 
       within ".menu-bar" do

--- a/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Participatory Process Breadcrumb" do
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:participatory_process, :published, organization:) }
+  let(:component) { create(:proposal_component, :published, participatory_space:) }
+  let(:router) { Decidim::EngineRouter.main_proxy(component) }
+  let!(:proposal) { create(:proposal, :published, component:) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  context "when there is no participatory process groups" do
+    let!(:participatory_process_group) { create(:participatory_process_group, :with_participatory_processes, organization:) }
+    let(:participatory_space) { participatory_process_group.participatory_processes.first }
+
+    scenario "shows breadcrumb with only participatory process group" do
+      visit decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Processes")
+        expect(page).to have_content(translated(participatory_process_group.title))
+      end
+    end
+
+    scenario "shows breadcrumb with only participatory process" do
+      visit decidim_participatory_processes.participatory_process_path(participatory_space)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Processes")
+        expect(page).to have_content(translated(participatory_process_group.title))
+        expect(page).to have_content(translated(participatory_space.title))
+      end
+    end
+
+    scenario "shows breadcrumb with participatory process and component" do
+      visit router.root_path
+
+      within ".menu-bar" do
+        expect(page).to have_content("Processes")
+        expect(page).to have_content(translated(participatory_process_group.title))
+        expect(page).to have_content(translated(participatory_space.title))
+        expect(page).to have_content(translated(component.name))
+      end
+    end
+  end
+
+  context "when there is a participatory process" do
+    scenario "shows breadcrumb with only participatory process" do
+      visit decidim_participatory_processes.participatory_process_path(participatory_space)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Processes")
+        expect(page).to have_content(translated(participatory_space.title))
+      end
+    end
+
+    scenario "shows breadcrumb with participatory process and component" do
+      visit router.root_path
+
+      within ".menu-bar" do
+        expect(page).to have_content("Processes")
+        expect(page).to have_content(translated(participatory_space.title))
+        expect(page).to have_content(translated(component.name))
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
@@ -13,7 +13,7 @@ describe "Participatory Process Breadcrumb" do
     switch_to_host(organization.host)
   end
 
-  context "when there is no participatory process groups" do
+  context "when there are no participatory process groups" do
     let!(:participatory_process_group) { create(:participatory_process_group, :with_participatory_processes, organization:) }
     let(:participatory_space) { participatory_process_group.participatory_processes.first }
 

--- a/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_breadcrumb_spec.rb
@@ -13,7 +13,7 @@ describe "Participatory Process Breadcrumb" do
     switch_to_host(organization.host)
   end
 
-  context "when there are no participatory process groups" do
+  context "when there is a participatory process group" do
     let!(:participatory_process_group) { create(:participatory_process_group, :with_participatory_processes, organization:) }
     let(:participatory_space) { participatory_process_group.participatory_processes.first }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in https://github.com/decidim/decidim/pull/15675, @andreslucena discovered that parent assembies were not displayed, and he fixed that particular scenario. 

While I was working on #15683, i have noticed that the Space context was missing from process space, so i have investigated. I have reached the conclusion that the issue comes from the breadcrumb PR recently merged

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15675
- Related to #15683
- Fixes #14980

#### Testing
1. Open the website on develop 
2. Visit any Participatory Process / Conference 
3. Visit Proposals component
4. See the Space context is missing 
5. Repeat steps 2-3 for Assemblies / Child assemblies
6. See the Space contexts are present 
7. Apply patch 
8. Repeat 2,3,5 visiting the Proposal component 
9. See the Space contexts are present

##### Participatory Groups
1. Apply patch 
2. Visit Participatory Processes  
3. Select a group 
4. See that you have a breadcrumb
5. Select from the page any resource
6. See breadcrumb contains the group as well

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
