### PR TITLE
Backport 'Add taxonomy missing strings' to v0.30

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -138,6 +138,9 @@ en:
         show_in_footer: Show in the footer
         title: Title
         weight: Order position
+      taxonomy:
+        item_name: Item name
+        parent_id: Parent
       user_group_csv_verification:
         file: File
     errors:


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15735 to v0.30

:hearts: Thank you!