### PR TITLE
Fix correct icon & name assignment for elections

### DIFF
--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -7,6 +7,11 @@ en:
       token_csv:
         file: File
         remove_all: Remove all current census data
+  activerecord:
+    models:
+      decidim/elections/election:
+        one: Election
+        other: Elections
   decidim:
     admin:
       menu:

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -29,7 +29,7 @@ module Decidim
       end
 
       initializer "decidim_elections.register_icons" do
-        Decidim.icons.register(name: "Decidim::Elections::Election", icon: "file-paper-2-line", description: "Elections", category: "activity", engine: :core)
+        Decidim.icons.register(name: "Decidim::Elections::Election", icon: "file-paper-2-line", description: "Elections", category: "activity", engine: :elections)
       end
 
       initializer "decidim_elections.add_cells_view_paths" do

--- a/decidim-elections/lib/decidim/elections/engine.rb
+++ b/decidim-elections/lib/decidim/elections/engine.rb
@@ -28,6 +28,10 @@ module Decidim
         get "/", to: redirect("elections", status: 301)
       end
 
+      initializer "decidim_elections.register_icons" do
+        Decidim.icons.register(name: "Decidim::Elections::Election", icon: "file-paper-2-line", description: "Elections", category: "activity", engine: :core)
+      end
+
       initializer "decidim_elections.add_cells_view_paths" do
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Elections::Engine.root}/app/cells")
         Cell::ViewModel.view_paths << File.expand_path("#{Decidim::Elections::Engine.root}/app/views") # for partials


### PR DESCRIPTION
#### :tophat: What? Why?
The search element of the application did not use the correct name assignment of the elections module, also the icon assigned to the module was incorrect. 

This PR fixes this by adding the https://remixicon.com/icon/file-paper-2-line from Remixicon as approved by @carolromero. 

#### :pushpin: Related Issues
- Fixes #15891

#### Testing
1. Start up your development_app
2. In the search hit enter
3. See the results on the left column with "Elections" and its icon properly assigned at the bottom

### :camera: Screenshots
<img width="301" height="96" alt="image" src="https://github.com/user-attachments/assets/f7f6eae9-5c4b-4a54-a663-0a1cd113e2a3" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visual icon for the Elections feature to improve UI representation.

* **Documentation**
  * Added English localization entries for singular and plural forms: "Election" / "Elections".

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->