### PR TITLE
Backport 'Fix "request too large" error when exporting initiatives' to v0.30

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -134,7 +134,7 @@ module Decidim
           end
         end
 
-        # GET /admin/initiatives/export
+        # POST /admin/initiatives/export
         def export
           enforce_permission_to :export, :initiatives
 
@@ -142,7 +142,7 @@ module Decidim
             current_user,
             current_organization,
             params[:format] || default_format,
-            params[:collection_ids].presence&.map(&:to_i)
+            params[:collection_ids].presence&.split(",")&.map(&:to_i)
           )
 
           flash[:notice] = t("decidim.admin.exports.notice")

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -15,11 +15,14 @@
      data-close-on-click="true">
   <ul class="vertical menu add-components">
     <% %w(CSV JSON).each do |format| %>
-      <%= link_to export_initiatives_path(format:, collection_ids:) do %>
-        <li class="exports--format--<%= format.downcase %> exports--initiatives">
-          <%= t("decidim.admin.exports.export_as", name: t("decidim.initiatives.admin.exports.initiatives"), export_format: format.upcase) %>
-        </li>
-      <% end %>
+      <li class="exports--format--<%= format.downcase %> exports--initiatives">
+        <%= form_with url: export_initiatives_path(format: format), method: :post, class: "dropdown__button" do |f| %>
+          <%= hidden_field_tag "collection_ids", collection_ids&.join(",") %>
+          <%= f.submit t("decidim.admin.exports.export_as",
+                         name: t("decidim.initiatives.admin.exports.initiatives"),
+                         export_format: format.upcase) %>
+        <% end %>
+      </li>
     <% end %>
   </ul>
 </div>

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -36,7 +36,7 @@ module Decidim
             end
 
             collection do
-              get :export
+              post :export
             end
 
             resources :attachments, controller: "initiative_attachments", except: [:show]

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -577,7 +577,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
     end
   end
 
-  context "when GET export" do
+  context "when POST export" do
     context "and user" do
       before do
         sign_in user, scope: :user
@@ -586,7 +586,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       it "is not allowed" do
         expect(Decidim::Initiatives::ExportInitiativesJob).not_to receive(:perform_later).with(user, "CSV", nil)
 
-        get :export, params: { format: :csv }
+        post :export, params: { format: :csv }
         expect(flash[:alert]).not_to be_empty
         expect(response).to have_http_status(:found)
       end
@@ -600,7 +600,7 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       it "is allowed" do
         expect(Decidim::Initiatives::ExportInitiativesJob).to receive(:perform_later).with(admin_user, organization, "csv", nil)
 
-        get :export, params: { format: :csv }
+        post :export, params: { format: :csv }
         expect(flash[:alert]).to be_nil
         expect(response).to have_http_status(:found)
       end
@@ -608,11 +608,12 @@ describe Decidim::Initiatives::Admin::InitiativesController do
       context "when a collection of ids is passed as a parameter" do
         let!(:initiatives) { create_list(:initiative, 3, organization:) }
         let(:collection_ids) { initiatives.map(&:id) }
+        let(:comma_separated_ids) { collection_ids.join(",") }
 
         it "enqueues the job" do
           expect(Decidim::Initiatives::ExportInitiativesJob).to receive(:perform_later).with(admin_user, organization, "csv", collection_ids)
 
-          get :export, params: { format: :csv, collection_ids: }
+          post :export, params: { format: :csv, collection_ids: comma_separated_ids }
           expect(flash[:alert]).to be_nil
           expect(response).to have_http_status(:found)
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15733 to v0.30

:hearts: Thank you!