### PR TITLE
Lock connection_pool to 2.5.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ PATH
       charlock_holmes (~> 0.7)
       chartkick (~> 5.1.2)
       concurrent-ruby (~> 1.3.0)
+      connection_pool (< 3)
       data_migrate (~> 11.3)
       date_validator (~> 0.12.0)
       devise (~> 4.7)
@@ -338,7 +339,7 @@ GEM
     cmdparse (3.0.7)
     commonmarker (0.23.12)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
+    connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
       rexml

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "cells-rails", "~> 0.1.3"
   s.add_dependency "charlock_holmes", "~> 0.7"
   s.add_dependency "chartkick", "~> 5.1.2"
+  s.add_dependency "connection_pool", "< 3"
   s.add_dependency "data_migrate", "~> 11.3"
   s.add_dependency "date_validator", "~> 0.12.0"
   s.add_dependency "devise", "~> 4.7"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -65,6 +65,7 @@ PATH
       charlock_holmes (~> 0.7)
       chartkick (~> 5.1.2)
       concurrent-ruby (~> 1.3.0)
+      connection_pool (< 3)
       data_migrate (~> 11.3)
       date_validator (~> 0.12.0)
       devise (~> 4.7)
@@ -338,7 +339,7 @@ GEM
     cmdparse (3.0.7)
     commonmarker (0.23.12)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
+    connection_pool (2.5.5)
     crack (1.0.0)
       bigdecimal
       rexml


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR I am locking connection_pool to version 2.5.5, as the next version 3.0 is causing errors, affecting Decidim 0.30. 
I am proposing to apply this PR and backport it, to ensure that no upcoming versions of connection_pool from 3.0 family would break  any releases of Decidim. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15743

#### Testing
1. Pipeline is green

:hearts: Thank you!
