### PR TITLE
Fix factories location pages module

### DIFF
--- a/decidim-pages/lib/decidim/pages/test/factories.rb
+++ b/decidim-pages/lib/decidim/pages/test/factories.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :page_component, parent: :component do
+    name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :pages).i18n_name }
+    manifest_name { :pages }
+    participatory_space { create(:participatory_process, :with_steps, organization:) }
+  end
+
+  factory :page, class: "Decidim::Pages::Page" do
+    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
+    component { build(:component, manifest_name: "pages") }
+  end
+end

--- a/decidim-pages/spec/factories.rb
+++ b/decidim-pages/spec/factories.rb
@@ -3,16 +3,4 @@
 require "decidim/components/namer"
 require "decidim/core/test/factories"
 require "decidim/participatory_processes/test/factories"
-
-FactoryBot.define do
-  factory :page_component, parent: :component do
-    name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :pages).i18n_name }
-    manifest_name { :pages }
-    participatory_space { create(:participatory_process, :with_steps, organization:) }
-  end
-
-  factory :page, class: "Decidim::Pages::Page" do
-    body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
-    component { build(:component, manifest_name: "pages") }
-  end
-end
+require "decidim/pages/test/factories"


### PR DESCRIPTION
#### :tophat: What? Why?
While working on a module in which i need the page component factory, i have noticed that i cannot access the decidim defined factory. This is mainly caused by the fact that pages component has it's factories defined in `decidim-pages/spec/factories.rb`, whereas all the other libraries do have it in `decdim-$moduleName/lib/decidim/$Namespace/test/factories.rb`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Pipelines should be green 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
