### PR TITLE
Fix sk trad key

### DIFF
--- a/decidim-meetings/config/locales/sk.yml
+++ b/decidim-meetings/config/locales/sk.yml
@@ -310,7 +310,7 @@ sk:
     participatory_spaces:
       highlighted_meetings:
         past_meetings: Minulé schôdze
-        see_all: Zobraziť všetky (%{count})
+        see_all: Zobraziť všetky stretnutia
         upcoming_meetings: Nadchádzajúce schôdzky
     resource_links:
       meetings_through_proposals:


### PR DESCRIPTION
#### :tophat: What? Why?
Fix inconsistent translation in Slovak locale (`sk.yml`) for the highlighted meetings "see_all" key.  
The previous translation included an unused interpolation `(%{count})`, which caused the placeholder to appear in the front-end.  
This PR aligns the Slovak version with the French and English translations.

#### :pushpin: Related Issues
- Related to [#315  ](https://github.com/OpenSourcePolitics/intern-tasks/issues/315)
- Fixes https://github.com/decidim/decidim/issues/15884

#### Testing
1. Enable the `sk` locale in Decidim.  
2. Visit a participatory process with highlighted meetings (`/processes/:slug?locale=sk`).  
3. Verify that the button text now displays `Zobraziť všetky schôdze` instead of `Zobraziť všetky (%{count})`.

### :camera: Screenshots
_Before:_ `Zobraziť všetky (%{count})`  
_After:_ `Zobraziť všetky schôdze`

<img width="1456" height="709" alt="Capture d’écran 2026-01-13 à 14 41 40" src="https://github.com/user-attachments/assets/c5358615-4e04-4d75-9ce0-670bd5b7ff47" />

:hearts: Thank you!
