### PR TITLE
Fix notification from Component publication

### DIFF
--- a/decidim-core/app/models/decidim/component.rb
+++ b/decidim-core/app/models/decidim/component.rb
@@ -108,6 +108,7 @@ module Decidim
 
       participatory_space.can_participate?(user)
     end
+    alias can_participate? can_participate_in_space?
 
     def private_non_transparent_space?
       return false unless participatory_space.respond_to?(:private_space?)

--- a/decidim-core/spec/system/notifications_spec.rb
+++ b/decidim-core/spec/system/notifications_spec.rb
@@ -111,6 +111,23 @@ describe "Notifications" do
         end
       end
     end
+
+    context "when the notification is from a component" do
+      let!(:notification) do
+        create(:notification, user:,
+                              resource: resource.component,
+                              event_name: "decidim.events.components.component_published",
+                              event_class: "Decidim::ComponentPublishedEvent")
+      end
+
+      before do
+        page.visit decidim.notifications_path
+      end
+
+      it "shows the notifications" do
+        expect(page).to have_css(".notification")
+      end
+    end
   end
 
   context "when the notification event has an action" do


### PR DESCRIPTION
#### :tophat: What? Why?

While checking notifications, I saw an exception. As far as I see this was introduced with #15002 (so we need to backport to the same releases that this fix was backported to).

#### :pushpin: Related Issues
 
- Related to #15002 
 
#### Testing

1. Sign in 
2. Unpublish and publish a component
3. Go to http://localhost:3000/notifications 

### :camera: Stacktrace

```ruby
ActionView::Template::Error (undefined method 'can_participate?' for an instance of Decidim::Component):

Causes:
NoMethodError (undefined method 'can_participate?' for an instance of Decidim::Component)
     9:   <% main_tag = main_enabled ? :main : :div %>
    10:   <%= content_tag main_tag, class: "layout-2col__main" do %>
    11:     <%= content_for :flash_messages %>
    12:     <%= yield %>
    13:   <% end %>
    14: </div>

activemodel (7.2.2.2) lib/active_model/attribute_methods.rb:512:in 'ActiveModel::AttributeMethods#method_missing'
activerecord (7.2.2.2) lib/active_record/attribute_methods.rb:491:in 'ActiveRecord::AttributeMethods#method_missing'
/home/apereira/Work/decidim-org/decidim/decidim-core/app/models/decidim/notification.rb:41:in 'Decidim::Notification#can_participate?'
/nix/store/khiwk1y8halaw4zfrhmh5r340lwaxzlq-ruby-3.4.7/lib/ruby/3.4.0/delegate.rb:87:in 'Delegator#method_missing'
/home/apereira/Work/decidim-org/decidim/decidim-core/app/cells/decidim/notification_cell.rb:10:in 'Decidim::NotificationCell#show'
cells (4.1.8) lib/cell/view_model.rb:114:in 'Cell::ViewModel::Rendering#render_state'
cells (4.1.8) lib/cell/caching.rb:46:in 'Cell::Caching#render_state'
cells (4.1.8) lib/cell/view_model.rb:92:in 'Cell::ViewModel::Rendering#call'
cells-rails (0.1.6) lib/cell/rails.rb:56:in 'Cell::RailsExtensions::ViewModel#call'
/home/apereira/Work/decidim-org/decidim/decidim-core/lib/decidim/view_model.rb:34:in 'block in Decidim::ViewModel#call'
/home/apereira/Work/decidim-org/decidim/decidim-core/lib/decidim/view_model.rb:81:in 'block in Decidim::ViewModel#instrument'
activesupport (7.2.2.2) lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
activesupport (7.2.2.2) lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
activesupport (7.2.2.2) lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
/home/apereira/Work/decidim-org/decidim/decidim-core/lib/decidim/view_model.rb:80:in 'Decidim::ViewModel#instrument'
/home/apereira/Work/decidim-org/decidim/decidim-core/lib/decidim/view_model.rb:33:in 'Decidim::ViewModel#call'
```

:hearts: Thank you!
