### PR TITLE
Sorting via created_at attribute within spaces

### DIFF
--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -169,7 +169,7 @@ module Decidim
 
       return base unless auth_object&.admin?
 
-      base + %w(published_at private_space parent_id)
+      base + %w(published_at created_at private_space parent_id)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-assemblies/spec/system/admin/admin_filters_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_filters_assemblies_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin sorting assemblies" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+  let!(:old_assembly) { create(:assembly, title: { en: "Old assembly" }, created_at: 3.weeks.ago, organization:) }
+  let!(:recent_assembly) { create(:assembly, title: { en: "Recent assembly" }, created_at: 1.day.ago, organization:) }
+  let!(:newest_assembly) { create(:assembly, title: { en: "Newest assembly" }, created_at: Time.current, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_assemblies.assemblies_path
+  end
+
+  context "when sorting assemblies by their creation" do
+    it "sorts by created_at descending by default" do
+      within "table thead" do
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Newest assembly")
+      expect(titles[1].text).to include("Recent assembly")
+      expect(titles[2].text).to include("Old assembly")
+    end
+
+    it "sorts by created_at ascending when clicked again" do
+      within "table thead" do
+        click_link "Created at"
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Old assembly")
+      expect(titles[1].text).to include("Recent assembly")
+      expect(titles[2].text).to include("Newest assembly")
+    end
+  end
+end

--- a/decidim-conferences/app/models/decidim/conference.rb
+++ b/decidim-conferences/app/models/decidim/conference.rb
@@ -157,7 +157,7 @@ module Decidim
 
       return base unless auth_object&.admin?
 
-      base + %w(published_at)
+      base + %w(published_at created_at)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-conferences/spec/system/admin/admin_filters_conferences_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_filters_conferences_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin sorting conferences" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+  let!(:old_conference) { create(:conference, title: { en: "Old conference" }, created_at: 3.weeks.ago, organization:) }
+  let!(:recent_conference) { create(:conference, title: { en: "Recent conference" }, created_at: 1.day.ago, organization:) }
+  let!(:newest_conference) { create(:conference, title: { en: "Newest conference" }, created_at: Time.current, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_conferences.conferences_path
+  end
+
+  context "when sorting conferences by their creation" do
+    it "sorts by created_at descending by default" do
+      within "table thead" do
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Newest conference")
+      expect(titles[1].text).to include("Recent conference")
+      expect(titles[2].text).to include("Old conference")
+    end
+
+    it "sorts by created_at ascending when clicked again" do
+      within "table thead" do
+        click_link "Created at"
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Old conference")
+      expect(titles[1].text).to include("Recent conference")
+      expect(titles[2].text).to include("Newest conference")
+    end
+  end
+end

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -168,12 +168,13 @@ module Decidim
       Decidim::InitiativePresenter.new(self)
     end
 
+    # Allows for sorting of these attributes in columns within the processes admin space (created_at, published_at etc)
     def self.ransackable_attributes(auth_object = nil)
       base = %w(search_text title description id id_string supports_count author_name author_nickname)
 
       return base unless auth_object&.admin?
 
-      base + %w(published_at state decidim_area_id type_id)
+      base + %w(published_at created_at state decidim_area_id type_id)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -168,7 +168,6 @@ module Decidim
       Decidim::InitiativePresenter.new(self)
     end
 
-    # Allows for sorting of these attributes in columns within the processes admin space (created_at, published_at etc)
     def self.ransackable_attributes(auth_object = nil)
       base = %w(search_text title description id id_string supports_count author_name author_nickname)
 

--- a/decidim-initiatives/spec/system/admin/admin_filters_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_filters_initiatives_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin sorting initiatives" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+  let!(:old_initiative) { create(:initiative, title: { en: "Old initiative" }, created_at: 3.weeks.ago, organization:) }
+  let!(:recent_initiative) { create(:initiative, title: { en: "Recent initiative" }, created_at: 1.day.ago, organization:) }
+  let!(:newest_initiative) { create(:initiative, title: { en: "Newest initiative" }, created_at: Time.current, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_initiatives.initiatives_path
+  end
+
+  context "when sorting initiatives by their creation" do
+    it "sorts by created_at descending by default" do
+      within "table thead" do
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Newest initiative")
+      expect(titles[1].text).to include("Recent initiative")
+      expect(titles[2].text).to include("Old initiative")
+    end
+
+    it "sorts by created_at ascending when clicked again" do
+      within "table thead" do
+        click_link "Created at"
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Old initiative")
+      expect(titles[1].text).to include("Recent initiative")
+      expect(titles[2].text).to include("Newest initiative")
+    end
+  end
+end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -212,11 +212,12 @@ module Decidim
       [:with_date, :with_any_taxonomies]
     end
 
+    # Allows for sorting by these attributes in columns within the admin interface eg (created_at, published_at etc)
     def self.ransackable_attributes(auth_object = nil)
       base = %w(title short_description description id)
       return base unless auth_object&.admin?
 
-      base + %w(private_space published_at decidim_participatory_process_group_id)
+      base + %w(private_space published_at created_at decidim_participatory_process_group_id)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -212,7 +212,7 @@ module Decidim
       [:with_date, :with_any_taxonomies]
     end
 
-    # Allows for sorting by these attributes in columns within the admin interface eg (created_at, published_at etc)
+    # Allows for sorting of these attributes in columns within the processes admin space (created_at, published_at etc)
     def self.ransackable_attributes(auth_object = nil)
       base = %w(title short_description description id)
       return base unless auth_object&.admin?

--- a/decidim-participatory_processes/app/models/decidim/participatory_process.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process.rb
@@ -212,7 +212,6 @@ module Decidim
       [:with_date, :with_any_taxonomies]
     end
 
-    # Allows for sorting of these attributes in columns within the processes admin space (created_at, published_at etc)
     def self.ransackable_attributes(auth_object = nil)
       base = %w(title short_description description id)
       return base unless auth_object&.admin?

--- a/decidim-participatory_processes/spec/system/admin/admin_filters_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_filters_participatory_process_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-describe "Admin sorts participatory processes" do
+describe "Admin sorting participatory processes" do
   let(:organization) { create(:organization) }
   let(:user) { create(:user, :admin, :confirmed, organization:) }
 
@@ -16,7 +16,7 @@ describe "Admin sorts participatory processes" do
     visit decidim_admin_participatory_processes.participatory_processes_path
   end
 
-  context "when sorting processes by created_at" do
+  context "when sorting processes by their creation" do
     it "sorts by created_at descending by default" do
       within "table thead" do
         click_link "Created at"

--- a/decidim-participatory_processes/spec/system/admin/admin_filters_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_filters_participatory_process_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin sorts participatory processes" do
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+  let!(:old_process) { create(:participatory_process, title: { en: "Old Process" }, created_at: 3.weeks.ago, organization:) }
+  let!(:recent_process) { create(:participatory_process, title: { en: "Recent Process" }, created_at: 1.day.ago, organization:) }
+  let!(:newest_process) { create(:participatory_process, title: { en: "Newest Process" }, created_at: Time.current, organization:) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_participatory_processes.participatory_processes_path
+  end
+
+  context "when sorting processes by created_at" do
+    it "sorts by created_at descending by default" do
+      within "table thead" do
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Newest Process")
+      expect(titles[1].text).to include("Recent Process")
+      expect(titles[2].text).to include("Old Process")
+    end
+
+    it "sorts by created_at ascending when clicked again" do
+      within "table thead" do
+        click_link "Created at"
+        click_link "Created at"
+      end
+
+      titles = page.all("table tbody tr td:first-child")
+      expect(titles[0].text).to include("Old Process")
+      expect(titles[1].text).to include("Recent Process")
+      expect(titles[2].text).to include("Newest Process")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
The `created_at` ransackable attribute was missing to allow the Created at column within all spaces in Decidim to be sorted via when they had been created (asc & desc/earliest & latest).

The method in charge of this is `def self.ransackable_attributes(auth_object = nil)` found within the model of each space.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/14497

#### Testing
1. Login 
2. Find head to processes
3. Make sure you have created processes with dates in the past. One is more than enough
4. Create a new process and save it. This will be a created as of today for the test
5. Head to the index of processes
6. Click the `created_at` column
7. See the date doesn't sort 
8. Apply patch
9. Repeat step 6 
10. See the date ascends & descends depending based on earliest, then latest.
11. Repeat steps 2-7 on `Assemblies`, `Conferences` and `Initiatives`.

### :camera: Screenshots
<img width="154" height="145" alt="image" src="https://github.com/user-attachments/assets/9e90237d-f47c-4fc1-b975-baa1873c147e" />

AFTER SORTING SAME COLUMN:
<img width="154" height="145" alt="image" src="https://github.com/user-attachments/assets/304237f9-fdaa-4dfc-857c-ad184ce59eb6" />


:hearts: Thank you!
