### PR TITLE
Fix errors in account page when login is disabled

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/account_form/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/account_form/controller.js
@@ -12,8 +12,10 @@ export default class extends Controller {
     this.newPwVisible = false;
     this.observer = null;
 
-    this.setupMutationObserver();
-    this.setupEmailChangeListener();
+    if (this.newPasswordPanel) {
+      this.setupMutationObserver();
+      this.setupEmailChangeListener();
+    }
   }
 
   toggleNewPassword() {

--- a/decidim-core/app/packs/src/decidim/controllers/account_form/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/account_form/controller.js
@@ -12,10 +12,8 @@ export default class extends Controller {
     this.newPwVisible = false;
     this.observer = null;
 
-    if (this.newPasswordPanel) {
-      this.setupMutationObserver();
-      this.setupEmailChangeListener();
-    }
+    this.setupMutationObserver();
+    this.setupEmailChangeListener();
   }
 
   toggleNewPassword() {
@@ -44,6 +42,10 @@ export default class extends Controller {
   }
 
   setupMutationObserver() {
+    if (!this.newPasswordPanel) {
+      return;
+    }
+
     this.observer = new MutationObserver(() => {
       let ariaHiddenValue = this.newPasswordPanel.getAttribute("aria-hidden");
       this.newPwVisible = ariaHiddenValue === "false";
@@ -56,6 +58,10 @@ export default class extends Controller {
   }
 
   setupEmailChangeListener() {
+    if (!this.emailField) {
+      return;
+    }
+
     this.emailField.addEventListener("change", () => {
       this.emailChanged = this.emailField.value !== this.originalEmail;
       this.toggleOldPassword();

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -31,6 +31,16 @@ describe "Account" do
 
     it_behaves_like "accessible page"
 
+    context "when login is not enabled" do
+      let(:organization) { create(:organization, users_registration_mode: "disabled") }
+      let(:user) { create(:user, :confirmed, password:) }
+
+      it "does not have js errors" do
+        sleep 1
+        expect_no_js_errors
+      end
+    end
+
     describe "update avatar" do
       it "can update avatar" do
         dynamically_attach_file(:user_avatar, Decidim::Dev.asset("avatar.jpg"), remove_before: true)


### PR DESCRIPTION
#### :tophat: What? Why?
While upgrading the application i manage to 0.31, i noticed that when the login is disabled, there is a JavaScript error . This PR fixes it. 

```
       http://1.lvh.me:5000/packs-test/js/decidim_core.js 1:41250 "%s\n\n%o\n\n%o" "Error connecting controller" TypeError: Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'Node'.
           at ce.setupMutationObserver (http://1.lvh.me:5000/packs-test/js/decidim_core.js:6:56358)
           at ce.connect (http://1.lvh.me:5000/packs-test/js/decidim_core.js:6:55684)
           at ln.connect (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:28574)
           at mn.connectContextForScope (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:31482)
           at gt.scopeConnected (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:38845)
           at Bn.elementMatchedValue (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:36995)
           at ut.tokenMatched (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:18522)
           at ke.tokenMatched (http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:17168)
           at http://1.lvh.me:5000/packs-test/js/decidim_core.js:2:17065
           at Array.forEach (<anonymous>) Object
```
#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15064

#### Testing
1. Login to the system panel 
2. Edit the organization and enable Developer Oauth 
3. Set the registration to "Access only can be done with external accounts" 
4. Click save 
5. Login in Frontend
6. Enable the Browser Console 
7. Visit your account page - http://localhost:3000/account
8. See there is a JS error 
9. Apply patch 
10. Repeat 5,6,7 
11. See there is no JS error.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
