### PR TITLE
Allow to create members in public assemblies

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb
@@ -16,7 +16,11 @@ shared_examples "inviting participatory space admins" do |check_private_space: t
         expect(page).to have_content("Components")
         expect(page).to have_content("Attachments")
         expect(page).to have_content(space_admins_label)
-        expect(page).to have_no_content("Members") if participatory_space.respond_to?(:private_space)
+        if participatory_space.is_a?(Decidim::Assembly)
+          expect(page).to have_content("Members")
+        elsif participatory_space.respond_to?(:private_space)
+          expect(page).to have_no_content("Members")
+        end
         expect(page).to have_content("Moderations")
       end
     end
@@ -31,7 +35,7 @@ shared_examples "inviting participatory space admins" do |check_private_space: t
         expect(page).to have_content("Components")
         expect(page).to have_content("Attachments")
         expect(page).to have_content(space_admins_label)
-        expect(page).to have_content("Members") if participatory_space.respond_to?(:private_space)
+        expect(page).to have_content("Members") if participatory_space.is_a?(Decidim::Assembly) || participatory_space.respond_to?(:private_space)
         expect(page).to have_content("Moderations")
       end
     end

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -123,6 +123,11 @@ module Decidim
       published? && (!private_space? || (private_space? && is_transparent?))
     end
 
+    # This is a overwrite for Decidim::HasPrivateUsers.members_public_page?
+    def members_public_page?
+      participatory_space_private_users.published.any?
+    end
+
     def to_param
       slug
     end

--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -55,7 +55,6 @@ module Decidim
 
       def user_can_read_private_users?
         return unless permission_action.subject == :space_private_user
-        return unless assembly.private_space?
 
         toggle_allow(user.admin? || can_manage_assembly?(role: :admin) || can_manage_assembly?(role: :collaborator))
       end

--- a/decidim-assemblies/spec/models/decidim/assembly_spec.rb
+++ b/decidim-assemblies/spec/models/decidim/assembly_spec.rb
@@ -123,6 +123,21 @@ module Decidim
       end
     end
 
+    describe ".members_public_page?" do
+      let!(:another_user) { create(:user, organization: assembly.organization) }
+      let!(:private_user) { create(:assembly_private_user, user: another_user, privatable_to: assembly, published: published) }
+      let(:published) { true }
+
+      it { is_expected.to be_truthy }
+
+      subject { assembly.members_public_page? }
+      context "when there are no published private users" do
+        let(:published) { false }
+
+        it { is_expected.to be_falsey }
+      end
+    end
+
     describe "scopes" do
       describe "public_spaces" do
         let!(:private_assembly) { create(:assembly, :private, :opaque) }

--- a/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
+++ b/decidim-assemblies/spec/permissions/decidim/assemblies/permissions_spec.rb
@@ -428,13 +428,7 @@ describe Decidim::Assemblies::Permissions do
       it_behaves_like "allows any action on subject", :moderation
       it_behaves_like "allows any action on subject", :assembly
       it_behaves_like "allows any action on subject", :assembly_user_role
-
-      context "when private assembly" do
-        let(:assembly) { create(:assembly, organization:, private_space: true) }
-        let!(:context) { { current_participatory_space: assembly } }
-
-        it_behaves_like "allows any action on subject", :space_private_user
-      end
+      it_behaves_like "allows any action on subject", :space_private_user
     end
 
     context "when user is an org admin" do
@@ -462,13 +456,7 @@ describe Decidim::Assemblies::Permissions do
       it_behaves_like "allows any action on subject", :moderation
       it_behaves_like "allows any action on subject", :assembly
       it_behaves_like "allows any action on subject", :assembly_user_role
-
-      context "when private assembly" do
-        let(:assembly) { create(:assembly, organization:, private_space: true) }
-        let!(:context) { { current_participatory_space: assembly } }
-
-        it_behaves_like "allows any action on subject", :space_private_user
-      end
+      it_behaves_like "allows any action on subject", :space_private_user
     end
   end
 

--- a/decidim-assemblies/spec/system/admin/admin_filters_assemblies_private_space_users_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_filters_assemblies_private_space_users_spec.rb
@@ -46,8 +46,7 @@ describe "Admin filters assemblies private space users" do
       visit decidim_admin_assemblies.participatory_space_private_users_path(assembly_slug: assembly.slug)
     end
 
-    it "restricts access" do
-      expect(page).to have_admin_callout("You are not authorized to perform this action.")
-    end
+    include_examples "filterable participatory space users"
+    include_examples "searchable participatory space users"
   end
 end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -36,7 +36,7 @@ describe "Admin manages assemblies" do
 
       it "shows the private user menu entry" do
         within_admin_sidebar_menu do
-          expect(page).to have_no_content("Members")
+          expect(page).to have_content("Members")
         end
       end
     end

--- a/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
+++ b/decidim-assemblies/spec/system/admin/assembly_admin_accesses_admin_sections_spec.rb
@@ -10,18 +10,7 @@ describe "Assembly admin accesses admin sections" do
     login_as user, scope: :user
   end
 
-  shared_examples "sees public space menu" do
-    it "can access all sections" do
-      expect(page).to have_content("Info")
-      expect(page).to have_content("Components")
-      expect(page).to have_content("Attachments")
-      expect(page).to have_content("Assembly admins")
-      expect(page).to have_no_content("Members")
-      expect(page).to have_content("Moderations")
-    end
-  end
-
-  shared_examples "sees private space menu" do
+  shared_examples "sees space menu" do
     it "can access all sections" do
       expect(page).to have_content("Info")
       expect(page).to have_content("Components")
@@ -42,13 +31,13 @@ describe "Assembly admin accesses admin sections" do
     end
 
     context "when is a public assembly" do
-      it_behaves_like "sees public space menu"
+      it_behaves_like "sees space menu"
     end
 
     context "when is a private assembly" do
       let(:assembly) { create(:assembly, organization:, private_space: true) }
 
-      it_behaves_like "sees private space menu"
+      it_behaves_like "sees space menu"
     end
   end
 
@@ -60,13 +49,13 @@ describe "Assembly admin accesses admin sections" do
     end
 
     context "when is a public assembly" do
-      it_behaves_like "sees public space menu"
+      it_behaves_like "sees space menu"
     end
 
     context "when is a private assembly" do
       let(:child_assembly) { create(:assembly, parent: assembly, organization:, private_space: true) }
 
-      it_behaves_like "sees private space menu"
+      it_behaves_like "sees space menu"
     end
 
     it_behaves_like "assembly admin manage assembly components"


### PR DESCRIPTION
#### :tophat: What? Why?
"Members" was a core feature of assemblies.
However since #13502 the members was merged with the "Private participants" feature. Which makes  sense for the assemblies case but not really for other participatory spaces.

This merged introduced a bug as the private participants are meant to be displayed in the admin only when the space is private while "members" should be always available. The result is that, currently, you can only have "members" if the space is private.

But we need "members" for public assemblies.

This could lead to a debate on how to better simplify the concept of "members".  One suggestion could be simply to add a new component with this functionality and the admins could just add it if they need it, regardless of the space type.


The solution implemented in this PR should be considered transitional to a more well defined model of "members".  The main issue here is that the nomenclature maintains "private users" kind of copies even if the assembly is not private. But as the feature is merged with "members" I think changing all the copies depending on the assembly visibility is not worth it. We better spend the time rethinking the "members" feature

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #15710

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
<img width="1169" height="306" alt="imatge" src="https://github.com/user-attachments/assets/7f8d701c-2a32-4b75-af9d-b328a518f87f" />
<img width="540" height="454" alt="imatge" src="https://github.com/user-attachments/assets/850bc0ba-8776-4020-bd62-eb2a6471a745" />


:hearts: Thank you!
