### PR TITLE
Fixing issue of link target reverting back to _blank

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -223,7 +223,7 @@ describe "Admin manages organization" do
       context "when the admin terms of service content has a link" do
         let(:terms_content) do
           <<~HTML
-            <p>foo<br><a href="https://www.decidim.org" target="_blank">link</a></p>
+            <p>foo<br><a target="_blank" href="https://www.decidim.org">link</a></p>
           HTML
         end
         let(:organization) do
@@ -238,7 +238,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-          )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org">link</a></p>')
+            )["innerHTML"]).to eq('<p>foo<br><br><a  target="_blank" href="https://www.decidim.org">link</a></p>')
         end
 
         it "does not create br tag inside a tag" do
@@ -246,7 +246,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-          )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org">link</a></p>')
+            )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org" >link</a></p>')
         end
       end
 
@@ -475,7 +475,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a target="_blank" href="https://www.decidim.org/"><u>link</u></a></p>
+            <p><strong>foo</strong><br><a href="https://www.decidim.org/" target="_blank" ><u>link</u></a></p>
             <p><br></p>
           HTML
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -238,7 +238,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-          )["innerHTML"]).to eq('<p>foo<br><br><a  target="_blank" href="https://www.decidim.org">link</a></p>')
+          )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" target="_blank">link</a></p>')
         end
 
         it "does not create br tag inside a tag" do
@@ -246,7 +246,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-          )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org" >link</a></p>')
+          )["innerHTML"]).to eq('<p>foo<br><br><a href="https://www.decidim.org" target="_blank">link</a></p>')
         end
       end
 
@@ -475,7 +475,7 @@ describe "Admin manages organization" do
         let(:parsed_content) do
           cnt = <<~HTML
             <p>testing</p>
-            <p><strong>foo</strong><br><a href="https://www.decidim.org/" target="_blank" ><u>link</u></a></p>
+            <p><strong>foo</strong><br><a href="https://www.decidim.org/" target="_blank"><u>link</u></a></p>
             <p><br></p>
           HTML
 

--- a/decidim-admin/spec/system/admin_manages_organization_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_spec.rb
@@ -238,7 +238,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-            )["innerHTML"]).to eq('<p>foo<br><br><a  target="_blank" href="https://www.decidim.org">link</a></p>')
+          )["innerHTML"]).to eq('<p>foo<br><br><a  target="_blank" href="https://www.decidim.org">link</a></p>')
         end
 
         it "does not create br tag inside a tag" do
@@ -246,7 +246,7 @@ describe "Admin manages organization" do
           find('#organization_admin_terms_of_service_body_en div[contenteditable="true"].ProseMirror').native.send_keys([:shift, :enter])
           expect(find(
             "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
-            )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org" >link</a></p>')
+          )["innerHTML"]).to eq('<p>foo<br><br><a target="_blank" href="https://www.decidim.org" >link</a></p>')
         end
       end
 

--- a/decidim-core/app/packs/src/decidim/editor/extensions/link/index.js
+++ b/decidim-core/app/packs/src/decidim/editor/extensions/link/index.js
@@ -28,7 +28,6 @@ export default Link.extend({
       ...this.parent?.(),
       allowTargetControl: false,
       HTMLAttributes: {
-        target: "_blank",
         class: null
       }
     }

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -44,7 +44,7 @@ describe("Link", () => {
   it("allows editing the link through the dialog", async () => {
     editorElement.focus();
     await updateContent(editorElement,
-      '<p>Hello, <a target="_blank" href="https://decidim.org">world</a>!</p>'
+      '<p>Hello, <a href="https://decidim.org" target="_blank" >world</a>!</p>'
     );
 
     // Set the editor cursor inside the link

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -37,7 +37,7 @@ describe("Link", () => {
     await sleep(50);
 
     expect(editor.getHTML()).toEqual(
-      '<p>Hello, <a target="_blank" href="https://decidim.org" >world</a>!</p>'
+      '<p>Hello, <a href=\"https://decidim.org\" target=\"_blank\">world</a>!</p>'
     );
   });
 

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -37,7 +37,7 @@ describe("Link", () => {
     await sleep(50);
 
     expect(editor.getHTML()).toEqual(
-      '<p>Hello, <a href="https://decidim.org" target="_blank" >world</a>!</p>'
+      '<p>Hello, <a target="_blank" href="https://decidim.org" >world</a>!</p>'
     );
   });
 

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -37,7 +37,7 @@ describe("Link", () => {
     await sleep(50);
 
     expect(editor.getHTML()).toEqual(
-      '<p>Hello, <a target="_blank" href="https://decidim.org">world</a>!</p>'
+      '<p>Hello, <a href="https://decidim.org" target="_blank" >world</a>!</p>'
     );
   });
 

--- a/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/extensions/link.test.js
@@ -37,7 +37,7 @@ describe("Link", () => {
     await sleep(50);
 
     expect(editor.getHTML()).toEqual(
-      '<p>Hello, <a href=\"https://decidim.org\" target=\"_blank\">world</a>!</p>'
+      '<p>Hello, <a href="https://decidim.org" target="_blank">world</a>!</p>'
     );
   });
 

--- a/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_link.js
+++ b/decidim-core/app/packs/src/decidim/editor/test/toolbar/shared/behaves_like_basic_link.js
@@ -26,7 +26,7 @@ export default (ctx) => {
       await sleep(0);
 
       expect(ctx.prosemirror.innerHTML).toEqual(
-        '<p>Hello, <a target="_blank" href="https://decidim.org">world</a>!</p>'
+        '<p>Hello, <a href="https://decidim.org" target="_blank">world</a>!</p>'
       );
     });
   });

--- a/decidim-core/spec/system/editor_spec.rb
+++ b/decidim-core/spec/system/editor_spec.rb
@@ -270,7 +270,7 @@ describe "Editor" do
       expect_value(
         <<~HTML
           <p>Hello, world!</p>
-          <p>Another <a target="_blank" href="https://decidim.org">paragraph.</a></p>
+          <p>Another <a href="https://decidim.org" target="_blank">paragraph.</a></p>
         HTML
       )
 

--- a/decidim-core/spec/system/editor_spec.rb
+++ b/decidim-core/spec/system/editor_spec.rb
@@ -270,7 +270,7 @@ describe "Editor" do
       expect_value(
         <<~HTML
           <p>Hello, world!</p>
-          <p>Another <a href="https://decidim.org" target="_blank">paragraph.</a></p>
+          <p>Another <a target="_blank" href="https://decidim.org">paragraph.</a></p>
         HTML
       )
 
@@ -299,7 +299,7 @@ describe "Editor" do
       expect_value(
         <<~HTML
           <p>Hello, world!</p>
-          <p>Another <a target="_blank" href="https://try.decidim.org">paragraph.</a></p>
+          <p>Another <a href="https://try.decidim.org" target="_blank">paragraph.</a></p>
         HTML
       )
 
@@ -1379,7 +1379,7 @@ describe "Editor" do
           select "New tab", from: "Target"
           find("button[data-action='save']").click
         end
-        expect_value(%(<p>Hello, <a target="_blank" href="https://docs.decidim.org">world</a>!</p>))
+        expect_value(%(<p>Hello, <a href="https://docs.decidim.org" target="_blank">world</a>!</p>))
 
         # Should show the bubble menu after the link is closed
         within ".editor" do

--- a/decidim-core/spec/system/link_target_spec.rb
+++ b/decidim-core/spec/system/link_target_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin editor link target remains" do
+  let(:organization) { create(:organization) }
+  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
+  let(:participatory_process) { create(:participatory_process, organization: organization) }
+  let(:component) { create(:component, manifest_name: "pages", participatory_space: participatory_process) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+  end
+
+  it "allows editing contents without target automatically changing" do
+    visit decidim_admin_participatory_processes.edit_component_path(participatory_process, component)
+
+    within ".global-settings" do
+      announcement_editor = first(".editor-container[data-options*='admin']")
+      skip "No admin editor found" unless announcement_editor
+
+      # creating initial link in same tab
+      editor_input = announcement_editor.find(".editor-input .ProseMirror")
+      editor_input.click
+      editor_input.send_keys("Test link")
+      page.execute_script("window.getSelection().selectAllChildren(arguments[0].firstChild)", editor_input)
+      toolbar = announcement_editor.find(".editor-toolbar")
+      link_button = toolbar.find("button[data-editor-type='link']")
+      link_button.click
+      send_keys("https://decidim.org")
+    end
+    
+    within "[data-dialog][aria-hidden='false']" do
+      find("button[data-action='save']").click
+    end
+    click_button "Update"
+    expect(page).to have_content("The component was updated successfully")
+    
+    # modifying content
+    visit decidim_admin_participatory_processes.edit_component_path(participatory_process, component)
+    within ".global-settings" do
+      announcement_editor = first(".editor-container[data-options*='admin']")
+      skip "No admin editor found" unless announcement_editor
+      editor_input = announcement_editor.find(".editor-input .ProseMirror")
+      editor_input.click
+      editor_input.send_keys(:enter, :enter, :arrow_up, "...more content")
+    end
+    click_button "Update"
+    expect(page).to have_content("The component was updated successfully")
+    
+    # checking link is still in same tab
+    visit decidim_admin_participatory_processes.edit_component_path(participatory_process, component)
+    announcement_editor = first(".editor-container[data-options*='admin']")
+    editor_input = announcement_editor.find(".editor-input .ProseMirror")
+    editor_input.click
+    page.execute_script("window.getSelection().selectAllChildren(arguments[0].firstChild)", editor_input)
+    within "[data-linkbubble-actions]" do
+      find("button", text: "Edit").click
+      sleep 1
+    end
+    expect(page).to have_text("Default (same tab)")
+  end
+end

--- a/decidim-core/spec/system/link_target_spec.rb
+++ b/decidim-core/spec/system/link_target_spec.rb
@@ -30,13 +30,13 @@ describe "Admin editor link target remains" do
       link_button.click
       send_keys("https://decidim.org")
     end
-    
+
     within "[data-dialog][aria-hidden='false']" do
       find("button[data-action='save']").click
     end
     click_button "Update"
     expect(page).to have_content("The component was updated successfully")
-    
+
     # modifying content
     visit decidim_admin_participatory_processes.edit_component_path(participatory_process, component)
     within ".global-settings" do
@@ -48,7 +48,7 @@ describe "Admin editor link target remains" do
     end
     click_button "Update"
     expect(page).to have_content("The component was updated successfully")
-    
+
     # checking link is still in same tab
     visit decidim_admin_participatory_processes.edit_component_path(participatory_process, component)
     announcement_editor = first(".editor-container[data-options*='admin']")
@@ -56,8 +56,7 @@ describe "Admin editor link target remains" do
     editor_input.click
     page.execute_script("window.getSelection().selectAllChildren(arguments[0].firstChild)", editor_input)
     within "[data-linkbubble-actions]" do
-      find("button", text: "Edit").click
-      sleep 1
+      click_button "Edit"
     end
     expect(page).to have_text("Default (same tab)")
   end


### PR DESCRIPTION


#### :tophat: What? Why?
*Please describe your pull request.*

#### :pushpin: Related Issues
#14438 
#15641 

#### Testing
On the admin dashboard, go to a component, create a link and set it to "Default (same tab)". When returning to the same edit and adding content the target will remain unchanged.

:hearts: Thank you!
