### PR TITLE
Fix collaborative texts name & icon in search

### DIFF
--- a/decidim-collaborative_texts/config/locales/en.yml
+++ b/decidim-collaborative_texts/config/locales/en.yml
@@ -16,6 +16,11 @@ en:
           body: Body
           draft: Draft
           version_number: Version number
+  activerecord:
+    models:
+      decidim/collaborative_texts/collaborative_text:
+        one: Collaborative text
+        other: Collaborative texts
   decidim:
     admin:
       tooltips:

--- a/decidim-collaborative_texts/config/locales/en.yml
+++ b/decidim-collaborative_texts/config/locales/en.yml
@@ -18,7 +18,7 @@ en:
           version_number: Version number
   activerecord:
     models:
-      decidim/collaborative_texts/collaborative_text:
+      decidim/collaborative_texts/document:
         one: Collaborative text
         other: Collaborative texts
   decidim:

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/engine.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/engine.rb
@@ -16,8 +16,8 @@ module Decidim
       end
 
       initializer "decidim_collaborative_texts.register_icons" do
-        Decidim.icons.register(name: "Decidim::CollaborativeTexts::CollaborativeText", icon: "draft-line", description: "Collaborative texts", category: "activity",
-                               engine: :CollaborativeTexts)
+        Decidim.icons.register(name: "Decidim::CollaborativeTexts::Document", icon: "draft-line", description: "Collaborative texts", category: "activity",
+                               engine: :collaborative_texts)
       end
 
       initializer "decidim_collaborative_texts.data_migrate", after: "decidim_core.data_migrate" do

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/engine.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/engine.rb
@@ -15,6 +15,11 @@ module Decidim
         get "/", to: redirect("documents", status: 301)
       end
 
+      initializer "decidim_collaborative_texts.register_icons" do
+        Decidim.icons.register(name: "Decidim::CollaborativeTexts::CollaborativeText", icon: "draft-line", description: "Collaborative texts", category: "activity",
+                               engine: :CollaborativeTexts)
+      end
+
       initializer "decidim_collaborative_texts.data_migrate", after: "decidim_core.data_migrate" do
         DataMigrate.configure do |config|
           config.data_migrations_path << root.join("db/data").to_s


### PR DESCRIPTION
#### :tophat: What? Why?
In the search of the app, we were filtering the incorrect name and logo of the collaborative texts module. This PR adds a new agreed Remixcion and correct naming of module. 

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/15970

#### Testing
1. Load up your app using the branch
2. Hit the search bar at the top
3. On the search module/component filter see on the bottom collaborative texts with correct icon

### :camera: Screenshots
Before in Nightly:
<img width="476" height="131" alt="image" src="https://github.com/user-attachments/assets/0c084405-588e-4d5f-acf0-1825d3443b9c" />

<img width="891" height="827" alt="image" src="https://github.com/user-attachments/assets/15a609f7-9b76-4ff7-a998-33a08e9faa93" />

After correct module collaborative texts with icon: 
<img width="476" height="131" alt="image" src="https://github.com/user-attachments/assets/f2162d09-4feb-42b9-9e1a-5773261bca68" />

After with correct module collaborative texts:
<img width="1189" height="757" alt="image" src="https://github.com/user-attachments/assets/4c65dde6-4e11-4391-a378-0ceb65e8934a" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual icon display for collaborative text documents in the activity section.

* **Documentation**
  * Added English language labels for collaborative text models.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->