### PR TITLE
Fix quality indicator content block

### DIFF
--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
@@ -21,7 +21,7 @@ module Decidim
         end
 
         def info_url
-          decidim.page_path("democratic-quality-indicators")
+          decidim.page_path("democratic-quality-indicators", locale: I18n.locale)
         end
       end
     end

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ParticipatoryProcesses::ContentBlocks::DemocraticQualityStatsCell, type: :cell do
+  subject { cell(described_class, content_block, context: { resource: }) }
+
+  let(:organization) { create(:organization) }
+  let(:resource) { create(:participatory_process, organization:) }
+  let(:content_block) { create(:content_block, organization:, manifest_name: :democratic_quality_stats, scope_name: :participatory_process_homepage, scoped_resource_id: resource.id) }
+
+  controller Decidim::ParticipatoryProcesses::ParticipatoryProcessesController
+
+  before do
+    allow(controller).to receive(:current_organization).and_return(organization)
+  end
+
+  describe "#info_url" do
+    it "generates the correct page path with locale" do
+      I18n.with_locale(:en) do
+        expect(subject.send(:info_url)).to eq("/en/pages/democratic-quality-indicators")
+      end
+    end
+
+    it "uses the current locale" do
+      I18n.with_locale(:es) do
+        expect(subject.send(:info_url)).to eq("/es/pages/democratic-quality-indicators")
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell_spec.rb
@@ -8,6 +8,7 @@ describe Decidim::ParticipatoryProcesses::ContentBlocks::DemocraticQualityStatsC
   let(:organization) { create(:organization) }
   let(:resource) { create(:participatory_process, organization:) }
   let(:content_block) { create(:content_block, organization:, manifest_name: :democratic_quality_stats, scope_name: :participatory_process_homepage, scoped_resource_id: resource.id) }
+  let(:html) { subject.call }
 
   controller Decidim::ParticipatoryProcesses::ParticipatoryProcessesController
 
@@ -26,6 +27,35 @@ describe Decidim::ParticipatoryProcesses::ContentBlocks::DemocraticQualityStatsC
       I18n.with_locale(:es) do
         expect(subject.send(:info_url)).to eq("/es/pages/democratic-quality-indicators")
       end
+    end
+  end
+
+  it "renders the democratic quality stats section" do
+    expect(html).to have_css("section#democratic_quality_stats")
+  end
+
+  it "renders the quality indicator section title" do
+    expect(html).to have_css("h2.home__section-title")
+  end
+
+  it "renders the global score indicator section" do
+    expect(html).to have_content("Global score")
+  end
+
+  it "renders the automatic metrics section title" do
+    expect(html).to have_content("Automatic metrics")
+  end
+
+  it "renders the automatic metrics indicators section" do
+    expect(html).to have_content("Citizen influence")
+    expect(html).to have_content("Hybridization")
+    expect(html).to have_content("Responsiveness")
+    expect(html).to have_content("Traceability")
+  end
+
+  it "includes a link to democratic quality indicators page" do
+    I18n.with_locale(:en) do
+      expect(html).to have_link(href: "/en/pages/democratic-quality-indicators")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The cell creating the Quality indicators content block was missing the locale defining the content block `democratic-quality-indicators`. 

I suspect this was missing from: https://github.com/decidim/decidim/pull/15157

#### :pushpin: Related Issues
- Fixes #15894

#### Testing
1. Sign in as admin
2. Go to a process in the admin dashboard
3. Click in Landing page layout
4. Add a Quality Indicator content block 
5. Enable it
6. Go to the show (public) page
7. See the page loaded with the block wherever you placed it.

### :camera: Screenshots
Click see process
<img width="1646" height="570" alt="image" src="https://github.com/user-attachments/assets/7c88f4b7-d6e1-4433-a392-4a95a590cb95" />

See content block loaded:
<img width="2008" height="1240" alt="image" src="https://github.com/user-attachments/assets/ff69b8a4-f0e7-4800-839d-c726b9c68a5f" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed locale-specific URL generation for democratic quality statistics to properly respect the current language setting.

* **Tests**
  * Added comprehensive test coverage for democratic quality statistics functionality, verifying locale-aware behavior and proper display of metrics and indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->