### PR TITLE
Remove duplicate inclusion of SanitizeHelper

### DIFF
--- a/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
+++ b/decidim-accountability/app/presenters/decidim/accountability/result_presenter.rb
@@ -8,7 +8,6 @@ module Decidim
     class ResultPresenter < Decidim::ResourcePresenter
       include Rails.application.routes.mounted_helpers
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       def result
         __getobj__

--- a/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
+++ b/decidim-blogs/app/presenters/decidim/blogs/post_presenter.rb
@@ -8,7 +8,6 @@ module Decidim
     class PostPresenter < Decidim::ResourcePresenter
       include Decidim::ResourceHelper
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       def author
         @author ||= if official?

--- a/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
+++ b/decidim-debates/app/presenters/decidim/debates/debate_presenter.rb
@@ -8,7 +8,6 @@ module Decidim
     class DebatePresenter < Decidim::ResourcePresenter
       include Decidim::TranslationsHelper
       include Decidim::ResourceHelper
-      include Decidim::SanitizeHelper
       include ActionView::Helpers::DateHelper
 
       def debate

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -5,7 +5,6 @@ module Decidim
     class ElectionPresenter < Decidim::ResourcePresenter
       include Decidim::ResourceHelper
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       def election
         __getobj__

--- a/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/agenda_item_presenter.rb
@@ -7,7 +7,6 @@ module Decidim
     #
     class AgendaItemPresenter < Decidim::ResourcePresenter
       include Decidim::ResourceHelper
-      include Decidim::SanitizeHelper
 
       def agenda_item
         __getobj__

--- a/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
+++ b/decidim-meetings/app/presenters/decidim/meetings/meeting_presenter.rb
@@ -8,7 +8,6 @@ module Decidim
     class MeetingPresenter < Decidim::ResourcePresenter
       include Decidim::ResourceHelper
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       alias super_title title
 

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/participatory_process_presenter.rb
@@ -5,7 +5,6 @@ module Decidim
     class ParticipatoryProcessPresenter < ResourcePresenter
       include Decidim::ResourceHelper
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       def hero_image_url
         process.attached_uploader(:hero_image).url

--- a/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/proposal_presenter.rb
@@ -8,7 +8,6 @@ module Decidim
     class ProposalPresenter < Decidim::ResourcePresenter
       include Rails.application.routes.mounted_helpers
       include ActionView::Helpers::UrlHelper
-      include Decidim::SanitizeHelper
 
       def author
         @author ||= if official?


### PR DESCRIPTION
#### :tophat: What? Why?
This PR cleans up the code, by removing duplicate SanitizeHelper in presenters.

#### Testing
1. Green pipeline 
2. open ResourcePresenter , see SanitizeHelper is being included 
3. See descendant classes do not have it. 

:hearts: Thank you!
