### PR TITLE
Remove legacy field banner image from initiative type

### DIFF
--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/create_initiative_type.rb
@@ -5,8 +5,6 @@ module Decidim
     module Admin
       # A command with all the business logic that creates a new initiative type
       class CreateInitiativeType < Decidim::Commands::CreateResource
-        fetch_file_attributes :banner_image
-
         fetch_form_attributes :title, :description, :signature_type, :comments_enabled, :attachments_enabled,
                               :undo_online_signatures_enabled, :custom_signature_end_date_enabled, :area_enabled,
                               :promoting_committee_enabled, :minimum_committee_members, :collect_user_extra_fields,

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/update_initiative_type.rb
@@ -6,8 +6,6 @@ module Decidim
       # A command with all the business logic that updates an
       # existing initiative type.
       class UpdateInitiativeType < Decidim::Commands::UpdateResource
-        fetch_file_attributes :banner_image
-
         fetch_form_attributes :title, :description, :signature_type, :attachments_enabled, :comments_enabled,
                               :undo_online_signatures_enabled, :custom_signature_end_date_enabled, :area_enabled,
                               :promoting_committee_enabled, :minimum_committee_members, :collect_user_extra_fields,

--- a/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
+++ b/decidim-initiatives/app/forms/decidim/initiatives/admin/initiative_type_form.rb
@@ -13,7 +13,6 @@ module Decidim
 
         translatable_attribute :title, String
         translatable_attribute :description, Decidim::Attributes::RichText
-        attribute :banner_image
         attribute :signature_type, String
         attribute :undo_online_signatures_enabled, Boolean
         attribute :attachments_enabled, Boolean
@@ -33,10 +32,7 @@ module Decidim
         validates :attachments_enabled, :undo_online_signatures_enabled, :custom_signature_end_date_enabled,
                   :area_enabled, :promoting_committee_enabled, inclusion: { in: [true, false] }
         validates :minimum_committee_members, numericality: { only_integer: true }, allow_nil: true
-        validates :banner_image, presence: true, if: ->(form) { !form.persisted? && form.context.initiative_type.nil? }
         validates :document_number_authorization_handler, presence: true, if: ->(form) { form.collect_user_extra_fields? }
-
-        validates :banner_image, passthru: { to: Decidim::InitiativesType }
 
         alias organization current_organization
 

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -184,14 +184,6 @@ module Decidim
       [:with_any_state, :with_any_type, :with_any_scope, :with_any_area]
     end
 
-    # Public: Overrides participatory space's banner image with the banner image defined
-    # for the initiative type.
-    #
-    # Returns Decidim::BannerImageUploader
-    def banner_image
-      type.attached_uploader(:banner_image)
-    end
-
     # Public: Whether the object's comments are visible or not.
     def commentable?
       type.comments_enabled?

--- a/decidim-initiatives/app/models/decidim/initiatives_type.rb
+++ b/decidim-initiatives/app/models/decidim/initiatives_type.rb
@@ -28,9 +28,6 @@ module Decidim
 
     validates :title, :description, :signature_type, presence: true
 
-    has_one_attached :banner_image
-    validates_upload :banner_image, uploader: Decidim::BannerImageUploader
-
     def allowed_signature_types_for_initiatives
       return %w(online offline any) if any_signature_type?
 

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives_types/_form.html.erb
@@ -17,12 +17,6 @@
       <div class="row column">
         <%= form.translated :editor, :description, aria: { label: :description } %>
       </div>
-
-      <div class="row">
-        <div class="columns">
-          <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
-        </div>
-      </div>
     </div>
   </div>
 

--- a/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
@@ -5,8 +5,6 @@
                            url: initiative_url(current_initiative.id, locale: current_locale)
                          }) %>
 
-<% provide :meta_image_url, current_initiative.type.attached_uploader(:banner_image).url %>
-
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
   <div class="text-center py-10">
     <h2 class="title-decorator inline-block text-left"><%= translated_attribute(current_initiative.title) %></h2>

--- a/decidim-initiatives/app/views/layouts/decidim/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative.html.erb
@@ -1,8 +1,6 @@
 <%= append_javascript_pack_tag "decidim_initiatives" %>
 <%= append_stylesheet_pack_tag "decidim_initiatives", media: "all" %>
 
-<% provide :meta_image_url, current_participatory_space.type.attached_uploader(:banner_image).url %>
-
 <%= render "layouts/decidim/application" do %>
   <%= render layout: "layouts/decidim/shared/layout_center" do %>
     <main>

--- a/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative_head.html.erb
@@ -1,8 +1,6 @@
 <%= append_javascript_pack_tag "decidim_initiatives" %>
 <%= append_stylesheet_pack_tag "decidim_initiatives", media: "all" %>
 
-<% provide :meta_image_url, current_initiative.type.attached_uploader(:banner_image).url %>
-
 <%= render partial: "layouts/decidim/header/follow_space_menu_bar_button", locals: { participatory_space: current_participatory_space } %>
 
 <%= render "layouts/decidim/application" do %>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -28,7 +28,6 @@ en:
       initiatives_type:
         area_enabled: Enable authors to choose the area for their initiative
         attachments_enabled: Enable attachments
-        banner_image: Banner image
         child_scope_threshold_enabled: Enable child scope signatures
         collect_user_extra_fields: Collect participant personal data on signature
         comments_enabled: Enable comments

--- a/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
+++ b/decidim-initiatives/lib/decidim/api/initiative_api_type.rb
@@ -9,7 +9,6 @@ module Decidim
       description "An initiative type"
 
       field :attachments_enabled, GraphQL::Types::Boolean, "Enable attachments on initiative types", null: true
-      field :banner_image, GraphQL::Types::String, "Banner image", null: true
       field :collect_user_extra_fields, GraphQL::Types::Boolean, "Collect participant personal data on signature", null: true
       field :comments_enabled, GraphQL::Types::Boolean, "Enable comments on initiative types", null: true
       field :custom_signature_end_date_enabled, GraphQL::Types::Boolean, "Enable participants to set custom signature end date", null: true
@@ -23,10 +22,6 @@ module Decidim
       field :title, Decidim::Core::TranslatedFieldType, "Initiative type name", null: true
       field :undo_online_signatures_enabled, GraphQL::Types::Boolean, "Enable participants to undo their online signatures", null: true
       field :validate_sms_code_on_votes, GraphQL::Types::Boolean, "Add SMS code validation step to signature process", null: true
-
-      def banner_image
-        object.attached_uploader(:banner_image).url
-      end
     end
   end
 end

--- a/decidim-initiatives/lib/decidim/initiatives/seeds.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/seeds.rb
@@ -48,8 +48,7 @@ module Decidim
         Decidim::InitiativesType.create!(
           title: Decidim::Faker::Localized.sentence(word_count: 5),
           description: Decidim::Faker::Localized.sentence(word_count: 25),
-          organization:,
-          banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil # Keep after organization
+          organization:
         )
       end
 

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -11,14 +11,6 @@ FactoryBot.define do
     title { generate_localized_title(:initiatives_type_title, skip_injection:) }
     description { generate_localized_description(:initiatives_type_description, skip_injection:) }
     organization
-    # Keep banner_image after organization
-    banner_image do
-      ActiveStorage::Blob.create_and_upload!(
-        io: File.open(Decidim::Dev.test_file("city2.jpeg", "image/jpeg")),
-        filename: "city2.jpeg",
-        content_type: "image/jpeg"
-      ).signed_id
-    end
     signature_type { :online }
     attachments_enabled { true }
     undo_online_signatures_enabled { true }

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/create_initiative_type_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/create_initiative_type_spec.rb
@@ -16,7 +16,7 @@ module Decidim
           let(:organization) { create(:organization) }
           let(:user) { create(:user, organization:) }
           let!(:initiative_type) do
-            build(:initiatives_type, banner_image: nil, organization:)
+            build(:initiatives_type, organization:)
           end
           let(:form) do
             form_klass

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_type_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/update_initiative_type_spec.rb
@@ -15,8 +15,7 @@ module Decidim
         context "when validation error" do
           let(:organization) { create(:organization) }
           let(:user) { create(:user, organization:) }
-          let!(:initiative_type) { create(:initiatives_type, organization:, banner_image:) }
-          let(:banner_image) { upload_test_file(Decidim::Dev.test_file("city2.jpeg", "image/jpeg")) }
+          let!(:initiative_type) { create(:initiatives_type, organization:) }
           let(:form) do
             form_klass
               .from_model(initiative_type)

--- a/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
+++ b/decidim-initiatives/spec/forms/admin/initiative_type_form_spec.rb
@@ -25,8 +25,7 @@ module Decidim
             area_enabled: false,
             comments_enabled:,
             promoting_committee_enabled:,
-            minimum_committee_members:,
-            banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg")
+            minimum_committee_members:
           }
         end
         let(:context) do

--- a/decidim-initiatives/spec/shared/create_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/create_initiative_type_example.rb
@@ -27,7 +27,6 @@ shared_examples "create an initiative type" do
         comments_enabled: true,
         promoting_committee_enabled: true,
         minimum_committee_members: 7,
-        banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: false,
         extra_fields_legal_information: Decidim::Faker::Localized.sentence(word_count: 25),
         child_scope_threshold_enabled: false,

--- a/decidim-initiatives/spec/shared/update_initiative_type_example.rb
+++ b/decidim-initiatives/spec/shared/update_initiative_type_example.rb
@@ -35,7 +35,6 @@ shared_examples "update an initiative type" do
         comments_enabled: true,
         promoting_committee_enabled: true,
         minimum_committee_members: 7,
-        banner_image: Decidim::Dev.test_file("city2.jpeg", "image/jpeg"),
         collect_user_extra_fields: false,
         extra_fields_legal_information: Decidim::Faker::Localized.sentence(word_count: 25).except("machine_translations"),
         document_number_authorization_handler: "",

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_types_spec.rb
@@ -38,8 +38,6 @@ describe "Admin manages initiatives types" do
 
       select("Online", from: "Signature type")
 
-      dynamically_attach_file(:initiatives_type_banner_image, Decidim::Dev.asset("city2.jpeg"))
-
       click_on "Create"
 
       expect(page).to have_admin_callout("A new initiative type has been successfully created")

--- a/decidim-initiatives/spec/system/initiatives_social_share_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_social_share_spec.rb
@@ -6,12 +6,11 @@ require "decidim/core/test/shared_examples/social_share_examples"
 describe "Social shares" do
   let(:organization) { create(:organization) }
   let!(:initiative) { create(:initiative, description:, scoped_type: initiative_type_scope, organization:) }
-  let!(:initiative_type) { create(:initiatives_type, banner_image:, organization:) }
+  let!(:initiative_type) { create(:initiatives_type, organization:) }
   let!(:initiative_type_scope) { create(:initiatives_type_scope, type: initiative_type) }
   let!(:attachment) { create(:attachment, :with_image, attached_to: initiative, file: attachment_file) }
   let(:content_block) { create(:content_block, organization:, manifest_name: :hero, scope_name: :homepage) }
   let(:description) { { en: "Description <p><img src=\"#{description_image_path}\"></p>" } }
-  let(:banner_image) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
   let!(:attachment_file) { Decidim::Dev.test_file("city3.jpeg", "image/jpeg") }
   let(:description_image_path) { Rails.application.routes.url_helpers.rails_blob_path(description_image, only_path: true) }
   let(:description_image) do

--- a/decidim-initiatives/spec/types/initiative_api_type_spec.rb
+++ b/decidim-initiatives/spec/types/initiative_api_type_spec.rb
@@ -98,14 +98,6 @@ module Decidim
         end
       end
 
-      describe "bannerImage" do
-        let(:query) { "{ bannerImage }" }
-
-        it "returns the banner image field" do
-          expect(response["bannerImage"]).to be_blob_url(model.banner_image.blob)
-        end
-      end
-
       describe "collectUserExtraFields" do
         let(:query) { "{ collectUserExtraFields }" }
 


### PR DESCRIPTION
#### :tophat: What? Why?

While doing some QA with the association team last week, we detected that Initiatves Types have a "Banner Image" field that isn't used publicly. As far as I see, it is only used for meta image purposes, so that's overkill.

This PR drops this field.

#### Testing

1. Sign in as admin
2. Go to [[http:/localhost:3000/admin/initiatives_types](https://beta.try.decidim.org/admin/initiatives_types)](https://beta.try.decidim.org/admin/initiatives_types) 
3. Click on “New initiative type”
4. See the field 
5. Upload an image
6. Save the initiative type
7. Try to find usage of this image (it doesn’t exist!)

### :camera: Screenshots

<img width="1912" height="1496" alt="image" src="https://github.com/user-attachments/assets/8ff0a4e4-fe5f-4556-b233-d7422724622d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed banner image upload functionality from initiative type administration, including the form field, database associations, and related validations.
  * Removed banner image references from initiative pages and social sharing meta tags.
  * Removed banner image field from the GraphQL API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->