### PR TITLE
Fix breadcrumb in conferences' program

### DIFF
--- a/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
@@ -10,6 +10,8 @@ module Decidim
 
       helper_method :collection, :conference, :meeting_days, :meeting_component
 
+      before_action :set_program_breadcrumb_item
+
       def show
         raise ActionController::RoutingError, "No meetings for this conference " if meetings.blank?
 
@@ -46,6 +48,17 @@ module Decidim
 
       def conference
         current_participatory_space
+      end
+
+      def set_program_breadcrumb_item
+        return unless meeting_component
+
+        context_breadcrumb_items << {
+          label: t("conference_program.index.title", scope: "decidim"),
+          url: decidim_conferences.conference_conference_program_path(current_participatory_space, meeting_component, locale: I18n.locale),
+          active: true,
+          resource: meeting_component
+        }
       end
     end
   end

--- a/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
+++ b/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
@@ -34,7 +34,22 @@ describe "Conferences Breadcrumb" do
 
   describe "with a program" do
     let(:meetings_component) { create(:meeting_component, :published, participatory_space:) }
-    let!(:meeting) { create(:meeting, :published, component: meetings_component, start_time: 1.day.from_now) }
+    let!(:meeting) { create(:meeting, :published, latitude:, longitude:, component: meetings_component, start_time: 1.day.from_now) }
+
+    let(:latitude) { 40.7504928941818 }
+    let(:longitude) { -73.993466492276 }
+    let(:geocoder_request_url) { "https://nominatim.openstreetmap.org/reverse?accept-language=en&addressdetails=1&format=json&lat=#{latitude}&lon=#{longitude}" }
+    let(:geocoder_response) { File.read(Decidim::Dev.asset("geocoder_result_osm.json")) }
+
+    before do
+      stub_request(:get, geocoder_request_url).with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "User-Agent" => "Ruby"
+        }
+      ).to_return(body: geocoder_response)
+    end
 
     scenario "shows breadcrumb with conference and program" do
       visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)

--- a/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
+++ b/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
@@ -32,16 +32,30 @@ describe "Conferences Breadcrumb" do
     end
   end
 
-  scenario "shows breadcrumb with conference and program" do
-    meetings_component = create(:meeting_component, :published, participatory_space:)
-    create(:meeting, :published, component: meetings_component, start_time: 1.day.from_now)
+  describe "with a program" do
+    let(:meetings_component) { create(:meeting_component, :published, participatory_space:) }
+    let!(:meeting) { create(:meeting, :published, component: meetings_component, start_time: 1.day.from_now) }
 
-    visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
+    scenario "shows breadcrumb with conference and program" do
+      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
 
-    within ".menu-bar" do
-      expect(page).to have_content("Conferences")
-      expect(page).to have_content(translated(participatory_space.title))
-      expect(page).to have_content(t("conference_program.index.title", scope: "decidim"))
+      within ".menu-bar" do
+        expect(page).to have_content("Conferences")
+        expect(page).to have_content(translated(participatory_space.title))
+        expect(page).to have_content("Program")
+      end
+    end
+
+    scenario "shows breadcrumb with conference, program, and meeting" do
+      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
+      click_on decidim_sanitize_translated(meeting.title)
+
+      within ".menu-bar" do
+        expect(page).to have_content("Conferences")
+        expect(page).to have_content(translated(participatory_space.title))
+        expect(page).to have_content("Program")
+        expect(page).to have_content(translated_attribute(meeting.title))
+      end
     end
   end
 end

--- a/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
+++ b/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
@@ -31,4 +31,17 @@ describe "Conferences Breadcrumb" do
       expect(page).to have_content(translated(component.name))
     end
   end
+
+  scenario "shows breadcrumb with conference and program" do
+    meetings_component = create(:meeting_component, :published, participatory_space:)
+    create(:meeting, :published, component: meetings_component, start_time: 1.day.from_now)
+
+    visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
+
+    within ".menu-bar" do
+      expect(page).to have_content("Conferences")
+      expect(page).to have_content(translated(participatory_space.title))
+      expect(page).to have_content(t("conference_program.index.title", scope: "decidim"))
+    end
+  end
 end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -204,7 +204,7 @@ module Decidim
 
       def conference_context?
         return false unless Decidim.module_installed?(:conferences)
-        return false unless current_participatory_space.present?
+        return false if current_participatory_space.blank?
 
         current_participatory_space.is_a?(Decidim::Conference)
       end

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -202,14 +202,44 @@ module Decidim
         nil
       end
 
+      def conference_context?
+        return false unless Decidim.module_installed?(:conferences)
+        return false unless current_participatory_space.present?
+
+        current_participatory_space.is_a?(Decidim::Conference)
+      end
+
+      # Override the add_current_component method when in conference context
+      # to avoid showing "Meetings" breadcrumb and show "Program" instead
+      def add_current_component
+        return {} if conference_context?
+
+        super
+      end
+
       def add_breadcrumb_item
         return {} if meeting.blank?
 
-        {
+        breadcrumb = {
           label: translated_attribute(meeting.title),
           url: Decidim::EngineRouter.main_proxy(current_component).meeting_path(meeting, locale: current_locale),
           active: false
         }
+
+        # If this meeting is being accessed from within a conference program context,
+        # add program breadcrumb to maintain proper navigation hierarchy
+        if conference_context?
+          program_path = decidim_conferences.conference_conference_program_path(current_participatory_space, current_component, locale: I18n.locale)
+
+          context_breadcrumb_items << {
+            label: t("conference_program.index.title", scope: "decidim"),
+            url: program_path,
+            active: false,
+            resource: current_component
+          }
+        end
+
+        breadcrumb
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When going to the Program/Meetings inside of a Conference, you have a couple of bugs related to the breadcrumb:

- on the index/list page, you don't have any breadcrumb with the page title
- if you go to a meeting inside of the conference (by clicking an element in the Program page), then you can't go back to the Program. And if you click in Meetings in the breadcrumb, then you see all the Program, but not with the list design that you'd expect

This PR fixes these both issues

#### :pushpin: Related Issues
 
- Fixes #10146 (it isn't exactly the same, but it is equivalent after the last changes in navigation/breadcrumb)

#### Testing

1. Go to a conference
2. Click in the Meetings button
3. See the breadcrumb (missing "Program" without the patch; with "Program" after the patch)
4. Click in a program item
5. See the breadcrumb (missing "Program" without the patch; with "Program" after the patch)

### :camera: Screenshots

#### Before

<img width="2534" height="1244" alt="image" src="https://github.com/user-attachments/assets/261b42d7-830c-44fe-b61c-1376d55cf9c8" />
<img width="2264" height="1290" alt="image" src="https://github.com/user-attachments/assets/3f91d5a3-f15d-4790-9c82-a2830847c52e" />

#### After

<img width="2386" height="1412" alt="image" src="https://github.com/user-attachments/assets/0e308e89-37b4-4c4c-a4c7-23223d992b49" />
<img width="2390" height="1558" alt="image" src="https://github.com/user-attachments/assets/784d71cb-ba84-469c-97c8-8c72e420bf8d" />

:hearts: Thank you!
