### PR TITLE
The height of the search bar and languages is not the same (desktop)

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -69,7 +69,7 @@ header {
       @apply hidden md:block col-span-2 col-start-5 xl:col-start-4;
 
       form {
-        @apply block relative rounded text-md border border-neutral-200 outline outline-1 outline-transparent rounded bg-background-2 leading-relaxed;
+        @apply block relative rounded text-md border border-neutral-200 outline outline-1 outline-transparent rounded bg-background-2 leading-none;
       }
 
       input[type="text"] {


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am fixing the the height of the search bar. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15299

#### Testing
1. Switch your branch to develop 
2. Visit the frontend interface 
3. Observe the header bar, the search & the language chooser 
4. Apply patch 
5. Repeat 1,2,3 
6. The height of the search bar should be the same 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
#### Before 
<img width="701" height="94" alt="image" src="https://github.com/user-attachments/assets/c84c74ca-f187-4abc-a6c6-8180334d14d1" />

#### After 
<img width="701" height="94" alt="image" src="https://github.com/user-attachments/assets/44d3ad23-f6fe-4fbf-9df7-9563e10321b7" />


:hearts: Thank you!
