### PR TITLE
Fix for explanation what means a draft and pending initiative

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_pending_initiatives.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_pending_initiatives.html.erb
@@ -1,5 +1,7 @@
 <h2 class="h5 md:h3 decorator"><%= t("title", scope: "decidim.initiatives.initiatives.pending_initiatives") %></h2>
 
+<%= cell("decidim/announcement", t("description", scope: "decidim.initiatives.initiatives.pending_initiatives")) %>
+
 <div class="card__grid-grid">
   <%= render pending_initiatives %>
 </div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -551,6 +551,7 @@ en:
           recent: Most recent
           recently_published: Most recently published
         pending_initiatives:
+          description: These initiatives are not public yet. Please review them and submit them for technical validation so they can be made public.
           title: Draft & Pending initiatives
         print:
           address: Address

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -194,6 +194,8 @@ describe "Initiatives" do
 
     context "when user does not have pending initiatives" do
       let!(:user) { create(:user, :confirmed, organization:) }
+      let!(:other_user) { create(:user, :confirmed, organization:) }
+      let!(:other_user_pending_initiative) { create(:initiative, :created, author: other_user, organization:) }
 
       before do
         switch_to_host(organization.host)
@@ -203,6 +205,10 @@ describe "Initiatives" do
 
       it "does not display the pending initiatives section" do
         expect(page).to have_no_css("#pending_initiatives")
+      end
+
+      it "does not display other users' pending initiatives" do
+        expect(page).to have_no_content(translated(other_user_pending_initiative.title, locale: :en))
       end
     end
   end

--- a/decidim-initiatives/spec/system/initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/initiatives_spec.rb
@@ -149,5 +149,61 @@ describe "Initiatives" do
         expect(page).to have_content("21")
       end
     end
+
+    context "when user has pending initiatives" do
+      let!(:user) { create(:user, :confirmed, organization:) }
+      let!(:pending_initiative) { create(:initiative, :created, author: user, organization:) }
+      let!(:validating_initiative) { create(:initiative, :validating, author: user, organization:) }
+
+      before do
+        switch_to_host(organization.host)
+        login_as user, scope: :user
+        visit decidim_initiatives.initiatives_path(locale: I18n.locale)
+      end
+
+      it "displays the pending initiatives section" do
+        expect(page).to have_css("#pending_initiatives")
+      end
+
+      it "displays the title for pending initiatives" do
+        within "#pending_initiatives" do
+          expect(page).to have_content("Draft & Pending initiatives")
+        end
+      end
+
+      it "displays the description for pending initiatives" do
+        within "#pending_initiatives" do
+          expect(page).to have_content("These initiatives are not public yet. Please review them and submit them for technical validation so they can be made public.")
+        end
+      end
+
+      it "lists the pending initiatives" do
+        within "#pending_initiatives" do
+          expect(page).to have_content(translated(pending_initiative.title, locale: :en))
+          expect(page).to have_content(translated(validating_initiative.title, locale: :en))
+        end
+      end
+
+      it "does not display pending initiatives in the main list" do
+        within "#initiatives" do
+          expect(page).to have_no_content(translated(pending_initiative.title, locale: :en))
+          expect(page).to have_no_content(translated(validating_initiative.title, locale: :en))
+        end
+      end
+    end
+
+    context "when user does not have pending initiatives" do
+      let!(:user) { create(:user, :confirmed, organization:) }
+
+      before do
+        switch_to_host(organization.host)
+        login_as user, scope: :user
+        visit decidim_initiatives.initiatives_path(locale: I18n.locale)
+      end
+
+      it "does not display the pending initiatives section" do
+        expect(page).to have_no_css("#pending_initiatives")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing some QA with the association team last week, we detected that when a participant have an initiative in draft, the block showed in the front-end is not clear enough. It’s difficult to understand if this is seen by everyone or why this initiatives are there. 
 
This PR fixes this problem by adding an announcement there.

#### Testing

1. Create an initiative
2. Do **not** send it to technical validation 
3. Go to /initiatives

### :camera: Screenshots

<img width="1707" height="1161" alt="image" src="https://github.com/user-attachments/assets/d2b3757b-a4c0-4453-b15c-1cd5b471ab69" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an informational announcement to the pending initiatives view explaining that initiatives require technical validation before becoming public.
  * Added a localized description for the pending initiatives announcement.

* **Tests**
  * Added system tests covering pages with and without pending initiatives, verifying the announcement, section title, description text, and correct listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->