### PR TITLE
Allow editing last question on receipt page for per-question elections

### DIFF
--- a/decidim-elections/app/controllers/concerns/decidim/elections/uses_votes_booth.rb
+++ b/decidim-elections/app/controllers/concerns/decidim/elections/uses_votes_booth.rb
@@ -49,10 +49,16 @@ module Decidim
 
       # Shows the receipt page
       def receipt
+        if params[:exit].present?
+          votes_buffer.clear
+          session_attributes.clear
+          return redirect_to(exit_path)
+        end
+
         enforce_permission_to(:create, :vote, election:)
 
-        votes_buffer.clear
-        session_attributes.clear
+        votes_buffer.clear unless election.per_question?
+
         return redirect_to(exit_path) unless election.votes.exists?(voter_uid: session[:voter_uid])
 
         render "decidim/elections/votes/receipt"

--- a/decidim-elections/app/controllers/decidim/elections/per_question_votes_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/per_question_votes_controller.rb
@@ -29,6 +29,7 @@ module Decidim
         enforce_permission_to(:create, :vote, election:)
 
         response_ids = params.dig(:response, question.id.to_s)
+        requeue_following_questions
         votes_buffer[question.id.to_s] = response_ids
         CastVotes.call(election, { question.id.to_s => response_ids }, voter_uid) do
           on(:ok) do
@@ -83,6 +84,13 @@ module Decidim
         return { action: :waiting } if next_question.blank?
 
         { action: :show, id: next_question }
+      end
+
+      def requeue_following_questions
+        election.questions
+                .where("position > ?", question.position)
+                .pluck(:id)
+                .each { |id| votes_buffer.delete(id.to_s) }
       end
     end
   end

--- a/decidim-elections/app/views/decidim/elections/votes/receipt.html.erb
+++ b/decidim-elections/app/views/decidim/elections/votes/receipt.html.erb
@@ -4,5 +4,22 @@
     <h2 class="h2 text-center mb-6"><%= t(".title") %></h2>
     <p class="text-center"><%= t(".description") %></p>
   </div>
-  <%= link_to t(".exit_button"), exit_path, class: "button button__secondary button__lg w-full mt-12" %>
+
+  <% editable_question = election.per_question? ? election.questions.enabled.unpublished_results.last : nil %>
+  <% exit_button_path = election.per_question? ? url_for(action: :receipt, exit: true) : exit_path %>
+  <% if editable_question.present? %>
+    <div class="vote-navigation w-full flex justify-between mt-8">
+      <%= link_to election_per_question_vote_path(election_id: election, id: editable_question),
+                  class: "button button__lg button__transparent-secondary" do %>
+        <%= icon "edit-line", class: "fill-current mr-2" %>
+        <%= t(".edit_vote") %>
+      <% end %>
+
+      <div class="ml-auto">
+        <%= link_to t(".exit_button"), exit_button_path, class: "button button__lg button__secondary" %>
+      </div>
+    </div>
+  <% else %>
+    <%= link_to t(".exit_button"), exit_button_path, class: "button button__secondary button__lg w-full mt-12" %>
+  <% end %>
 </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -316,7 +316,8 @@ en:
           max_choices_exceeded: You cannot select more than %{max} options. Please go back and adjust your selection.
           next: Next
         receipt:
-          description: Yo can vote again at any time while the voting period is open. Your previous vote will be overwritten by the new one.
+          description: You can vote again at any time while the voting period is open. Your previous vote will be overwritten by the new one.
+          edit_vote: Edit your vote
           exit_button: Exit the voting booth
           title: Your votes have been cast successfully
     metadata:

--- a/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
@@ -171,3 +171,73 @@ shared_examples "a per question votable election with already voted questions" d
     expect(page).to have_no_content("Edit your vote")
   end
 end
+
+shared_examples "a per question votable election with edit from receipt" do
+  it "allows editing votes from receipt page" do
+    click_on "Vote"
+    choose translated_attribute(question1.response_options.first.body)
+    click_on "Cast vote"
+    check translated_attribute(question2.response_options.first.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(receipt_election_votes_path)
+    expect(page).to have_link("Edit your vote")
+    expect(page).to have_link("Exit the voting booth")
+
+    click_on "Edit your vote"
+    expect(page).to have_current_path(election_vote_path(question2))
+    expect(find("input[value='#{question2.response_options.first.id}']")).to be_checked
+
+    click_on "Back"
+    expect(page).to have_current_path(election_vote_path(question1))
+    expect(find("input[value='#{question1.response_options.first.id}']")).to be_checked
+
+    choose translated_attribute(question1.response_options.second.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(election_vote_path(question2))
+
+    check translated_attribute(question2.response_options.second.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(receipt_election_votes_path)
+    expect(election.votes.where(voter_uid:).size).to eq(3)
+
+    click_on "Exit the voting booth"
+    expect(page).to have_current_path(election_path)
+    expect(page).to have_content("You have already voted.")
+  end
+end
+
+shared_examples "a per question votable election with edit from receipt when all questions enabled" do
+  it "allows editing any question from receipt page" do
+    click_on "Vote"
+    choose translated_attribute(question1.response_options.first.body)
+    click_on "Cast vote"
+    check translated_attribute(question2.response_options.first.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(receipt_election_votes_path)
+
+    click_on "Edit your vote"
+    expect(page).to have_current_path(election_vote_path(question2))
+
+    click_on "Back"
+    expect(page).to have_current_path(election_vote_path(question1))
+
+    choose translated_attribute(question1.response_options.second.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(election_vote_path(question2))
+    expect(find("input[value='#{question2.response_options.first.id}']")).to be_checked
+
+    click_on "Cast vote"
+    expect(page).to have_current_path(receipt_election_votes_path)
+
+    click_on "Edit your vote"
+    click_on "Back"
+    choose translated_attribute(question1.response_options.first.body)
+    click_on "Cast vote"
+    uncheck translated_attribute(question2.response_options.first.body)
+    check translated_attribute(question2.response_options.second.body)
+    click_on "Cast vote"
+    expect(page).to have_current_path(receipt_election_votes_path)
+    expect(election.votes.where(voter_uid:).size).to eq(2)
+  end
+end
+

--- a/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
@@ -240,4 +240,3 @@ shared_examples "a per question votable election with edit from receipt when all
     expect(election.votes.where(voter_uid:).size).to eq(2)
   end
 end
-

--- a/decidim-elections/spec/controllers/decidim/elections/per_question_votes_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/per_question_votes_controller_spec.rb
@@ -29,6 +29,7 @@ module Decidim
         allow(controller).to receive(:current_participatory_space).and_return(component.participatory_space)
         allow(controller).to receive(:current_component).and_return(component)
         allow(controller).to receive(:election_vote_path).and_return(election_vote_path)
+        allow(controller).to receive(:second_election_vote_path).and_return(second_election_vote_path)
         allow(controller).to receive(:new_election_vote_path).and_return(new_election_vote_path)
         allow(controller).to receive(:election_path).and_return(election_path)
         allow(controller).to receive(:waiting_election_votes_path).and_return(waiting_election_votes_path)
@@ -118,13 +119,22 @@ module Decidim
           end
 
           it "casts the votes and redirects to the receipt page if successful" do
-            # ensure there are no pending votes
-            allow(controller).to receive(:votes_buffer).and_return({ question.id.to_s => [question.response_options.first.id], second_question.id.to_s => [second_question.response_options.first.id] })
+            session[:votes_buffer] = { question.id.to_s => [question.response_options.first.id.to_s], second_question.id.to_s => [second_question.response_options.first.id.to_s] }
 
             expect(controller).to receive(:redirect_to).with(action: :receipt)
-            patch :update, params: params.merge(id: question.id, response: { question.id.to_s => [question.response_options.first.id] })
+            patch :update, params: params.merge(id: second_question.id, response: { second_question.id.to_s => [second_question.response_options.first.id] })
             expect(session[:voter_uid]).to eq(user.to_global_id.to_s)
             expect(flash[:notice]).to eq(I18n.t("votes.cast.success", scope: "decidim.elections"))
+          end
+
+          it "clears subsequent questions from buffer when updating a previous question" do
+            session[:votes_buffer] = { question.id.to_s => [question.response_options.first.id.to_s], second_question.id.to_s => [second_question.response_options.first.id.to_s] }
+
+            expect(controller).to receive(:redirect_to).with(action: :show, id: second_question)
+            patch :update, params: params.merge(id: question.id, response: { question.id.to_s => [question.response_options.second.id] })
+
+            expect(session[:votes_buffer]).not_to have_key(second_question.id.to_s)
+            expect(session[:votes_buffer][question.id.to_s]).to eq([question.response_options.second.id.to_s])
           end
         end
       end
@@ -217,12 +227,19 @@ module Decidim
 
               it_behaves_like "a redirect to the waiting room", :receipt
 
-              it "renders the receipt page" do
-                expect(controller.send(:votes_buffer)).to receive(:clear)
-                expect(controller.send(:session_attributes)).to receive(:clear)
+              it "renders the receipt page without clearing session" do
+                expect(controller.send(:votes_buffer)).not_to receive(:clear)
+                expect(controller.send(:session_attributes)).not_to receive(:clear)
                 get :receipt, params: params
                 expect(response).to have_http_status(:ok)
                 expect(subject).to render_template(:receipt)
+              end
+
+              it "clears session when exit param is present" do
+                expect(controller.send(:votes_buffer)).to receive(:clear)
+                expect(controller.send(:session_attributes)).to receive(:clear)
+                get :receipt, params: params.merge(exit: true)
+                expect(response).to redirect_to(election_path)
               end
             end
           end

--- a/decidim-elections/spec/controllers/decidim/elections/votes_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/votes_controller_spec.rb
@@ -235,12 +235,19 @@ module Decidim
               create(:election_vote, voter_uid: session[:voter_uid], question: question, response_option: question.response_options.first)
             end
 
-            it "renders the receipt page" do
+            it "renders the receipt page and clears votes buffer" do
               expect(controller.send(:votes_buffer)).to receive(:clear)
-              expect(controller.send(:session_attributes)).to receive(:clear)
+              expect(controller.send(:session_attributes)).not_to receive(:clear)
               get :receipt, params: params
               expect(response).to have_http_status(:ok)
               expect(subject).to render_template(:receipt)
+            end
+
+            it "clears session when exit param is present" do
+              expect(controller.send(:votes_buffer)).to receive(:clear)
+              expect(controller.send(:session_attributes)).to receive(:clear)
+              get :receipt, params: params.merge(exit: true)
+              expect(response).to redirect_to(election_path)
             end
           end
         end

--- a/decidim-elections/spec/system/user_votes_in_an_per_question_election_spec.rb
+++ b/decidim-elections/spec/system/user_votes_in_an_per_question_election_spec.rb
@@ -73,6 +73,19 @@ describe "Dashboard" do
     it_behaves_like "a per question votable election with already voted questions"
   end
 
+  context "when editing votes from receipt page" do
+    let!(:question1) { create(:election_question, :with_response_options, :voting_enabled, skip_injection: true, question_type: "single_option", election:, position: 1) }
+    let!(:question2) { create(:election_question, :with_response_options, :voting_enabled, election:, skip_injection: true, position: 2) }
+
+    before do
+      login_as user, scope: :user
+      visit election_path
+    end
+
+    it_behaves_like "a per question votable election with edit from receipt"
+    it_behaves_like "a per question votable election with edit from receipt when all questions enabled"
+  end
+
   context "when the election is real time" do
     let(:election) { create(:election, :published, :ongoing, :with_internal_users_census, :real_time, :with_questions) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Added "Edit your vote" button on receipt page for per-question elections to allow editing the last question.

#### :pushpin: Related Issues
- Fixes #15664 

#### Testing
  1. Create a per-question election with 2+ questions, enable voting
  2. Vote on all questions until receipt page
  3. Verify "Edit your vote" button appears
  4. Click it and confirm you can edit the last question

### :camera: Screenshots
<img width="858" height="544" alt="Screenshot 2025-12-05 at 11 30 26" src="https://github.com/user-attachments/assets/c2252c66-73a5-430c-85f7-f5c5d793a851" />

:hearts: Thank you!
