### PR TITLE
Fix "request too large" error when exporting initiatives

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -142,7 +142,7 @@ module Decidim
             current_user,
             current_organization,
             params[:format] || default_format,
-            params[:collection_ids].presence&.map(&:to_i)
+            params[:collection_ids].presence&.split(",")&.map(&:to_i)
           )
 
           flash[:notice] = t("decidim.admin.exports.notice")

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -134,7 +134,7 @@ module Decidim
           end
         end
 
-        # GET /admin/initiatives/export
+        # POST /admin/initiatives/export
         def export
           enforce_permission_to :export, :initiatives
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -16,9 +16,8 @@
         <%= form_with url: export_initiatives_path(format: format), method: :post, class: "dropdown__button" do |f| %>
           <%= hidden_field_tag "collection_ids", collection_ids&.join(",") %>
           <%= f.submit t("decidim.admin.exports.export_as",
-            name: t("decidim.initiatives.admin.exports.initiatives"),
-            export_format: format.upcase
-          ) %>
+                         name: t("decidim.initiatives.admin.exports.initiatives"),
+                         export_format: format.upcase) %>
         <% end %>
       </li>
     <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -13,8 +13,12 @@
   <ul id="dropdown-exports-<%= menu_id %>-<%= dropdown_id(collection_ids) %>" class="dropdown dropdown__bottom" aria-hidden="true">
     <% %w(CSV JSON).each do |format| %>
       <li class="dropdown__item">
-        <%= link_to export_initiatives_path(format:, collection_ids:), class: "dropdown__button" do %>
-          <%= t("decidim.admin.exports.export_as", name: t("decidim.initiatives.admin.exports.initiatives"), export_format: format.upcase) %>
+        <%= form_with url: export_initiatives_path(format: format), method: :post, class: "dropdown__button" do |f| %>
+          <%= hidden_field_tag "collection_ids", collection_ids&.join(",") %>
+          <%= f.submit t("decidim.admin.exports.export_as",
+            name: t("decidim.initiatives.admin.exports.initiatives"),
+            export_format: format.upcase
+          ) %>
         <% end %>
       </li>
     <% end %>

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -36,7 +36,7 @@ module Decidim
             end
 
             collection do
-              get :export
+              post :export
             end
 
             resources :attachments, controller: "initiative_attachments", except: [:show]

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -577,7 +577,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
     end
   end
 
-  context "when GET export" do
+  context "when POST export" do
     context "and user" do
       before do
         sign_in user, scope: :user
@@ -586,7 +586,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       it "is not allowed" do
         expect(Decidim::Initiatives::ExportInitiativesJob).not_to receive(:perform_later).with(user, "CSV", nil)
 
-        get :export, params: { format: :csv }
+        post :export, params: { format: :csv }
         expect(flash[:alert]).not_to be_empty
         expect(response).to have_http_status(:found)
       end
@@ -600,7 +600,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       it "is allowed" do
         expect(Decidim::Initiatives::ExportInitiativesJob).to receive(:perform_later).with(admin_user, organization, "csv", nil)
 
-        get :export, params: { format: :csv }
+        post :export, params: { format: :csv }
         expect(flash[:alert]).to be_nil
         expect(response).to have_http_status(:found)
       end
@@ -612,7 +612,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
         it "enqueues the job" do
           expect(Decidim::Initiatives::ExportInitiativesJob).to receive(:perform_later).with(admin_user, organization, "csv", collection_ids)
 
-          get :export, params: { format: :csv, collection_ids: }
+          post :export, params: { format: :csv, collection_ids: }
           expect(flash[:alert]).to be_nil
           expect(response).to have_http_status(:found)
         end

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -608,11 +608,12 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       context "when a collection of ids is passed as a parameter" do
         let!(:initiatives) { create_list(:initiative, 3, organization:) }
         let(:collection_ids) { initiatives.map(&:id) }
+        let(:comma_separated_ids) { collection_ids.join(",") }
 
         it "enqueues the job" do
           expect(Decidim::Initiatives::ExportInitiativesJob).to receive(:perform_later).with(admin_user, organization, "csv", collection_ids)
 
-          post :export, params: { format: :csv, collection_ids: }
+          post :export, params: { format: :csv, collection_ids: comma_separated_ids }
           expect(flash[:alert]).to be_nil
           expect(response).to have_http_status(:found)
         end


### PR DESCRIPTION
#### :tophat: What? Why?
Exporting a lot of initiatives causes a "request too large" error, as the ids of each initiative is added as a url parameter in `collection_ids[]`. When having a lot of them (hundreds), the url is too long and the server returns an error.

Changing the `link_to` to use the POST method is not enough, as the ids are sent as url params. They have to be sent in the request body. Additionally, instead of sending multiple `collection_ids[]=1&collection_ids[]=2&...`, it would be easier to send just one hidden input with a comma separated list of ids.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/11103

#### Testing
Sign in as admin, go to the dashboard/initiatives, add some filters and click on export.

### :camera: Screenshots

<img width="1795" height="576" alt="image" src="https://github.com/user-attachments/assets/af82b48e-ac65-4a6a-a5c8-513070625af0" />


:hearts: Thank you!
