### PR TITLE
Add locale code next to the locales name when creating an organization

### DIFF
--- a/decidim-system/app/views/decidim/system/organizations/new.html.erb
+++ b/decidim-system/app/views/decidim/system/organizations/new.html.erb
@@ -33,7 +33,7 @@
         <tbody>
           <% localized_locales.each do |locale| %>
             <tr>
-              <td><%= locale.name %></td>
+              <td><%= locale.name %> (<%= locale.id %>)</td>
               <td><%= check_box_tag "organization[available_locales][#{locale.id}]", locale.id, @form.available_locales.include?(locale.id), class: "!m-0" %></td>
               <td><%= radio_button_tag "organization[default_locale]", locale.id, @form.default_locale == locale.id, class: "!m-0" %></td>
             </tr>

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 describe "Organizations" do
   let(:admin) { create(:admin) }
+  let(:available_locales) { %w(en ca es fr it) }
 
   shared_examples "form hiding advanced settings" do
     it "hides advanced settings" do
@@ -16,6 +17,10 @@ describe "Organizations" do
 
   context "when an admin authenticated" do
     before do
+      I18n.available_locales = available_locales
+      Decidim.available_locales = available_locales
+      I18n.backend.reload!
+
       login_as admin, scope: :admin
       visit decidim_system.root_path
     end
@@ -38,6 +43,13 @@ describe "Organizations" do
         end
         expect(find(:xpath, "//input[@name='organization[users_registration_mode]']", match: :first).value).to eq("enabled")
         expect(find(:xpath, "//input[@name='organization[users_registration_mode]']", match: :first)).to be_checked
+      end
+
+      it "shows the available locales" do
+        available_locales.each do |locale|
+          expect(page).to have_selector("input#organization_available_locales_#{locale}")
+          expect(page).to have_content("#{I18n.with_locale(locale) { I18n.t("name", scope: "locale") }} (#{locale})")
+        end
       end
 
       it "creates a new organization" do

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -42,7 +42,7 @@ describe "Organizations" do
 
       it "shows the available locales" do
         Decidim.available_locales.each do |locale|
-          expect(page).to have_selector("input#organization_available_locales_#{locale}")
+          expect(page).to have_xpath("//input[@id='organization_available_locales_#{locale}']")
           expect(page).to have_content("#{I18n.with_locale(locale) { I18n.t("name", scope: "locale") }} (#{locale})")
         end
       end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -4,7 +4,6 @@ require "spec_helper"
 
 describe "Organizations" do
   let(:admin) { create(:admin) }
-  let(:available_locales) { %w(en ca es fr it) }
 
   shared_examples "form hiding advanced settings" do
     it "hides advanced settings" do
@@ -17,10 +16,6 @@ describe "Organizations" do
 
   context "when an admin authenticated" do
     before do
-      I18n.available_locales = available_locales
-      Decidim.available_locales = available_locales
-      I18n.backend.reload!
-
       login_as admin, scope: :admin
       visit decidim_system.root_path
     end
@@ -46,7 +41,7 @@ describe "Organizations" do
       end
 
       it "shows the available locales" do
-        available_locales.each do |locale|
+        Decidim.available_locales.each do |locale|
           expect(page).to have_selector("input#organization_available_locales_#{locale}")
           expect(page).to have_content("#{I18n.with_locale(locale) { I18n.t("name", scope: "locale") }} (#{locale})")
         end


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

During the development of the [Decidim Installer](https://github.com/decidim/docker/pull/119), I've found myself multiple time in the system panel creating a new organization. 

Since this new system allows the use of every language inside Decidim, I've seen that we have multiple dialectal variations for different languages, and it's quite difficult to know which one we are choosing.

With this PR we add, after the name of the locale, the id of it. So a `Castellano` would change to `Castellano (es-PY)`.

Another way we could handle this is that the name of the locale in our locales would be changed to specify with variety it is. This seems to be the way for `Français canadien`, `Português brasileiro` and some others.

#### Testing
*Describe the best way to test or validate your PR.*

1. Go to the system panel
2. Go to create a new organization
3. See that the list of Organization locales now display the iso code of the language.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

Before
<img width="1445" height="622" alt="Before" src="https://github.com/user-attachments/assets/9e247302-cbfd-4caf-9d0f-9caeb2e70992" />

After
<img width="1445" height="622" alt="After" src="https://github.com/user-attachments/assets/8e64aa09-e3a4-4b91-95b0-c3c49c1a18d7" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Locales table now displays each locale ID in parentheses next to its display name for clearer identification when creating organizations.
* **Tests**
  * Added system tests verifying that all available locales are listed and that each locale's localized name (formatted as "<Name> (<locale>)") is rendered correctly during the organization creation flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->