### PR TITLE
Attachment not persisting on error.

### DIFF
--- a/decidim-admin/spec/system/admin_manages_attachments_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_attachments_spec.rb
@@ -8,27 +8,7 @@ module Decidim::Admin
     let!(:participatory_process) { create(:participatory_process, organization:) }
     let!(:admin) { create(:user, :admin, :confirmed, organization:) }
     let!(:attachment) { create(:attachment, attached_to: participatory_process) }
-    let(:form) do
-      instance_double(
-        AttachmentForm,
-        title: {
-          en: "",
-          ca: "",
-          es: ""
-        },
-        description: {
-          en: "",
-          ca: "",
-          es: ""
-        },
-        file:,
-        link: nil,
-        attachment_collection: nil,
-        current_user: user,
-        weight: 2
-      )
-    end
-
+    
     before do
       switch_to_host(organization.host)
       login_as admin, scope: :user

--- a/decidim-admin/spec/system/admin_manages_attachments_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_attachments_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Admin
+  describe "Admin manages attachments" do
+    let(:organization) { create(:organization) }
+    let!(:user) do
+      create(
+        :user,
+        :confirmed,
+        :admin,
+        organization:
+      )
+    end
+    let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:attachment) { create(:attachment, attached_to: participatory_process) }
+
+    let(:form) do
+      instance_double(
+        AttachmentForm,
+        title: {
+          en: "An image",
+          ca: "Una imatge",
+          es: "Una imagen"
+        },
+        description: {
+          en: "A city",
+          ca: "Una ciutat",
+          es: "Una ciudad"
+        },
+        file:,
+        link: nil,
+        attachment_collection: nil,
+        current_user: user,
+        weight: 2
+      )
+    end
+    let(:file) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")) }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+    end
+
+    context "when managing attachments" do
+      it "can update an attachment" do
+        within "#attachments" do
+          within "tr", text: translated(attachment.title) do
+            find("button[data-controller='dropdown']").click
+            click_on "Edit"
+          end
+        end
+
+        within ".edit_attachment" do
+          fill_in_i18n(
+            :attachment_title,
+            "#attachment-title-tabs",
+            en: "This is a nice photo",
+            es: "Una foto muy guay",
+            ca: "Aquesta foto és ben xula"
+          )
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        within "#attachments table" do
+          expect(page).to have_text("This is a nice photo")
+        end
+      end
+    end
+  end
+end

--- a/decidim-admin/spec/system/admin_manages_attachments_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_attachments_spec.rb
@@ -8,7 +8,7 @@ module Decidim::Admin
     let!(:participatory_process) { create(:participatory_process, organization:) }
     let!(:admin) { create(:user, :admin, :confirmed, organization:) }
     let!(:attachment) { create(:attachment, attached_to: participatory_process) }
-    
+
     before do
       switch_to_host(organization.host)
       login_as admin, scope: :user

--- a/decidim-admin/spec/system/admin_manages_attachments_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_attachments_spec.rb
@@ -5,29 +5,21 @@ require "spec_helper"
 module Decidim::Admin
   describe "Admin manages attachments" do
     let(:organization) { create(:organization) }
-    let!(:user) do
-      create(
-        :user,
-        :confirmed,
-        :admin,
-        organization:
-      )
-    end
     let!(:participatory_process) { create(:participatory_process, organization:) }
+    let!(:admin) { create(:user, :admin, :confirmed, organization:) }
     let!(:attachment) { create(:attachment, attached_to: participatory_process) }
-
     let(:form) do
       instance_double(
         AttachmentForm,
         title: {
-          en: "An image",
-          ca: "Una imatge",
-          es: "Una imagen"
+          en: "",
+          ca: "",
+          es: ""
         },
         description: {
-          en: "A city",
-          ca: "Una ciutat",
-          es: "Una ciudad"
+          en: "",
+          ca: "",
+          es: ""
         },
         file:,
         link: nil,
@@ -36,39 +28,48 @@ module Decidim::Admin
         weight: 2
       )
     end
-    let(:file) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg")) }
 
     before do
       switch_to_host(organization.host)
-      login_as user, scope: :user
+      login_as admin, scope: :user
+      visit decidim_admin_participatory_processes.edit_participatory_process_path(participatory_process)
     end
 
     context "when managing attachments" do
-      it "can update an attachment" do
-        within "#attachments" do
-          within "tr", text: translated(attachment.title) do
-            find("button[data-controller='dropdown']").click
-            click_on "Edit"
-          end
+      it "will persist picture when error is present" do
+        within_admin_sidebar_menu do
+          click_on "Attachments"
         end
 
-        within ".edit_attachment" do
+        within "#attachments" do
+          click_on "New attachment"
+        end
+
+        within ".new_attachment" do
           fill_in_i18n(
             :attachment_title,
             "#attachment-title-tabs",
-            en: "This is a nice photo",
-            es: "Una foto muy guay",
-            ca: "Aquesta foto és ben xula"
+            en: "",
+            es: "",
+            ca: ""
           )
+        end
 
+        within ".new_attachment" do
+          find_by_id("trigger-file").click
+        end
+
+        dynamically_attach_file(:attachment_file, Decidim::Dev.asset("city.jpeg"))
+
+        within ".new_attachment" do
           find("*[type=submit]").click
         end
 
-        expect(page).to have_admin_callout("successfully")
-
-        within "#attachments table" do
-          expect(page).to have_text("This is a nice photo")
+        within ".new_attachment" do
+          find("*[type=submit]").click
         end
+
+        expect(page).to have_css("img[src*='city.jpeg']")
       end
     end
   end

--- a/decidim-core/app/cells/decidim/attachments_file_tab/show.erb
+++ b/decidim-core/app/cells/decidim/attachments_file_tab/show.erb
@@ -1,3 +1,3 @@
 <div class="row column">
-  <%= form.upload :file, button_class: "button button__sm button__transparent-secondary" %>
+  <%= form.upload :file, attachments: form.object.file.present? ? [form.object.file] : [], button_class: "button button__sm button__transparent-secondary" %>
 </div>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -22,7 +22,7 @@
     <div class="upload-modal__files" data-active-uploads="<%= modal_id %>">
       <% attachments.each do |attachment| %>
         <% next if [Array, Hash].any? { |klass| attachment.is_a? klass } %>
-        <% is_persisted_attachment = attachment.is_a?(Decidim::Attachment) %>
+        <% is_persisted_attachment = attachment.is_a?(Decidim::Attachment) && attachment.persisted? %>
         <% attachment_blob = blob(attachment) %>
 
         <div class="attachment-details" <%= 'data-attachment-id="' + attachment.id.to_s + '"' if is_persisted_attachment %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
@@ -41,7 +41,9 @@
               <%= link_to title_for(attachment), file_attachment_path(attachment), class: "w-full break-all mb-2" %>
             <% end %>
           <% end %>
-          <%= form.hidden_field attribute, value: attachment_blob&.signed_id, id: "hidden_#{attribute}_#{attachment_blob&.id}" %>
+          <% if attachment_blob.present? %>
+            <%= form.hidden_field attribute, value: attachment_blob.signed_id, id: "hidden_#{attribute}_#{attachment_blob.id}" %>
+          <% end %>
         </div>
       <% end %>
     </div>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -26,7 +26,7 @@
         <% attachment_blob = blob(attachment) %>
 
         <div class="attachment-details" <%= 'data-attachment-id="' + attachment.id.to_s + '"' if is_persisted_attachment %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
-          <% if file_attachment_path(attachment) && attachment_blob.image? %>
+          <% if file_attachment_path(attachment) && attachment_blob&.image? %>
             <div><%= image_tag(file_attachment_path(attachment), alt: "") %></div>
           <% elsif uploader_default_image_path(attribute).present? %>
             <div><%= image_tag uploader_default_image_path(attribute) %></div>
@@ -35,7 +35,7 @@
           <% if has_title? %>
             <span><%= title_for(attachment) %></span>
           <% else %>
-            <% if attachment_blob.image? %>
+            <% if attachment_blob&.image? %>
               <span><%= title_for(attachment) %></span>
             <% else %>
               <%= link_to title_for(attachment), file_attachment_path(attachment), class: "w-full break-all mb-2" %>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -25,7 +25,7 @@
         <% is_persisted_attachment = attachment.is_a?(Decidim::Attachment) && attachment.persisted? %>
         <% attachment_blob = blob(attachment) %>
 
-        <div class="attachment-details" <% if is_persisted_attachment %>data-attachment-id="<%= attachment.id %>"<% end %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
+        <div class="attachment-details"<% if is_persisted_attachment %> data-attachment-id="<%= attachment.id %>"<% end %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
           <% if file_attachment_path(attachment) && attachment_blob&.image? %>
             <div><%= image_tag(file_attachment_path(attachment), alt: "") %></div>
           <% elsif uploader_default_image_path(attribute).present? %>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -22,9 +22,11 @@
     <div class="upload-modal__files" data-active-uploads="<%= modal_id %>">
       <% attachments.each do |attachment| %>
         <% next if [Array, Hash].any? { |klass| attachment.is_a? klass } %>
+        <% is_persisted_attachment = attachment.is_a?(Decidim::Attachment) %>
+        <% attachment_blob = blob(attachment) %>
 
-        <div class="attachment-details" data-attachment-id="<%= attachment.id %>" data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded">
-          <% if file_attachment_path(attachment) && blob(attachment).image? %>
+        <div class="attachment-details" <%= 'data-attachment-id="' + attachment.id.to_s + '"' if is_persisted_attachment %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
+          <% if file_attachment_path(attachment) && attachment_blob.image? %>
             <div><%= image_tag(file_attachment_path(attachment), alt: "") %></div>
           <% elsif uploader_default_image_path(attribute).present? %>
             <div><%= image_tag uploader_default_image_path(attribute) %></div>
@@ -32,14 +34,14 @@
 
           <% if has_title? %>
             <span><%= title_for(attachment) %></span>
-            <%= form.hidden_field attribute, multiple: true, value: attachment.id, id: attachment.id %>
           <% else %>
-            <% if blob(attachment).image? %>
+            <% if attachment_blob.image? %>
               <span><%= title_for(attachment) %></span>
             <% else %>
               <%= link_to title_for(attachment), file_attachment_path(attachment), class: "w-full break-all mb-2" %>
             <% end %>
           <% end %>
+          <%= form.hidden_field attribute, value: attachment_blob&.signed_id, id: "hidden_#{attribute}_#{attachment_blob&.id}" %>
         </div>
       <% end %>
     </div>

--- a/decidim-core/app/cells/decidim/upload_modal/files.erb
+++ b/decidim-core/app/cells/decidim/upload_modal/files.erb
@@ -25,7 +25,7 @@
         <% is_persisted_attachment = attachment.is_a?(Decidim::Attachment) && attachment.persisted? %>
         <% attachment_blob = blob(attachment) %>
 
-        <div class="attachment-details" <%= 'data-attachment-id="' + attachment.id.to_s + '"' if is_persisted_attachment %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
+        <div class="attachment-details" <% if is_persisted_attachment %>data-attachment-id="<%= attachment.id %>"<% end %> data-title="<%= title_for(attachment) %>" data-filename="<%= file_name_for(attachment) %>" data-state="uploaded" data-hidden-field="<%= attachment_blob&.signed_id %>">
           <% if file_attachment_path(attachment) && attachment_blob&.image? %>
             <div><%= image_tag(file_attachment_path(attachment), alt: "") %></div>
           <% elsif uploader_default_image_path(attribute).present? %>

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -112,12 +112,19 @@ describe "Admin edits proposals" do
 
       let!(:document) { create(:attachment, :with_pdf, attached_to: proposal) }
 
-      it "can be remove attachment" do
+      it "can remove attachment" do
         visit_component_admin
         within "tr", text: translated_attribute(proposal.title) do
           find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
+
+        click_on("Edit attachments")
+        within "li[data-filename='#{document.file.blob.filename}']" do
+          click_on("Remove")
+        end
+        click_on("Save")
+
         within ".item__edit-form" do
           click_on "Update"
         end
@@ -129,7 +136,7 @@ describe "Admin edits proposals" do
           find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
-        expect(page).to have_no_content("Current file")
+        expect(page).to have_no_content(document.file.blob.filename)
       end
 
       it "can attach a file" do


### PR DESCRIPTION
#### :tophat: What? Why?
A fix and supporting test for an issue.

#### :pushpin: Related Issues

- Fixes #12583 

#### Testing
Go to the attachments in a process, upload an image, submit it without any description to get an error message, submit again, usually the image would disappear, but the fix keeps it there ☺️

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added system tests for admin attachment management covering upload (including an error-path submission), display, and removal; updated admin proposal tests to verify attachments are removed.

* **Bug Fixes**
  * Improved upload modal and attachment display handling to distinguish persisted vs new attachments, always include hidden identifiers for uploads, and reliably pass attachments into forms for consistent upload and rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->