### PR TITLE
Add AWS Bucket configuration for public assets

### DIFF
--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -64,7 +64,7 @@ To have public assets in your application, so that you do not rely on the Active
 6. Click "Save changes"
 7. In the permissions tab, identify "Bucket policy" and click "Edit"
 8. Set your policy as in the below example.
-   - If you do not know your "AWS-ARN" value, visit properties tab
+   - If you do not know your "Resource" value (ARN), visit the bucket's properties tab. For demonstration purposes we will use `arn:aws:s3:::my-bucket`
    - The "AWS-ARN" should look like `arn:aws:s3:::$YOUR-BUCKET-NAME`
 9. Click "Save changes"
 
@@ -78,7 +78,7 @@ To have public assets in your application, so that you do not rely on the Active
             "Effect": "Allow",
             "Principal": "*",
             "Action": "s3:GetObject",
-            "Resource": "AWS-ARN/*"
+            "Resource": "arn:aws:s3:::my-bucket/*"
         }
     ]
 }

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -49,7 +49,7 @@ Read more at https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html[Ama
 
 ==== Public assets
 
-To have public assets in your application, so that you do not rely on the ActiveStorege redirect system, you need to configure your bucket as follows:
+To have public assets in your application, so that you do not rely on the ActiveStorage redirect system, you need to configure your bucket as follows:
 
 1. Visit your AWS S3 account
 2. Select the bucket you are setting as upload

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -60,7 +60,7 @@ To have public assets in your application, so that you do not rely on the Active
   - "Block public access to buckets and objects granted through new access control lists (ACLs)"
   - "Block public access to buckets and objects granted through any access control lists (ACLs)"
   - "Block public access to buckets and objects granted through new public bucket or access point policies"
-  -  "Block public and cross-account access to buckets and objects through any public bucket or access point policies"
+  - "Block public and cross-account access to buckets and objects through any public bucket or access point policies"
 6. Click *Save changes*
 7. Still in the *Permissions tab*, locate the *Bucket policy section* and click *Edit*.
 8. Add a bucket policy similar to the example below.

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -47,6 +47,48 @@ Locate the bucket, go into the "Permissions" tab and find the section titled "CO
 
 Read more at https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html[Amazon S3 CORS documentation].
 
+==== Public assets
+
+To have public assets in your application, so that you do not rely on the ActiveStorege redirect system, you need to configure your bucket as follows:
+
+1. Visit your AWS S3 account
+2. Select the bucket you are setting as upload
+3. Visit permissions tab
+4. Click edit on "Block public access" section
+5. In the screen that opens, uncheck all the checkboxes
+  - Uncheck "Block all public access"
+  - Uncheck "Block public access to buckets and objects granted through new access control lists (ACLs)"
+  - Uncheck "Block public access to buckets and objects granted through any access control lists (ACLs)"
+  - Uncheck "Block public access to buckets and objects granted through new public bucket or access point policies"
+  - Uncheck "Block public and cross-account access to buckets and objects through any public bucket or access point policies"
+6. Click "Save changes"
+7. In the permissions tab, identify "Bucket policy" and click "Edit"
+8. Set your policy as in the below example.
+   - If you do not know your "AWS-ARN" value, visit properties tab
+   - The "AWS-ARN" should look like `arn:aws:s3:::$YOUR-BUCKET-NAME`
+9. Click "Save changes"
+
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement1",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "AWS-ARN/*"
+        }
+    ]
+}
+----
+
+[NOTE]
+====
+If you use any other provider than the default (`local`) you will need to also configure the xref:customize:content_security_policy.adoc[Content security policy]. For the directives "img-src", "media-src", and "connect-src"` adding some additional content like https://$YOUR-BUCKET-NAME.s3.$YOUR-AWS-REGION.amazonaws.com/*  (should look like: https://my-bucket.s3.eu-west-1.amazonaws.com)
+====
+
 ===  Google Cloud Storage
 
 Google Cloud Storage requires you to use the `gsutil` command line tool to set the CORS policy on your bucket. First you need to know the name of your bucket and then use the following command (replace `your-bucket-name` with the actual name of the bucket):

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -86,7 +86,7 @@ To have public assets in your application, so that you do not rely on the Active
 
 [NOTE]
 ====
-If you use any other provider than the default (`local`) you will need to also configure the xref:customize:content_security_policy.adoc[Content security policy]. For the directives "img-src", "media-src", and "connect-src"` adding some additional content like https://$YOUR-BUCKET-NAME.s3.$YOUR-AWS-REGION.amazonaws.com/*  (should look like: https://my-bucket.s3.eu-west-1.amazonaws.com)
+If you use any other provider than the default (`local`) you will need to also configure the xref:customize:content_security_policy.adoc[Content security policy]. For the directives "img-src", "media-src", and "connect-src" adding some additional content like https://$YOUR-BUCKET-NAME.s3.$YOUR-AWS-REGION.amazonaws.com/*  (should look like: https://my-bucket.s3.eu-west-1.amazonaws.com)
 ====
 
 ===  Google Cloud Storage

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -51,22 +51,21 @@ Read more at https://docs.aws.amazon.com/AmazonS3/latest/userguide/cors.html[Ama
 
 To have public assets in your application, so that you do not rely on the ActiveStorage redirect system, you need to configure your bucket as follows:
 
-1. Visit your AWS S3 account
-2. Select the bucket you are setting as upload
-3. Visit permissions tab
-4. Click edit on "Block public access" section
-5. In the screen that opens, uncheck all the checkboxes
-  - Uncheck "Block all public access"
-  - Uncheck "Block public access to buckets and objects granted through new access control lists (ACLs)"
-  - Uncheck "Block public access to buckets and objects granted through any access control lists (ACLs)"
-  - Uncheck "Block public access to buckets and objects granted through new public bucket or access point policies"
-  - Uncheck "Block public and cross-account access to buckets and objects through any public bucket or access point policies"
-6. Click "Save changes"
-7. In the permissions tab, identify "Bucket policy" and click "Edit"
-8. Set your policy as in the below example.
-   - If you do not know your "Resource" value (ARN), visit the bucket's properties tab. For demonstration purposes we will use `arn:aws:s3:::my-bucket`
-9. Click "Save changes"
-
+1. Go to your AWS S3 console
+2. Select the bucket you are using for uploads
+3. Open the *Permissions* tab
+4. In the *Block public access* section, click *Edit*
+5. Disable all blocking options by *unchecking* every box:
+  - "Block all public access"
+  - "Block public access to buckets and objects granted through new access control lists (ACLs)"
+  - "Block public access to buckets and objects granted through any access control lists (ACLs)"
+  - "Block public access to buckets and objects granted through new public bucket or access point policies"
+  -  "Block public and cross-account access to buckets and objects through any public bucket or access point policies"
+6. Click *Save changes*
+7. Still in the *Permissions tab*, locate the *Bucket policy section* and click *Edit*.
+8. Add a bucket policy similar to the example below.
+   - If you are unsure of your bucket’s ARN, you can find it in the Properties tab. For this example, we use  `arn:aws:s3:::your-bucket-name`
+9. Click *Save changes*
 [source,json]
 ----
 {
@@ -77,7 +76,7 @@ To have public assets in your application, so that you do not rely on the Active
             "Effect": "Allow",
             "Principal": "*",
             "Action": "s3:GetObject",
-            "Resource": "arn:aws:s3:::my-bucket/*"
+            "Resource": "arn:aws:s3:::your-bucket-name/*"
         }
     ]
 }
@@ -85,7 +84,7 @@ To have public assets in your application, so that you do not rely on the Active
 
 [NOTE]
 ====
-If you use any other provider than the default (`local`) you will need to also configure the xref:customize:content_security_policy.adoc[Content security policy]. For the directives "img-src", "media-src", and "connect-src" adding some additional content like https://$YOUR-BUCKET-NAME.s3.$YOUR-AWS-REGION.amazonaws.com/*  (should look like: https://my-bucket.s3.eu-west-1.amazonaws.com)
+If you use any other provider than the default (`local`) you will need to also configure the xref:customize:content_security_policy.adoc[Content security policy]. For the directives "img-src", "media-src", and "connect-src" adding some additional content like https://$YOUR-BUCKET-NAME.s3.$YOUR-AWS-REGION.amazonaws.com/*  (should look like: https://your-bucket-name.s3.eu-west-1.amazonaws.com)
 ====
 
 ===  Google Cloud Storage

--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -65,7 +65,6 @@ To have public assets in your application, so that you do not rely on the Active
 7. In the permissions tab, identify "Bucket policy" and click "Edit"
 8. Set your policy as in the below example.
    - If you do not know your "Resource" value (ARN), visit the bucket's properties tab. For demonstration purposes we will use `arn:aws:s3:::my-bucket`
-   - The "AWS-ARN" should look like `arn:aws:s3:::$YOUR-BUCKET-NAME`
 9. Click "Save changes"
 
 [source,json]


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15005 we perform some changes that allow users to use public assets. Recently we had some issues following the documentation to set public assets for meta.decidim.org. This PR fixes the documentation. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/pull/15005
- Fixes #?

#### Testing
1. get the latest changes from documentation project
2. checkout this branch 
3. Build the documentation website locally
4. Navigate to Configure / Services / Active Storage page 
5. See the new subsection under Amazon S3 config. 

### :camera: Screenshots
<img width="1534" height="909" alt="image" src="https://github.com/user-attachments/assets/c50be121-3c19-42ce-a37d-bc48071b9fa7" />
<img width="1681" height="538" alt="image" src="https://github.com/user-attachments/assets/f6abd71a-7c28-41b2-8913-a8375c3dcafa" />

:hearts: Thank you!
