### PR TITLE
Private assembly components restricted to users

### DIFF
--- a/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
+++ b/decidim-assemblies/app/permissions/decidim/assemblies/permissions.rb
@@ -110,8 +110,9 @@ module Decidim
 
         return disallow! unless can_view_private_space?
         return allow! if user&.admin?
-        return allow! if assembly.published?
+        return allow! if !assembly.private_space? && assembly.published?
         return allow! if user_can_preview_space?
+        return allow! if assembly.users.include?(user)
 
         toggle_allow(can_manage_assembly?)
       end


### PR DESCRIPTION
#### :tophat: What? Why?
The permission logic to "private" and "transparent" assemblies allowed users to see components within the space. This fix allows only members to see components of a space made private, even if its transparent.

#### :pushpin: Related Issues
- Fixes #15933

#### Testing
1. Create a private assembly
2. Make it private and transparent, (settings are in edit in the same form as the creation)

### :camera: Screenshots

:hearts: Thank you!
