### PR TITLE
Rename createMeetings to createMeeting in GraphQL API mutation

### DIFF
--- a/decidim-meetings/spec/lib/decidim/api/mutations/create_meeting_type_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/api/mutations/create_meeting_type_spec.rb
@@ -51,7 +51,7 @@ module Decidim
       let(:root_value) { current_component }
       let(:query) do
         <<~GRAPHQL
-          mutation createMeetings($input: CreateMeetingInput!){
+          mutation createMeeting($input: CreateMeetingInput!){
             createMeeting(input: $input) {
               id
               title { translation(locale: "#{translation_locale}") }

--- a/docs/modules/develop/pages/api/reference/components/meetings/create.adoc
+++ b/docs/modules/develop/pages/api/reference/components/meetings/create.adoc
@@ -38,7 +38,7 @@ The `CreateMeeting` mutation allows authenticated users to create new meetings i
 
 [source,graphql]
 ----
-mutation createMeetings($componentId: ID!, $input: CreateMeetingInput!){
+mutation createMeeting($componentId: ID!, $input: CreateMeetingInput!){
   component(id: $componentId) {
     ...on MeetingsMutation{
       createMeeting(input: $input) {

--- a/docs/modules/develop/pages/api/reference/components/meetings/create.adoc
+++ b/docs/modules/develop/pages/api/reference/components/meetings/create.adoc
@@ -46,7 +46,7 @@ mutation createMeeting($componentId: ID!, $input: CreateMeetingInput!){
         title {
           translation(locale: "en")
         }
-        description {          
+        description {
           translation(locale: "en")
         }
         address
@@ -62,7 +62,7 @@ mutation createMeeting($componentId: ID!, $input: CreateMeetingInput!){
         }
       }
     }
-  } 
+  }
 }
 ----
 


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #15790, I noticed that we were referring to createProposal (singular) as the mutation name, but in #15796 we were referring to createMeeting**s** (plural). 

I prefer using the singular. This PR fixes this little detail.

#### :pushpin: Related Issues
 
- Related to #15790 and #15796
 

#### Testing

Everything should work the same, green is beautiful  

:hearts: Thank you!
