### PR TITLE
Fix disabled 'true' continue button in initiatives creation/edit

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -66,7 +66,7 @@
           <%= t(".discard") %>
         <% end %>
       <% end %>
-      <%= f.submit t(".continue"), class: "button button__sm md:button__lg button__secondary", data: { disable_with: true } %>
+      <%= f.submit t(".continue"), class: "button button__sm md:button__lg button__secondary", data: { disable_with: t(".continue") } %>
     </div>
   </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

While doing some QA with the association team last week, we detected that when creating or editing an initiative, there's a flash of the "true" word in the button. This PR fixes it. 


#### Testing

Create or edit an initiative and see the button

### :camera: Screenshots

#### Before
[Kooha-2026-01-28-12-02-27.webm](https://github.com/user-attachments/assets/9a8b95eb-2b9a-4308-9c2d-644b20a3a8c0)

#### After
[Kooha-2026-01-28-12-01-42.webm](https://github.com/user-attachments/assets/f6337817-7a12-431d-9b72-00b5eb32e2c4)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated form submission button to display localized text while processing instead of generic disabled state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->