### PR TITLE
Change references from Faker::Twitter to Faker::X

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,7 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    faker (3.5.2)
+    faker (3.5.3)
       i18n (>= 1.8.11, < 2)
     faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)

--- a/decidim-conferences/lib/decidim/conferences/seeds.rb
+++ b/decidim-conferences/lib/decidim/conferences/seeds.rb
@@ -115,7 +115,7 @@ module Decidim
           short_bio: Decidim::Faker::Localized.wrapped("<p>", "</p>") do
             Decidim::Faker::Localized.paragraph(sentence_count: 3)
           end,
-          twitter_handle: ::Faker::Twitter.unique.screen_name,
+          twitter_handle: ::Faker::X.unique.screen_name,
           personal_url: ::Faker::Internet.url,
           published_at: Time.current,
           conference:

--- a/decidim-core/lib/decidim/core/seeds.rb
+++ b/decidim-core/lib/decidim/core/seeds.rb
@@ -140,7 +140,7 @@ module Decidim
       end
 
       def create_organization!
-        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::Twitter.unique.screen_name)
+        smtp_label = ENV.fetch("SMTP_FROM_LABEL", ::Faker::X.unique.screen_name)
         smtp_email = ENV.fetch("SMTP_FROM_EMAIL", ::Faker::Internet.email)
 
         primary_color, secondary_color, tertiary_color = [
@@ -168,7 +168,7 @@ module Decidim
             from: "#{smtp_label} <#{smtp_email}>",
             from_email: smtp_email,
             from_label: smtp_label,
-            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::Twitter.unique.screen_name),
+            user_name: ENV.fetch("SMTP_USERNAME", ::Faker::X.unique.screen_name),
             encrypted_password: Decidim::AttributeEncryptor.encrypt(ENV.fetch("SMTP_PASSWORD", ::Faker::Internet.password(min_length: 8))),
             address: ENV.fetch("SMTP_ADDRESS", nil) || ENV.fetch("DECIDIM_HOST", "localhost"),
             port: ENV.fetch("SMTP_PORT", nil) || ENV.fetch("DECIDIM_SMTP_PORT", "25")

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -29,7 +29,7 @@ module Decidim
       user = Decidim::User.find_or_initialize_by(email:)
       user.update!(
         name: ::Faker::Name.name,
-        nickname: "#{::Faker::Twitter.unique.screen_name}-#{rand(10_000)}"[0...20],
+        nickname: "#{::Faker::X.unique.screen_name}-#{rand(10_000)}"[0...20],
         password: "decidim123456789",
         organization:,
         confirmed_at: Time.current,

--- a/decidim-dev/config/rubocop/faker/configuration.yml
+++ b/decidim-dev/config/rubocop/faker/configuration.yml
@@ -406,7 +406,7 @@ Faker/DeprecatedArguments:
         - days
         - period
         - format
-    Faker::Twitter:
+    Faker::X:
       user:
         - include_status
         - include_email

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -411,7 +411,7 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
-    faker (3.5.2)
+    faker (3.5.3)
       i18n (>= 1.8.11, < 2)
     faraday (2.13.4)
       faraday-net_http (>= 2.0, < 3.5)

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -172,7 +172,7 @@ module Decidim
       end
 
       def random_nickname
-        "#{::Faker::Twitter.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
+        "#{::Faker::X.unique.screen_name}-#{SecureRandom.hex(4)}"[0, 20]
       end
 
       def random_email(suffix:)


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Change the use of `Faker::Twitter` to `Faker::X` as Faker has deprecated the use of Twitter. It's in their freshly baked release: https://github.com/faker-ruby/faker/releases/tag/v3.5.3

There's not really a need to do this, but in a upgrade process of today we just found this bunch of messages and it's a bit annoying.

DEPRECATION WARNING: Faker::Twitter is deprecated. Use Faker::X instead.

#### :pushpin: Related Issues
*Link your PR to an issue*
I haven't created a issue.

#### Testing
*Describe the best way to test or validate your PR.*
Run the seed before this PR, run them again after.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1093" height="1702" alt="image" src="https://github.com/user-attachments/assets/0cde58d3-5789-4541-ac7b-8f2e0bedc1b3" />


:hearts: Thank you!
