### PR TITLE
Change Vote button to Edit vote when user has already voted

### DIFF
--- a/decidim-elections/app/views/decidim/elections/elections/_election_aside.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_election_aside.html.erb
@@ -1,7 +1,8 @@
 <section class="layout-aside__section">
   <div class="election__aside-vote layout-aside__ctas-buttons" data-controller="sticky-buttons">
     <% if election.ongoing? %>
-      <%= link_to t("vote_button", scope: "decidim.elections.elections.show"), new_election_vote_path(election), class: "button button__secondary button__lg" %>
+      <% button_key = voted_by_current_user?(election) ? "edit_vote_button" : "vote_button" %>
+      <%= link_to t(button_key, scope: "decidim.elections.elections.show"), new_election_vote_path(election), class: "button button__secondary button__lg" %>
       <% if voted_by_current_user?(election) %>
         <div class="election__aside-voted mt-6 hidden lg:block">
           <span><%= icon "check-line", class: "fill-success inline mr-2" %></span>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -257,6 +257,7 @@ en:
           active_voting_until: 'Active voting until: %{end_date}'
           check_census_button: Check if I can vote
           check_census_explanation: This election has not started yet, but you can check if you are included in the census.
+          edit_vote_button: Edit vote
           vote_button: Vote
           voted: You have already voted. You can vote again, only your last vote will be counted.
           votes_count:

--- a/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/per_question_vote_examples.rb
@@ -31,7 +31,7 @@ shared_examples "a csv token per question votable election" do
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
     expect(election.votes.where(voter_uid:).size).to eq(3)
-    click_on "Vote"
+    click_on "Edit vote"
     expect(page).to have_current_path(new_election_vote_path)
     fill_in "Email", with: election.voters.first.data["email"]
     fill_in "Token", with: election.voters.first.data["token"]
@@ -73,7 +73,7 @@ shared_examples "a per question votable election" do
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
     expect(election.votes.where(voter_uid:).size).to eq(2)
-    click_on "Vote"
+    click_on "Edit vote"
     expect(find("input[value='#{question1.response_options.first.id}']")).to be_checked
     choose translated_attribute(question1.response_options.second.body)
     click_on "Cast vote"
@@ -114,7 +114,7 @@ shared_examples "a per question votable election with published results" do
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
     expect(election.votes.where(voter_uid:).size).to eq(1)
-    click_on "Vote"
+    click_on "Edit vote"
     expect(page).to have_current_path(election_vote_path(question2))
     expect(find("input[value='#{question2.response_options.first.id}']")).to be_checked
     expect(find("input[value='#{question2.response_options.second.id}']")).not_to be_checked

--- a/decidim-elections/lib/decidim/elections/test/vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/vote_examples.rb
@@ -52,7 +52,7 @@ shared_examples "a votable election" do
     click_on "Vote"
 
     fill_in_votes
-    click_on "Vote"
+    click_on "Edit vote"
     expect(page).to have_current_path(election_vote_path(election.questions.first))
   end
 end
@@ -131,7 +131,7 @@ shared_examples "a csv token votable election" do
     fill_in "Token", with: election.voters.first.data["token"]
     click_on "Access"
     fill_in_votes
-    click_on "Vote"
+    click_on "Edit vote"
     expect(page).to have_current_path(new_election_vote_path)
     fill_in "Email", with: election.voters.first.data["email"]
     fill_in "Token", with: election.voters.first.data["token"]
@@ -169,7 +169,8 @@ end
 
 shared_examples "an editable votable election" do
   it "Allows the user to edit the vote" do
-    click_on "Vote"
+    expect(page).to have_link("Edit vote")
+    click_on "Edit vote"
     expect(page).to have_current_path(election_vote_path(election.questions.first))
     expect(find("input[value='#{election.questions.first.response_options.first.id}']")).to be_checked
     expect(find("input[value='#{election.questions.first.response_options.second.id}']")).not_to be_checked
@@ -191,6 +192,7 @@ end
 
 shared_examples "a csv token editable votable election" do
   it "Allows the user to edit the vote" do
+    expect(page).to have_link("Vote")
     click_on "Vote"
     expect(page).to have_current_path(new_election_vote_path)
     expect(page).to have_content("Verify your identity")


### PR DESCRIPTION
#### :tophat: What? Why?
Added conditional button text in election aside - shows "Vote" for new voters and "Edit vote" for users who have already voted.

#### :pushpin: Related Issues
- Fixes #15666 

#### Testing
  1. Go to an ongoing election page
  2. See "Vote" button
  3. Complete voting and return to election page
  4. See "Edit vote" button and "You have already voted" message

:hearts: Thank you!
