### PR TITLE
Fix proposal to proposal component import

### DIFF
--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
@@ -13,7 +13,7 @@ module Decidim
         attribute :import_proposals, Boolean
         attribute :keep_answers, Boolean
         attribute :keep_authors, Boolean
-        attribute :states, Array
+        attribute :states, Array[String]
 
         validates :origin_component_id, :origin_component, :states, :current_component, presence: true
         validates :import_proposals, allow_nil: false, acceptance: true
@@ -42,6 +42,17 @@ module Decidim
           origin_components.map do |component|
             [component.name[I18n.locale.to_s], component.id]
           end
+        end
+
+        def available_states(component_id = nil)
+          scope = Decidim::Proposals::ProposalState
+          scope = scope.where(component: Decidim::Component.find(component_id)) if component_id.present?
+
+          states = scope.pluck(:token).uniq.map do |token|
+            OpenStruct.new(token:, title: token.humanize)
+          end
+
+          states + [OpenStruct.new(token: "not_answered", title: I18n.t("decidim.proposals.answers.not_answered"))]
         end
 
         private

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
@@ -10,13 +10,11 @@ module Decidim
         mimic :proposals_import
 
         attribute :origin_component_id, Integer
-        attribute :import_proposals, Boolean
         attribute :keep_answers, Boolean
         attribute :keep_authors, Boolean
         attribute :states, Array[String]
 
         validates :origin_component_id, :origin_component, :states, :current_component, presence: true
-        validates :import_proposals, allow_nil: false, acceptance: true
         validate :valid_states
 
         def states_collection

--- a/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
+++ b/decidim-proposals/app/forms/decidim/proposals/admin/proposals_import_form.rb
@@ -57,7 +57,7 @@ module Decidim
 
         def valid_states
           return if states.all? do |state|
-            states_collection.pluck(:token).include?(state)
+            available_states(origin_component_id).pluck(:token).include?(state)
           end
 
           errors.add(:states, :invalid)

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -29,9 +29,6 @@
               <div class="row column">
                 <%= f.check_box :keep_answers %>
               </div>
-              <div class="row column">
-                <%= f.check_box :import_proposals %>
-              </div>
             </div>
           </div>
         </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -21,7 +21,7 @@
                   <label class="ml-4"><%= t(".proposal_states") %></label>
                   <span class="help-text ml-4"><%= t(".proposal_states_help") %></span>
                   <div class="row column">
-                    <%= f.collection_check_boxes :internal_states, @form.available_states, :token, ->(a) { translated_attribute(a.title) } do |builder| %>
+                    <%= f.collection_check_boxes :states, @form.available_states, :token, ->(a) { translated_attribute(a.title) } do |builder| %>
                     <div>
                       <%= builder.label { builder.check_box + builder.text } %>
                     </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -18,8 +18,6 @@
               <div class="row column">
                 <%= f.label t(".select_states") %>
                 <% if @form.available_states.any? %>
-                  <label class="ml-4"><%= t(".proposal_states") %></label>
-                  <span class="help-text ml-4"><%= t(".proposal_states_help") %></span>
                   <div class="row column">
                     <%= f.collection_check_boxes :states, @form.available_states, :token, ->(a) { translated_attribute(a.title) } do |builder| %>
                     <div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -16,7 +16,7 @@
                 <%= f.select :origin_component_id, @form.origin_components_collection, prompt: t(".select_component") %>
               </div>
               <div class="row column">
-                <%= f.label t(".select_states") %>
+                <label class="ml-4"><%= t(".select_states") %></label>
                 <% if @form.available_states.any? %>
                   <div class="row column">
                     <%= f.collection_check_boxes :states, @form.available_states, :token, ->(a) { translated_attribute(a.title) } do |builder| %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_imports/new.html.erb
@@ -17,9 +17,15 @@
               </div>
               <div class="row column">
                 <%= f.label t(".select_states") %>
-                <%= f.collection_check_boxes :states, @form.states_collection, :token, :title do |b| %>
-                  <div>
-                    <%= b.label { b.check_box + translated_attribute(b.text) } %>
+                <% if @form.available_states.any? %>
+                  <label class="ml-4"><%= t(".proposal_states") %></label>
+                  <span class="help-text ml-4"><%= t(".proposal_states_help") %></span>
+                  <div class="row column">
+                    <%= f.collection_check_boxes :internal_states, @form.available_states, :token, ->(a) { translated_attribute(a.title) } do |builder| %>
+                    <div>
+                      <%= builder.label { builder.check_box + builder.text } %>
+                    </div>
+                    <% end %>
                   </div>
                 <% end %>
               </div>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
         file: File
       proposals_import:
         import_proposals: Import proposals
-        keep_answers: Keep state and answers
+        keep_answers: Keep statuses and answers
         keep_authors: Keep original authors
     errors:
       models:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -692,6 +692,8 @@ en:
             select_component: Please select a component
             select_states: Check the status of the proposals to import
             title: Import proposals from another component
+            proposal_states: Proposal States
+            proposal_states_help: Select one or more proposal states to import into projects. By selecting none, you will import all published proposals that have not already been imported in other budgets from this component.
         proposals_merges:
           create:
             invalid: 'There was a problem merging the selected proposals because some of them:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -690,10 +690,8 @@ en:
             create: Import proposals
             no_components: There are no other proposal components in this participatory space to import the proposals from.
             select_component: Please select a component
-            select_states: Import only proposals with these statuses. If none are selected, all proposals will be imported
+            select_states: Import only proposals with these statuses, if none are selected, all proposals will be imported.
             title: Import proposals from another component
-            proposal_states: Proposal States
-            proposal_states_help: Select one or more proposal states to import into projects. By selecting none, you will import all published proposals that have not already been imported in other budgets from this component.
         proposals_merges:
           create:
             invalid: 'There was a problem merging the selected proposals because some of them:'

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -690,7 +690,7 @@ en:
             create: Import proposals
             no_components: There are no other proposal components in this participatory space to import the proposals from.
             select_component: Please select a component
-            select_states: Import only proposals with these statuses, if none are selected, all proposals will be imported.
+            select_states: Import only proposals with these statuses. If none are selected, all proposals will be imported.
             title: Import proposals from another component
         proposals_merges:
           create:

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -690,7 +690,7 @@ en:
             create: Import proposals
             no_components: There are no other proposal components in this participatory space to import the proposals from.
             select_component: Please select a component
-            select_states: Check the status of the proposals to import
+            select_states: Import only proposals with these statuses. If none are selected, all proposals will be imported
             title: Import proposals from another component
             proposal_states: Proposal States
             proposal_states_help: Select one or more proposal states to import into projects. By selecting none, you will import all published proposals that have not already been imported in other budgets from this component.

--- a/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_import_form_spec.rb
+++ b/decidim-proposals/spec/forms/decidim/proposals/admin/proposals_import_form_spec.rb
@@ -12,13 +12,11 @@ module Decidim
         let(:component) { proposal.component }
         let(:origin_component) { create(:proposal_component, participatory_space: component.participatory_space) }
         let(:states) { %w(accepted) }
-        let(:import_proposals) { true }
         let(:params) do
           {
             states:,
             keep_authors: false,
-            origin_component_id: origin_component.try(:id),
-            import_proposals:
+            origin_component_id: origin_component.try(:id)
           }
         end
 
@@ -51,10 +49,10 @@ module Decidim
           it { is_expected.to be_invalid }
         end
 
-        context "when the import proposals is not accepted" do
-          let(:import_proposals) { false }
+        context "when importing from multiple states" do
+          let(:states) { %w(accepted rejected) }
 
-          it { is_expected.to be_invalid }
+          it { is_expected.to be_valid }
         end
 
         describe "states" do

--- a/decidim-proposals/spec/shared/import_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/import_proposals_examples.rb
@@ -75,7 +75,6 @@ shared_examples "import proposals" do
       select origin_component.name["en"], from: "Origin component"
       check "Accepted"
       check "Keep original authors" if keep_authors
-      check "Import proposals"
     end
 
     click_on "Import proposals"


### PR DESCRIPTION
#### :tophat: What? Why?
The proposals import to proposal component task doesn't work as it should, including the allowing the user to import proposals via custom states. This PR brings changes to the proposal to proposals component import including:

- Updated states selection information
- Updated checkbox for importing "Keep statuses and answers"
- Custom states from original proposal component
- Removed "import proposals" checkbox.  

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/14325

#### Testing
1. Login
2. Head to a space and create two proposal components.
3. Make sure you have seeded proposals on one component (proposals 2) with one custom state, if not create them ;)
4. Head to the 2nd proposal component
5. Click import 
6. See the custom import state reflected on the import page
7. See the labels updated on the information states and check box for "Keep statuses and answers".
8. Select a no. of states and import freely
9. Check against the current proposals with states in proposal 1 

### :camera: Screenshots
<img width="1771" height="957" alt="image" src="https://github.com/user-attachments/assets/57ff3aa4-c65c-48a0-a42a-25cae5ce8ff4" />

New proposals with custom test status (original proposal component)
<img width="2281" height="599" alt="image" src="https://github.com/user-attachments/assets/bc58b962-38f0-49f1-bb46-a80182cfd5cc" />

New proposals imported into new proposal component (Proposals 2)
<img width="2335" height="694" alt="image" src="https://github.com/user-attachments/assets/df1e6ed0-d04f-4633-91f0-07b8f87e5505" />



:hearts: Thank you!
