### PR TITLE
Make results searcheable

### DIFF
--- a/decidim-accountability/app/models/decidim/accountability/result.rb
+++ b/decidim-accountability/app/models/decidim/accountability/result.rb
@@ -39,13 +39,15 @@ module Decidim
 
       after_save :update_parent_progress, if: -> { parent_id.present? }
 
-      searchable_fields(
-        scope_id: :decidim_scope_id,
-        participatory_space: { component: :participatory_space },
-        A: :title,
-        D: :description,
-        datetime: :start_date
-      )
+      searchable_fields({
+                          scope_id: :decidim_scope_id,
+                          participatory_space: { component: :participatory_space },
+                          A: :title,
+                          D: :description,
+                          datetime: :start_date
+                        },
+                        index_on_create: ->(result) { result.visible? },
+                        index_on_update: ->(result) { result.visible? })
 
       geocoded_by :address
 

--- a/decidim-accountability/db/data/20260113140600_reindex_results.rb
+++ b/decidim-accountability/db/data/20260113140600_reindex_results.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ReindexResults < ActiveRecord::Migration[7.2]
+  def up
+    Decidim::Component.where(manifest_name: :accountability).find_each do |component|
+      component.manifest.run_hooks(:publish, component)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -16,14 +16,14 @@ Decidim.register_component(:accountability) do |component|
   end
 
   component.on(:publish) do |instance|
-    Decidim::Accountability::Result.where(component: instance).find_each do |result|
-      Decidim::UpdateSearchIndexesJob.perform_later([result])
+    Decidim::Accountability::Result.where(decidim_component_id: instance).find_in_batches(batch_size: 10) do |batch|
+      Decidim::UpdateSearchIndexesJob.perform_later(batch)
     end
   end
 
   component.on(:unpublish) do |instance|
-    Decidim::Accountability::Result.where(component: instance).find_each do |result|
-      Decidim::RemoveSearchIndexesJob.perform_later([result])
+    Decidim::Accountability::Result.where(decidim_component_id: instance).find_in_batches(batch_size: 10) do |batch|
+      Decidim::RemoveSearchIndexesJob.perform_later(batch)
     end
   end
 

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -15,6 +15,18 @@ Decidim.register_component(:accountability) do |component|
     raise StandardError, "Cannot remove this component" if Decidim::Accountability::Result.where(component: instance).any?
   end
 
+  component.on(:publish) do |instance|
+    Decidim::Accountability::Result.where(component: instance).find_each do |result|
+      Decidim::UpdateSearchIndexesJob.perform_later([result])
+    end
+  end
+
+  component.on(:unpublish) do |instance|
+    Decidim::Accountability::Result.where(component: instance).find_each do |result|
+      Decidim::RemoveSearchIndexesJob.perform_later([result])
+    end
+  end
+
   # These actions permissions can be configured in the admin panel
   component.actions = %w(comment vote_comment)
 
@@ -22,7 +34,7 @@ Decidim.register_component(:accountability) do |component|
     resource.model_class_name = "Decidim::Accountability::Result"
     resource.template = "decidim/accountability/results/linked_results"
     resource.card = "decidim/accountability/result"
-    resource.searchable = false
+    resource.searchable = true
     resource.actions = %w(comment vote_comment)
   end
 

--- a/decidim-accountability/lib/decidim/accountability/component.rb
+++ b/decidim-accountability/lib/decidim/accountability/component.rb
@@ -16,13 +16,13 @@ Decidim.register_component(:accountability) do |component|
   end
 
   component.on(:publish) do |instance|
-    Decidim::Accountability::Result.where(decidim_component_id: instance).find_in_batches(batch_size: 10) do |batch|
+    Decidim::Accountability::Result.where(component: instance).find_in_batches(batch_size: 10) do |batch|
       Decidim::UpdateSearchIndexesJob.perform_later(batch)
     end
   end
 
   component.on(:unpublish) do |instance|
-    Decidim::Accountability::Result.where(decidim_component_id: instance).find_in_batches(batch_size: 10) do |batch|
+    Decidim::Accountability::Result.where(component: instance).find_in_batches(batch_size: 10) do |batch|
       Decidim::RemoveSearchIndexesJob.perform_later(batch)
     end
   end

--- a/decidim-accountability/spec/db/data/reindex_results_spec.rb
+++ b/decidim-accountability/spec/db/data/reindex_results_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./db/data/20260113140600_reindex_results"
+
+describe ReindexResults do
+  let(:migrator) do
+    described_class.new.tap do |m|
+      m.verbose = false
+    end
+  end
+
+  describe "#up" do
+    context "when the component is published" do
+      let(:component) { create(:accountability_component, published_at: Time.zone.now) }
+
+      context "and there are results" do
+        let!(:results) { create_list(:result, 2, component:) }
+
+        it "those are added to index" do
+          Decidim::SearchableResource.delete_all
+
+          expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+          perform_enqueued_jobs { migrator.migrate(:up) }
+          expect(Decidim::SearchableResource.where(resource: results)).not_to be_empty
+          # 3 languages multiplied by 2 results
+          expect(Decidim::SearchableResource.where(resource: results).count).to eq(6)
+        end
+      end
+
+      context "and there are deleted results" do
+        let!(:results) { create_list(:result, 2, component:) }
+
+        it "those are added to index" do
+          results.map(&:destroy)
+          Decidim::SearchableResource.delete_all
+
+          expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+          perform_enqueued_jobs { migrator.migrate(:up) }
+          expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+        end
+      end
+
+      context "and there are no results" do
+        let!(:results) { [] }
+
+        it "does not reindex the results" do
+          Decidim::SearchableResource.delete_all
+
+          expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+          perform_enqueued_jobs { migrator.migrate(:up) }
+          expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+        end
+      end
+    end
+
+    context "when the component is not published" do
+      let(:component) { create(:accountability_component, published_at: nil) }
+      let!(:results) { create_list(:result, 2, component:) }
+
+      it "does not reindex the results" do
+        Decidim::SearchableResource.delete_all
+
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+        perform_enqueued_jobs { migrator.migrate(:up) }
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+      end
+    end
+
+    context "when the component is deleted" do
+      let(:component) { create(:accountability_component, published_at: Time.zone.now, deleted_at: Time.zone.now) }
+      let!(:results) { create_list(:result, 2, component:) }
+
+      it "does not reindex the results" do
+        Decidim::SearchableResource.delete_all
+
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+        perform_enqueued_jobs { migrator.migrate(:up) }
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+      end
+    end
+  end
+end

--- a/decidim-accountability/spec/lib/decidim/accountability/component_spec.rb
+++ b/decidim-accountability/spec/lib/decidim/accountability/component_spec.rb
@@ -21,4 +21,40 @@ describe "Accountability component" do # rubocop:disable RSpec/DescribeClass
       it_behaves_like "has mandatory config setting", :comments_max_length
     end
   end
+
+  describe "hooks" do
+    let!(:results) { create_list(:result, 5, component:) }
+
+    describe "publish" do
+      let(:component) { create(:accountability_component, published_at: nil) }
+
+      it "adds the results to search index" do
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+        component.publish!
+
+        perform_enqueued_jobs do
+          component.manifest.run_hooks(:publish, component)
+        end
+
+        expect(Decidim::SearchableResource.where(resource: results)).to be_present
+        # 3 languages multiplied by 5 results
+        expect(Decidim::SearchableResource.where(resource: results).count).to eq(15)
+      end
+    end
+
+    describe "unpublish" do
+      it "removes the results from search index" do
+        # 3 languages multiplied by 5 results
+        expect(Decidim::SearchableResource.where(resource: results).count).to eq(15)
+        expect(Decidim::SearchableResource.where(resource: results)).to be_present
+        component.unpublish!
+
+        perform_enqueued_jobs do
+          component.manifest.run_hooks(:publish, component)
+        end
+
+        expect(Decidim::SearchableResource.where(resource: results)).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
While working on #15834 i have noticed that the Accountability component registers the `result` resource, which states that the result should not be searchable. Browsing the Result model, i have seen it includes `Decidim::Searchable`  concern which created a contradiction. 
Asking the @decidim/product about the behavior, they confirmed that results should be filterable. This PR does just that. 

#### Testing
1. As an user visit the search page. 
2. See there is no `Result` option in the left menu 
3. See that you cannot search for any results 
4. Apply the patch 
5. Restart your server. Wait for queues to run 
6. Refresh the Search page
7. See that you have Results entries and you can filter / search through it

### :camera: Screenshots

#### Nightly without feature 
<img width="369" height="892" alt="image" src="https://github.com/user-attachments/assets/82be6687-bb43-468d-8a19-81c8e0c33aab" />

#### Dev - having the feature 
<img width="348" height="904" alt="image" src="https://github.com/user-attachments/assets/76f254f4-9c19-4d3b-b41b-e6104709e896" />

:hearts: Thank you!
