### PR TITLE
Fix promoting committee members page in Initiatives' admin

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -13,7 +13,7 @@
 
     <div class="row column">
       <div data-committee_link>
-        <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>
+        <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>
         <%= icon_link_to "clipboard-line", "#", t(".invite_to_committee_help"), class: "card--list__data__icon invite-users-link" %>
       </div>
     </div>

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_committee_members_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_committee_members_spec.rb
@@ -16,7 +16,7 @@ describe "User manages the initiatives committee members page" do
     let(:initiative_type) { create(:initiatives_type, :promoting_committee_disabled, organization:) }
 
     it "does not have the committee members section" do
-      expect(page).not_to have_content("Committee members")
+      expect(page).to have_no_content("Committee members")
     end
   end
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_committee_members_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_committee_members_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "User manages the initiatives committee members page" do
+  include_context "when admins initiative"
+
+  before do
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+    visit decidim_admin_initiatives.initiatives_path
+    click_on translated(initiative.title)
+  end
+
+  context "when the initiative does not have promoting committee" do
+    let(:initiative_type) { create(:initiatives_type, :promoting_committee_disabled, organization:) }
+
+    it "does not have the committee members section" do
+      expect(page).not_to have_content("Committee members")
+    end
+  end
+
+  context "when the initiative has promoting committee" do
+    let(:initiative_type) { create(:initiatives_type, :promoting_committee_enabled, organization:) }
+
+    before do
+      click_on "Committee members"
+    end
+
+    it "has the committee members section" do
+      expect(page).to have_content("Committee members")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out initiatives, I found out that we've boken a page with #14432.

This PR fixes that page and also adds a spec that would've detected the error.

#### Testing

1. sign in as admin
2. go to initiatives in the admin panel
3. click on one initiative title
4. click in the "Committe members" entry in the sidebar (URL like  http://localhost:3000/admin/initiatives/i-1/committee_requests
) 
5. see error 

### :camera: Screenshots
<img width="1255" height="668" alt="image" src="https://github.com/user-attachments/assets/e2e5831b-1ebd-4f96-9fb9-93fa8311c8c8" />

### Stacktrace

``` 
Randomized with seed 31812

User manages the initiatives committee members page
  when the initiative does not have promoting committee
    does not have the committee members section
  when the initiative has promoting committee
2025-12-22 16:41:24 +0100 SEVERE: http://2.lvh.me:5000/admin/initiatives/i-204/committee_requests - Failed to load resource: the server responded with a status of 500 (Internal Server Error)
    has the committee members section (FAILED - 1)

Failures:

  1) User manages the initiatives committee members page when the initiative has promoting committee has the committee members section
     Failure/Error: <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>

     ActionView::Template::Error:
       No route matches {action: "new", controller: "decidim/initiatives/committee_requests", initiative_slug: "i-204", locale: #<Decidim::Initiative id: 204, title: {"en" => "<script>alert(\"initiative_title\");</script> Corrupti sunt qui. 73", "es" => "<script>alert(\"initiative_title\");</script> Perspiciatis sunt et. 74", "machine_translations" => {"ca" => "<script>alert(\"initiative_title\");</script> Commodi reprehenderit laudantium. 75"}}, description: {"en" => "<p><script>alert(\"initiative_description\");</script> Beatae quos aliquid. 76</p>", "es" => "<p><script>alert(\"initiative_description\");</script> Consequatur magnam et. 77</p>", "machine_translations" => {"ca" => "<p><script>alert(\"initiative_description\");</script> Voluptatem aut qui. 78</p>"}}, decidim_organization_id: 124, decidim_author_id: 900, published_at: "2025-12-22 15:41:23.174803000 +0000", state: "open", signature_type: "online", signature_start_date: "2025-12-21", signature_end_date: "2026-04-21", answer: nil, answered_at: nil, answer_url: nil, created_at: "2025-12-22 15:41:23.182620000 +0000", updated_at: "2025-12-22 15:41:23.182620000 +0000", decidim_user_group_id: nil, scoped_type_id: 226, first_progress_notification_at: nil, second_progress_notification_at: nil, decidim_author_type: "Decidim::UserBaseEntity", reference: "LLD-INIT-2025-12-204", online_votes: {}, offline_votes: {}, decidim_area_id: nil, comments_count: 0, follows_count: 0, deleted_at: nil>}, possible unmatched constraints: [:locale]

     [Screenshot Image]: file:///home/apereira/Work/decidim-org/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_user_manages_the_initiatives_committee_members_page_when_the_initiative_has_promoting_committee_has_the_committee_members_section_821.png

     [Screenshot HTML]: file:///home/apereira/Work/decidim-org/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_user_manages_the_initiatives_committee_members_page_when_the_initiative_has_promoting_committee_has_the_committee_members_section_821.html

```

:hearts: Thank you!
