### PR TITLE
Fix accountability pipeline

### DIFF
--- a/decidim-accountability/spec/db/data/reindex_results_spec.rb
+++ b/decidim-accountability/spec/db/data/reindex_results_spec.rb
@@ -23,9 +23,12 @@ describe ReindexResults do
 
         it "those are added to index" do
           Decidim::SearchableResource.delete_all
+          clear_enqueued_jobs
 
           expect(Decidim::SearchableResource.where(resource: results)).to be_empty
-          perform_enqueued_jobs(only: Decidim::UpdateSearchIndexesJob) { migrator.migrate(:up) }
+          expect { migrator.migrate(:up) }.to have_enqueued_job(Decidim::UpdateSearchIndexesJob).at_least(1).times
+
+          perform_enqueued_jobs(only: Decidim::UpdateSearchIndexesJob)
           expect(Decidim::SearchableResource.where(resource: results)).not_to be_empty
           # 3 languages multiplied by 2 results
           expect(Decidim::SearchableResource.where(resource: results).count).to eq(6)


### PR DESCRIPTION
#### :tophat: What? Why?
Back in https://github.com/decidim/decidim/pull/15881, we have made the results searcheable. even though the pipeline was green at that moment, it broke after merge. This PR fixes it.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15896
- Related to #15881

#### Testing
Green pipeline after several runs

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test verification approach for job enqueueing in result indexing to improve test reliability and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->