### PR TITLE
Prevent server error on proposal page when the user is not logged in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -914,6 +914,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/decidim-proposals/app/cells/decidim/proposals/proposal_vote/show.erb
+++ b/decidim-proposals/app/cells/decidim/proposals/proposal_vote/show.erb
@@ -1,4 +1,4 @@
-<% if !current_settings.votes_hidden? && (current_component.participatory_space.can_participate?(current_user) || current_user.admin?) %>
+<% if !current_settings.votes_hidden? && (current_component.participatory_space.can_participate?(current_user) || current_user&.admin?) %>
   <% if component_settings.participatory_texts_enabled? && from_proposals_list %>
     <%= render partial: "decidim/proposals/proposals/participatory_texts/proposal_votes_count", locals: { proposal: resource, from_proposals_list: true } %>
   <% else %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_votes_count.html.erb
@@ -1,4 +1,4 @@
-<% if !current_settings.votes_hidden? && (current_component.participatory_space.can_participate?(current_user) || current_user.admin?) %>
+<% if !current_settings.votes_hidden? && (current_component.participatory_space.can_participate?(current_user) || current_user&.admin?) %>
   <% if component_settings.participatory_texts_enabled? && from_proposals_list %>
     <%= render partial: "decidim/proposals/proposals/participatory_texts/proposal_votes_count", locals: { proposal:, from_proposals_list: true } %>
   <% else %>

--- a/decidim-proposals/spec/system/private_space_proposal_spec.rb
+++ b/decidim-proposals/spec/system/private_space_proposal_spec.rb
@@ -33,6 +33,28 @@ describe "Private Space Proposal" do
           expect(page).to have_no_link("New proposal")
         end
       end
+
+      context "when the component has votes enabled and the proposal has votes" do
+        let!(:proposal) { create(:proposal, :official, :with_votes, component:) }
+
+        before do
+          component.default_step_settings = component.default_step_settings.to_h.merge({ votes_enabled: true })
+          component.save!
+        end
+
+        context "when accessing the proposal page" do
+          let(:target_path) { Decidim::ResourceLocatorPresenter.new(proposal).path }
+
+          before do
+            visit target_path
+          end
+
+          it "can access the page but cannot see the votes" do
+            expect(page).to have_content(proposal.title["en"])
+            expect(page).to have_no_content("Votes")
+          end
+        end
+      end
     end
 
     context "when the user is logged in" do


### PR DESCRIPTION
#### :tophat: What? Why?

Prevent server error on proposal page when the user is not logged in, the proposal component is private and transparent, and it displays the votes.

#### :pushpin: Related Issues

- Fixes #14401

#### Testing

1. Log in as an admin.
2. Configure a proposal component to display votes.
3. Make the space of the proposal component private and transparent.
4. Log out.
5. View the proposal page without displaying the votes.

:hearts: Thank you!
