### PR TITLE
Fix copy meeting taxonomies

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/copy_meeting.rb
@@ -44,7 +44,7 @@ module Decidim
           @copied_meeting = Decidim.traceability.create!(
             Meeting,
             form.current_user,
-            taxonomies: form.taxonomies,
+            taxonomizations: form.taxonomizations,
             title: parsed_title,
             description: parsed_description,
             end_time: form.end_time,

--- a/decidim-meetings/spec/commands/admin/copy_meeting_fields_spec.rb
+++ b/decidim-meetings/spec/commands/admin/copy_meeting_fields_spec.rb
@@ -31,7 +31,7 @@ module Decidim
             invalid?: false,
             current_user: user,
             current_organization: organization,
-            taxonomies: [],
+            taxonomizations: [],
             title: { "en" => "Copied Meeting" },
             description: { "en" => "Copied description" },
             end_time: 2.hours.from_now,

--- a/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/copy_meeting_spec.rb
@@ -42,7 +42,7 @@ module Decidim::Meetings
         reminder_enabled: meeting.reminder_enabled,
         send_reminders_before_hours: meeting.send_reminders_before_hours,
         reminder_message_custom_content: meeting.reminder_message_custom_content,
-        taxonomies: meeting.taxonomies,
+        taxonomizations: meeting.taxonomizations,
         services_to_persist:,
         current_user:,
         questionnaire: Decidim::Forms::Questionnaire.new,

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_copy_spec.rb
@@ -15,10 +15,16 @@ describe "Admin copies meetings" do
   let(:meeting_end_date) { ((base_date + 2.days) + 1.month).strftime("%d/%m/%Y") }
   let(:meeting_end_time) { (base_date + 4.hours).strftime("%H:%M") }
   let(:taxonomies) { [taxonomy] }
+  let(:root_taxonomy) { create(:taxonomy, organization:) }
+  let!(:taxonomy) { create(:taxonomy, parent: root_taxonomy, organization:) }
+  let(:taxonomy_filter) { create(:taxonomy_filter, root_taxonomy:) }
+  let!(:taxonomy_filter_item) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy) }
+  let(:taxonomy_filter_ids) { [taxonomy_filter.id] }
 
   include_context "when managing a component as an admin"
 
   before do
+    component.update!(settings: { taxonomy_filters: taxonomy_filter_ids })
     visit current_path
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes the Taxonomies issue on Copy meeting.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #15718

#### Testing

1. As a admin, log in to admin panel
2. Identify a space, and edit to assign taxonomies 
3. Click update
4. Visit meeting component, and set some root taxonomies 
5. Edit a meeting from admin panel, assign any taxonomies 
6. On Component index page in admin, click actions for chosen meeting, click Duplicate
7. Update the title and date with a new one > confirm by clicking on the "copy" button at the bottom of the screen
8. Error screen
9. Apply patch 
10. Repeat 6 & 7 
11. See error is not present anymore 

Other way: 
1. copy the specs from this PR 
2. Save it on develop
3. Run specs
4. See error (looks like: `Decidim::Taxonomy(#29552) expected, got 18 which is an instance of Integer(#2448)`)

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
