### PR TITLE
Fix error when there are too many aliases in GraphQL API

### DIFF
--- a/decidim-api/config/locales/en.yml
+++ b/decidim-api/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
         invalid_locale: Invalid locale provided
         locale_argument_error: There was an error while internally handling i18n data
         not_found: "%{type} not found"
+        too_many_aliases_error: Too many aliases used. You have used %{size} aliases, but %{limit} are allowed.
         permission_not_set: Permission has not been set for this %{type}
         unauthorized_field: You cannot view or edit %{field} field on %{type} because you do not have permission
         unauthorized_mutation: You do not have permission to perform this mutation

--- a/decidim-api/config/locales/en.yml
+++ b/decidim-api/config/locales/en.yml
@@ -6,8 +6,8 @@ en:
         invalid_locale: Invalid locale provided
         locale_argument_error: There was an error while internally handling i18n data
         not_found: "%{type} not found"
-        too_many_aliases_error: Too many aliases used. You have used %{size} aliases, but %{limit} are allowed.
         permission_not_set: Permission has not been set for this %{type}
+        too_many_aliases_error: Too many aliases used. You have used %{size} aliases, but %{limit} are allowed.
         unauthorized_field: You cannot view or edit %{field} field on %{type} because you do not have permission
         unauthorized_mutation: You do not have permission to perform this mutation
         unauthorized_object: You cannot view or edit this %{type} because you do not have permissions

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -23,6 +23,7 @@ module Decidim
       Decidim::Env.new("API_SCHEMA_MAX_COMPLEXITY", 5000).to_i
     end
 
+    # Public. Defines how many aliases are permitted in a query
     config_accessor :max_aliases do
       Decidim::Env.new("API_SCHEMA_MAX_ALIASES", 5).to_i
     end

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -23,6 +23,10 @@ module Decidim
       Decidim::Env.new("API_SCHEMA_MAX_COMPLEXITY", 5000).to_i
     end
 
+    config_accessor :max_aliases do
+      Decidim::Env.new("API_SCHEMA_MAX_ALIASES", 5).to_i
+    end
+
     # defines the schema max_depth to configure GraphQL query max_depth
     config_accessor :schema_max_depth do
       Decidim::Env.new("API_SCHEMA_MAX_DEPTH", 15).to_i

--- a/decidim-api/lib/decidim/api.rb
+++ b/decidim-api/lib/decidim/api.rb
@@ -23,7 +23,7 @@ module Decidim
       Decidim::Env.new("API_SCHEMA_MAX_COMPLEXITY", 5000).to_i
     end
 
-    # Public. Defines how many aliases are permitted in a query
+    # defines how many aliases are permitted in a query
     config_accessor :max_aliases do
       Decidim::Env.new("API_SCHEMA_MAX_ALIASES", 5).to_i
     end

--- a/decidim-api/lib/decidim/api/alias_analyzer.rb
+++ b/decidim-api/lib/decidim/api/alias_analyzer.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Api
+    class AliasAnalyzer < GraphQL::Analysis::AST::Analyzer
+      def initialize(query)
+        super
+
+        @aliases = {}
+      end
+
+      def on_enter_field(node, _parent, _visitor)
+        if node.alias.present?
+          alias_name = node.alias
+          @aliases[alias_name] ||= 1
+        end
+      end
+
+      def result
+        GraphQL::AnalysisError.new("Too many aliases used: #{@aliases.keys.join(",")}") if @aliases.size > Decidim::Api.max_aliases
+      end
+    end
+  end
+end

--- a/decidim-api/lib/decidim/api/alias_analyzer.rb
+++ b/decidim-api/lib/decidim/api/alias_analyzer.rb
@@ -10,14 +10,13 @@ module Decidim
       end
 
       def on_enter_field(node, _parent, _visitor)
-        if node.alias.present?
-          alias_name = node.alias
-          @aliases[alias_name] ||= 1
-        end
+        @aliases[node.alias] ||= 1 if node.alias.present?
       end
 
       def result
-        GraphQL::AnalysisError.new("Too many aliases used: #{@aliases.keys.join(",")}") if @aliases.size > Decidim::Api.max_aliases
+        if @aliases.size > Decidim::Api.max_aliases
+          Errors::TooManyAliasesError.new(I18n.t("decidim.api.errors.too_many_aliases_error", size: @aliases.size, limit: Decidim::Api.max_aliases))
+        end
       end
     end
   end

--- a/decidim-api/lib/decidim/api/alias_analyzer.rb
+++ b/decidim-api/lib/decidim/api/alias_analyzer.rb
@@ -6,11 +6,11 @@ module Decidim
       def initialize(query)
         super
 
-        @aliases = {}
+        @aliases = Set.new
       end
 
       def on_enter_field(node, _parent, _visitor)
-        @aliases[node.alias] ||= 1 if node.alias.present?
+        @aliases.add(node.alias) if node.alias.present?
       end
 
       def result

--- a/decidim-api/lib/decidim/api/errors/too_many_aliases_error.rb
+++ b/decidim-api/lib/decidim/api/errors/too_many_aliases_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Api
+    module Errors
+      # i18n-tasks-use t("decidim.api.errors.too_many_aliases_error")
+
+      class TooManyAliasesError < GraphQL::AnalysisError
+        def to_h
+          super.merge({ "extensions" => { "code" => "TOO_MANY_ALIASES_ERROR" } })
+        end
+      end
+    end
+  end
+end

--- a/decidim-api/lib/decidim/api/schema.rb
+++ b/decidim-api/lib/decidim/api/schema.rb
@@ -11,6 +11,8 @@ module Decidim
       max_depth Decidim::Api.schema_max_depth
       max_complexity Decidim::Api.schema_max_complexity
 
+      query_analyzer AliasAnalyzer
+
       orphan_types(Api.orphan_types)
 
       def self.unauthorized_object(error)

--- a/decidim-api/lib/decidim/api/test/type_context.rb
+++ b/decidim-api/lib/decidim/api/test/type_context.rb
@@ -43,6 +43,7 @@ shared_context "with a graphql class type" do
       UNAUTHORIZED_OBJECT_ERROR
       MUTATION_NOT_AUTHORIZED_ERROR
       VALIDATION_ERROR
+      TOO_MANY_ALIASES_ERROR
     ).include?(code)
 
     raise GraphQL::ExecutionError, error["message"]

--- a/decidim-api/lib/decidim/api/types.rb
+++ b/decidim-api/lib/decidim/api/types.rb
@@ -12,6 +12,7 @@ module Decidim
 
     module Errors
       autoload :LocaleError, "decidim/api/errors/locale_error"
+      autoload :TooManyAliasesError, "decidim/api/errors/too_many_aliases_error"
       autoload :InvalidLocaleError, "decidim/api/errors/invalid_locale_error"
       autoload :AttributeValidationError, "decidim/api/errors/attribute_validation_error"
       autoload :MutationNotAuthorizedError, "decidim/api/errors/mutation_not_authorized_error"

--- a/decidim-api/lib/decidim/api/types.rb
+++ b/decidim-api/lib/decidim/api/types.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   module Api
+    autoload :AliasAnalyzer, "decidim/api/alias_analyzer"
     autoload :QueryType, "decidim/api/query_type"
     autoload :MutationType, "decidim/api/mutation_type"
     autoload :Schema, "decidim/api/schema"

--- a/decidim-api/spec/lib/decidim/api/schema_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/schema_spec.rb
@@ -29,7 +29,7 @@ module Decidim
           around do |example|
             aliases = Decidim::Api.max_aliases
 
-            # 5 is the default value, we have a number alias in the above query definition, and we just set a higher number
+            # 5 is the default value, we have 6 aliases in the above query definition, and we just set a higher number
             Decidim::Api.max_aliases = 10
             example.run
 

--- a/decidim-api/spec/lib/decidim/api/schema_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/schema_spec.rb
@@ -12,12 +12,12 @@ module Decidim
       context "when restricting number of aliases" do
         let!(:query) do
           %({
-          invalias0 : __typename
-          invalias1 : __typename
-          invalias2 : __typename
-          invalias3 : __typename
-          invalias4 : __typename
-          invalias5 : __typename
+          invalidAlias0 : __typename
+          invalidAlias1 : __typename
+          invalidAlias2 : __typename
+          invalidAlias3 : __typename
+          invalidAlias4 : __typename
+          invalidAlias5 : __typename
         })
         end
 
@@ -37,7 +37,7 @@ module Decidim
           end
 
           it "runs successfully" do
-            expect(response).to include("invalias0" => "Query")
+            expect(response).to include("invalidAlias0" => "Query")
           end
         end
       end
@@ -45,16 +45,16 @@ module Decidim
       context "when allowing number of aliases" do
         let!(:query) do
           %({
-          invalias0 : __typename
-          invalias1 : __typename
-          invalias2 : __typename
-          invalias3 : __typename
-          invalias4 : __typename
+          invalidAlias0 : __typename
+          invalidAlias1 : __typename
+          invalidAlias2 : __typename
+          invalidAlias3 : __typename
+          invalidAlias4 : __typename
         })
         end
 
         it "runs successfully" do
-          expect(response).to include("invalias0" => "Query")
+          expect(response).to include("invalidAlias0" => "Query")
         end
       end
     end

--- a/decidim-api/spec/lib/decidim/api/schema_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/schema_spec.rb
@@ -22,7 +22,7 @@ module Decidim
         end
 
         it "raises an error" do
-          expect { response }.to raise_error(GraphQL::ExecutionError)
+          expect { response }.to raise_error(Errors::TooManyAliasesError, "Too many aliases used. You have used 6 aliases, but 5 are allowed.")
         end
 
         context "when using a custom value" do

--- a/decidim-api/spec/lib/decidim/api/schema_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/schema_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test"
+
+module Decidim
+  module Api
+    describe Schema do
+      include_context "with a graphql class type"
+      let(:type_class) { Decidim::Api::QueryType }
+
+      context "when restricting number of aliases" do
+        let!(:query) do
+          %({
+          invalias0 : __typename
+          invalias1 : __typename
+          invalias2 : __typename
+          invalias3 : __typename
+          invalias4 : __typename
+          invalias5 : __typename
+        })
+        end
+
+        it "raises an error" do
+          expect { response }.to raise_error(GraphQL::ExecutionError)
+        end
+
+        context "when using a custom value" do
+          around do |example|
+            aliases = Decidim::Api.max_aliases
+
+            # 5 is the default value, we have a number alias in the above query definition, and we just set a higher number
+            Decidim::Api.max_aliases = 10
+            example.run
+
+            Decidim::Api.max_aliases = aliases
+          end
+
+          it "runs successfully" do
+            expect(response).to include("invalias0" => "Query")
+          end
+        end
+      end
+
+      context "when allowing number of aliases" do
+        let!(:query) do
+          %({
+          invalias0 : __typename
+          invalias1 : __typename
+          invalias2 : __typename
+          invalias3 : __typename
+          invalias4 : __typename
+        })
+        end
+
+        it "runs successfully" do
+          expect(response).to include("invalias0" => "Query")
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/config/rubocop/graphql/configuration.yml
+++ b/decidim-dev/config/rubocop/graphql/configuration.yml
@@ -18,6 +18,7 @@ GraphQL/ObjectDescription:
     - "**/lib/decidim/api/graphql_permissions.rb"
     - "**/lib/decidim/api/functions/*"
     - "**/lib/decidim/api/errors/*"
+    - "decidim-api/lib/decidim/api/alias_analyzer.rb"
     - "spec/**/*"
     - "test/**/*"
 

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -781,6 +781,11 @@ Read more about this at xref:services:pdf.adoc[PDF signing] service page.
 | false
 | No
 
+| API_SCHEMA_MAX_ALIASES
+| This Environment variable instructs Decidim how many aliases should allow for the types being used in a query
+| 5
+| No
+
 |PROPOSALS_PARTICIPATORY_SPACE_HIGHLIGHTED_PROPOSALS_LIMIT
 |Number of proposals to be shown in blocks with highlighted content across different participatory spaces.
 |4

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -782,7 +782,7 @@ Read more about this at xref:services:pdf.adoc[PDF signing] service page.
 | No
 
 | API_SCHEMA_MAX_ALIASES
-| This Environment variable instructs Decidim how many aliases should be allowed for the types being used in a query
+| This Environment variable instructs Decidim how many aliases should be allowed in a GraphQL query
 | 5
 | No
 

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -782,7 +782,7 @@ Read more about this at xref:services:pdf.adoc[PDF signing] service page.
 | No
 
 | API_SCHEMA_MAX_ALIASES
-| This Environment variable instructs Decidim how many aliases should allow for the types being used in a query
+| This Environment variable instructs Decidim how many aliases should be allowed for the types being used in a query
 | 5
 | No
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am adding a Decidim setting to enable how many aliases we allow in a query.

```
query {
  invalidAlias0: __typename 
  invalidAlias1: __typename 
  invalidAlias2: __typename 
  invalidAlias3: __typename 
  invalidAlias4: __typename 
  invalidAlias5: __typename
}
```
#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #13254

#### Testing
1. Visit the admin api 
2. Insert in the query, the above example 
3. Apply patch 
4. Repeat step 2, See there is an error. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
