### PR TITLE
Missing route on admin-engine initiatives

### DIFF
--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -70,6 +70,7 @@ module Decidim
               end
               resources :component_share_tokens, except: [:show], path: "share_tokens", as: "share_tokens"
               resources :exports, only: :create
+              resources :reminders, only: [:new, :create]
             end
 
             resources :moderations do


### PR DESCRIPTION
#### :tophat: What? Why?
While working #15573 I noticed budgets couldn't be accessed via the Initiatives participatory space. 

Not sure what caused this and for how long, but has blocked work on #15657 due to the vote button when using the `Ephemeral example authorization (Direct)` permission.

Thanks to @alecslupu for a fix suggestion! 🎉

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/15693

#### Testing
1. Login
2. Head to an initiative space and create a budgets component.
3. Save and click on that budget
4. See it can be accessed.

### :camera: Screenshots
<img width="1694" height="701" alt="image" src="https://github.com/user-attachments/assets/ee72d61c-3b8d-41af-a7b2-6e4ccd91710f" />

:hearts: Thank you!
