### PR TITLE
Add total votes count to election results in admin and public views

### DIFF
--- a/decidim-elections/app/packs/src/decidim/elections/live_results_update.js
+++ b/decidim-elections/app/packs/src/decidim/elections/live_results_update.js
@@ -12,6 +12,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const optionVoteCountTexts = () => document.querySelectorAll("[data-option-votes-count-text]");
   const optionVotePercentTexts = () => document.querySelectorAll("[data-option-votes-percent-text]");
   const optionVoteWidths = () => document.querySelectorAll("[data-option-votes-width]");
+  const questionTotalVotesTexts = () => document.querySelectorAll("[data-question-total-votes-text]");
   
   const animateText = (element, value) => {
     if (element.textContent === value) {
@@ -24,6 +25,15 @@ document.addEventListener("DOMContentLoaded", () => {
     }, 1000);
   };
   
+  const digQuestionValue = (questionId, data, key) => {
+    const questions = data.questions || [];
+    const question = questions.find((item) => item.id === parseInt(questionId, 10));
+    if (!question || !(key in question)) {
+      return null;
+    }
+    return question[key];
+  };
+
   const digOptionValue = (questionId, optionId, data, key) => {
     data.questions = data.questions || [];
     const question = data.questions.find((item) => item.id === parseInt(questionId, 10));
@@ -55,6 +65,11 @@ document.addEventListener("DOMContentLoaded", () => {
       questionElement.id = `question-${question.id}`;
       questionElement.classList.remove("hidden");
       questionElement.querySelector("[data-question-body]").textContent = question.body;
+      const totalVotesElement = questionElement.querySelector("[data-question-total-votes-text]");
+      if (totalVotesElement) {
+        totalVotesElement.dataset.questionTotalVotesText = question.id;
+        totalVotesElement.textContent = question.total_votes_text || "";
+      }
       const optionsContainer = questionElement.querySelector("[data-options-container]");
       question.response_options.forEach((option) => {
         const optionElement = optionTemplate.cloneNode(true);
@@ -104,6 +119,13 @@ document.addEventListener("DOMContentLoaded", () => {
         const val = digOptionValue(questionId, optionId, data, "votes_percent")
         if (val) {
           el.style.width = `${val}%`;
+        }
+      });
+      questionTotalVotesTexts().forEach((el) => {
+        const questionId = el.dataset.questionTotalVotesText;
+        const val = digQuestionValue(questionId, data, "total_votes_text");
+        if (val) {
+          animateText(el, val);
         }
       });
       // repeat for ongoing elections only

--- a/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
+++ b/decidim-elections/app/presenters/decidim/elections/election_presenter.rb
@@ -42,7 +42,13 @@ module Decidim
               body: translated_attribute(question.body),
               position: question.position,
               voting_enabled: question.voting_enabled?,
-              published_results: question.published_results?,
+              published_results: question.published_results?
+            }.tap do |hash|
+              next unless admin || result_published_questions.include?(question)
+
+              hash[:total_votes] = question.total_votes
+              hash[:total_votes_text] = I18n.t("total_votes", scope: "decidim.elections.elections.vote_results", count: question.total_votes)
+            end.merge(
               response_options: question.response_options.map do |option|
                 {
                   id: option.id,
@@ -56,7 +62,7 @@ module Decidim
                   hash[:votes_percent] = option.votes_percent
                 end
               end
-            }
+            )
           end
         }
       end

--- a/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions_with_results.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/dashboard/_questions_with_results.html.erb
@@ -35,6 +35,11 @@
                 <td data-option-votes-percent-text="<%= question.id %>,<%= option.id %>"><%= number_to_percentage(option.votes_percent, precision: 1) %></td>
               </tr>
             <% end %>
+            <tr>
+              <td class="w-2/3 border-none"><%= t("decidim.elections.admin.dashboard.questions_table.total") %></td>
+              <td class="border-none"></td>
+              <td class="border-none" data-question-total-votes-text="<%= question.id %>"><%= t("votes_count", scope: "decidim.elections.admin.dashboard.questions_table", count: question.total_votes) %></td>
+            </tr>
             </tbody>
           </table>
         </div>

--- a/decidim-elections/app/views/decidim/elections/elections/_vote_results_question.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/_vote_results_question.html.erb
@@ -9,5 +9,9 @@
     <% question.response_options.each_with_index do |option, index| %>
       <%= render "decidim/elections/elections/vote_results_option", option: %>
     <% end %>
+    <div class="py-4 flex justify-between items-center">
+      <span><%= t("decidim.elections.elections.vote_results.total") %></span>
+      <span data-question-total-votes-text="<%= question.id %>"><%= t("total_votes", scope: "decidim.elections.elections.vote_results", count: question.total_votes) %></span>
+    </div>
   </div>
 </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
           questions_table:
             answer: Answers
             percentage: Percentage
+            total: Total
             votes: Votes
             votes_count:
               one: 1 vote
@@ -269,6 +270,10 @@ en:
             per_question: Results are available per question. You can see the results for each question after voting is enabled and results are published.
             real_time: Results are available in real time. You can see the results while voting is in progress.
           title: Results
+          total: 'TOTAL:'
+          total_votes:
+            one: 1 vote
+            other: "%{count} votes"
       models:
         election:
           fields:

--- a/decidim-elections/spec/controllers/decidim/elections/admin/elections_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/admin/elections_controller_spec.rb
@@ -117,6 +117,8 @@ module Decidim
                   "position" => election_question.position,
                   "voting_enabled" => false,
                   "published_results" => false,
+                  "total_votes" => 0,
+                  "total_votes_text" => "0 votes",
                   "response_options" => election_question.response_options.map do |ro|
                     {
                       "id" => ro.id,

--- a/decidim-elections/spec/presenters/decidim/elections/election_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/elections/election_presenter_spec.rb
@@ -43,6 +43,45 @@ module Decidim
         it { expect(presenter.title).to be_nil }
         it { expect(presenter.election_path).to be_nil }
       end
+
+      describe "#to_json" do
+        let(:election) { create(:election, :published, :real_time, :ongoing, component:) }
+        let!(:question) { create(:election_question, :with_response_options, election:) }
+        let!(:vote) { create(:election_vote, question:, response_option: question.response_options.first, voter_uid: "voter1") }
+
+        context "when admin is true" do
+          subject(:json) { presenter.to_json(admin: true) }
+
+          it "includes total_votes for each question" do
+            question_json = json[:questions].find { |q| q[:id] == question.id }
+            expect(question_json[:total_votes]).to eq(1)
+            expect(question_json[:total_votes_text]).to eq("1 vote")
+          end
+        end
+
+        context "when admin is false and results are published" do
+          subject(:json) { presenter.to_json(admin: false) }
+
+          it "includes total_votes for questions with published results" do
+            question_json = json[:questions].find { |q| q[:id] == question.id }
+            expect(question_json[:total_votes]).to eq(1)
+            expect(question_json[:total_votes_text]).to eq("1 vote")
+          end
+        end
+
+        context "when admin is false and results are not published" do
+          let(:election) { create(:election, :published, :per_question, :ongoing, component:) }
+          let!(:question) { create(:election_question, :with_response_options, election:, voting_enabled_at: Time.current, published_results_at: nil) }
+
+          subject(:json) { presenter.to_json(admin: false) }
+
+          it "does not include total_votes for questions without published results" do
+            question_json = json[:questions].find { |q| q[:id] == question.id }
+            expect(question_json).not_to have_key(:total_votes)
+            expect(question_json).not_to have_key(:total_votes_text)
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-elections/spec/system/admin/dashboard_spec.rb
+++ b/decidim-elections/spec/system/admin/dashboard_spec.rb
@@ -133,6 +133,27 @@ describe "Dashboard" do
         expect(page).to have_no_content("Election has not started yet.")
         expect(page).to have_no_content("Publish results")
       end
+
+      it "shows total votes for each question" do
+        questions.each do |question|
+          within("#question_#{question.id}") do
+            expect(page).to have_content("Total")
+            expect(page).to have_css("[data-question-total-votes-text='#{question.id}']", text: "0 votes")
+          end
+        end
+      end
+
+      context "when there are votes" do
+        let!(:questions) { create_list(:election_question, 3, :with_response_options, election:) }
+        let!(:vote) { create(:election_vote, question: questions.first, response_option: questions.first.response_options.first, voter_uid: "voter1") }
+
+        it "shows the correct total votes count" do
+          visit election_dashboard_path
+          within("#question_#{questions.first.id}") do
+            expect(page).to have_css("[data-question-total-votes-text='#{questions.first.id}']", text: "1 vote")
+          end
+        end
+      end
     end
   end
 
@@ -174,6 +195,15 @@ describe "Dashboard" do
         expect(page).to have_button("Publish results", count: 0, disabled: false)
         expect(page).to have_button("Publish results", count: election.questions.size, disabled: true)
         expect(page).to have_button("Enable voting", count: 3, disabled: false)
+      end
+
+      it "shows total votes for each question" do
+        questions.each do |question|
+          within("#question_#{question.id}") do
+            expect(page).to have_content("Total")
+            expect(page).to have_css("[data-question-total-votes-text='#{question.id}']", text: "0 votes")
+          end
+        end
       end
 
       context "when a question is enabled" do
@@ -262,6 +292,15 @@ describe "Dashboard" do
         expect(page).to have_no_content("Election has not started yet.")
         expect(page).to have_button("Publish results")
       end
+
+      it "shows total votes for each question" do
+        questions.each do |question|
+          within("#question_#{question.id}") do
+            expect(page).to have_content("Total")
+            expect(page).to have_css("[data-question-total-votes-text='#{question.id}']", text: "0 votes")
+          end
+        end
+      end
     end
   end
 
@@ -271,6 +310,15 @@ describe "Dashboard" do
     it "shows the published results status" do
       expect(page).to have_content("Finished")
       expect(page).to have_no_button("Results published at")
+    end
+
+    it "shows total votes for each question" do
+      questions.each do |question|
+        within("#question_#{question.id}") do
+          expect(page).to have_content("Total")
+          expect(page).to have_css("[data-question-total-votes-text='#{question.id}']", text: "0 votes")
+        end
+      end
     end
   end
 

--- a/decidim-elections/spec/system/election_results_spec.rb
+++ b/decidim-elections/spec/system/election_results_spec.rb
@@ -32,6 +32,11 @@ describe "Dashboard" do
     expect(div).to have_content("#{count} vote")
   end
 
+  def expect_total_votes(question, count)
+    div = find("[data-question-total-votes-text='#{question.id}']")
+    expect(div).to have_content("#{count} vote")
+  end
+
   it "shows the results" do
     expect(page).to have_content("Results")
     within "#question-#{question1.id}" do
@@ -53,6 +58,8 @@ describe "Dashboard" do
     expect_vote_count(question2, option21, "0")
     expect_vote_percent(question2, option22, "0.0%")
     expect_vote_count(question2, option22, "0")
+    expect_total_votes(question1, "0")
+    expect_total_votes(question2, "0")
 
     create(:election_vote, question: question1, voter_uid: "voter1", response_option: option11)
     create(:election_vote, question: question2, voter_uid: "voter1", response_option: option22)
@@ -66,6 +73,8 @@ describe "Dashboard" do
     expect_vote_count(question2, option21, "0")
     expect_vote_percent(question2, option22, "100.0%")
     expect_vote_count(question2, option22, "1")
+    expect_total_votes(question1, "1")
+    expect_total_votes(question2, "1")
   end
 
   context "when the election is per question" do
@@ -100,6 +109,7 @@ describe "Dashboard" do
       expect_vote_count(question1, option11, "0")
       expect_vote_percent(question1, option12, "0.0%")
       expect_vote_count(question1, option12, "0")
+      expect_total_votes(question1, "0")
 
       question1.update(published_results_at: Time.current)
       question2.update(voting_enabled_at: Time.current)
@@ -112,6 +122,7 @@ describe "Dashboard" do
       expect_vote_count(question1, option11, "1")
       expect_vote_percent(question1, option12, "0.0%")
       expect_vote_count(question1, option12, "0")
+      expect_total_votes(question1, "1")
       expect(page).to have_no_selector("#question-#{question2.id}")
 
       question2.update(published_results_at: Time.current)
@@ -125,6 +136,7 @@ describe "Dashboard" do
       expect_vote_count(question2, option21, "1")
       expect_vote_percent(question2, option22, "0.0%")
       expect_vote_count(question2, option22, "0")
+      expect_total_votes(question2, "1")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Added total votes count display for each question in election results:
  - Admin dashboard: added "Total" row in questions results table
  - Public view: added "TOTAL:" line at the bottom of each question's results
  - ElectionPresenter: added `total_votes` and `total_votes_text` to JSON response
  - JavaScript: updated `live_results_update.js` to handle dynamic total votes updates for per-question elections

#### :pushpin: Related Issues
- Fixes #15667

#### Testing
  Admin panel:
  1. Create an election with questions
  2. Start the election and cast some votes
  3. Go to admin dashboard
  4. Verify "Total" row appears at the bottom of each question's results table

  Public view:
  1. Create a real_time or after_end election
  2. Cast votes and publish results
  3. View election page
  4. Verify "TOTAL:" appears at the bottom of each question with vote count

  Per-question election:
  1. Create a per_question election
  2. Enable voting and publish results for a question
  3. Verify total votes updates dynamically when new question results are published

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)
<img width="600" height="1039" alt="Screenshot 2025-12-09 at 12 45 50" src="https://github.com/user-attachments/assets/cda2209b-cbc4-4e8b-845b-a653232a5825" />
<img width="600" height="911" alt="Screenshot 2025-12-09 at 12 03 18" src="https://github.com/user-attachments/assets/8edb2273-455d-4411-b29c-94e2009a51c6" />
<img width="600" height="957" alt="Screenshot 2025-12-09 at 12 02 11" src="https://github.com/user-attachments/assets/61427e44-54c9-4531-82cc-f061d43be491" />

:hearts: Thank you!
