### PR TITLE
Fix survey matrix responses export in forms

### DIFF
--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -29,7 +29,7 @@ module Decidim
           return "-" if response.choices.empty?
 
           choices = response.choices.map do |choice|
-            matrix_row_body = (translated_attribute(choice.matrix_row.body) if choice.matrix_row&.body)
+            matrix_row_body = (translated_attribute(choice.matrix_row.body) if response.question.matrix? && choice.matrix_row&.body)
 
             {
               response_option_body: choice.try(:response_option).try(:translated_body),

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -28,16 +28,32 @@ module Decidim
           return attachments if response.attachments.any?
           return "-" if response.choices.empty?
 
-          choices = response.choices.map do |choice|
-            matrix_row_body = (translated_attribute(choice.matrix_row.body) if response.question.matrix? && choice.matrix_row&.body)
+          choices = build_choices
 
+          render_choices_list(choices)
+        end
+
+        private
+
+        def build_choices
+          response.choices.map do |choice|
+            matrix_row_body = matrix_row_body_for(choice)
             {
               response_option_body: choice.try(:response_option).try(:translated_body),
               choice_body: body_or_custom_body(choice),
               matrix_row_body:
             }
           end
+        end
 
+        def matrix_row_body_for(choice)
+          return unless response.question.matrix?
+          return unless choice.matrix_row&.body
+
+          translated_attribute(choice.matrix_row.body)
+        end
+
+        def render_choices_list(choices)
           content_tag(:ul) do
             if response.question.question_type == "single_option"
               choice(choices.first)

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -29,9 +29,12 @@ module Decidim
           return "-" if response.choices.empty?
 
           choices = response.choices.map do |choice|
+            matrix_row_body = (translated_attribute(choice.matrix_row.body) if choice.matrix_row&.body)
+
             {
               response_option_body: choice.try(:response_option).try(:translated_body),
-              choice_body: body_or_custom_body(choice)
+              choice_body: body_or_custom_body(choice),
+              matrix_row_body:
             }
           end
 
@@ -69,9 +72,15 @@ module Decidim
         end
 
         def choice(choice_hash)
+          # rubocop:disable Style/StringConcatenation
           content_tag :li do
-            render_body_for choice_hash
+            if choice_hash[:matrix_row_body].present?
+              content_tag(:strong, choice_hash[:matrix_row_body]) + ": " + render_body_for(choice_hash)
+            else
+              render_body_for choice_hash
+            end
           end
+          # rubocop:enable Style/StringConcatenation
         end
 
         def render_body_for(choice_hash)

--- a/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
+++ b/decidim-forms/app/presenters/decidim/forms/admin/questionnaire_response_presenter.rb
@@ -88,15 +88,13 @@ module Decidim
         end
 
         def choice(choice_hash)
-          # rubocop:disable Style/StringConcatenation
           content_tag :li do
             if choice_hash[:matrix_row_body].present?
-              content_tag(:strong, choice_hash[:matrix_row_body]) + ": " + render_body_for(choice_hash)
+              content_tag(:strong, choice_hash[:matrix_row_body]) + ": " + render_body_for(choice_hash) # rubocop:disable Style/StringConcatenation
             else
               render_body_for choice_hash
             end
           end
-          # rubocop:enable Style/StringConcatenation
         end
 
         def render_body_for(choice_hash)

--- a/decidim-forms/lib/decidim/exporters/form_pdf.rb
+++ b/decidim-forms/lib/decidim/exporters/form_pdf.rb
@@ -12,7 +12,14 @@ module Decidim
 
       class QuestionnaireResponsePresenter < Decidim::Forms::Admin::QuestionnaireResponsePresenter
         def choice(choice_hash)
-          render_body_for choice_hash
+          if choice_hash[:matrix_row_body].present?
+            row_text = choice_hash[:matrix_row_body]
+            option_text = choice_hash[:response_option_body]
+            custom_text = choice_hash[:choice_body].present? ? " (#{choice_hash[:choice_body]})" : ""
+            "#{row_text}: #{option_text}#{custom_text}"
+          else
+            render_body_for choice_hash
+          end
         end
 
         delegate :attachments, to: :response
@@ -25,7 +32,8 @@ module Decidim
           choices = response.choices.map do |choice|
             {
               response_option_body: choice.try(:response_option).try(:translated_body),
-              choice_body: body_or_custom_body(choice)
+              choice_body: body_or_custom_body(choice),
+              matrix_row_body: choice.try(:matrix_row).try(:body) ? translated_attribute(choice.matrix_row.body) : nil
             }
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
When using the matrix options within surveys, questions within the row were not exportable, not allowing reviewers to see what question a user responded too.

This fix also allows us to fix the display of the responses presenter within the responses tab in surveys. 

#### :pushpin: Related Issues
- Fixes #15872 

#### Testing
1. As an admin create a survey with matrix (multiple_options) choices.
2. Add 2 statements and 2 response options.
3. Head to settings and "allow responses".
4. Save.
5. Click "see survey"
6. Now answer the survey clicking any choices you created within the multiple choice matrix
7. Once responded, click Edit 
8. Head to the responses tab.
9. Click the 3 dots at the end of the table and press export
10. Find the export you just exported using letter_opener
11. Download the export
12. See the matrix properly exporting the questions along with responses

### :camera: Screenshots
Matrix questions:
<img width="1265" height="315" alt="image" src="https://github.com/user-attachments/assets/3476f432-2894-420b-8ce9-7b060189797c" />

PDF Export:
<img width="1444" height="720" alt="image" src="https://github.com/user-attachments/assets/9fc41217-55d0-4f1e-8386-23e83e7834ea" />

Presenter update:
<img width="1399" height="700" alt="image" src="https://github.com/user-attachments/assets/f102281e-8e73-408c-9ead-29fb135b3b49" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Matrix-type questionnaire responses now display matrix row labels before choice text (rendered in bold with a colon) and include any choice body suffixes consistently in both preview and PDF export formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->