### PR TITLE
Fixing bug of off center external link warning modals in design pages

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_modal.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_modal.scss
@@ -2,7 +2,11 @@
   @apply invisible opacity-0 fixed z-50 inset-0 bg-[rgba(0,0,0,0.25)] transition duration-300;
 
   & > * {
-    @apply absolute inset-1/2 ltr:-translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
+    @apply absolute inset-1/2 translate-x-[-50%] translate-y-[-50%] w-[90%] lg:max-w-[900px] max-h-[95vh] h-fit overflow-y-auto p-6 bg-white z-50 rounded shadow-[0_4px_6px_rgba(211,211,211,0.25)];
+
+    [dir="rtl"] & {
+      @apply translate-x-[50%];
+    }
 
     & > svg:only-child {
       @apply w-8 h-8 mx-auto text-gray-2 fill-current animate-spin;


### PR DESCRIPTION
#### :tophat: What? Why?
The design pages have off centered modals, this is making sure they are aligned correctly.

#### :pushpin: Related Issues
#15238 

#### Testing
If you go to the '/design' page of the develop app and open an external link so the warning modal pops up, it will be centered.

:hearts: Thank you!
