### PR TITLE
Refactor attachments tab in budgets' projects and initiatives

### DIFF
--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -6,10 +6,11 @@ module Decidim
     class ProjectsController < Decidim::Budgets::ApplicationController
       include FilterResource
       include NeedsCurrentOrder
+      include Decidim::AttachmentsHelper
       include Decidim::Budgets::Orderable
       include Decidim::IconHelper
 
-      helper_method :projects, :project, :budget, :all_geocoded_projects, :tabs, :panels, :resource_added?
+      helper_method :projects, :project, :budget, :all_geocoded_projects, :resource_added?, :tab_panel_items
 
       before_action :set_focus_mode_if_voting_open
 
@@ -64,16 +65,8 @@ module Decidim
         voting_finished? && budget.projects.selected.any?
       end
 
-      def tabs
-        @tabs ||= items.map { |item| item.slice(:id, :text, :icon) }
-      end
-
-      def panels
-        @panels ||= items.map { |item| item.slice(:id, :method, :args) }
-      end
-
-      def items
-        @items ||= [
+      def tab_panel_items
+        @tab_panel_items ||= [
           {
             enabled: ProjectHistoryCell.new(@project).render?,
             id: "included_history",
@@ -82,22 +75,7 @@ module Decidim
             method: :cell,
             args: ["decidim/budgets/project_history", @project]
           },
-          {
-            enabled: @project.photos.present?,
-            id: "images",
-            text: t("decidim.application.photos.photos"),
-            icon: resource_type_icon_key("images"),
-            method: :cell,
-            args: ["decidim/images_panel", @project]
-          },
-          {
-            enabled: @project.documents.present?,
-            id: "documents",
-            text: t("decidim.application.documents.documents"),
-            icon: resource_type_icon_key("documents"),
-            method: :cell,
-            args: ["decidim/documents_panel", @project]
-          }
+          *attachments_tab_panel_items(@project)
         ].select { |item| item[:enabled] }
       end
 

--- a/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
+++ b/decidim-budgets/app/views/decidim/budgets/projects/show.html.erb
@@ -54,24 +54,8 @@ edit_link(
       </div>
     </section>
     <section class="layout-main__section">
-      <% if tabs.any? %>
-        <div class="mt-8" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
-          <ul class="tab-x-container">
-            <% tabs.each_with_index do |tab, i| %>
-              <li>
-                <button id="trigger-<%= tab[:id] %>" class="tab-x" data-controls="panel-<%= tab[:id] %>" data-open="<%= "true" if i.zero? %>">
-                  <%= icon tab[:icon], class: "text-gray fill-current" %><%= tab[:text] %>
-                </button>
-              </li>
-            <% end %>
-          </ul>
-
-          <% panels.each do |panel| %>
-            <div id="panel-<%= panel[:id] %>" class="py-8 panel-container">
-              <%= send(panel[:method], *panel[:args]) %>
-            </div>
-          <% end %>
-        </div>
+      <% if tab_panel_items.any? %>
+        <%= cell "decidim/tab_panels", tab_panel_items %>
       <% end %>
     </section>
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -22,6 +22,7 @@ module Decidim
       include InitiativeSlug
       include FilterResource
       include Paginable
+      include Decidim::AttachmentsHelper
       include Decidim::FormFactory
       include Decidim::Initiatives::Orderable
       include TypeSelectorOptions
@@ -30,7 +31,7 @@ module Decidim
       include SingleInitiativeType
       include Decidim::IconHelper
 
-      helper_method :collection, :initiatives, :pending_initiatives, :filter, :stats, :tabs, :panels
+      helper_method :collection, :initiatives, :pending_initiatives, :filter, :stats, :tab_panel_items
       helper_method :initiative_type, :available_initiative_types
 
       before_action :authorize_participatory_space, only: [:show]
@@ -176,33 +177,8 @@ module Decidim
         @stats ||= InitiativeStatsPresenter.new(initiative: current_initiative)
       end
 
-      def tabs
-        @tabs ||= items.map { |item| item.slice(:id, :text, :icon) }
-      end
-
-      def panels
-        @panels ||= items.map { |item| item.slice(:id, :method, :args) }
-      end
-
-      def items
-        @items ||= [
-          {
-            enabled: @current_initiative.photos.present?,
-            id: "images",
-            text: t("decidim.application.photos.photos"),
-            icon: resource_type_icon_key("images"),
-            method: :cell,
-            args: ["decidim/images_panel", @current_initiative]
-          },
-          {
-            enabled: @current_initiative.documents.present?,
-            id: "documents",
-            text: t("decidim.application.documents.documents"),
-            icon: resource_type_icon_key("documents"),
-            method: :cell,
-            args: ["decidim/documents_panel", @current_initiative]
-          }
-        ].select { |item| item[:enabled] }
+      def tab_panel_items
+        @tab_panel_items ||= attachments_tab_panel_items(@current_initiative)
       end
     end
   end

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -180,24 +180,8 @@ edit_link(
 </section>
 
 <section class="layout-main__section">
-  <% if tabs.any? %>
-    <div class="mt-8" data-controller="accordion" data-multiselectable="false" data-collapsible="false">
-      <ul class="tab-x-container">
-        <% tabs.each_with_index do |tab, i| %>
-          <li>
-            <button id="trigger-<%= tab[:id] %>" class="tab-x" data-controls="panel-<%= tab[:id] %>" data-open="<%= "true" if i.zero? %>">
-              <%= icon tab[:icon], class: "text-gray fill-current" %><%= tab[:text] %>
-            </button>
-          </li>
-        <% end %>
-      </ul>
-
-      <% panels.each do |panel| %>
-        <div id="panel-<%= panel[:id] %>" class="py-8">
-          <%= send(panel[:method], *panel[:args]) %>
-        </div>
-      <% end %>
-    </div>
+  <% if tab_panel_items.any? %>
+    <%= cell "decidim/tab_panels", tab_panel_items %>
   <% end %>
 </section>
 


### PR DESCRIPTION
#### :tophat: What? Why?

While doing a review, we found out that there was some views that were implementing Tabs manually instead of using the cells approach. This PR changes this to make it consistent with the rest of the application.

The behavior isn't changed (so it is a refactor). 

#### :pushpin: Related Issues

- Fixes #11456

#### Testing

1. Go to a budgets' project with attachments. It should behave the same as before this PR
1. Go to an initiative with attachments. It should behave the same as before this PR

### :camera: Screenshots 

<img width="2324" height="1410" alt="image" src="https://github.com/user-attachments/assets/917d812e-af5a-48ba-954d-177d3d5ce0c2" />
<img width="2464" height="1580" alt="image" src="https://github.com/user-attachments/assets/969c507c-969a-4b52-a9d4-55c49b073292" />

:hearts: Thank you!
