### PR TITLE
Admin moderation unable to undo reported users

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/unreport_user.rb
+++ b/decidim-admin/app/commands/decidim/admin/unreport_user.rb
@@ -19,7 +19,7 @@ module Decidim
       #
       # Returns nothing.
       def call
-        return broadcast(:invalid) unless @reportable.reported?
+        return broadcast(:invalid) unless @reportable.reported? || @reportable.user_moderation
 
         unreport!
         broadcast(:ok, @reportable)

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -128,7 +128,7 @@ describe "Admin manages global moderations" do
         click_on "Undo the report"
       end
 
-      expect(page).to have_admin_callout("successfully unreported")
+      expect(page).to have_admin_callout("Resource successfully unreported.")
     end
   end
 

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -115,6 +115,23 @@ describe "Admin manages global moderations" do
     end
   end
 
+  context "when unreporting reported participant" do
+    let!(:reported_user) { create(:user, :confirmed, organization:) }
+    let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
+    let!(:report) { create(:user_report, moderation:, user:, reason: "spam") }
+
+    it "unreports a reported participant" do
+      visit decidim_admin.moderated_users_path
+
+      within "tr[data-id=\"#{moderation.id}\"]" do
+        find("button[data-controller='dropdown']").click
+        click_on "Undo the report"
+      end
+
+      expect(page).to have_admin_callout("successfully unreported")
+    end
+  end
+
   context "when performing bulk actions" do
     let!(:reportables) { create_list(:dummy_resource, 4, component: current_component) }
     let!(:moderations) do

--- a/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_global_moderations_spec.rb
@@ -115,7 +115,7 @@ describe "Admin manages global moderations" do
     end
   end
 
-  context "when unreporting reported participant" do
+  context "when un-reporting reported participant" do
     let!(:reported_user) { create(:user, :confirmed, organization:) }
     let!(:moderation) { create(:user_moderation, user: reported_user, report_count: 1) }
     let!(:report) { create(:user_report, moderation:, user:, reason: "spam") }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     participatory_scope { generate_localized_title(:participatory_process_participatory_scope, skip_injection:) }
     participatory_structure { generate_localized_title(:participatory_process_participatory_structure, skip_injection:) }
     announcement { generate_localized_title(:participatory_process_announcement, skip_injection:) }
-    # has_members { false }
+    has_members { false }
     private_space { false }
     start_date { Date.current }
     end_date { 2.months.from_now }

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
     participatory_scope { generate_localized_title(:participatory_process_participatory_scope, skip_injection:) }
     participatory_structure { generate_localized_title(:participatory_process_participatory_structure, skip_injection:) }
     announcement { generate_localized_title(:participatory_process_announcement, skip_injection:) }
-    has_members { false }
+    # has_members { false }
     private_space { false }
     start_date { Date.current }
     end_date { 2.months.from_now }


### PR DESCRIPTION
#### :tophat: What? Why?
This is a Fix for the bug descibed.

#### :pushpin: Related Issues
#15838 

#### Testing
1. Go to admin panel.
2. Go to 'participants' on the right hand side bar.
3. Select 'participants' in secondary side bar.
4. Block a user and give justification.
5. See 'blocked' users and unblock user.
6. You should be in 'Reported participants', select 'undo the report' action.
7. See fix!  ('Resource successfully unreported.').

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue preventing administrators from successfully undoing user reports in certain moderation scenarios. The undo report functionality now works correctly across all user moderation cases in the global moderation admin interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->