### PR TITLE
Fix process and assembly admin members action logs

### DIFF
--- a/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/admin_log/assembly_presenter.rb
@@ -59,9 +59,20 @@ module Decidim
           "activemodel.attributes.assembly"
         end
 
+        # i18n-tasks-use t("decidim.admin_log.assembly.create")
+        # i18n-tasks-use t("decidim.admin_log.assembly.publish")
+        # i18n-tasks-use t("decidim.admin_log.assembly.unpublish")
+        # i18n-tasks-use t("decidim.admin_log.assembly.update")
+        # i18n-tasks-use t("decidim.admin_log.assembly.import")
+        # i18n-tasks-use t("decidim.admin_log.assembly.export")
+        # i18n-tasks-use t("decidim.admin_log.assembly.duplicate")
+        # i18n-tasks-use t("decidim.admin_log.assembly.soft_delete")
+        # i18n-tasks-use t("decidim.admin_log.assembly.restore")
+        # i18n-tasks-use t("decidim.admin_log.assembly.publish_all_members")
+        # i18n-tasks-use t("decidim.admin_log.assembly.unpublish_all_members")
         def action_string
           case action
-          when "create", "publish", "unpublish", "update", "duplicate", "export", "import", "soft_delete", "restore"
+          when "create", "publish", "unpublish", "update", "duplicate", "export", "import", "soft_delete", "restore", "publish_all_members", "unpublish_all_members"
             "decidim.admin_log.assembly.#{action}"
           else
             super

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -219,9 +219,11 @@ en:
         export: "%{user_name} exported the %{resource_name} assembly"
         import: "%{user_name} imported the %{resource_name} assembly"
         publish: "%{user_name} published the %{resource_name} assembly"
+        publish_all_members: "%{user_name} published all members of the %{resource_name} assembly"
         restore: "%{user_name} restored the %{resource_name} assembly"
         soft_delete: "%{user_name} moved to trash the %{resource_name} assembly"
         unpublish: "%{user_name} unpublished the %{resource_name} assembly"
+        unpublish_all_members: "%{user_name} unpublished all members of the %{resource_name} assembly"
         update: "%{user_name} updated the %{resource_name} assembly"
       assembly_member:
         create: "%{user_name} created the %{resource_name} member in the %{space_name} assembly"

--- a/decidim-assemblies/spec/system/admin/admin_filters_assemblies_private_space_users_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_filters_assemblies_private_space_users_spec.rb
@@ -9,7 +9,7 @@ describe "Admin filters assemblies private space users" do
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
   let(:assembly) { create(:assembly, organization:, private_space: true) }
 
-  let!(:invited_user1) { create(:user, name:, organization:) }
+  let!(:invited_user1) { create(:user, name:, organization:, invitation_sent_at: 1.day.ago, invitation_accepted_at: Time.current) }
   let!(:invited_member1) { create(:assembly_member, user: invited_user1, privatable_to: assembly) }
   let!(:invited_user2) { create(:user, email:, organization:) }
   let!(:invited_member2) { create(:assembly_member, user: invited_user2, privatable_to: assembly) }
@@ -19,10 +19,14 @@ describe "Admin filters assemblies private space users" do
 
   let(:resource_controller) { Decidim::Assemblies::Admin::MembersController }
 
-  context "when managing private process" do
-    before do
-      invited_user1.update!(invitation_sent_at: 1.day.ago, invitation_accepted_at: Time.current)
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_assemblies.members_path(assembly_slug: assembly.slug)
+  end
 
+  context "when managing private space" do
+    before do
       switch_to_host(organization.host)
       login_as user, scope: :user
       visit decidim_admin_assemblies.edit_assembly_path(assembly)
@@ -38,16 +42,26 @@ describe "Admin filters assemblies private space users" do
   context "when managing members in a public process" do
     let(:assembly) { create(:assembly, organization:, private_space: false) }
 
-    before do
-      invited_user1.update!(invitation_sent_at: 1.day.ago, invitation_accepted_at: Time.current)
-
-      switch_to_host(organization.host)
-      login_as user, scope: :user
-      visit decidim_admin_assemblies.members_path(assembly_slug: assembly.slug)
-    end
-
     it "restricts access" do
       expect(page).to have_admin_callout("You are not authorized to perform this action.")
+    end
+  end
+
+  describe "when publishing all members" do
+    let!(:member) { create(:member, :unpublished, user:, privatable_to: assembly) }
+
+    it "publishes all members" do
+      click_on "Publish all"
+
+      sleep(1)
+      expect(member.reload).to be_published
+    end
+
+    it "displays the correct log message" do
+      click_on "Publish all"
+      sleep(1)
+      visit decidim_admin.root_path
+      expect(page).to have_content("published all members of the #{translated(assembly.title)} assembly")
     end
   end
 end

--- a/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
+++ b/decidim-participatory_processes/app/presenters/decidim/participatory_processes/admin_log/participatory_process_presenter.rb
@@ -35,9 +35,20 @@ module Decidim
           }
         end
 
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.create")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.publish")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.unpublish")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.update")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.import")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.export")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.duplicate")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.soft_delete")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.restore")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.publish_all_members")
+        # i18n-tasks-use t("decidim.admin_log.participatory_process.unpublish_all_members")
         def action_string
           case action
-          when "create", "publish", "unpublish", "update", "import", "export", "duplicate", "soft_delete", "restore"
+          when "create", "publish", "unpublish", "update", "import", "export", "duplicate", "soft_delete", "restore", "publish_all_members", "unpublish_all_members"
             "decidim.admin_log.participatory_process.#{action}"
           else
             super

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -283,9 +283,11 @@ en:
         export: "%{user_name} exported the %{resource_name} participatory process"
         import: "%{user_name} imported the %{resource_name} participatory process"
         publish: "%{user_name} published the %{resource_name} participatory process"
+        publish_all_members: "%{user_name} published all members of the %{resource_name} participatory process"
         restore: "%{user_name} restored the %{resource_name} participatory process"
         soft_delete: "%{user_name} trashed the %{resource_name} participatory process"
         unpublish: "%{user_name} unpublished the %{resource_name} participatory process"
+        unpublish_all_members: "%{user_name} unpublished all members of the %{resource_name} participatory process"
         update: "%{user_name} updated the %{resource_name} participatory process"
       participatory_process_group:
         create: "%{user_name} created the %{resource_name} participatory process group"

--- a/decidim-participatory_processes/spec/shared/manage_participatory_process_members_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_participatory_process_members_examples.rb
@@ -54,6 +54,24 @@ shared_examples "manage participatory process members examples" do
     end
   end
 
+  describe "when publishing all members" do
+    let!(:member) { create(:member, :unpublished, user:, privatable_to: participatory_process) }
+
+    it "publishes all members" do
+      click_on "Publish all"
+
+      sleep(1)
+      expect(member.reload).to be_published
+    end
+
+    it "displays the correct log message" do
+      click_on "Publish all"
+      sleep(1)
+      visit decidim_admin.root_path
+      expect(page).to have_content("published all members of the #{translated(participatory_process.title)} participatory process")
+    end
+  end
+
   describe "when managing different users" do
     before do
       create(:member, user: other_user, privatable_to: participatory_process)


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing #15749, i have noticed that when you publish or unpublish the space members, the action seen by user is "Performed some action"


#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. fetch latest develop 
2. Login as admin ( and visit admin interface) 
3. Identify a Process and make it private 
4. Visit members area and invite a member 
5. Click the interface buttons ( Publish all, Unpublish all )  
6. Visit the action_log
7. See action names 
8. Repeat 3,4,5,6,7 for Assembly 
9. Apply patch ( you may need to restart dev server )
10. Visit homepage 
11. See normal names 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

#### Before
<img width="906" height="699" alt="image" src="https://github.com/user-attachments/assets/af7e55b2-1824-45fe-9504-c471101ec222" />

#### After 
<img width="989" height="713" alt="image" src="https://github.com/user-attachments/assets/ddd5c8d6-c2d6-4180-82c8-112728e8c94c" />

:hearts: Thank you!
