### PR TITLE
Enable EnforcedShorthandSyntax: always on rubocop configuration

### DIFF
--- a/decidim-admin/app/jobs/decidim/admin/participatory_space/destroy_members_follows_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/participatory_space/destroy_members_follows_job.rb
@@ -19,7 +19,7 @@ module Decidim
 
           return if space.respond_to?(:can_participate?) && space.can_participate?(user)
 
-          follows = Decidim::Follow.where(user: user)
+          follows = Decidim::Follow.where(user:)
           follows.where(followable: space).destroy_all
 
           destroy_children_follows(follows, space)

--- a/decidim-admin/spec/jobs/decidim/admin/participatory_space/destroy_members_follows_job_spec.rb
+++ b/decidim-admin/spec/jobs/decidim/admin/participatory_space/destroy_members_follows_job_spec.rb
@@ -11,7 +11,7 @@ module Decidim
         let!(:normal_user) { create(:user, organization:) }
         let!(:follow) { create(:follow, followable: participatory_space, user: normal_user) }
         let(:component) { create(:dummy_component, participatory_space:) }
-        let(:resource) { create(:dummy_resource, component: component, author: user) }
+        let(:resource) { create(:dummy_resource, component:, author: user) }
         let!(:followed_resource) { create(:follow, followable: resource, user: normal_user) }
 
         context "when assembly is private and non transparent" do

--- a/decidim-api/app/models/decidim/api/api_user.rb
+++ b/decidim-api/app/models/decidim/api/api_user.rb
@@ -54,7 +54,7 @@ module Decidim
       end
 
       def follows?(followable)
-        Decidim::Follow.where(user: self, followable: followable).any?
+        Decidim::Follow.where(user: self, followable:).any?
       end
 
       # Public: whether the user accepts direct messages from another

--- a/decidim-api/lib/decidim/api/query_type.rb
+++ b/decidim-api/lib/decidim/api/query_type.rb
@@ -65,7 +65,7 @@ module Decidim
       end
 
       def participant_details(id: nil, nickname: nil)
-        participant = Decidim::Core::UserEntityFinder.new.call(object, { id: id, nickname: nickname }, context)
+        participant = Decidim::Core::UserEntityFinder.new.call(object, { id:, nickname: }, context)
         return nil unless participant
 
         return nil unless Decidim::Core::ParticipantDetailsType.authorized?(participant, context)

--- a/decidim-api/spec/controllers/decidim/api/sessions_controller_spec.rb
+++ b/decidim-api/spec/controllers/decidim/api/sessions_controller_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::Api::SessionsController do
   let(:organization) { create(:organization) }
   let(:api_key) { "user_key" }
   let(:api_secret) { "decidim123456789" }
-  let!(:user) { create(:api_user, organization: organization, api_key: api_key, api_secret: api_secret) }
+  let!(:user) { create(:api_user, organization:, api_key:, api_secret:) }
   let(:params) do
     {
       api_user: {
@@ -36,7 +36,7 @@ describe Decidim::Api::SessionsController do
   describe "sign in" do
     it "returns JWT token when credentials are valid" do
       expect(request.env[Warden::JWTAuth::Hooks::PREPARED_TOKEN_ENV_KEY]).not_to be_present
-      post :create, params: params
+      post(:create, params:)
       expect(response).to have_http_status(:ok)
       token = request.env[Warden::JWTAuth::Hooks::PREPARED_TOKEN_ENV_KEY]
       expect(token).to be_present
@@ -53,7 +53,7 @@ describe Decidim::Api::SessionsController do
 
     it "renders resource without JWT token in body when `Tokendispatcher::ENV_KEY` is nil" do
       request.env[Warden::JWTAuth::Middleware::TokenDispatcher::ENV_KEY] = nil
-      post :create, params: params
+      post(:create, params:)
       expect(request.env[Warden::JWTAuth::Hooks::PREPARED_TOKEN_ENV_KEY]).to be_present
       parsed_response_body = JSON.parse(response.body)
       expect(parsed_response_body.has_key?("jwt_token")).to be(false)

--- a/decidim-api/spec/requests/apiauth_spec.rb
+++ b/decidim-api/spec/requests/apiauth_spec.rb
@@ -15,12 +15,12 @@ RSpec.describe "Api authentication" do
   context "with api user" do
     let(:key) { "dummykey123456" }
     let(:secret) { "decidim123456789" }
-    let!(:user) { create(:api_user, organization: organization, api_key: key, api_secret: secret) }
+    let!(:user) { create(:api_user, organization:, api_key: key, api_secret: secret) }
     let(:params) do
       {
         api_user: {
-          key: key,
-          secret: secret
+          key:,
+          secret:
         }
       }
     end
@@ -35,7 +35,7 @@ RSpec.describe "Api authentication" do
     end
 
     it "signs in" do
-      post sign_in_path, params: params
+      post(sign_in_path, params:)
       expect(response.headers["Authorization"]).to be_present
       expect(response.body["jwt_token"]).to be_present
       parsed_response_body = JSON.parse(response.body)
@@ -51,7 +51,7 @@ RSpec.describe "Api authentication" do
     end
 
     it "signs out" do
-      post sign_in_path, params: params
+      post(sign_in_path, params:)
       expect(response).to have_http_status(:ok)
       authorization = response.headers["Authorization"]
       original_count = Decidim::Api::JwtDenylist.count
@@ -61,7 +61,7 @@ RSpec.describe "Api authentication" do
 
     context "when signed in" do
       before do
-        post sign_in_path, params: params
+        post sign_in_path, params:
       end
 
       it "can use token to post to api" do
@@ -78,7 +78,7 @@ RSpec.describe "Api authentication" do
 
     context "when not signed in" do
       it "does not return session details" do
-        post "/api", params: { query: query }
+        post "/api", params: { query: }
         parsed_response = JSON.parse(response.body)
         expect(parsed_response).to match("data" => { "session" => nil })
       end
@@ -87,7 +87,7 @@ RSpec.describe "Api authentication" do
 
   context "with normal user" do
     let(:password) { "decidim123456789" }
-    let!(:user) { create(:user, :confirmed, organization: organization, password:) }
+    let!(:user) { create(:user, :confirmed, organization:, password:) }
     let(:params) do
       {
         user: {
@@ -98,7 +98,7 @@ RSpec.describe "Api authentication" do
     end
 
     it "does not authenticate user" do
-      post sign_in_path, params: params
+      post(sign_in_path, params:)
 
       parsed_response = JSON.parse(response.body)
       anonymized_key = parsed_response["api_key"]

--- a/decidim-assemblies/spec/system/admin/admin_manages_assembly_soft_delete_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assembly_soft_delete_spec.rb
@@ -14,12 +14,12 @@ describe "Admin manages assembly soft delete" do
   it_behaves_like "manage trashed resource", "assembly"
 
   context "when a user is collaborator" do
-    let!(:assembly) { create(:assembly, organization: organization) }
-    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:assembly) { create(:assembly, organization:) }
+    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:collaborator_role) do
       create(:assembly_user_role,
              user: collaborator_user,
-             assembly: assembly,
+             assembly:,
              role: :collaborator)
     end
 
@@ -36,12 +36,12 @@ describe "Admin manages assembly soft delete" do
   end
 
   context "when a user is evaluator" do
-    let!(:assembly) { create(:assembly, organization: organization) }
-    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:assembly) { create(:assembly, organization:) }
+    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:evaluator_role) do
       create(:assembly_user_role,
              user: evaluator_user,
-             assembly: assembly,
+             assembly:,
              role: :evaluator)
     end
 
@@ -58,12 +58,12 @@ describe "Admin manages assembly soft delete" do
   end
 
   context "when a user is moderator" do
-    let!(:assembly) { create(:assembly, organization: organization) }
-    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:assembly) { create(:assembly, organization:) }
+    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:moderator_role) do
       create(:assembly_user_role,
              user: moderator_user,
-             assembly: assembly,
+             assembly:,
              role: :moderator)
     end
 
@@ -80,12 +80,12 @@ describe "Admin manages assembly soft delete" do
   end
 
   context "when a user is a space admin" do
-    let!(:assembly) { create(:assembly, organization: organization) }
-    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:assembly) { create(:assembly, organization:) }
+    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:admin_role) do
       create(:assembly_user_role,
              user: admin_user,
-             assembly: assembly,
+             assembly:,
              role: :admin)
     end
 

--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -26,7 +26,7 @@ module Decidim
 
       def create
         enforce_permission_to :create, :blogpost
-        @form = form(Decidim::Blogs::PostForm).from_params(params, current_component: current_component)
+        @form = form(Decidim::Blogs::PostForm).from_params(params, current_component:)
 
         CreatePost.call(@form) do
           on(:ok) do |new_post|
@@ -48,7 +48,7 @@ module Decidim
 
       def update
         enforce_permission_to :update, :blogpost, blogpost: post
-        @form = form(PostForm).from_params(params, current_component: current_component)
+        @form = form(PostForm).from_params(params, current_component:)
 
         UpdatePost.call(@form, post) do
           on(:ok) do |post|

--- a/decidim-blogs/app/forms/decidim/blogs/post_form.rb
+++ b/decidim-blogs/app/forms/decidim/blogs/post_form.rb
@@ -48,7 +48,7 @@ module Decidim
       end
 
       def post
-        @post ||= Post.find_by(id: id)
+        @post ||= Post.find_by(id:)
       end
 
       def participatory_space_manifest

--- a/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
   description: translated_attribute(current_component.participatory_space.try(:description)),
   title: t("decidim.components.pagination.page_title",
-           component_name: component_name,
+           component_name:,
            current_page: paginate_posts.current_page,
            total_pages: paginate_posts.total_pages ),
   url: posts_url,

--- a/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/show.html.erb
@@ -39,7 +39,7 @@
           <%= cell "decidim/author", post_presenter.author, from: post, context_actions: [:date], layout: :compact %>
         </div>
         <%= render "decidim/shared/resource_actions", resource: post do %>
-          <%= render "decidim/blogs/posts/menu_actions", post: post %>
+          <%= render "decidim/blogs/posts/menu_actions", post: %>
         <% end %>
       </div>
     </div>

--- a/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/_budget_summary.html.erb
@@ -1,6 +1,6 @@
 <div id="order-progress<%= "-responsive" if responsive %>" class="budget-summary <%= responsive ? "block md:hidden" : "hidden md:block" %>" data-progress-reference data-safe-url="<%= budget_url(budget) %>">
   <% if responsive %>
-    <%= render partial: "decidim/budgets/projects/order_progress_summary/content_responsive", locals: { focus_mode_origin: focus_mode_origin } %>
+    <%= render partial: "decidim/budgets/projects/order_progress_summary/content_responsive", locals: { focus_mode_origin: } %>
   <% else %>
     <%= render partial: "decidim/budgets/projects/order_progress_summary/content" %>
   <% end %>

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -110,7 +110,7 @@ describe "Explore projects", :slow do
             [-142.15275006889419, 33.33377235135252],
             [-55.28745034772282, -35.587843900166945]
           ]
-          Decidim::Budgets::Project.where(budget: budget).geocoded.each_with_index do |project, index|
+          Decidim::Budgets::Project.where(budget:).geocoded.each_with_index do |project, index|
             project.update!(latitude: coordinates[index][0], longitude: coordinates[index][1]) if coordinates[index]
           end
 

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/seeds.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/seeds.rb
@@ -29,7 +29,7 @@ module Decidim
           name: Decidim::Components::Namer.new(participatory_space.organization.available_locales, :collaborative_texts).i18n_name,
           manifest_name: :collaborative_texts,
           published_at: Time.current,
-          participatory_space: participatory_space
+          participatory_space:
         }
 
         Decidim.traceability.perform_action!(

--- a/decidim-collaborative_texts/spec/commands/decidim/collaborative_texts/admin/update_document_spec.rb
+++ b/decidim-collaborative_texts/spec/commands/decidim/collaborative_texts/admin/update_document_spec.rb
@@ -22,7 +22,7 @@ module Decidim
             title:,
             body:,
             draft?: draft,
-            draft: draft,
+            draft:,
             accepting_suggestions:,
             coauthorships: [Decidim::Coauthorship.new(author: organization)]
           )
@@ -68,11 +68,11 @@ module Decidim
               .with(last_version, user, updated_keys, {
                       extra: {
                         document_id: document.id,
-                        title: title,
+                        title:,
                         version_number: 1
                       },
                       resource: {
-                        title: title
+                        title:
                       },
                       participatory_space: {
                         title: document.participatory_space.title
@@ -116,11 +116,11 @@ module Decidim
               .with(Decidim::CollaborativeTexts::Version, user, { document:, body: document.body, draft: true }, {
                       extra: {
                         document_id: document.id,
-                        title: title,
+                        title:,
                         version_number: 2
                       },
                       resource: {
-                        title: title
+                        title:
                       },
                       participatory_space: {
                         title: document.participatory_space.title

--- a/decidim-collaborative_texts/spec/controllers/decidim/collaborative_texts/admin/documents_controller_spec.rb
+++ b/decidim-collaborative_texts/spec/controllers/decidim/collaborative_texts/admin/documents_controller_spec.rb
@@ -15,8 +15,8 @@ module Decidim
         let(:document_versions) { [build(:collaborative_text_version)] }
         let(:params) do
           {
-            title: title,
-            body: body
+            title:,
+            body:
           }
         end
         let(:title) { "A nice test document" }
@@ -69,7 +69,7 @@ module Decidim
           describe "POST #create" do
             it "creates a new document and redirects to index" do
               expect do
-                post :create, params: params
+                post :create, params:
               end.to change(Document, :count).by(1)
               expect(response).to redirect_to(documents_path)
               expect(flash[:notice]).to eq("Document successfully created.")
@@ -80,7 +80,7 @@ module Decidim
 
               it "does not create a document" do
                 expect do
-                  post :create, params: params
+                  post :create, params:
                 end.not_to change(Document, :count)
                 expect(response).to render_template(:new)
                 expect(flash.now[:alert]).to eq("There was a problem creating the document.")
@@ -98,7 +98,7 @@ module Decidim
 
           describe "PATCH #update" do
             it "updates the document and redirects to index" do
-              patch :update, params: { id: collaborative_text_document.id, title: "Updated Title", body: body }
+              patch :update, params: { id: collaborative_text_document.id, title: "Updated Title", body: }
               expect(response).to redirect_to(documents_path)
             end
           end
@@ -121,7 +121,7 @@ module Decidim
               let(:title) { "" }
 
               it "does not update the document settings" do
-                patch :update_settings, params: { id: collaborative_text_document.id, title: "", body: body }
+                patch :update_settings, params: { id: collaborative_text_document.id, title: "", body: }
                 expect(response).to render_template(:edit_settings)
                 expect(flash.now[:alert]).to eq("There was a problem updating the document.")
               end

--- a/decidim-collaborative_texts/spec/controllers/decidim/collaborative_texts/suggestions_controller_spec.rb
+++ b/decidim-collaborative_texts/spec/controllers/decidim/collaborative_texts/suggestions_controller_spec.rb
@@ -30,7 +30,7 @@ module Decidim
 
       describe "GET #index" do
         it "returns a success response" do
-          get :index, params: params
+          get(:index, params:)
           expect(response).to have_http_status(:ok)
           body = JSON.parse(response.body)
           expect(body.first.keys).to contain_exactly("changeset", "createdAt", "id", "profileHtml", "status", "summary", "type")
@@ -60,7 +60,7 @@ module Decidim
         let(:first_node) { "1" }
 
         it "returns an error when user is not signed in" do
-          post :create, params: params
+          post(:create, params:)
           expect(response).to have_http_status(:unprocessable_entity)
           body = JSON.parse(response.body)
           expect(body["message"]).to eq("You are not authorized to perform this action.")
@@ -73,7 +73,7 @@ module Decidim
 
           it "creates a new suggestion" do
             expect do
-              post :create, params: params
+              post :create, params:
             end.to change(Suggestion, :count).by(1)
             expect(response).to have_http_status(:ok)
             body = JSON.parse(response.body)
@@ -84,7 +84,7 @@ module Decidim
             let(:first_node) { "" }
 
             it "returns an error" do
-              post :create, params: params
+              post(:create, params:)
               expect(response).to have_http_status(:unprocessable_entity)
               body = JSON.parse(response.body)
               expect(body["message"]).to eq("There was a problem creating the suggestion. Invalid selected nodes.")

--- a/decidim-collaborative_texts/spec/models/decidim/collaborative_texts/document_spec.rb
+++ b/decidim-collaborative_texts/spec/models/decidim/collaborative_texts/document_spec.rb
@@ -33,7 +33,7 @@ module Decidim
 
       it "current version points to last created" do
         document.save!
-        version = create(:collaborative_text_version, created_at: 1.second.from_now, document: document)
+        version = create(:collaborative_text_version, created_at: 1.second.from_now, document:)
         expect(document.reload.document_versions.count).to eq(4)
         expect(document.document_versions_count).to eq(4)
         expect(document.current_version).to eq(version)

--- a/decidim-collaborative_texts/spec/permissions/decidim/collaborative_texts/permissions_spec.rb
+++ b/decidim-collaborative_texts/spec/permissions/decidim/collaborative_texts/permissions_spec.rb
@@ -9,7 +9,7 @@ describe Decidim::CollaborativeTexts::Permissions do
   let(:context) do
     {
       current_component: collaborative_text_component,
-      document: document
+      document:
     }
   end
   let(:collaborative_text_component) { create(:collaborative_text_component) }

--- a/decidim-collaborative_texts/spec/presenters/decidim/collaborative_texts/admin_log/document_presenter_spec.rb
+++ b/decidim-collaborative_texts/spec/presenters/decidim/collaborative_texts/admin_log/document_presenter_spec.rb
@@ -6,7 +6,7 @@ module Decidim
   module CollaborativeTexts
     module AdminLog
       describe DocumentPresenter do
-        let(:action_log) { double("ActionLog", action: action, resource: resource, extra: extra, version: version) }
+        let(:action_log) { double("ActionLog", action:, resource:, extra:, version:) }
         let(:resource) { double("Document", document_versions: [document]) }
         let(:document) { create(:collaborative_text_document, body: "This is and example body") }
         let(:extra) { { "extra" => { "version_number" => "2", "body" => document.body } } }

--- a/decidim-collaborative_texts/spec/types/integration_schema_spec.rb
+++ b/decidim-collaborative_texts/spec/types/integration_schema_spec.rb
@@ -36,7 +36,7 @@ describe "Decidim::Api::QueryType" do
   let!(:current_component) { create(:collaborative_text_component, participatory_space: participatory_process) }
   let!(:document) { create(:collaborative_text_document, component: current_component, published_at: 2.days.ago) }
   let!(:document_version) { create(:collaborative_text_version, document:) }
-  let!(:suggestions) { create_list(:collaborative_text_suggestion, 2, document_version: document_version) }
+  let!(:suggestions) { create_list(:collaborative_text_suggestion, 2, document_version:) }
   let(:author) { nil }
   let(:document_single_result) do
     {

--- a/decidim-conferences/spec/system/admin/admin_manages_conference_soft_delete_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conference_soft_delete_spec.rb
@@ -14,12 +14,12 @@ describe "Admin manages conference soft delete" do
   it_behaves_like "manage trashed resource", "conference"
 
   context "when a user is collaborator" do
-    let!(:conference) { create(:conference, organization: organization) }
-    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:conference) { create(:conference, organization:) }
+    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:collaborator_role) do
       create(:conference_user_role,
              user: collaborator_user,
-             conference: conference,
+             conference:,
              role: :collaborator)
     end
 
@@ -36,12 +36,12 @@ describe "Admin manages conference soft delete" do
   end
 
   context "when a user is evaluator" do
-    let!(:conference) { create(:conference, organization: organization) }
-    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:conference) { create(:conference, organization:) }
+    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:evaluator_role) do
       create(:conference_user_role,
              user: evaluator_user,
-             conference: conference,
+             conference:,
              role: :evaluator)
     end
 
@@ -58,12 +58,12 @@ describe "Admin manages conference soft delete" do
   end
 
   context "when a user is moderator" do
-    let!(:conference) { create(:conference, organization: organization) }
-    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:conference) { create(:conference, organization:) }
+    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:moderator_role) do
       create(:conference_user_role,
              user: moderator_user,
-             conference: conference,
+             conference:,
              role: :moderator)
     end
 
@@ -80,12 +80,12 @@ describe "Admin manages conference soft delete" do
   end
 
   context "when a user is a space admin" do
-    let!(:conference) { create(:conference, organization: organization) }
-    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:conference) { create(:conference, organization:) }
+    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:admin_role) do
       create(:conference_user_role,
              user: admin_user,
-             conference: conference,
+             conference:,
              role: :admin)
     end
 

--- a/decidim-core/app/serializers/decidim/exporters/participatory_space_serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/participatory_space_serializer.rb
@@ -28,7 +28,7 @@ module Decidim
           short_description: resource.short_description,
           description: resource.description,
           promoted: resource.promoted,
-          component_settings: component_settings
+          component_settings:
         }
       end
 

--- a/decidim-core/db/migrate/20250523104311_move_cta_to_hero_content_block.rb
+++ b/decidim-core/db/migrate/20250523104311_move_cta_to_hero_content_block.rb
@@ -8,7 +8,7 @@ class MoveCtaToHeroContentBlock < ActiveRecord::Migration[7.0]
   def up
     Decidim::ContentBlock.reset_column_information
     Organization.find_each do |organization|
-      content_block = Decidim::ContentBlock.find_by(organization: organization, scope_name: :homepage, manifest_name: :hero)
+      content_block = Decidim::ContentBlock.find_by(organization:, scope_name: :homepage, manifest_name: :hero)
       settings = {}
       cta_button_text = organization.cta_button_text || {}
       settings = cta_button_text.inject(settings) { |acc, (k, v)| acc.update("cta_button_text_#{k}" => v) }

--- a/decidim-core/db/migrate/20250527122040_move_highlighted_content_banner_settings_to_content_block.rb
+++ b/decidim-core/db/migrate/20250527122040_move_highlighted_content_banner_settings_to_content_block.rb
@@ -11,7 +11,7 @@ class MoveHighlightedContentBannerSettingsToContentBlock < ActiveRecord::Migrati
     Decidim::ContentBlock.reset_column_information
 
     Organization.find_each do |organization|
-      content_block = Decidim::ContentBlock.find_by(organization: organization, scope_name: :homepage, manifest_name: :highlighted_content_banner)
+      content_block = Decidim::ContentBlock.find_by(organization:, scope_name: :homepage, manifest_name: :highlighted_content_banner)
       settings = extract_settings(organization)
 
       # We need to do a workaround for getting the image, as ActiveStorage is polymorphic and expects that the `record_type` is the class name of the model

--- a/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 module Decidim
   describe MenuHelper do
     let(:organization) { create(:organization) }
-    let(:user) { create(:user, organization: organization) }
+    let(:user) { create(:user, organization:) }
     let!(:process) { create(:participatory_process, :active, weight: 1, organization:) }
     let!(:process_two) { create(:participatory_process, :active, weight: 2, organization:) }
     let!(:process_three) { create(:participatory_process, :active, :promoted, weight: 3, organization:) }

--- a/decidim-core/spec/lib/oauth/token_generator_spec.rb
+++ b/decidim-core/spec/lib/oauth/token_generator_spec.rb
@@ -13,7 +13,7 @@ module Decidim
       let(:scopes) { "profile" }
       let(:options) do
         {
-          application: application,
+          application:,
           resource_owner_id: user.id,
           scopes: ::Doorkeeper::OAuth::Scopes.from_string(scopes)
         }

--- a/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_digest_mailer_spec.rb
@@ -81,7 +81,7 @@ module Decidim
       context "when the space is private and user has access" do
         let!(:participatory_space) { create(:participatory_process, :private, organization:) }
         let(:component) { create(:component, :published, manifest_name: "dummy", participatory_space:) }
-        let!(:member) { create(:member, privatable_to: participatory_space, user: user) }
+        let!(:member) { create(:member, privatable_to: participatory_space, user:) }
 
         it "displays the notification" do
           expect(subject.body).to include(test_content)
@@ -92,7 +92,7 @@ module Decidim
       context "when the space is transparent and user has access" do
         let!(:participatory_space) { create(:assembly, :transparent, :private, organization:) }
         let(:component) { create(:component, :published, manifest_name: "dummy", participatory_space:) }
-        let!(:member) { create(:member, privatable_to: participatory_space, user: user) }
+        let!(:member) { create(:member, privatable_to: participatory_space, user:) }
 
         it "displays the notification" do
           expect(subject.body).to include(test_content)

--- a/decidim-core/spec/presenters/decidim/stats_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/stats_presenter_spec.rb
@@ -8,14 +8,14 @@ describe Decidim::StatsPresenter, type: :presenter do
 
   describe "#collection" do
     let(:priority) { Decidim::StatsRegistry::MEDIUM_PRIORITY }
-    let(:conditions) { { priority: priority } }
+    let(:conditions) { { priority: } }
 
     before do
-      allow(presenter).to receive(:all_stats).with(priority: priority).and_return([
-                                                                                    { name: "stat_1", data: [1, 23] },
-                                                                                    { name: "stat_2", data: [0] },
-                                                                                    { name: "stat_3", data: [45] }
-                                                                                  ])
+      allow(presenter).to receive(:all_stats).with(priority:).and_return([
+                                                                           { name: "stat_1", data: [1, 23] },
+                                                                           { name: "stat_2", data: [0] },
+                                                                           { name: "stat_3", data: [45] }
+                                                                         ])
     end
 
     it "returns stats with non-empty data" do
@@ -31,10 +31,10 @@ describe Decidim::StatsPresenter, type: :presenter do
     end
 
     it "sums the data of stats with the same name" do
-      allow(presenter).to receive(:all_stats).with(priority: priority).and_return([
-                                                                                    { name: "stat_1", data: [12, 3] },
-                                                                                    { name: "stat_1", data: [4] }
-                                                                                  ])
+      allow(presenter).to receive(:all_stats).with(priority:).and_return([
+                                                                           { name: "stat_1", data: [12, 3] },
+                                                                           { name: "stat_1", data: [4] }
+                                                                         ])
 
       result = presenter.collection(priority:)
 

--- a/decidim-core/spec/queries/decidim/inactive_users_query_spec.rb
+++ b/decidim-core/spec/queries/decidim/inactive_users_query_spec.rb
@@ -15,21 +15,21 @@ describe Decidim::InactiveUsersQuery do
   let!(:inactive_recent_sign_in) { create(:user, organization:, current_sign_in_at: 400.days.ago, created_at: 400.days.ago, extended_data: {}) }
   let!(:active_recent_sign_in) { create(:user, organization:, current_sign_in_at: 200.days.ago, created_at: 200.days.ago, extended_data: {}) }
   let!(:user_reminder_due) do
-    create(:user, organization: organization,
+    create(:user, organization:,
                   current_sign_in_at: 294.days.ago,
                   created_at: 400.days.ago,
                   extended_data: { "inactivity_notification" => { "notification_type" => "first", "sent_at" => 23.days.ago } })
   end
 
   let!(:user_ready_for_removal) do
-    create(:user, organization: organization,
+    create(:user, organization:,
                   current_sign_in_at: 400.days.ago,
                   created_at: 400.days.ago,
                   extended_data: { "inactivity_notification" => { "notification_type" => "second", "sent_at" => 40.days.ago } })
   end
 
   let!(:user_logged_in_after_notification) do
-    create(:user, organization: organization,
+    create(:user, organization:,
                   current_sign_in_at: 1.day.ago,
                   created_at: 400.days.ago,
                   extended_data: { "inactivity_notification" => { "notification_type" => "second", "sent_at" => 7.days.ago } })

--- a/decidim-core/spec/system/editor_spec.rb
+++ b/decidim-core/spec/system/editor_spec.rb
@@ -1274,7 +1274,7 @@ describe "Editor" do
     it "allows selecting resource mentions with a slash" do
       allow(Decidim::SearchableResource).to receive(:where).with(
         resource_type: %w(Decidim::Proposals::Proposal),
-        organization: organization,
+        organization:,
         decidim_participatory_space: participatory_space,
         locale: I18n.locale
       ).and_return(double(

--- a/decidim-core/spec/system/link_target_spec.rb
+++ b/decidim-core/spec/system/link_target_spec.rb
@@ -4,8 +4,8 @@ require "spec_helper"
 
 describe "Admin editor link target remains" do
   let(:organization) { create(:organization) }
-  let(:admin) { create(:user, :admin, :confirmed, organization: organization) }
-  let(:participatory_process) { create(:participatory_process, organization: organization) }
+  let(:admin) { create(:user, :admin, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
   let(:component) { create(:component, manifest_name: "pages", participatory_space: participatory_process) }
 
   before do

--- a/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_remove_deleted_users_left_data_spec.rb
@@ -15,7 +15,7 @@ describe "rake decidim:upgrade:remove_deleted_users_left_data", type: :task, ver
     create(:reminder, user: deleted_user)
     create(:private_export, attached_to: deleted_user)
     create(:identity, user: deleted_user)
-    create(:follow, followable: deleted_user, user: user)
+    create(:follow, followable: deleted_user, user:)
     create(:follow, followable: user, user: deleted_user)
     create(:member, user: deleted_user)
 

--- a/decidim-core/spec/tasks/upgrade/fix_deleted_private_follows_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/fix_deleted_private_follows_spec.rb
@@ -8,7 +8,7 @@ describe "rake decidim:upgrade:fix_deleted_private_follows", type: :task do
   let(:user) { create(:user, :admin, :confirmed, organization:) }
   let(:second_user) { create(:user, :confirmed, organization:) }
   let(:component) { create(:dummy_component, :published, participatory_space:) }
-  let!(:followable) { create(:dummy_resource, component: component, author: user) }
+  let!(:followable) { create(:dummy_resource, component:, author: user) }
   let!(:follow) { create(:follow, user:, followable: participatory_space) }
   let!(:unwanted_follow) { create(:follow, user: second_user, followable: participatory_space) }
   let!(:resource_follow) { create(:follow, followable:, user:) }

--- a/decidim-debates/app/views/decidim/debates/debates/index.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
   description: translated_attribute(current_participatory_space.short_description),
   title: t("decidim.components.pagination.page_title",
-           component_name: component_name,
+           component_name:,
            current_page: paginated_debates.current_page,
            total_pages: paginated_debates.total_pages ),
   url: debates_url,

--- a/decidim-dev/config/rubocop/ruby/configuration.yml
+++ b/decidim-dev/config/rubocop/ruby/configuration.yml
@@ -521,6 +521,7 @@ Style/GuardClause:
   MinBodyLength: 6
 
 Style/HashSyntax:
+  EnforcedShorthandSyntax: always
   EnforcedStyle: no_mixed_keys
   SupportedStyles:
     # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys

--- a/decidim-elections/app/commands/decidim/elections/admin/process_census.rb
+++ b/decidim-elections/app/commands/decidim/elections/admin/process_census.rb
@@ -9,7 +9,7 @@ module Decidim
         def attributes
           {
             census_manifest: resource.census.name,
-            census_settings: census_settings
+            census_settings:
           }
         end
 

--- a/decidim-elections/app/commands/decidim/elections/cast_votes.rb
+++ b/decidim-elections/app/commands/decidim/elections/cast_votes.rb
@@ -40,11 +40,11 @@ module Decidim
         voted_questions.each do |question, responses|
           raise StandardError, "No responses for question #{question.id}" if responses.blank?
 
-          question.votes.where(voter_uid: voter_uid).destroy_all
+          question.votes.where(voter_uid:).destroy_all
           responses.each do |response_option|
             question.votes.create!(
-              voter_uid: voter_uid,
-              response_option: response_option
+              voter_uid:,
+              response_option:
             )
           end
         end

--- a/decidim-elections/app/controllers/concerns/decidim/elections/uses_votes_booth.rb
+++ b/decidim-elections/app/controllers/concerns/decidim/elections/uses_votes_booth.rb
@@ -91,7 +91,7 @@ module Decidim
 
       def previous_responses
         @previous_responses ||= election.questions.to_h do |question|
-          [question.id.to_s, question.votes.where(voter_uid: voter_uid).pluck(:response_option_id).map(&:to_s)]
+          [question.id.to_s, question.votes.where(voter_uid:).pluck(:response_option_id).map(&:to_s)]
         end
       end
     end

--- a/decidim-elections/app/controllers/decidim/elections/admin/census_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/census_controller.rb
@@ -11,15 +11,15 @@ module Decidim
         before_action :set_census_manifest, only: [:edit, :update]
 
         def edit
-          enforce_permission_to :update, :census, election: election
+          enforce_permission_to(:update, :census, election:)
 
-          @form = form(election.census.admin_form.constantize).from_params(election.census_settings, election: election) if election.census && election.census.admin_form.present?
+          @form = form(election.census.admin_form.constantize).from_params(election.census_settings, election:) if election.census && election.census.admin_form.present?
         end
 
         def update
-          enforce_permission_to :update, :census, election: election
+          enforce_permission_to(:update, :census, election:)
 
-          @form = form(election.census.admin_form.constantize).from_params(params, election: election) if election.census.admin_form.present?
+          @form = form(election.census.admin_form.constantize).from_params(params, election:) if election.census.admin_form.present?
 
           ProcessCensus.call(@form, election) do
             on(:ok) do

--- a/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
+++ b/decidim-elections/app/controllers/decidim/elections/admin/elections_controller.rb
@@ -46,7 +46,7 @@ module Decidim
         end
 
         def update
-          enforce_permission_to :update, :election, election: election
+          enforce_permission_to(:update, :election, election:)
 
           @form = form(Decidim::Elections::Admin::ElectionForm).from_params(params, current_component:, election:)
 
@@ -64,7 +64,7 @@ module Decidim
         end
 
         def publish
-          enforce_permission_to :publish, :election, election: election
+          enforce_permission_to(:publish, :election, election:)
 
           PublishElection.call(election, current_user) do
             on(:ok) do
@@ -80,7 +80,7 @@ module Decidim
         end
 
         def unpublish
-          enforce_permission_to :unpublish, :election, election: election
+          enforce_permission_to(:unpublish, :election, election:)
 
           Decidim::Elections::Admin::UnpublishElection.call(election, current_user) do
             on(:ok) do
@@ -96,7 +96,7 @@ module Decidim
         end
 
         def dashboard
-          enforce_permission_to :dashboard, :election, election: election
+          enforce_permission_to(:dashboard, :election, election:)
 
           respond_to do |format|
             format.html { render :dashboard }
@@ -107,7 +107,7 @@ module Decidim
         end
 
         def update_status
-          enforce_permission_to :update, :election, election: election
+          enforce_permission_to(:update, :election, election:)
 
           status_action = params[:status_action]
           UpdateElectionStatus.call(status_action, election) do
@@ -123,7 +123,7 @@ module Decidim
         end
 
         def toggle_census_check
-          enforce_permission_to :update, :election, election: election
+          enforce_permission_to(:update, :election, election:)
 
           value = ActiveModel::Type::Boolean.new.cast(params[:allow_census_check_before_start])
           election.update!(allow_census_check_before_start: value)

--- a/decidim-elections/app/forms/decidim/elections/censuses/internal_users_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/censuses/internal_users_form.rb
@@ -29,7 +29,7 @@ module Decidim
             [
               adapter,
               Decidim::Verifications::Authorizations.new(
-                organization: organization,
+                organization:,
                 user: current_user,
                 name: adapter.name
               ).first

--- a/decidim-elections/app/models/decidim/elections/vote.rb
+++ b/decidim-elections/app/models/decidim/elections/vote.rb
@@ -31,7 +31,7 @@ module Decidim
 
       def max_votable_options
         return unless question && response_option
-        return if question.votes.where.not(id: id).where(voter_uid: voter_uid).count < question.max_votable_options
+        return if question.votes.where.not(id:).where(voter_uid:).count < question.max_votable_options
 
         errors.add(:response_option, :invalid)
       end

--- a/decidim-elections/app/views/decidim/elections/admin/censuses/_internal_users_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/censuses/_internal_users_form.html.erb
@@ -10,7 +10,7 @@
     <div class="row">
       <%= builder.label { builder.check_box + builder.text } %>
       <div id="authorization-handler-<%= builder.value %>" class="authorization-handler my-4 ml-6" style="display: <%= form.object.authorization_handlers_names.include?(builder.value) ? "block" : "none" %>;">
-        <%= render "decidim/elections/admin/censuses/internal_users_options_form", form: form, handler_name: builder.value %>
+        <%= render "decidim/elections/admin/censuses/internal_users_options_form", form:, handler_name: builder.value %>
       </div>
     </div>
   <% end %>

--- a/decidim-elections/app/views/decidim/elections/admin/elections/_election-tr.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_election-tr.html.erb
@@ -25,6 +25,6 @@
     <%= election.census&.label %>
   </td>
   <td data-label="<%= t("actions.title", scope: "decidim.elections") %>" class="table-list__actions">
-    <%= render partial: "decidim/elections/admin/elections/actions", locals: { election: election, view: view } %>
+    <%= render partial: "decidim/elections/admin/elections/actions", locals: { election:, view: } %>
   </td>
 </tr>

--- a/decidim-elections/app/views/decidim/elections/censuses/_internal_users_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/censuses/_internal_users_form.html.erb
@@ -17,7 +17,7 @@
         </div>
     <% end %>
     <%= link_to t(".exit_button"), exit_path, class: "button button__secondary button__lg w-full mt-12" %>
-    <%= render "decidim/elections/censuses/submit_button", form: form, disabled: true %>
+    <%= render "decidim/elections/censuses/submit_button", form:, disabled: true %>
   <% else %>
     <% redirect_url = new_election_vote_path(election) %>
     <div class="verification__container">
@@ -54,7 +54,7 @@
         <% end %>
       <% end %>
     </div>
-    <%= render "decidim/elections/censuses/submit_button", form: form %>
+    <%= render "decidim/elections/censuses/submit_button", form: %>
     <% end %>
 <% else %>
   <%= render partial: "decidim/devise/shared/login_boxes", locals: { scope: "decidim.elections.censuses.internal_users" } %>

--- a/decidim-elections/app/views/decidim/elections/censuses/_token_csv_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/censuses/_token_csv_form.html.erb
@@ -1,4 +1,4 @@
 <%= form.text_field :email, label: t(".email"), placeholder: t(".email_placeholder"), autofocus: true, required: true %>
 <%= form.text_field :token, label: t(".token"), placeholder: t(".token_placeholder"), required: true %>
 
-<%= render "decidim/elections/censuses/submit_button", form: form %>
+<%= render "decidim/elections/censuses/submit_button", form: %>

--- a/decidim-elections/app/views/decidim/elections/elections/index.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
      description: translated_attribute(current_participatory_space.short_description),
      title: t("decidim.components.pagination.page_title",
-              component_name: component_name,
+              component_name:,
               current_page: paginated_elections.current_page,
               total_pages: paginated_elections.total_pages ),
      url: elections_url,

--- a/decidim-elections/app/views/decidim/elections/elections/show.html.erb
+++ b/decidim-elections/app/views/decidim/elections/elections/show.html.erb
@@ -9,7 +9,7 @@
     resource_locator(election).edit,
     :update,
     :election,
-    election: election
+    election:
   )
 %>
 

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -47,7 +47,7 @@ module Decidim
           manifest.voter_form_partial = "decidim/elections/censuses/token_csv_form"
           manifest.after_update_command = "Decidim::Elections::Admin::Censuses::TokenCsv"
           manifest.user_query do |election|
-            Decidim::Elections::Voter.where(election: election)
+            Decidim::Elections::Voter.where(election:)
           end
         end
 

--- a/decidim-elections/lib/decidim/elections/seeds.rb
+++ b/decidim-elections/lib/decidim/elections/seeds.rb
@@ -89,7 +89,7 @@ module Decidim
       def create_voters_for!(election)
         number_of_records.times do |i|
           Decidim::Elections::Voter.create!(
-            election: election,
+            election:,
             data: {
               "email" => "user#{i + 1}@example.org",
               "token" => SecureRandom.hex(6).upcase

--- a/decidim-elections/lib/decidim/elections/test/vote_controller_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/vote_controller_examples.rb
@@ -2,9 +2,9 @@
 
 def do_action(action)
   if [:show, :confirm, :waiting, :receipt].include?(action)
-    get action, params: params
+    get(action, params:)
   else
-    patch action, params: params
+    patch action, params:
   end
 end
 
@@ -39,7 +39,7 @@ end
 shared_examples "an authenticated vote controller" do
   describe "GET new" do
     it "renders the new vote form" do
-      get :new, params: params
+      get(:new, params:)
       expect(response).to have_http_status(:ok)
       expect(assigns(:form)).to be_a(Decidim::Elections::Censuses::InternalUsersForm)
       expect(subject).to render_template("decidim/elections/votes/new")
@@ -52,7 +52,7 @@ shared_examples "an authenticated vote controller" do
 
       it "redirects to the question path" do
         expect(controller).to receive(:redirect_to).with(action: :show, id: question)
-        get :new, params: params
+        get(:new, params:)
 
         expect(controller.send(:session_authenticated?)).to be true
         expect(response).to render_template("decidim/elections/votes/new")
@@ -63,7 +63,7 @@ shared_examples "an authenticated vote controller" do
   describe "POST create" do
     it "renders the new form with errors when the form is invalid" do
       expect(controller).to receive(:redirect_to).with(action: :new)
-      post :create, params: params
+      post(:create, params:)
 
       expect(controller.send(:session_authenticated?)).to be false
       expect(controller.send(:voter_uid)).to be_nil
@@ -77,7 +77,7 @@ shared_examples "an authenticated vote controller" do
 
       it "creates the session credentials and redirects to form again" do
         expect(controller).to receive(:redirect_to).with(action: :show, id: question)
-        post :create, params: params
+        post(:create, params:)
 
         expect(session[:session_attributes]).to be_present
         expect(controller.send(:session_authenticated?)).to be true

--- a/decidim-elections/lib/decidim/elections/test/vote_examples.rb
+++ b/decidim-elections/lib/decidim/elections/test/vote_examples.rb
@@ -44,7 +44,7 @@ def fill_in_votes
   click_on "Exit the voting booth"
   expect(page).to have_current_path(election_path)
   expect(page).to have_content("You have already voted.")
-  expect(election.votes.where(voter_uid: voter_uid).size).to eq(3)
+  expect(election.votes.where(voter_uid:).size).to eq(3)
 end
 
 shared_examples "a votable election" do
@@ -163,7 +163,7 @@ shared_examples "a csv token votable election" do
     click_on "Exit the voting booth"
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
-    expect(election.votes.where(voter_uid: voter_uid).size).to eq(2)
+    expect(election.votes.where(voter_uid:).size).to eq(2)
   end
 end
 
@@ -186,7 +186,7 @@ shared_examples "an editable votable election" do
     click_on "Exit the voting booth"
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
-    expect(election.votes.where(voter_uid: voter_uid).size).to eq(3)
+    expect(election.votes.where(voter_uid:).size).to eq(3)
   end
 end
 
@@ -214,6 +214,6 @@ shared_examples "a csv token editable votable election" do
     click_on "Exit the voting booth"
     expect(page).to have_current_path(election_path)
     expect(page).to have_content("You have already voted.")
-    expect(election.votes.where(voter_uid: voter_uid).size).to eq(3)
+    expect(election.votes.where(voter_uid:).size).to eq(3)
   end
 end

--- a/decidim-elections/spec/commands/decidim/elections/admin/create_election_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/create_election_spec.rb
@@ -84,8 +84,8 @@ module Decidim
                 Decidim::Elections::Election,
                 current_user,
                 hash_including(
-                  title: title,
-                  description: description,
+                  title:,
+                  description:,
                   start_at:,
                   end_at:,
                   results_availability: "after_end",

--- a/decidim-elections/spec/commands/decidim/elections/admin/update_questions_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/admin/update_questions_spec.rb
@@ -25,7 +25,7 @@ module Decidim
         let(:second_question_second_option) { second_question.response_options.second }
 
         let(:context_params) do
-          { current_organization: organization, current_user: current_user }
+          { current_organization: organization, current_user: }
         end
 
         context "when updating an existing question" do
@@ -180,7 +180,7 @@ module Decidim
 
         context "when the form is invalid" do
           let(:form) do
-            double("Form", invalid?: true, current_user: current_user, current_organization: organization, questions: [])
+            double("Form", invalid?: true, current_user:, current_organization: organization, questions: [])
           end
           let(:command) { described_class.new(form, election) }
 

--- a/decidim-elections/spec/controllers/decidim/elections/admin/census_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/admin/census_controller_spec.rb
@@ -38,7 +38,7 @@ module Decidim
             let(:params) { { id: election.id, manifest: :token_csv, file: valid_file } }
 
             it "processes the census and redirects with a success message" do
-              patch :update, params: params
+              patch(:update, params:)
 
               expect(flash[:notice]).to eq(I18n.t("decidim.elections.admin.census.update.success"))
               expect(response).to redirect_to(dashboard_election_path)
@@ -49,7 +49,7 @@ module Decidim
             let(:params) { { id: election.id, manifest: :token_csv, file: invalid_file } }
 
             it "renders the edit view with an error message" do
-              patch :update, params: params
+              patch(:update, params:)
 
               expect(flash[:alert]).to eq(I18n.t("decidim.elections.admin.census.update.error"))
               expect(response).to render_template(:edit)

--- a/decidim-elections/spec/controllers/decidim/elections/census_checks_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/census_checks_controller_spec.rb
@@ -28,7 +28,7 @@ module Decidim
 
       describe "GET new" do
         it "renders the census check form" do
-          get :new, params: params
+          get(:new, params:)
 
           expect(response).to have_http_status(:ok)
           expect(assigns(:form)).to be_present
@@ -40,7 +40,7 @@ module Decidim
           end
 
           it "redirects to the success page" do
-            get :new, params: params
+            get(:new, params:)
 
             expect(response).to redirect_to(census_check_path)
           end
@@ -66,7 +66,7 @@ module Decidim
 
       describe "GET show" do
         it "redirects to the form when the session is not authenticated" do
-          get :show, params: params
+          get(:show, params:)
 
           expect(response).to redirect_to(new_census_check_path)
           expect(flash[:alert]).to eq(I18n.t("decidim.elections.votes.check_census.failed"))
@@ -78,7 +78,7 @@ module Decidim
           end
 
           it "renders the success page" do
-            get :show, params: params
+            get(:show, params:)
 
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:show)

--- a/decidim-elections/spec/controllers/decidim/elections/per_question_votes_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/per_question_votes_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
       let(:user) { create(:user, :confirmed, organization: component.organization) }
       let(:component) { create(:elections_component) }
       let(:election) { create(:election, :published, :with_internal_users_census, :per_question, :ongoing, component:) }
-      let!(:existing_vote) { create(:election_vote, question: question, response_option: question.response_options.first, voter_uid: "some-id") }
+      let!(:existing_vote) { create(:election_vote, question:, response_option: question.response_options.first, voter_uid: "some-id") }
       let!(:question) { create(:election_question, :with_response_options, :voting_enabled, election:) }
       let!(:second_question) { create(:election_question, :with_response_options, :voting_enabled, election:) }
 
@@ -49,7 +49,7 @@ module Decidim
           it_behaves_like "a redirect to the waiting room", :show
 
           it "renders the voting form" do
-            get :show, params: params
+            get(:show, params:)
             expect(response).to have_http_status(:ok)
             expect(controller.helpers.question).to eq(question)
             expect(subject).to render_template(:show)
@@ -58,14 +58,14 @@ module Decidim
           it "redirects to the next question if the current question is not enabled" do
             question.update(voting_enabled_at: nil)
             expect(controller).to receive(:redirect_to).with(action: :show, id: second_question)
-            get :show, params: params
+            get(:show, params:)
             expect(response).to have_http_status(:ok)
           end
 
           it "redirects to the next question if the current question has published results" do
             question.update(published_results_at: Time.current)
             expect(controller).to receive(:redirect_to).with(action: :show, id: second_question)
-            get :show, params: params
+            get(:show, params:)
             expect(response).to have_http_status(:ok)
           end
         end
@@ -152,7 +152,7 @@ module Decidim
             allow(controller).to receive(:votes_buffer).and_return({ question.id.to_s => [question.response_options.first.id] })
 
             expect(controller).to receive(:redirect_to).with(action: :show, id: second_question)
-            get :waiting, params: params
+            get(:waiting, params:)
             expect(response).to have_http_status(:ok)
           end
 
@@ -163,7 +163,7 @@ module Decidim
 
             it "redirects to the non voted question" do
               expect(controller).to receive(:redirect_to).with(action: :show, id: question)
-              get :waiting, params: params
+              get(:waiting, params:)
               expect(response).to have_http_status(:ok)
             end
 
@@ -172,13 +172,13 @@ module Decidim
 
               it "redirects to the non voted question" do
                 expect(controller).to receive(:redirect_to).with(action: :show, id: question)
-                get :waiting, params: params
+                get(:waiting, params:)
                 expect(response).to have_http_status(:ok)
               end
 
               it "renders the waiting page if votes_buffer exist" do
                 allow(controller).to receive(:votes_buffer).and_return({ question.id.to_s => [question.response_options.first.id] })
-                get :waiting, params: params
+                get(:waiting, params:)
                 expect(response).to have_http_status(:ok)
                 expect(subject).to render_template(:waiting)
               end
@@ -191,7 +191,7 @@ module Decidim
               allow(controller).to receive(:votes_buffer).and_return({ question.id.to_s => [question.response_options.first.id] })
 
               expect(controller).to receive(:url_for).with(action: :show, id: second_question)
-              get :waiting, params: params, format: :json
+              get :waiting, params:, format: :json
               expect(response).to have_http_status(:ok)
               expect(JSON.parse(response.body)).to have_key("url")
             end
@@ -215,13 +215,13 @@ module Decidim
             end
 
             it "redirects to the election path" do
-              get :receipt, params: params
+              get(:receipt, params:)
               expect(response).to redirect_to(election_path)
             end
 
             context "when the election has votes for the voter UID" do
               before do
-                create(:election_vote, voter_uid: session[:voter_uid], question: question, response_option: question.response_options.first)
+                create(:election_vote, voter_uid: session[:voter_uid], question:, response_option: question.response_options.first)
                 create(:election_vote, voter_uid: session[:voter_uid], question: second_question, response_option: second_question.response_options.first)
               end
 
@@ -230,7 +230,7 @@ module Decidim
               it "renders the receipt page without clearing session" do
                 expect(controller.send(:votes_buffer)).not_to receive(:clear)
                 expect(controller.send(:session_attributes)).not_to receive(:clear)
-                get :receipt, params: params
+                get(:receipt, params:)
                 expect(response).to have_http_status(:ok)
                 expect(subject).to render_template(:receipt)
               end

--- a/decidim-elections/spec/controllers/decidim/elections/votes_controller_spec.rb
+++ b/decidim-elections/spec/controllers/decidim/elections/votes_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
       let(:user) { create(:user, :confirmed, organization: component.organization) }
       let(:component) { create(:elections_component) }
       let(:election) { create(:election, :published, :with_internal_users_census, :ongoing, component:) }
-      let!(:existing_vote) { create(:election_vote, question: question, response_option: question.response_options.first, voter_uid: "some-id") }
+      let!(:existing_vote) { create(:election_vote, question:, response_option: question.response_options.first, voter_uid: "some-id") }
       let!(:question) { create(:election_question, :with_response_options, :voting_enabled, election:) }
       let!(:second_question) { create(:election_question, :with_response_options, :voting_enabled, election:) }
 
@@ -52,7 +52,7 @@ module Decidim
         end
 
         it "renders the voting form" do
-          get :show, params: params
+          get(:show, params:)
           expect(response).to have_http_status(:ok)
           expect(controller.helpers.question).to eq(question)
           expect(subject).to render_template(:show)
@@ -158,7 +158,7 @@ module Decidim
           end
 
           it "renders the confirmation page" do
-            get :confirm, params: params
+            get(:confirm, params:)
             expect(response).to have_http_status(:ok)
             expect(subject).to render_template(:confirm)
           end
@@ -184,7 +184,7 @@ module Decidim
           it "casts the votes and redirects to the receipt page" do
             expect(controller.send(:votes_buffer)).to receive(:clear)
             expect(controller.send(:session_attributes)).to receive(:clear)
-            post :cast, params: params
+            post(:cast, params:)
             expect(session[:voter_uid]).to eq(user.to_global_id.to_s)
             expect(response).to redirect_to(receipt_election_votes_path)
             expect(flash[:notice]).to eq(I18n.t("votes.cast.success", scope: "decidim.elections"))
@@ -198,7 +198,7 @@ module Decidim
             end
 
             it "redirects to the confirm page if votes are incomplete" do
-              post :cast, params: params
+              post(:cast, params:)
               expect(response).to redirect_to(confirm_election_votes_path)
               expect(flash[:alert]).to eq(I18n.t("votes.cast.invalid", scope: "decidim.elections"))
             end
@@ -208,7 +208,7 @@ module Decidim
 
       describe "GET receipt" do
         it "redirects to the election path" do
-          get :receipt, params: params
+          get(:receipt, params:)
           expect(response).to redirect_to(election_path)
         end
 
@@ -218,7 +218,7 @@ module Decidim
           end
 
           it "redirects to the election path" do
-            get :receipt, params: params
+            get(:receipt, params:)
             expect(response).to redirect_to(election_path)
           end
         end
@@ -232,13 +232,13 @@ module Decidim
 
           context "when the election has votes for the voter UID" do
             before do
-              create(:election_vote, voter_uid: session[:voter_uid], question: question, response_option: question.response_options.first)
+              create(:election_vote, voter_uid: session[:voter_uid], question:, response_option: question.response_options.first)
             end
 
             it "renders the receipt page and clears votes buffer" do
               expect(controller.send(:votes_buffer)).to receive(:clear)
               expect(controller.send(:session_attributes)).not_to receive(:clear)
-              get :receipt, params: params
+              get(:receipt, params:)
               expect(response).to have_http_status(:ok)
               expect(subject).to render_template(:receipt)
             end

--- a/decidim-elections/spec/forms/decidim/elections/admin/question_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/question_form_spec.rb
@@ -20,10 +20,10 @@ module Decidim
 
         let(:attributes) do
           {
-            body_en: body_en,
-            description_en: description_en,
-            question_type: question_type,
-            response_options: response_options
+            body_en:,
+            description_en:,
+            question_type:,
+            response_options:
           }
         end
 
@@ -58,11 +58,11 @@ module Decidim
         describe "max_choices validation" do
           let(:attributes) do
             {
-              body_en: body_en,
-              description_en: description_en,
-              question_type: question_type,
-              response_options: response_options,
-              max_choices: max_choices
+              body_en:,
+              description_en:,
+              question_type:,
+              response_options:,
+              max_choices:
             }
           end
 

--- a/decidim-elections/spec/forms/decidim/elections/admin/questions_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/questions_form_spec.rb
@@ -35,7 +35,7 @@ module Decidim
 
         subject(:form) do
           described_class.from_params(attributes).with_context(
-            current_organization: current_organization
+            current_organization:
           )
         end
 

--- a/decidim-elections/spec/forms/decidim/elections/admin/token_csv_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/token_csv_form_spec.rb
@@ -8,7 +8,7 @@ module Decidim
       module Censuses
         describe TokenCsvForm do
           let(:organization) { create(:organization) }
-          let(:attributes) { { file: file, remove_all: remove_all } }
+          let(:attributes) { { file:, remove_all: } }
           let(:remove_all) { false }
 
           subject { described_class.new(attributes).with_context(current_organization: organization) }

--- a/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
+++ b/decidim-elections/spec/permissions/decidim/elections/admin/permissions_spec.rb
@@ -14,7 +14,7 @@ describe Decidim::Elections::Admin::Permissions do
       election:
     }
   end
-  let(:permission_action) { Decidim::PermissionAction.new(scope: scope, action: action_name, subject: action_subject) }
+  let(:permission_action) { Decidim::PermissionAction.new(scope:, action: action_name, subject: action_subject) }
   let(:scope) { :admin }
   let(:action_name) { :foo }
   let(:action_subject) { :foo }

--- a/decidim-elections/spec/presenters/decidim/elections/election_presenter_spec.rb
+++ b/decidim-elections/spec/presenters/decidim/elections/election_presenter_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:election) do
         create(:election,
-               component: component,
+               component:,
                title: { en: "Test election" })
       end
 

--- a/decidim-elections/spec/system/admin/admin_manages_election_census_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_election_census_spec.rb
@@ -99,7 +99,7 @@ describe "Admin manages election census" do
     let(:available_authorizations) { %w(dummy_authorization_handler another_dummy_authorization_handler) }
 
     before do
-      organization.update!(available_authorizations: available_authorizations)
+      organization.update!(available_authorizations:)
     end
 
     context "when no verification handlers are selected" do

--- a/decidim-forms/app/commands/decidim/forms/response_questionnaire.rb
+++ b/decidim-forms/app/commands/decidim/forms/response_questionnaire.rb
@@ -79,7 +79,7 @@ module Decidim
       end
 
       def clear_responses!
-        Response.where(questionnaire: questionnaire, user: current_user, session_token: form.context.session_token, ip_hash: form.context.ip_hash).destroy_all
+        Response.where(questionnaire:, user: current_user, session_token: form.context.session_token, ip_hash: form.context.ip_hash).destroy_all
       end
 
       def response_questionnaire

--- a/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/show.html.erb
@@ -39,7 +39,7 @@
           <% else %>
             <% body = t("decidim.forms.questionnaires.show.questionnaire_responded.body") %>
           <% end %>
-          <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_responded.title"), body: body }) %>
+          <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_responded.title"), body: }) %>
         <% else %>
           <% if @form.responses_by_step.flatten.empty? %>
             <%= cell("decidim/announcement", t("decidim.forms.questionnaires.show.empty")) %>

--- a/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
+++ b/decidim-forms/spec/forms/decidim/forms/admin/display_condition_form_spec.rb
@@ -112,7 +112,7 @@ module Decidim
 
         describe "#questions_for_select" do
           let(:questions_for_select) { subject.questions_for_select(questionnaire, question.id) }
-          let!(:separator_question) { create(:questionnaire_question, questionnaire: questionnaire, question_type: "separator") }
+          let!(:separator_question) { create(:questionnaire_question, questionnaire:, question_type: "separator") }
 
           it "returns an array of arrays containing translated body, id, and a hash" do
             expect(questions_for_select.first.first).to eq(

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -13,7 +13,7 @@
   <ul id="dropdown-exports-<%= menu_id %>-<%= dropdown_id(collection_ids) %>" class="dropdown dropdown__bottom" aria-hidden="true">
     <% %w(CSV JSON).each do |format| %>
       <li class="dropdown__item">
-        <%= form_with url: export_initiatives_path(format: format), method: :post, class: "dropdown__button" do |f| %>
+        <%= form_with url: export_initiatives_path(format:), method: :post, class: "dropdown__button" do |f| %>
           <%= hidden_field_tag "collection_ids", collection_ids&.join(",") %>
           <%= f.submit t("decidim.admin.exports.export_as",
                          name: t("decidim.initiatives.admin.exports.initiatives"),

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -22,7 +22,7 @@
 <% if promoters_committee_members.count.positive? %>
   <div class="block">
     <% current_initiative.committee_members.each do |request| %>
-      <%= render partial: "committee_member", locals: { request: request } %>
+      <%= render partial: "committee_member", locals: { request: } %>
     <% end %>
   </div>
 <% end %>

--- a/decidim-initiatives/spec/services/decidim/initiatives/progress_notifier_spec.rb
+++ b/decidim-initiatives/spec/services/decidim/initiatives/progress_notifier_spec.rb
@@ -65,7 +65,7 @@ module Decidim
           double(
             "initiative",
             author:,
-            followers: followers,
+            followers:,
             committee_members: double("committee_members", approved: approved_committee_members)
           )
         end

--- a/decidim-meetings/app/commands/decidim/meetings/admin/mark_as_attendee.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/mark_as_attendee.rb
@@ -34,7 +34,7 @@ module Decidim
             resource: meeting,
             affected_users: [registration.user],
             extra: {
-              registration: registration
+              registration:
             }
           )
         end

--- a/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
+++ b/decidim-meetings/app/events/decidim/meetings/update_meeting_event.rb
@@ -11,9 +11,9 @@ module Decidim
         I18n.t(
           "notification_title",
           scope: i18n_scope,
-          changed_fields: changed_fields,
+          changed_fields:,
           resource_title: translated_attribute(resource.title),
-          resource_path: resource_path
+          resource_path:
         ).html_safe
       end
 

--- a/decidim-meetings/spec/commands/admin/copy_meeting_fields_spec.rb
+++ b/decidim-meetings/spec/commands/admin/copy_meeting_fields_spec.rb
@@ -9,9 +9,9 @@ module Decidim
         subject { described_class.new(form, meeting) }
 
         let(:organization) { create(:organization) }
-        let(:participatory_process) { create(:participatory_process, organization: organization) }
+        let(:participatory_process) { create(:participatory_process, organization:) }
         let(:current_component) { create(:component, manifest_name: "meetings", participatory_space: participatory_process) }
-        let(:user) { create(:user, :admin, :confirmed, organization: organization) }
+        let(:user) { create(:user, :admin, :confirmed, organization:) }
         let(:meeting) { create(:meeting, :published, component: current_component, **meeting_attributes) }
 
         let(:meeting_attributes) do

--- a/decidim-meetings/spec/commands/join_waitlist_spec.rb
+++ b/decidim-meetings/spec/commands/join_waitlist_spec.rb
@@ -7,17 +7,17 @@ module Decidim::Meetings
     subject { described_class.new(meeting, form) }
 
     let(:organization) { create(:organization) }
-    let(:participatory_process) { create(:participatory_process, organization: organization) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:component) { create(:component, manifest_name: :meetings, participatory_space: participatory_process) }
     let(:available_slots) { 2 }
     let(:meeting) do
       create(:meeting,
-             component: component,
+             component:,
              registrations_enabled: true,
-             available_slots: available_slots)
+             available_slots:)
     end
 
-    let(:user) { create(:user, :confirmed, organization: organization, notifications_sending_frequency: "none") }
+    let(:user) { create(:user, :confirmed, organization:, notifications_sending_frequency: "none") }
     let(:form) do
       Decidim::Meetings::JoinMeetingForm.new.with_context(
         current_user: user
@@ -35,7 +35,7 @@ module Decidim::Meetings
 
     context "when all conditions are met" do
       before do
-        create_list(:registration, available_slots, meeting: meeting, status: :registered)
+        create_list(:registration, available_slots, meeting:, status: :registered)
       end
 
       it "broadcasts ok" do
@@ -58,7 +58,7 @@ module Decidim::Meetings
 
     context "when the user is already registered" do
       before do
-        create(:registration, meeting: meeting, user: user, status: :registered)
+        create(:registration, meeting:, user:, status: :registered)
       end
 
       it "broadcasts invalid" do
@@ -74,7 +74,7 @@ module Decidim::Meetings
 
     context "when the form is invalid" do
       before do
-        create_list(:registration, available_slots, meeting: meeting, status: :registered)
+        create_list(:registration, available_slots, meeting:, status: :registered)
         allow(form).to receive(:valid?).and_return(false)
       end
 

--- a/decidim-meetings/spec/controllers/decidim/meetings/registrations_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/registrations_controller_spec.rb
@@ -27,7 +27,7 @@ module Decidim::Meetings
         context "with available slots" do
           it "creates registration and redirects" do
             expect do
-              post :create, params: params
+              post :create, params:
             end.to change(Registration, :count).by(1)
 
             expect(flash[:notice]).to eq(I18n.t("registrations.create.success", scope: "decidim.meetings"))
@@ -36,10 +36,10 @@ module Decidim::Meetings
         end
 
         context "when no available slots" do
-          let!(:registrations) { create_list(:registration, 10, meeting: meeting) }
+          let!(:registrations) { create_list(:registration, 10, meeting:) }
 
           it "shows error message" do
-            post :create, params: params
+            post(:create, params:)
 
             expect(flash[:alert]).to eq(I18n.t("registrations.create.invalid", scope: "decidim.meetings"))
             expect(response).to redirect_to(my_meeting_path)
@@ -49,7 +49,7 @@ module Decidim::Meetings
 
       context "when user not authenticated" do
         it "redirects to login" do
-          post :create, params: params
+          post(:create, params:)
           expect(response).to redirect_to("/users/sign_in")
         end
       end
@@ -76,7 +76,7 @@ module Decidim::Meetings
         meeting.update!(
           registrations_enabled: true,
           registration_form_enabled: true,
-          questionnaire: questionnaire
+          questionnaire:
         )
       end
 
@@ -84,7 +84,7 @@ module Decidim::Meetings
         context "when joining directly" do
           it "answers questionnaire and redirects" do
             expect do
-              post :respond, params: params
+              post :respond, params:
             end.to change { meeting.registrations.count }.by(1)
 
             expect(flash[:notice]).to eq(I18n.t("registrations.create.success", scope: "decidim.meetings"))
@@ -94,11 +94,11 @@ module Decidim::Meetings
 
         context "when joining waitlist" do
           let(:meeting) { create(:meeting, component:, available_slots: 10) }
-          let!(:registrations) { create_list(:registration, 10, meeting: meeting) }
+          let!(:registrations) { create_list(:registration, 10, meeting:) }
 
           it "adds user to waitlist and redirects" do
             expect do
-              post :respond, params: params
+              post :respond, params:
             end.to change { meeting.registrations.where(status: :waiting_list).count }.by(1)
 
             expect(flash[:notice]).to eq(I18n.t("registrations.waitlist.success", scope: "decidim.meetings"))
@@ -116,7 +116,7 @@ module Decidim::Meetings
         end
 
         it "shows error message" do
-          post :respond, params: params
+          post(:respond, params:)
 
           expect(flash[:alert]).to eq(I18n.t("response.invalid", scope: "decidim.forms.questionnaires"))
           expect(response).to render_template("decidim/forms/questionnaires/show")
@@ -126,7 +126,7 @@ module Decidim::Meetings
 
     describe "POST join_waitlist" do
       let(:meeting) { create(:meeting, component:, available_slots: 10) }
-      let!(:registrations) { create_list(:registration, 10, meeting: meeting) }
+      let!(:registrations) { create_list(:registration, 10, meeting:) }
       let(:params) { { meeting_id: meeting.id } }
 
       before { sign_in user }
@@ -134,7 +134,7 @@ module Decidim::Meetings
       context "when meeting has no available slots" do
         it "adds user to waitlist" do
           expect do
-            post :join_waitlist, params: params
+            post :join_waitlist, params:
           end.to change(Registration.on_waiting_list, :count).by(1)
 
           expect(flash[:notice]).to eq(I18n.t("registrations.waitlist.success", scope: "decidim.meetings"))
@@ -151,7 +151,7 @@ module Decidim::Meetings
 
       it "destroys registration" do
         expect do
-          delete :destroy, params: params
+          delete :destroy, params:
         end.to change(Registration, :count).by(-1)
 
         expect(flash[:notice]).to match(/successfully/)

--- a/decidim-meetings/spec/system/meeting_waiting_list_spec.rb
+++ b/decidim-meetings/spec/system/meeting_waiting_list_spec.rb
@@ -58,7 +58,7 @@ describe "Meeting waiting list" do
 
     context "when the meeting has no available slots" do
       before do
-        create_list(:registration, available_slots, meeting: meeting)
+        create_list(:registration, available_slots, meeting:)
       end
 
       context "when the user is not logged in" do
@@ -111,13 +111,13 @@ describe "Meeting waiting list" do
 
   context "when the meeting is full and a user cancels their registration" do
     context "and there are users on the waiting list" do
-      let!(:registrations) { create_list(:registration, available_slots, meeting: meeting) }
+      let!(:registrations) { create_list(:registration, available_slots, meeting:) }
       let(:users_on_waitlist) { create_list(:user, 5, :confirmed, organization:) }
       let(:first_waitlist_user) { users_on_waitlist.first }
 
       let!(:waitlist_entries) do
         users_on_waitlist.map.with_index do |user, index|
-          create(:registration, meeting: meeting, user: user, status: "waiting_list", created_at: Time.current - index.minutes)
+          create(:registration, meeting:, user:, status: "waiting_list", created_at: Time.current - index.minutes)
         end
       end
 

--- a/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_democratic_quality_stats_presenter_spec.rb
+++ b/decidim-participatory_processes/spec/presenters/decidim/participatory_processes/participatory_process_democratic_quality_stats_presenter_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:organization) { create(:organization) }
       let(:process) { create(:participatory_process, organization:) }
-      let(:content_block) { double("content_block", settings: settings) }
+      let(:content_block) { double("content_block", settings:) }
       let(:settings) do
         double(
           functional_diversity_invited: 2.5,

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_soft_delete_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_soft_delete_spec.rb
@@ -14,12 +14,12 @@ describe "Admin manages participatory process soft delete" do
   it_behaves_like "manage trashed resource", "participatory process"
 
   context "when a user is collaborator" do
-    let!(:participatory_process) { create(:participatory_process, organization: organization) }
-    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:collaborator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:collaborator_role) do
       create(:participatory_process_user_role,
              user: collaborator_user,
-             participatory_process: participatory_process,
+             participatory_process:,
              role: :collaborator)
     end
 
@@ -36,12 +36,12 @@ describe "Admin manages participatory process soft delete" do
   end
 
   context "when a user is evaluator" do
-    let!(:participatory_process) { create(:participatory_process, organization: organization) }
-    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:evaluator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:evaluator_role) do
       create(:participatory_process_user_role,
              user: evaluator_user,
-             participatory_process: participatory_process,
+             participatory_process:,
              role: :evaluator)
     end
 
@@ -58,12 +58,12 @@ describe "Admin manages participatory process soft delete" do
   end
 
   context "when a user is moderator" do
-    let!(:participatory_process) { create(:participatory_process, organization: organization) }
-    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:moderator_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:moderator_role) do
       create(:participatory_process_user_role,
              user: moderator_user,
-             participatory_process: participatory_process,
+             participatory_process:,
              role: :moderator)
     end
 
@@ -80,12 +80,12 @@ describe "Admin manages participatory process soft delete" do
   end
 
   context "when a user is a space admin" do
-    let!(:participatory_process) { create(:participatory_process, organization: organization) }
-    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization: organization) }
+    let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:admin_user) { create(:user, :admin_terms_accepted, :confirmed, organization:) }
     let!(:admin_role) do
       create(:participatory_process_user_role,
              user: admin_user,
-             participatory_process: participatory_process,
+             participatory_process:,
              role: :admin)
     end
 

--- a/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/index.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
   description: translated_attribute(current_participatory_space.short_description),
   title: t("decidim.components.pagination.page_title",
-           component_name: component_name,
+           component_name:,
            current_page: @proposals.current_page,
            total_pages: @proposals.total_pages ),
   url: proposals_url,

--- a/decidim-proposals/spec/controllers/decidim/proposals/admin/proposal_answers_controller_spec.rb
+++ b/decidim-proposals/spec/controllers/decidim/proposals/admin/proposal_answers_controller_spec.rb
@@ -64,7 +64,7 @@ module Decidim
 
             context "when the update is successful." do
               it "renders ProposalsAdmin#index view" do
-                post :update, params: params
+                post(:update, params:)
                 expect(response).to have_http_status(:found)
                 expect(subject).to redirect_to(proposals_path)
               end

--- a/decidim-proposals/spec/lib/tasks/upgrade/fix_state_spec.rb
+++ b/decidim-proposals/spec/lib/tasks/upgrade/fix_state_spec.rb
@@ -11,7 +11,7 @@ describe "rake decidim_proposals:upgrade:fix_state", type: :task do
 
     before do
       proposal_state = proposal.proposal_state = Decidim::Proposals::ProposalState.where(component: component2).first
-      proposal.update!(proposal_state: proposal_state)
+      proposal.update!(proposal_state:)
     end
 
     it "does not throw an exception" do
@@ -24,7 +24,7 @@ describe "rake decidim_proposals:upgrade:fix_state", type: :task do
 
     before do
       proposal_state = proposal.proposal_state = Decidim::Proposals::ProposalState.where(component: component2).first
-      proposal.update!(proposal_state: proposal_state)
+      proposal.update!(proposal_state:)
     end
 
     it "sets the state of the correct component" do

--- a/decidim-proposals/spec/types/proposal_mutation_type_spec.rb
+++ b/decidim-proposals/spec/types/proposal_mutation_type_spec.rb
@@ -25,9 +25,9 @@ module Decidim
         {
           input: {
             attributes: {
-              state: state,
+              state:,
               answerContent: answer_content,
-              cost: cost,
+              cost:,
               costReport: cost_report,
               executionPeriod: execution_period
             }
@@ -52,10 +52,10 @@ module Decidim
 
       before do
         component.update!(
-          settings: { proposal_answering_enabled: proposal_answering_enabled },
+          settings: { proposal_answering_enabled: },
           step_settings: {
             component.participatory_space.active_step.id => {
-              proposal_answering_enabled: proposal_answering_enabled,
+              proposal_answering_enabled:,
               answers_with_costs: proposal_answers_with_costs?
             }
           }

--- a/decidim-surveys/app/views/decidim/surveys/surveys/not_allowed.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/not_allowed.html.erb
@@ -17,6 +17,6 @@
   <%= render partial: "decidim/shared/component_announcement" if current_component.manifest_name == "surveys" %>
   <section>
     <% body = t("decidim.forms.questionnaires.show.questionnaire_responded.body") %>
-    <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_responded.title"), body: body }) %>
+    <%= cell("decidim/announcement", { title: t("decidim.forms.questionnaires.show.questionnaire_responded.title"), body: }) %>
   </section>
 <% end %>

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -73,7 +73,7 @@ Decidim.register_component(:surveys) do |component|
 
   component.exports :published_survey_user_responses do |exports|
     exports.collection do |component|
-      survey = Decidim::Surveys::Survey.find_by(component: component)
+      survey = Decidim::Surveys::Survey.find_by(component:)
 
       Decidim::Forms::Response
         .joins(:question)

--- a/decidim-system/app/controllers/decidim/system/api_users_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/api_users_controller.rb
@@ -29,7 +29,7 @@ module Decidim
         RefreshApiUserSecret.call(api_user, current_admin) do
           on(:ok) do |secret|
             flash[:notice] = I18n.t("api_user.refresh.success", scope: "decidim.system", user: api_user.api_key)
-            session[:api_user] = { id: api_user.id, secret: secret }
+            session[:api_user] = { id: api_user.id, secret: }
             redirect_to action: :index
           end
 
@@ -41,11 +41,11 @@ module Decidim
       end
 
       def create
-        @form = ::Decidim::System::ApiUserForm.from_params(params.merge!(name: params[:admin][:name], organization: organization))
+        @form = ::Decidim::System::ApiUserForm.from_params(params.merge!(name: params[:admin][:name], organization:))
         CreateApiUser.call(@form, current_admin) do
           on(:ok) do |api_user, secret|
             flash[:notice] = I18n.t("api_user.create.success", scope: "decidim.system", user: api_user.api_key)
-            session[:api_user] = { id: api_user.id, secret: secret }
+            session[:api_user] = { id: api_user.id, secret: }
             redirect_to action: :index
           end
 

--- a/decidim-system/spec/commands/decidim/system/create_api_user_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_api_user_spec.rb
@@ -18,7 +18,7 @@ module Decidim
         double(
           valid?: valid,
           organization: organization.id,
-          name: name
+          name:
         )
       end
 

--- a/decidim-system/spec/commands/decidim/system/refresh_api_user_secret_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/refresh_api_user_secret_spec.rb
@@ -9,7 +9,7 @@ module Decidim
 
       let(:command) { subject.call }
       let!(:organization) { create(:organization) }
-      let(:api_user) { create(:api_user, organization: organization) }
+      let(:api_user) { create(:api_user, organization:) }
       let(:admin) { create(:admin) }
       let(:valid) { true }
       let(:name) { "Dummy name" }

--- a/decidim-system/spec/forms/decidim/system/api_user_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/api_user_form_spec.rb
@@ -13,7 +13,7 @@ module Decidim
 
       let(:attributes) do
         {
-          name: name,
+          name:,
           organization: organization_id
         }
       end
@@ -29,7 +29,7 @@ module Decidim
       end
 
       context "when name is already exist" do
-        let!(:api_user) { create(:api_user, organization: organization, name: name) }
+        let!(:api_user) { create(:api_user, organization:, name:) }
 
         it { is_expected.not_to be_valid }
       end

--- a/decidim-system/spec/system/explore_api_credentials_spec.rb
+++ b/decidim-system/spec/system/explore_api_credentials_spec.rb
@@ -36,7 +36,7 @@ describe "Explore API credentials" do
   end
 
   context "with API users" do
-    let!(:set) { create_list(:api_user, 3, organization: organization) }
+    let!(:set) { create_list(:api_user, 3, organization:) }
     let!(:set1) { create_list(:api_user, 4, organization: organization1) }
 
     before do

--- a/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
+++ b/decidim-templates/app/views/decidim/templates/admin/proposal_answer_templates/index.html.erb
@@ -25,7 +25,7 @@
           <% @templates.each do |template| %>
             <tr data-proposal_answer-id="<%= template.id %>">
               <td data-label="<%= t("template.name", scope: "decidim.models") %>">
-                <%= link_to_if allowed_to?(:update, :template, template: template), translated_attribute(template.name), edit_proposal_answer_template_path(template) %>
+                <%= link_to_if allowed_to?(:update, :template, template:), translated_attribute(template.name), edit_proposal_answer_template_path(template) %>
               </td>
               <td data-label="<%= t(".proposal_state_id") %>">
                 <%= proposal_state(template) %>


### PR DESCRIPTION
#### :tophat: What? Why?

Bacjk in https://github.com/decidim/decidim/pull/15808#discussion_r2631092995 we detected that the default for the rubocop setting `EnforcedShorthandSyntax` is `either`, so:

```ruby

# good
{foo: foo, bar: bar}

# good
{foo: foo, bar:}

# good
{foo:, bar:}

```

I think both me and @alecslupu are form the school that "if we can write less, then it is good", so we prefer to have `always`: 

```ruby
# bad
{foo: foo, bar: bar}

# good
{foo:, bar:}

# good - allowed to mix syntaxes
{foo:, bar: baz}
```


#### :pushpin: Related Issues
 
- Related to  https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax

#### Testing

Everything should be green
There should be less characters in the code!  


:hearts: Thank you!
