### PR TITLE
Remove unecessary inclusions of admin assets on initiatives frontend

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_share_committee_link.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_share_committee_link.html.erb
@@ -19,5 +19,3 @@
     </div>
   </div>
 </div>
-
-<%= append_javascript_pack_tag "decidim_initiatives_admin" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
@@ -51,5 +51,3 @@
     </div>
   <% end %>
 </div>
-
-<%= append_javascript_pack_tag "decidim_initiatives_admin" %>


### PR DESCRIPTION
#### :tophat: What? Why?

There are some inclusions of the admin JS assets in the initiatives frontend page. This PR removes them (as far as I see, they're no longer necessary). 

#### :pushpin: Related Issues
 
- Fixes #10802

#### Testing

Everything should be green / CI should pass 

:hearts: Thank you!
