### PR TITLE
Make the numbers in seeds non-harcoded and respect SLOW_SEEDS

### DIFF
--- a/decidim-accountability/lib/decidim/accountability/seeds.rb
+++ b/decidim-accountability/lib/decidim/accountability/seeds.rb
@@ -43,7 +43,7 @@ module Decidim
       end
 
       def create_statuses!(component:)
-        5.times do |i|
+        config_value(:accountability_statuses_count).times do |i|
           Decidim::Accountability::Status.create!(
             component:,
             name: Decidim::Faker::Localized.word,
@@ -61,7 +61,7 @@ module Decidim
         parent_taxonomy = root_taxonomy.children.sample || create_taxonomy!(name: ::Faker::Lorem.sentence(word_count: 5), parent: root_taxonomy)
         taxonomies = [parent_taxonomy]
 
-        2.times do
+        config_value(:accountability_taxonomies_count).times do
           taxonomies << if parent_taxonomy.children.count > 1
                           parent_taxonomy.children.sample
                         else

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -20,16 +20,16 @@ module Decidim
 
           @organization = resource.organization
 
-          rand(0..6).times do
+          rand(0..config_value(:comments_count)).times do
             comment1 = create_comment(resource)
             NewCommentNotificationCreator.new(comment1, []).create
 
-            if [true, false].sample
+            if rand < config_value(:comments_nested_probability)
               comment2 = create_comment(comment1, resource)
               NewCommentNotificationCreator.new(comment2, []).create
             end
 
-            next if [true, false].sample
+            next if rand < config_value(:comments_vote_skip_probability)
 
             create_votes(comment1) if comment1
             create_votes(comment2) if comment2
@@ -39,6 +39,14 @@ module Decidim
         private
 
         attr_reader :organization
+
+        def config_value(key)
+          slow_seeds? ? Decidim::Seeds::SEEDS_CONFIG[key][:slow] : Decidim::Seeds::SEEDS_CONFIG[key][:fast]
+        end
+
+        def slow_seeds?
+          Decidim::Env.new("SLOW_SEEDS").present?
+        end
 
         # Creates a comment for a given resource.
         #
@@ -74,7 +82,7 @@ module Decidim
         #
         # @return nil
         def create_votes(comment)
-          rand(0..12).times do
+          rand(0..config_value(:comments_votes_count)).times do
             author = random_user
             next if CommentVote.where(comment:, author:).any?
 

--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "decidim/seeds"
+
 module Decidim
   module Comments
     # A comment can belong to many Commentable models. This class is responsible

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -7,6 +7,19 @@ require "decidim/faker/localized"
 module Decidim
   # Base class to be inherited from the different modules' seeds classes
   class Seeds
+    SEEDS_CONFIG = {
+      comments_count: { slow: 6, fast: 2 },
+      comments_nested_probability: { slow: 0.5, fast: 0.2 },
+      comments_vote_skip_probability: { slow: 0.5, fast: 0.7 },
+      comments_votes_count: { slow: 12, fast: 3 },
+      surveys_responses_count: { slow: 200, fast: 20 },
+      surveys_response_options_count: { slow: 3, fast: 2 },
+      surveys_matrix_rows_count: { slow: 3, fast: 2 },
+      initiatives_votes_count: { slow: 50, fast: 10 },
+      accountability_statuses_count: { slow: 5, fast: 3 },
+      accountability_taxonomies_count: { slow: 2, fast: 1 }
+    }.freeze
+
     protected
 
     def slow_seeds?
@@ -15,6 +28,10 @@ module Decidim
 
     def number_of_records
       slow_seeds? ? rand(3..5) : 1
+    end
+
+    def config_value(key)
+      slow_seeds? ? SEEDS_CONFIG[key][:slow] : SEEDS_CONFIG[key][:fast]
     end
 
     def organization

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -93,7 +93,7 @@ module Decidim
 
       def create_initiative_votes!(initiative:)
         users = []
-        rand(50).times do
+        rand(0..config_value(:initiatives_votes_count)).times do
           author = (Decidim::User.all - users).sample
           initiative.votes.create!(author:, scope: initiative.scope, hash_id: SecureRandom.hex)
           users << author

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -17,7 +17,7 @@ module Decidim
 
         Decidim::Proposals.create_default_states!(component, admin_user)
 
-        number_of_records = slow_seeds? ? 10 : rand(25..50)
+        number_of_records = slow_seeds? ? rand(25..50) : rand(5..10)
 
         (5..number_of_records).to_a.sample.times do |n|
           proposal = create_proposal!(component:)

--- a/decidim-surveys/lib/decidim/surveys/seeds.rb
+++ b/decidim-surveys/lib/decidim/surveys/seeds.rb
@@ -20,7 +20,7 @@ module Decidim
 
           next if questionnaire.questionnaire_for.allow_responses
 
-          rand(200).times { create_responses!(questionnaire:) }
+          rand(0..config_value(:surveys_responses_count)).times { create_responses!(questionnaire:) }
         end
       end
 
@@ -90,7 +90,7 @@ module Decidim
             position: index + 2
           )
 
-          3.times do
+          config_value(:surveys_response_options_count).times do
             question.response_options.create!(body: Decidim::Faker::Localized.sentence)
           end
 
@@ -114,7 +114,7 @@ module Decidim
             position: index
           )
 
-          3.times do |position|
+          config_value(:surveys_matrix_rows_count).times do |position|
             question.response_options.create!(body: Decidim::Faker::Localized.sentence)
             question.matrix_rows.create!(body: Decidim::Faker::Localized.sentence, position:)
           end


### PR DESCRIPTION
#### :tophat: What? Why?

This PR changes some hardcoded values that we still had in the Seed classes, so it is dynamic and respects the SLOW_SEEDS environment variable. The aim is to improve the build time in the fast seeds. 

#### :pushpin: Related Issues

- Related to #15916 (as I can't check out the Codespaces feature as it is too slow)

#### Testing

Recreate a new seeded DB:

```bash
$ time bin/rails db:drop db:setup
```

###### Before 

```
real    23m33.522s
user    20m26.508s
sys     0m36.619s
```

###### After

```
real    3m48.181s
user    3m11.498s
sys     0m8.391s
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced database seeding: many seed counts (statuses, taxonomies, comments, votes, initiatives, proposals, survey responses/options/matrix rows) are now configurable and adapt to fast/slow seed modes.
  * Introduced a fast/slow seed mode toggle to control seed volume and nested behavior, improving flexibility for test/demo setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->