### PR TITLE
Fix HashSyntax rubocop offence in `project_import_proposals_form.rb`

### DIFF
--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_import_proposals_form.rb
@@ -38,7 +38,7 @@ module Decidim
           scope = scope.where(component: Decidim::Component.find(component_id)) if component_id.present?
 
           states = scope.pluck(:token).uniq.map do |token|
-            OpenStruct.new(token: token, title: token.humanize)
+            OpenStruct.new(token:, title: token.humanize)
           end
 
           states + [OpenStruct.new(token: "not_answered", title: I18n.t("decidim.proposals.answers.not_answered"))]


### PR DESCRIPTION
#### :tophat: What? Why?
This is a fix for the link error in the develop pipeline, introduced by https://github.com/decidim/decidim/pull/15630

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15630

#### Testing
Green pipeline

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
