### PR TITLE
Do not show "more information" modal when there isn't any

### DIFF
--- a/decidim-budgets/app/views/decidim/budgets/projects/order_progress_summary/_content.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/order_progress_summary/_content.html.erb
@@ -2,11 +2,13 @@
   <%= render partial: "decidim/budgets/projects/order_progress_summary/progress_box" %>
   <%= render partial: "decidim/budgets/projects/order_progress_summary/progress_box_buttons" %>
 
-  <div class="budget-summary__button-modal">
-    <button type="button" data-dialog-open="budget-modal-info" aria-haspopup="dialog" tabindex="0" class="button button__text button__xs underline font-bold">
-      <%= t("more_information", scope: "decidim.budgets.budget_information_modal") %>
-    </button>
-  </div>
+  <% if cell("decidim/budgets/budget_information_modal", budget).more_information.present? %>
+    <div class="budget-summary__button-modal">
+      <button type="button" data-dialog-open="budget-modal-info" aria-haspopup="dialog" tabindex="0" class="button button__text button__xs underline font-bold">
+        <%= t("more_information", scope: "decidim.budgets.budget_information_modal") %>
+      </button>
+    </div>
+  <% end %>
 
   <div class="w-screen max-w-screen progressbox-fixed-wrapper" data-progressbox-fixed>
     <div class="gap-0 layout-item py-4 items-center budget-summary__progressbar">

--- a/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_budgets_spec.rb
@@ -175,4 +175,30 @@ describe "Admin manages budgets" do
     it_behaves_like "manage soft deletable resource", "budget"
     it_behaves_like "manage trashed resource", "budget"
   end
+
+  describe "more information button" do
+    context "when budget has more_information content" do
+      let!(:budget_with_info) { create(:budget, :with_projects, component: current_component) }
+
+      before do
+        current_component.update!(settings: { more_information_modal: { en: "Additional budget information" } })
+      end
+
+      it "displays the more information button" do
+        visit Decidim::EngineRouter.main_proxy(current_component).budget_projects_path(budget_with_info)
+
+        expect(page).to have_button("More information")
+      end
+    end
+
+    context "when budget has no more_information content" do
+      let!(:budget_without_info) { create(:budget, :with_projects, component: current_component) }
+
+      it "does not display the more information button" do
+        visit Decidim::EngineRouter.main_proxy(current_component).budget_projects_path(budget_without_info)
+
+        expect(page).to have_no_button("More information")
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When adding no information within the `more_information` modal now does not display a useless modal link within the budgets index. A condition extracted from budgets index allows us to hide or display the modal with or without information 

#### :pushpin: Related Issues
- Fixes #13943

#### Testing
1. Login 
2. Head to a configured budgets component within a space in admin
3. Configure it 
4. Find the more information modal at the end of the form 
5. Add some info in the modal and save
6. Head to the budgets index
7. See it link displayed
8. Repeat steps 2, 3, 4
9. Remove the info in the modal and save 
10. Head to the index of the budget 
11. See no more link appearing

### :camera: Screenshots
NO MODAL LINK
<img width="926" height="147" alt="image" src="https://github.com/user-attachments/assets/f4d2bb6f-cd19-492c-b52e-315824c3196f" />

EMPTY MODAL:
<img width="249" height="174" alt="image" src="https://github.com/user-attachments/assets/9cf057bf-58a6-4dcc-b4a6-07705dca927d" />

:hearts: Thank you!
