### PR TITLE
Move the initiatives actions to the admins' table

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/edit.html.erb
@@ -13,70 +13,8 @@
       <div class="item__edit-sticky">
         <div class="item__edit-sticky-container">
           <%= f.submit t(".update"), class: "button button__sm button__secondary" if allowed_to? :update, :initiative, initiative: current_initiative %>
-
-            <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
-              <%= link_to t(".send_to_technical_validation"),
-                          send_to_technical_validation_initiative_path(current_initiative),
-                          class: "button button__sm button__secondary",
-                          data: { confirm: t(".confirm_send_to_technical_validation") } %>
-            <% elsif current_initiative.created? %>
-              <%= link_to t(".send_to_technical_validation"), "#", class: "button button__sm button__secondary" %>
-            <% end %>
-
-            <% if allowed_to? :publish, :initiative, initiative: current_initiative %>
-              <%= link_to t("actions.publish", scope: "decidim.admin"),
-                          publish_initiative_path(current_initiative),
-                          method: :post,
-                          class: "button button__sm button__secondary",
-                          data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :unpublish, :initiative, initiative: current_initiative %>
-              <%= link_to t("actions.unpublish", scope: "decidim.admin"),
-                          unpublish_initiative_path(current_initiative),
-                          method: :delete,
-                          class: "button button__sm button__secondary",
-                          data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :accept, :initiative, initiative: current_initiative %>
-                <%= link_to t(".accept"),
-                            accept_initiative_path(current_initiative),
-                            method: :post,
-                            class: "button button__sm button__secondary",
-                            data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :reject, :initiative, initiative: current_initiative %>
-                <%= link_to t(".reject"),
-                            reject_initiative_path(current_initiative),
-                            method: :delete,
-                            class: "button button__sm button__secondary",
-                            data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :discard, :initiative, initiative: current_initiative %>
-              <%= link_to t(".discard"),
-                          discard_initiative_path(current_initiative),
-                          method: :delete,
-                          class: "button button__sm button__secondary",
-                          data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :export_votes, :initiative, initiative: current_initiative %>
-              <%= link_to t(".export_votes"),
-                          export_votes_initiative_path(current_initiative, format: :csv),
-                          class: "button button__sm button__secondary",
-                          data: { confirm: t(".confirm") } %>
-            <% end %>
-
-            <% if allowed_to? :export_pdf_signatures, :initiative, initiative: current_initiative %>
-              <%= link_to t(".export_pdf_signatures"),
-                          export_pdf_signatures_initiative_path(current_initiative, format: :pdf),
-                          class: "button button__sm button__secondary" %>
-            <% end %>
-       </div>
-     </div>
+        </div>
+      </div>
     <% end %>
   </div>
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -114,6 +114,119 @@
                       <%= link %>
                     </li>
                   <% end %>
+
+                  <% if allowed_to? :send_to_technical_validation, :initiative, initiative: initiative %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.send_to_technical_validation_initiative_path(initiative),
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_send_to_technical_validation", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "arrow-right-line" %>
+                        <%= t("send_to_technical_validation", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% elsif initiative.created? %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <div class="dropdown__button-disabled">
+                        <%= icon "arrow-right-line", class: "text-gray" %>
+                        <span><%= t("send_to_technical_validation", scope: "decidim.initiatives.admin.initiatives.edit") %></span>
+                      </div>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :publish, :initiative, initiative: initiative %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.publish_initiative_path(initiative),
+                                  method: :post,
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_publish", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "check-double-line" %>
+                        <%= t("actions.publish", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+
+                    <hr>
+                  <% end %>
+
+                  <% if allowed_to? :unpublish, :initiative, initiative: initiative %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.unpublish_initiative_path(initiative),
+                                  method: :delete,
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_unpublish", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "notification-3-line" %>
+                        <%= t("actions.unpublish", scope: "decidim.admin") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :accept, :initiative, initiative: initiative %>
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.accept_initiative_path(initiative),
+                                  method: :post,
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_accept", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "check-line" %>
+                        <%= t("accept", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :reject, :initiative, initiative: initiative %>
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.reject_initiative_path(initiative),
+                                  method: :delete,
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_reject", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "close-line" %>
+                        <%= t("reject", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :discard, :initiative, initiative: initiative %>
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.discard_initiative_path(initiative),
+                                  method: :delete,
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_discard", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "delete-bin-line" %>
+                        <%= t("discard", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :export_votes, :initiative, initiative: initiative %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.export_votes_initiative_path(initiative, format: :csv),
+                                  class: "dropdown__button",
+                                  data: { confirm: t("confirm_export_votes", scope: "decidim.initiatives.admin.initiatives.edit") } do %>
+                        <%= icon "download-cloud-2-line" %>
+                        <%= t("export_votes", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% end %>
+
+                  <% if allowed_to? :export_pdf_signatures, :initiative, initiative: initiative %>
+                    <hr>
+
+                    <li class="dropdown__item">
+                      <%= link_to decidim_admin_initiatives.export_pdf_signatures_initiative_path(initiative, format: :pdf),
+                                  class: "dropdown__button" do %>
+                        <%= icon "file-3-line" %>
+                        <%= t("export_pdf_signatures", scope: "decidim.initiatives.admin.initiatives.edit") %>
+                      <% end %>
+                    </li>
+                  <% end %>
                 </ul>
               </div>
 

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -259,7 +259,13 @@ en:
           edit:
             accept: Accept initiative
             confirm: Are you sure?
-            confirm_send_to_technical_validation: Are you sure?
+            confirm_accept: Are you sure you want to accept it?
+            confirm_discard: Are you sure you want to discard it?
+            confirm_export_votes: Are you sure you want to export the votes?
+            confirm_publish: Are you sure you want to publish it?
+            confirm_reject: Are you sure you want to reject it?
+            confirm_send_to_technical_validation: Are you sure you want to send it to technical validation?
+            confirm_unpublish: Are you sure you want to unpublish it?
             discard: Discard the initiative
             export_pdf_signatures: Export PDF of signatures
             export_votes: Export signatures


### PR DESCRIPTION
#### :tophat: What? Why?

While doing some QA with the association team last week, we detected that the user journey to validate initiatives it’s not obvious enough (you have to ‘edit’ and ‘publish’ the initiative). These actions are in the edit form, and it is difficult to find because is not intuitive and consistent with other actions from other spaces/components.

<img width="1558" height="531" alt="image" src="https://github.com/user-attachments/assets/cbbfbc39-402a-4500-949b-7c4b6c7d4c1e" />

This PR fixes this issue by migrating these actions from the Edit page to the index table (as we do in other spaces/components).

(This is a fine line between a `type: fix` and a `type: change` - I'm leaning to change, but it is up to the reviewer 😄) 

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/initiatives
3. See the actions 

### :camera: Screenshots

<img width="2730" height="1270" alt="image" src="https://github.com/user-attachments/assets/9b076d9c-349b-46ec-896d-ea30ed7b0fbc" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized initiative administration actions from the edit page to a dropdown menu on the initiatives list for streamlined workflow management.

* **New Features**
  * Added confirmation dialogs for key initiative lifecycle actions including publish, unpublish, accept, reject, discard, and export functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->