### PR TITLE
Fix validation error in user name regular expression

### DIFF
--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -20,7 +20,7 @@ module Decidim
     has_one :blocking, class_name: "Decidim::UserBlock", foreign_key: :id, primary_key: :block_id, dependent: :destroy
 
     # Regex for name & nickname format validations
-    REGEXP_NAME = /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|])/
+    REGEXP_NAME = /\A(?!.*[<>?%&\^*#@()\[\]=+:;"{}\\|\n\r])/m
     REGEXP_NICKNAME = /\A[a-z0-9_-]+\z/
 
     has_one_attached :avatar

--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -53,5 +53,33 @@ module Decidim
         end
       end
     end
+
+    describe "#validates :nickname" do
+      context "when nickname is john_doe" do
+        let(:user) { build(:user, organization:, nickname: "john_doe") }
+
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+
+      context "when nickname contains newlines" do
+        let(:user) { build(:user, organization:, nickname: "john\n<script>alert('nickname')</script>") }
+
+        it "is invalid" do
+          expect(user).not_to be_valid
+          expect(user.errors[:nickname]).to be_present
+        end
+      end
+
+      context "when nickname contains carriage return" do
+        let(:user) { build(:user, organization:, nickname: "john\r<script>alert('nickname')</script>") }
+
+        it "is invalid" do
+          expect(user).not_to be_valid
+          expect(user.errors[:nickname]).to be_present
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -9,19 +9,48 @@ module Decidim
     let(:organization) { create(:organization) }
     let(:user) { build(:user, organization:) }
 
-    let(:user_followed) { create(:user, organization: user.organization) }
-    let(:public_resource) { create(:dummy_resource, :published) }
-    let(:user_blocked) { create(:user, organization: user.organization, blocked: true) }
-
-    before do
-      create(:follow, user:, followable: user_followed)
-      create(:follow, user:, followable: public_resource)
-      create(:follow, user:, followable: user_blocked)
-    end
-
     describe "public followings" do
+      let(:user_followed) { create(:user, organization: user.organization) }
+      let(:public_resource) { create(:dummy_resource, :published) }
+      let(:user_blocked) { create(:user, organization: user.organization, blocked: true) }
+
+      before do
+        user.save!
+        create(:follow, user:, followable: user_followed)
+        create(:follow, user:, followable: public_resource)
+        create(:follow, user:, followable: user_blocked)
+      end
+
       it "return all the things followed unless the blocked users" do
         expect(subject.public_followings).to contain_exactly(public_resource, user_followed)
+      end
+    end
+
+    describe "#validates :name" do
+      context "when name is John Doe" do
+        let(:user) { build(:user, organization:, name: "John Doe") }
+
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+
+      context "when name contains newlines" do
+        let(:user) { build(:user, organization:, name: "John\n<script>alert('name')</script>") }
+
+        it "is invalid" do
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to be_present
+        end
+      end
+
+      context "when name contains carriage return" do
+        let(:user) { build(:user, organization:, name: "John\r<script>alert('name')</script>") }
+
+        it "is invalid" do
+          expect(user).not_to be_valid
+          expect(user.errors[:name]).to be_present
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes a validation error that we found in the user name field.
 
#### Testing

Everything should work well, and the user name should be validated better 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent invalid characters, including newlines and carriage returns, from being entered in user names and nicknames.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->