### PR TITLE
Remove deprecation comment for `Decidim::AttributeObject::Model`

### DIFF
--- a/decidim-core/lib/decidim/attribute_object/model.rb
+++ b/decidim-core/lib/decidim/attribute_object/model.rb
@@ -107,11 +107,6 @@ module Decidim
       # through symbols by calling `obj.attributes[:key]` or
       # `obj.attributes.slice(:key1, :key2)`. In the legacy Virtus models, this
       # returned a hash with symbol keys.
-      #
-      # Deprecated:
-      # Attributes access through symbols is deprecated and may be removed in
-      # future versions. Please refactor all your attributes calls to access the
-      # attributes through string keys.
       def attributes
         super.with_indifferent_access
       end


### PR DESCRIPTION
#### :tophat: What? Why?

As we discussed on  #15676, we prefer to not break the apps and just use the indifferent access approach (expecting both symbols and strings for the keys of this API).
 
#### Testing

As it is a removal of a comment, everything should be green 

:hearts: Thank you!
