### PR TITLE
Allow Attachment to answer to `can_participate?` based on it's attached model

### DIFF
--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -20,7 +20,6 @@ module Decidim
     validates :content_type, presence: true
 
     delegate :attached?, to: :file
-    delegate :can_participate?, to: :attached_to
 
     default_scope { order(arel_table[:weight].asc, arel_table[:id].asc) }
 
@@ -130,6 +129,13 @@ module Decidim
 
     def self.log_presenter_class_for(_log)
       Decidim::AdminLog::AttachmentPresenter
+    end
+
+    def can_participate?(user)
+      return true unless attached_to
+      return true unless attached_to.respond_to?(:can_participate?)
+
+      attached_to.can_participate?(user)
     end
   end
 end

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -20,6 +20,7 @@ module Decidim
     validates :content_type, presence: true
 
     delegate :attached?, to: :file
+    delegate :can_participate?, to: :attached_to
 
     default_scope { order(arel_table[:weight].asc, arel_table[:id].asc) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

The model attachment is missing a `can_participate?` function. With this PR we are delegating that to the model at the `attached_to` field.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #15949

#### Testing
*Describe the best way to test or validate your PR.*
You can reproduce the same steps as in the related issue.

Also, you can test in the console if an attachment now answers to this function.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Attachments now inherit participation status from the content they’re attached to, so uploaded files reflect the same participation permissions and visibility as their parent items. This streamlines permission handling and improves consistency when viewing or interacting with attachments across the platform.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->