### PR TITLE
Fix displaying the URL of a meeting if the iframe visibility is not defined

### DIFF
--- a/decidim-core/app/cells/decidim/address_cell.rb
+++ b/decidim-core/app/cells/decidim/address_cell.rb
@@ -55,9 +55,8 @@ module Decidim
 
     def display_online_meeting_url?
       return true unless model.respond_to?(:online?)
-      return true unless model.respond_to?(:iframe_access_level_allowed_for_user?)
 
-      model.online? && model.iframe_access_level_allowed_for_user?(current_user)
+      model.online? && model.online_meeting_url.present?
     end
 
     private

--- a/decidim-core/spec/cells/decidim/address_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/address_cell_spec.rb
@@ -58,7 +58,6 @@ describe Decidim::AddressCell, type: :cell do
     before do
       allow(model).to receive(:online?).and_return true
       allow(model).to receive(:type_of_meeting).and_return :online
-      allow(model).to receive(:iframe_access_level_allowed_for_user?).and_return true
       allow(model).to receive(:online_meeting_url).and_return online_meeting_url
     end
 
@@ -71,6 +70,16 @@ describe Decidim::AddressCell, type: :cell do
 
       it "renders the escaped URL" do
         expect(subject).to have_content "https://decidim.org/?v=h%3Cscript%3Ealert(1)%3C/script%3E"
+      end
+    end
+
+    context "when no URL is present" do
+      before do
+        allow(model).to receive(:online_meeting_url).and_return " "
+      end
+
+      it "does not render the URL" do
+        expect(subject).to have_no_css ".address__online-meeting-url"
       end
     end
   end

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -322,8 +322,8 @@ describe "Meeting live event access" do
       it "not shown to not signed in users" do
         visit_meeting
 
-        expect(page).to have_no_css(".address__hints")
-        expect(page).to have_no_content(meeting.online_meeting_url)
+        expect(page).to have_css(".address__hints")
+        expect(page).to have_content(meeting.online_meeting_url)
       end
     end
 
@@ -350,8 +350,8 @@ describe "Meeting live event access" do
       it "not shown to registered users" do
         visit_meeting
 
-        expect(page).to have_no_css(".address__hints")
-        expect(page).to have_no_content(meeting.online_meeting_url)
+        expect(page).to have_css(".address__hints")
+        expect(page).to have_content(meeting.online_meeting_url)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When opening a meeting, address information shows the URL of the meeting if this one is "online".
<img width="1316" height="405" alt="imatge" src="https://github.com/user-attachments/assets/7ce19665-6cc5-49c8-9a7f-3781370b2bb3" />

However, currently if you don't define the "Iframe embed type" and "Iframe access level" to something different that "none", you won't see the URL.
<img width="626" height="566" alt="imatge" src="https://github.com/user-attachments/assets/1cb8ccc1-979d-42c4-8f0a-adfed076dd53" />

The URL of the meeting in most case is not embeded in an iframe, people just adds it to their agenda and fo to the link. And, if you want to hide, simply don't write anything to it. So it makes no sense to display this value depending on the obscure setting of the iframe (that most people don't really understand).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
