### PR TITLE
Show responses menu entry in Surveys' admin

### DIFF
--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -69,7 +69,7 @@
                     <li class="dropdown__item">
                       <%= link_to survey_responses_path(survey), class: "dropdown__button" do %>
                         <%= icon "draft-line" %>
-                        <%= t("actions.export_responses", scope: "decidim.surveys") %>
+                        <%= t("actions.responses", scope: "decidim.surveys") %>
                       <% end %>
                     </li>
                   <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -61,10 +61,18 @@
 
                   <li class="dropdown__item">
                     <%= link_to edit_questions_questions_survey_path(survey), class: "dropdown__button" do %>
-                      <%= icon "survey-line" %>
+                      <%= icon "question-answer-line" %>
                       <%= t("actions.manage_questions", scope: "decidim.surveys") %>
                     <% end %>
                   </li>
+                  <% if survey.questionnaire.responses.any? %>
+                    <li class="dropdown__item">
+                      <%= link_to survey_responses_path(survey), class: "dropdown__button" do %>
+                        <%= icon "survey-line" %>
+                        <%= t("actions.export_responses", scope: "decidim.surveys") %>
+                      <% end %>
+                    </li>
+                  <% end %>
 
                   <hr>
 

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -69,7 +69,7 @@
                     <li class="dropdown__item">
                       <%= link_to survey_responses_path(survey), class: "dropdown__button" do %>
                         <%= icon "survey-line" %>
-                        <%= t("actions.export_responses", scope: "decidim.surveys") %>
+                        <%= t("actions.responses", scope: "decidim.surveys") %>
                       <% end %>
                     </li>
                   <% end %>

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -68,7 +68,7 @@
                   <% if survey.questionnaire.responses.any? %>
                     <li class="dropdown__item">
                       <%= link_to survey_responses_path(survey), class: "dropdown__button" do %>
-                        <%= icon "survey-line" %>
+                        <%= icon "draft-line" %>
                         <%= t("actions.export_responses", scope: "decidim.surveys") %>
                       <% end %>
                     </li>

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -72,6 +72,7 @@ en:
         manage_questions: Questions
         new_survey: New survey
         preview: Preview
+        responses: Responses
         responses_alert: Delete responses at publish is active for this survey. There are currently %{responses_count} responses that will be destroyed if you continue.
         title: Actions
       admin:

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -69,7 +69,6 @@ en:
         confirm_destroy: Are you sure you want to delete this?
         destroy: Destroy
         edit: Edit
-        export_responses: Responses
         manage_questions: Questions
         new_survey: New survey
         preview: Preview

--- a/decidim-surveys/config/locales/en.yml
+++ b/decidim-surveys/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
         confirm_destroy: Are you sure you want to delete this?
         destroy: Destroy
         edit: Edit
+        export_responses: Responses
         manage_questions: Questions
         new_survey: New survey
         preview: Preview

--- a/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
+++ b/decidim-surveys/spec/system/admin_manages_surveys_spec.rb
@@ -342,6 +342,35 @@ describe "Admin manages surveys" do
     end
   end
 
+  context "when the survey has responses or more" do
+    let!(:question) do
+      create(:questionnaire_question, questionnaire:)
+    end
+    let!(:response) { create(:response, questionnaire:, question:) }
+
+    before do
+      visit manage_questionnaire_path
+    end
+
+    it "allows access to responses" do
+      within "tr", text: decidim_sanitize_translated(survey.title) do
+        find("button[data-controller='dropdown']").click
+        expect(page).to have_link("Responses")
+      end
+    end
+  end
+
+  context "when the survey has no responses" do
+    let!(:question) { create(:questionnaire_question, questionnaire:) }
+
+    it "does not show the Responses button" do
+      within "tr", text: decidim_sanitize_translated(survey.title) do
+        find("button[data-controller='dropdown']").click
+        expect(page).to have_no_link("Responses")
+      end
+    end
+  end
+
   context "when updates the questionnaire" do
     let(:description) do
       {
@@ -376,6 +405,10 @@ describe "Admin manages surveys" do
 
   def questionnaire_public_path
     main_component_path(component)
+  end
+
+  def manage_questionnaire_path
+    Decidim::EngineRouter.admin_proxy(component).surveys_path
   end
 
   private


### PR DESCRIPTION
#### :tophat: What? Why?
Fixed the correct icon for responses & survey questionnaire within the drop-down. Added a path within the surveys tab, desperately needed for navigating the component if there are responses.  

#### :pushpin: Related Issues
- Fixes #15260 

#### Testing
1. Login
2. Head to a space with the surveys component
3. Make sure that component has responses to a survey. Rebuild the `development_app` if needed.
4. Click on a survey with responses
5. Click a survey drop down and see responses tab with the proper icon and path to responses tab.
6. See the questionnaire has the proper icon.

### :camera: Screenshots
<img width="1100" height="739" alt="image" src="https://github.com/user-attachments/assets/521eedac-3374-44e5-a864-6f2956bd173c" />

:hearts: Thank you!
