### PR TITLE
Fix questionnaire drag-and-drop blocking input text selection

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/draggable-table.js
+++ b/decidim-admin/app/packs/src/decidim/admin/draggable-table.js
@@ -4,30 +4,48 @@ import createSortList from "src/decidim/admin/sort_list.component"
  * Draggable table
  *
  * This script is used to make a table draggable.
- * It works with two data attributes:
+ * It works with the following data attributes:
  *
  * - data-draggable-table: The table that will be draggable.
  * - data-sort-url: The URL where the order will be sent.
+ * - data-draggable-handle: (optional) CSS selector for the drag handle element.
+ *   When specified, dragging can only be initiated from this element.
+ * - data-draggable-placeholder: (optional) HTML for the placeholder element.
  */
 document.addEventListener("turbo:load", () => {
-  createSortList("[data-draggable-table]", {
-    onSortUpdate: ($children) => {
-      const children = $children.toArray();
+  document.querySelectorAll("[data-draggable-table]").forEach((container) => {
+    const options = {
+      forcePlaceholderSize: true,
+      onSortUpdate: ($children) => {
+        const children = $children.toArray();
 
-      if (children.length === 0) {
-        return;
+        if (children.length === 0) {
+          return;
+        }
+
+        const parent = children[0].parentNode;
+        const sortUrl = parent.dataset.sortUrl;
+        const order = children.map((child) => child.dataset.recordId);
+
+        if (sortUrl && sortUrl !== "#") {
+          $.ajax({
+            method: "PUT",
+            url: sortUrl,
+            contentType: "application/json",
+            data: JSON.stringify({ order_ids: order }) // eslint-disable-line camelcase
+          });
+        }
       }
+    };
 
-      const parent = children[0].parentNode;
-      const sortUrl = parent.dataset.sortUrl;
-      const order = children.map((child) => child.dataset.recordId);
-
-      $.ajax({
-        method: "PUT",
-        url: sortUrl,
-        contentType: "application/json",
-        data: JSON.stringify({ order_ids: order }) // eslint-disable-line camelcase
-      });
+    // Read optional configuration from data attributes
+    if (container.dataset.draggableHandle) {
+      options.handle = container.dataset.draggableHandle;
     }
+    if (container.dataset.draggablePlaceholder) {
+      options.placeholder = container.dataset.draggablePlaceholder;
+    }
+
+    createSortList(container, options);
   });
 })

--- a/decidim-admin/app/packs/src/decidim/admin/sort_list.component.js
+++ b/decidim-admin/app/packs/src/decidim/admin/sort_list.component.js
@@ -6,7 +6,7 @@ class SortListComponent {
   /**
    * Creates a sortable list using hmtl5sortable function.
    *
-   * @param {String} sortListSelector The list selector that has to be sortable.
+   * @param {String|HTMLElement} sortListSelector The list selector or element that has to be sortable.
    * @param {Object} options An object containing the same options as html5sortable. It also includes
    *                an extra option `onSortUpdate`, a callback which returns the children collection
    *                whenever the list order has been changed.
@@ -14,7 +14,8 @@ class SortListComponent {
    * @returns {void} Nothing.
    */
   constructor(sortListSelector, options) {
-    if ($(sortListSelector).length > 0) {
+    const $element = $(sortListSelector);
+    if ($element.length > 0) {
       sortable(sortListSelector, options)[0].addEventListener("sortupdate", (event) => {
         const $children = $(event.target).children();
 

--- a/decidim-demographics/app/views/decidim/demographics/admin/questions/_questions_form.html.erb
+++ b/decidim-demographics/app/views/decidim/demographics/admin/questions/_questions_form.html.erb
@@ -33,7 +33,7 @@
     <%= render "decidim/forms/admin/questionnaires/display_condition_template", form: question_form, editable: questionnaire.questions_editable?, template_id: "display-condition-template-dummy" %>
     <%= render "decidim/forms/admin/questionnaires/matrix_row_template", form: question_form, editable: questionnaire.questions_editable?, template_id: "matrix-row-template-dummy" %>
   <% end %>
-  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" id="questionnaire-questions-list">
+  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" data-draggable-handle=".card-divider" id="questionnaire-questions-list">
     <% @form.questions.each_with_index do |question, index| %>
       <%= fields_for "questions[questions][]", question do |question_form| %>
         <% if question.separator? %>
@@ -69,35 +69,6 @@
   <script>
     document.addEventListener("turbo:load", function () {
       window.Decidim.createEditableForm();
-
-      // Function to initialize the sortable functionality
-      function initializeSortable() {
-        const container = document.querySelector("#questionnaire-questions-list");
-        const questionCards = container?.querySelectorAll(".card.questionnaire-question");
-
-        if (!container || !questionCards?.length) return;
-
-        questionCards.forEach(card => {
-          card.setAttribute("draggable", "true");
-          card.setAttribute("role", "option");
-          card.setAttribute("aria-grabbed", "false");
-        });
-
-        window.Decidim?.createSortableList?.("#questionnaire-questions-list");
-      }
-
-      // Initialize on load and when new options such as questions etc are added
-      initializeSortable();
-
-      const observer = new MutationObserver(() => {
-        clearTimeout(observer.timer);
-        observer.timer = setTimeout(initializeSortable, 500);
-      });
-
-      const container = document.querySelector("#questionnaire-questions-list");
-      if (container) {
-        observer.observe(container, { childList: true, subtree: true });
-      }
     });
   </script>
 <% end %>

--- a/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_form.html.erb
@@ -16,7 +16,7 @@
     <%= render "decidim/elections/admin/questions/response_option_template", form: question_form, editable: true, template_id: "response-option-template-dummy" %>
   <% end %>
 
-  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" id="questionnaire-questions-list">
+  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" data-draggable-handle=".card-divider" id="questionnaire-questions-list">
     <% @form.questions.each_with_index do |question, index| %>
       <%= fields_for "questions[]", question do |question_form| %>
         <%= render "decidim/elections/admin/questions/question",
@@ -35,34 +35,5 @@
 <script>
   document.addEventListener("turbo:load", function () {
     window.Decidim.createEditableForm();
-
-    // Function to initialize the sortable functionality
-    function initializeSortable() {
-      const container = document.querySelector("#questionnaire-questions-list");
-      const questionCards = container?.querySelectorAll(".card.questionnaire-question");
-
-      if (!container || !questionCards?.length) return;
-
-      questionCards.forEach(card => {
-        card.setAttribute("draggable", "true");
-        card.setAttribute("role", "option");
-        card.setAttribute("aria-grabbed", "false");
-      });
-
-      window.Decidim?.createSortableList?.("#questionnaire-questions-list");
-    }
-
-    // Initialize on load and when new options such as questions etc are added
-    initializeSortable();
-
-    const observer = new MutationObserver(() => {
-      clearTimeout(observer.timer);
-      observer.timer = setTimeout(initializeSortable, 500);
-    });
-
-    const container = document.querySelector("#questionnaire-questions-list");
-    if (container) {
-      observer.observe(container, { childList: true, subtree: true });
-    }
   });
 </script>

--- a/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
@@ -7,7 +7,6 @@ import AutoSelectOptionsFromUrl from "src/decidim/forms/admin/auto_select_option
 import createLiveTextUpdateComponent from "src/decidim/forms/admin/live_text_update.component"
 import AutoButtonsByPositionComponent from "src/decidim/admin/auto_buttons_by_position.component"
 import AutoLabelByPositionComponent from "src/decidim/admin/auto_label_by_position.component"
-import createSortList from "src/decidim/admin/sort_list.component"
 import createDynamicFields from "src/decidim/admin/dynamic_fields.component"
 import createFieldDependentInputs from "src/decidim/admin/field_dependent_inputs.component"
 import initLanguageChangeSelect from "src/decidim/admin/choose_language"
@@ -99,16 +98,16 @@ export default function createEditableForm() {
     })
   };
 
-  const createSortableList = () => {
-    createSortList(".questionnaire-questions-list:not(.published)", {
-      handle: ".question-divider",
-      placeholder: '<div style="border-style: dashed; border-color: #000"></div>',
-      forcePlaceholderSize: true,
-      onSortUpdate: () => {
+  // Listen for sortupdate events from html5sortable (initialized by draggable-table.js)
+  const setupSortUpdateListener = () => {
+    const container = document.querySelector(".questionnaire-questions-list:not(.published)");
+    if (container && !container.dataset.sortListenerAttached) {
+      container.addEventListener("sortupdate", () => {
         autoLabelByPosition.run();
         autoButtonsByPosition.run();
-      }
-    });
+      });
+      container.dataset.sortListenerAttached = "true";
+    }
   };
 
   const createDynamicQuestionTitle = (fieldId) => {
@@ -386,7 +385,7 @@ export default function createEditableForm() {
     moveDownFieldButtonSelector: ".move-down-question",
     onAddField: ($field) => {
       setupInitialQuestionAttributes($field);
-      createSortableList();
+      setupSortUpdateListener();
 
       autoLabelByPosition.run();
       autoButtonsByPosition.run();
@@ -422,7 +421,7 @@ export default function createEditableForm() {
     }
   });
 
-  createSortableList();
+  setupSortUpdateListener();
 
   $(fieldSelector).each((idx, el) => {
     const $target = $(el);

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_questions_form.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_questions_form.html.erb
@@ -40,7 +40,7 @@
     <%= cell("decidim/announcement", t(".already_responded_warning"), callout_class: "warning" ) %>
   <% end %>
 
-  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" id="questionnaire-questions-list">
+  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" data-draggable-handle=".card-divider" id="questionnaire-questions-list">
     <% @form.questions.each_with_index do |question, index| %>
       <%= fields_for "questions[questions][]", question do |question_form| %>
         <% if question.separator? %>
@@ -76,35 +76,6 @@
    <script>
     document.addEventListener("turbo:load", function () {
       window.Decidim.createEditableForm();
-
-      // Function to initialize the sortable functionality
-      function initializeSortable() {
-        const container = document.querySelector("#questionnaire-questions-list");
-        const questionCards = container?.querySelectorAll(".card.questionnaire-question");
-
-        if (!container || !questionCards?.length) return;
-
-        questionCards.forEach(card => {
-          card.setAttribute("draggable", "true");
-          card.setAttribute("role", "option");
-          card.setAttribute("aria-grabbed", "false");
-        });
-
-        window.Decidim?.createSortableList?.("#questionnaire-questions-list");
-      }
-
-      // Initialize on load and when new options such as questions etc are added
-      initializeSortable();
-
-      const observer = new MutationObserver(() => {
-        clearTimeout(observer.timer);
-        observer.timer = setTimeout(initializeSortable, 500);
-      });
-
-      const container = document.querySelector("#questionnaire-questions-list");
-      if (container) {
-        observer.observe(container, { childList: true, subtree: true });
-      }
     });
   </script>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_form.html.erb
@@ -24,7 +24,7 @@
     <%= render "decidim/meetings/admin/poll/response_option_template", form: question_form, editable: true, template_id: "response-option-template-dummy" %>
   <% end %>
 
-  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" id="questionnaire-questions-list">
+  <div class="questionnaire-questions-list flex flex-col py-6 gap-6 last:pb-0" data-draggable-table data-sort-url="#" data-draggable-handle=".card-divider" id="questionnaire-questions-list">
     <% @form.questions.each_with_index do |question, index| %>
       <%= fields_for "questionnaire[questions][]", question do |question_form| %>
         <%= render "decidim/meetings/admin/poll/question",
@@ -45,34 +45,5 @@
 <script>
   document.addEventListener("turbo:load", function () {
     window.Decidim.createEditableForm();
-
-    // Function to initialize the sortable functionality
-    function initializeSortable() {
-      const container = document.querySelector("#questionnaire-questions-list");
-      const questionCards = container?.querySelectorAll(".card.questionnaire-question");
-
-      if (!container || !questionCards?.length) return;
-
-      questionCards.forEach(card => {
-        card.setAttribute("draggable", "true");
-        card.setAttribute("role", "option");
-        card.setAttribute("aria-grabbed", "false");
-      });
-
-      window.Decidim?.createSortableList?.("#questionnaire-questions-list");
-    }
-
-    // Initialize on load and when new options such as questions etc are added
-    initializeSortable();
-
-    const observer = new MutationObserver(() => {
-      clearTimeout(observer.timer);
-      observer.timer = setTimeout(initializeSortable, 500);
-    });
-
-    const container = document.querySelector("#questionnaire-questions-list");
-    if (container) {
-      observer.observe(container, { childList: true, subtree: true });
-    }
   });
 </script>


### PR DESCRIPTION
#### :tophat: What? Why?
Root cause: `draggable-table.js `initialized `html5sortable` without the handle option, allowing drag to start from anywhere inside the card.

  Solution:
  - Added `data-draggable-handle `attribute support to `draggable-table.js`
  - Added `data-draggable-handle=".card-divider"` to questionnaire containers
  - Removed duplicate sortable initialization code from templates

  Now dragging only works from the card header (`.card-divider`), while form inputs remain fully interactive.

#### :pushpin: Related Issues
- Fixes #15663 

#### Testing
  Test drag-and-drop questions in: Surveys, Elections, Meetings (Poll), Demographics

  - Verify text selection works in input fields
  - Verify dragging works only from card header

:hearts: Thank you!
