### PR TITLE
Make the document a required field in spaces import

### DIFF
--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
@@ -31,6 +31,7 @@ module Decidim
         attribute :import_components, Boolean, default: true
         attribute :document, Decidim::Attributes::Blob
 
+        validates :document, presence: true
         validates :document, file_content_type: { allow: ACCEPTED_TYPES.values }
         validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
         validates :title, translatable_presence: true

--- a/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
+++ b/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Assemblies
+    module Admin
+      describe AssemblyImportForm do
+        subject { form }
+
+        let(:organization) { create(:organization) }
+        let(:document) { upload_test_file(Decidim::Dev.asset("assemblies.json"), content_type: "application/json", return_blob: true) }
+        let(:slug) { "imported-assembly-slug" }
+        let(:title) do
+          {
+            en: "Imported Assembly",
+            es: "Asamblea Importada",
+            ca: "Assemblea Importada"
+          }
+        end
+
+        let(:params) do
+          {
+            slug:,
+            title_en: title[:en],
+            title_es: title[:es],
+            title_ca: title[:ca],
+            document:,
+            import_steps: true,
+            import_attachments: true,
+            import_components: true
+          }
+        end
+
+        let(:form) do
+          described_class.from_params(params).with_context(
+            current_organization: organization
+          )
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when document is missing" do
+          let(:document) { nil }
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).not_to be_empty
+          end
+        end
+
+        context "when document content type is not valid" do
+          let(:document) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), return_blob: true) }
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).not_to be_empty
+          end
+        end
+
+        context "when slug is missing" do
+          let(:slug) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when slug is not valid" do
+          let(:slug) { "123-invalid-slug" }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when slug is not unique" do
+          before do
+            create(:assembly, slug:, organization:)
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on slug" do
+            form.valid?
+            expect(form.errors[:slug]).not_to be_empty
+          end
+        end
+
+        context "when default language in title is missing" do
+          let(:title) do
+            {
+              ca: "Assemblea Importada"
+            }
+          end
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
@@ -30,6 +30,7 @@ module Decidim
         attribute :import_components, Boolean, default: true
         attribute :document, Decidim::Attributes::Blob
 
+        validates :document, presence: true
         validates :document, file_content_type: { allow: ACCEPTED_TYPES.values }
         validates :slug, presence: true, format: { with: Decidim::ParticipatoryProcess.slug_format }
         validates :title, translatable_presence: true

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
@@ -10,7 +10,7 @@
       </div>
 
       <div class="row column">
-        <%= form.upload :document, required: true, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary" %>
+        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary" %>
       </div>
 
       <div class="card-divider">

--- a/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module ParticipatoryProcesses
+    module Admin
+      describe ParticipatoryProcessImportForm do
+        subject { form }
+
+        let(:organization) { create(:organization) }
+        let(:document) { upload_test_file(Decidim::Dev.asset("participatory_processes.json"), content_type: "application/json", return_blob: true) }
+        let(:slug) { "imported-process-slug" }
+        let(:title) do
+          {
+            en: "Imported Process",
+            es: "Proceso Importado",
+            ca: "Procés Importat"
+          }
+        end
+
+        let(:params) do
+          {
+            slug:,
+            title_en: title[:en],
+            title_es: title[:es],
+            title_ca: title[:ca],
+            document:,
+            import_steps: true,
+            import_attachments: true,
+            import_components: true
+          }
+        end
+
+        let(:form) do
+          described_class.from_params(params).with_context(
+            current_organization: organization
+          )
+        end
+
+        context "when everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "when document is missing" do
+          let(:document) { nil }
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).not_to be_empty
+          end
+        end
+
+        context "when document content type is not valid" do
+          let(:document) { upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), return_blob: true) }
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).not_to be_empty
+          end
+        end
+
+        context "when slug is missing" do
+          let(:slug) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when slug is not valid" do
+          let(:slug) { "123-invalid-slug" }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when slug is not unique" do
+          before do
+            create(:participatory_process, slug:, organization:)
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on slug" do
+            form.valid?
+            expect(form.errors[:slug]).not_to be_empty
+          end
+        end
+
+        context "when default language in title is missing" do
+          let(:title) do
+            {
+              ca: "Procés Importat"
+            }
+          end
+
+          it { is_expected.to be_invalid }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #15895, I'm trying to make the import assembly feature work but I'm finding too many bugs in the process.

This PR is the first of a series to make this feature work with a bit lower number of bugs.

The first two that I found are related to the document upload field itself. 

1. on assemblies, if an admin goes to this form and doesn't actually uploads the document, then it'll have a 500 error. The fix is to add the validation in the form object
2. ~~on proceses, if an admin goes to this form and doesn't actually uploads the document, then it doesn't show any error. The fix is to remove the required HTML5 attribute from this form, as it doesn't play nice with the upload that we have.~~  this is actually related to another change that I'm doing, you can ignore this for now 

#### Testing

For assemblies:

1. Sign in as admin
3. Go to  http://localhost:3000/admin/assemblies/imports 
4. Fill the title and the slug - do NOT upload the document
5. Click in Import
6. (Before the patch) See server-side error
6. (After the patch) See error in the form

### Stacktrace

```
TypeError (no implicit conversion of nil into String):

json (2.18.0) lib/json/common.rb:353:in 'JSON::Ext::Parser.parse'
json (2.18.0) lib/json/common.rb:353:in 'JSON.parse'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:56:in 'Decidim::Assemblies::Admin::ImportAssembly#document_parsed'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:52:in 'Decidim::Assemblies::Admin::ImportAssembly#assemblies'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:41:in 'Decidim::Assemblies::Admin::ImportAssembly#import_assembly'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:28:in 'block in Decidim::Assemblies::Admin::ImportAssembly#call'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/transaction.rb:616:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activesupport (7.2.2.2) lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/transaction.rb:613:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/database_statements.rb:361:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.2.2) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/connection_pool.rb:421:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.2.2) lib/active_record/connection_handling.rb:296:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.2.2) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:30:in 'Decidim::Command#transaction'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:27:in 'Decidim::Assemblies::Admin::ImportAssembly#call'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:19:in 'Decidim::Command.call'
/workspaces/decidim/decidim-assemblies/app/controllers/decidim/assemblies/admin/assembly_imports_controller.rb:18:in 'Decidim::Assemblies::Admin::AssemblyImportsController#create'
actionpack (7.2.2.2) lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'
actionpack (7.2.2.2) lib/abstract_controller/base.rb:226:in 'AbstractController::Base#process_action'
actionpack (7.2.2.2) lib/action_controller/metal/rendering.rb:193:in 'ActionController::Rendering#process_action'
actionpack (7.2.2.2) lib/abstract_controller/callbacks.rb:261:in 'block in AbstractController::Callbacks#process_action'
activesupport (7.2.2.2) lib/active_support/callbacks.rb:121:in 'block in ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.2.2) lib/active_support/core_ext/time/zones.rb:65:in 'Time.use_zone'
/workspaces/decidim/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in 'Decidim::Admin::ApplicationController#use_organization_time_zone'
```

### :camera: Screenshots

#### Before

<img width="1312" height="632" alt="image" src="https://github.com/user-attachments/assets/a355dd6d-6722-4859-94f8-4dd2e9a1a347" />

#### After

<img width="1593" height="668" alt="image" src="https://github.com/user-attachments/assets/cdab7b12-4ca6-4a79-963c-da012ecb7f87" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import flows now enforce that a valid document must be provided server-side; submissions without a proper document are rejected with clear errors.
  * The import form UI no longer marks the document field as client-side required (server validation still applies).

* **Tests**
  * Added comprehensive tests covering document, slug, title and import-option validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->