### PR TITLE
Show errors outside of the upload modal

### DIFF
--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -71,13 +71,12 @@ module Decidim
     end
 
     # By default FoundationRailsHelper adds form errors next to input, but since input is in the modal
-    # and modal is hidden by default, we need to add an additional validation field to the form.
+    # and modal is hidden by default, we add a hidden checkbox field to handle HTML5 validation.
     # This should only be necessary when file is required by the form.
+    # Note: Validation errors are now displayed in the main form area, not inside the modal.
     def input_validation_field
       object_name = form.object.present? ? "#{form.object.model_name.param_key}[#{add_attribute}_validation]" : "#{add_attribute}_validation"
-      input = check_box_tag object_name, 1, attachments.present?, class: "reset-defaults", hidden: true, label: false, required: required?
-      message = form.send(:abide_error_element, add_attribute) + form.send(:error_and_help_text, add_attribute)
-      input + message
+      check_box_tag object_name, 1, attachments.present?, class: "reset-defaults", hidden: true, label: false, required: required?
     end
 
     def explanation

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -76,7 +76,11 @@ module Decidim
     # Note: Validation errors are now displayed in the main form area, not inside the modal.
     def input_validation_field
       object_name = form.object.present? ? "#{form.object.model_name.param_key}[#{add_attribute}_validation]" : "#{add_attribute}_validation"
-      check_box_tag object_name, 1, attachments.present?, class: "reset-defaults", hidden: true, label: false, required: required?
+      check_box_tag object_name, 1, attachments.present?, class: "reset-defaults", hidden: true, label: false, required: required?, id: validation_field_id
+    end
+
+    def validation_field_id
+      "#{attribute}_validation"
     end
 
     def explanation

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -366,11 +366,13 @@ module Decidim
         button_edit_label: I18n.t("decidim.forms.upload.labels.replace")
       }.merge(options)
 
-      ::Decidim::ViewModel.cell(
+      upload_cell = ::Decidim::ViewModel.cell(
         "decidim/upload_modal",
         self,
         options
       ).call
+
+      upload_cell + error_and_help_text(attribute, options)
     end
 
     def max_file_size(record, attribute)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -372,7 +372,7 @@ module Decidim
         options
       ).call
 
-      upload_cell + error_and_help_text(attribute, options)
+      upload_cell + error_and_help_text(attribute, options) + (options[:required] ? abide_error_element(attribute, for: "#{attribute}_validation") : "")
     end
 
     def max_file_size(record, attribute)
@@ -628,19 +628,23 @@ module Decidim
     # does it.
     #
     # attribute - The name of the attribute of the field.
+    # options - A Hash of options:
+    #           :for - The ID of the input field this error is for (adds data-form-error-for attribute)
     #
     # Returns a String.
-    def abide_error_element(attribute)
+    def abide_error_element(attribute, options = {})
       defaults = []
       defaults << :"decidim.forms.errors.#{object.class.model_name.i18n_key}.#{attribute}"
       defaults << :"decidim.forms.errors.#{attribute}"
       defaults << :"forms.errors.#{attribute}"
       defaults << :"decidim.forms.errors.error"
 
-      options = { count: 1, default: defaults }
+      i18n_options = { count: 1, default: defaults }
 
-      text = I18n.t(defaults.shift, **options)
-      content_tag(:span, text, class: "form-error")
+      text = I18n.t(defaults.shift, **i18n_options)
+      tag_options = { class: "form-error" }
+      tag_options[:"data-form-error-for"] = options[:for] if options[:for]
+      content_tag(:span, text, tag_options)
     end
 
     def tab_element_class_for(type, index)

--- a/decidim-core/lib/decidim/form_builder.rb
+++ b/decidim-core/lib/decidim/form_builder.rb
@@ -372,7 +372,11 @@ module Decidim
         options
       ).call
 
-      upload_cell + error_and_help_text(attribute, options) + (options[:required] ? abide_error_element(attribute, for: "#{attribute}_validation") : "")
+      options_without_help = options.dup
+      options_without_help.delete(:help)
+      options_without_help.delete(:help_text)
+
+      upload_cell + error_and_help_text(attribute, options_without_help) + (options[:required] ? abide_error_element(attribute, for: "#{attribute}_validation") : "")
     end
 
     def max_file_size(record, attribute)

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -66,6 +66,12 @@ describe Decidim::UploadModalCell, type: :cell do
     it "renders the required field indicator" do
       expect(subject).to have_css("label .label-required", text: "Required field")
     end
+
+    it "does not render error or help text inside the modal" do
+      # Error and help text should be rendered outside the modal by the form builder
+      expect(subject).to have_no_css(".form-error")
+      expect(subject).to have_no_css(".help-text")
+    end
   end
 
   context "when attachment is present" do

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -63,6 +63,10 @@ describe Decidim::UploadModalCell, type: :cell do
       expect(subject).to have_css("input[name='dummy[#{attribute}_validation]']", visible: :hidden)
     end
 
+    it "renders the hidden checkbox with the correct ID for Foundation Abide" do
+      expect(subject).to have_css("input##{attribute}_validation", visible: :hidden)
+    end
+
     it "renders the required field indicator" do
       expect(subject).to have_css("label .label-required", text: "Required field")
     end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -814,16 +814,15 @@ module Decidim
         let(:output) { builder.upload :image, attributes }
 
         before do
-          allow(resource).to receive(:errors).and_return(image: ["can't be blank"])
+          allow(resource).to receive(:errors).and_return(image: ["cannot be blank"])
         end
 
         it "renders error and help text after the upload cell" do
           expect(parsed.css(".form-error")).not_to be_empty
-          expect(parsed.css(".help-text")).not_to be_empty
         end
 
         it "renders the error message" do
-          expect(parsed.css(".form-error").text).to include("can't be blank")
+          expect(parsed.css(".form-error").text).to include("cannot be blank")
         end
       end
 
@@ -834,6 +833,19 @@ module Decidim
         it "renders help text after the upload cell" do
           expect(parsed.css(".help-text")).not_to be_empty
           expect(parsed.css(".help-text").text).to include("Upload a valid image file")
+        end
+      end
+
+      context "when the field is required" do
+        let(:attributes) { { required: true } }
+        let(:output) { builder.upload :image, attributes }
+
+        it "renders the HTML5 validation error element outside the modal" do
+          expect(parsed.css("span.form-error")).not_to be_empty
+        end
+
+        it "renders the error element with data-form-error-for linking to the validation field" do
+          expect(parsed.css("span.form-error[data-form-error-for='image_validation']")).not_to be_empty
         end
       end
     end

--- a/decidim-core/spec/lib/form_builder_spec.rb
+++ b/decidim-core/spec/lib/form_builder_spec.rb
@@ -808,6 +808,34 @@ module Decidim
           end
         end
       end
+
+      context "with errors on the field" do
+        let(:attributes) { {} }
+        let(:output) { builder.upload :image, attributes }
+
+        before do
+          allow(resource).to receive(:errors).and_return(image: ["can't be blank"])
+        end
+
+        it "renders error and help text after the upload cell" do
+          expect(parsed.css(".form-error")).not_to be_empty
+          expect(parsed.css(".help-text")).not_to be_empty
+        end
+
+        it "renders the error message" do
+          expect(parsed.css(".form-error").text).to include("can't be blank")
+        end
+      end
+
+      context "with help_text option" do
+        let(:attributes) { { help_text: "Upload a valid image file" } }
+        let(:output) { builder.upload :image, attributes }
+
+        it "renders help text after the upload cell" do
+          expect(parsed.css(".help-text")).not_to be_empty
+          expect(parsed.css(".help-text").text).to include("Upload a valid image file")
+        end
+      end
     end
 
     describe "#data_picker" do


### PR DESCRIPTION
#### :tophat: What? Why?

Related to the changes that I'm proposing at #15980, if there's an error in the form related to the modal, this error isn't shown. 
#### :pushpin: Related Issues

- Fixes #15892 
- Fixes #11678
- Fixes #10357

#### Testing

1. Go to the new attachments form
2. Do not fill any field
3. Click in the "Create attachment" button
4. See the error

### :camera: Screenshots

#### Before

<img width="2646" height="1698" alt="image" src="https://github.com/user-attachments/assets/927de559-e3ec-4103-a338-f729d5333952" />

#### After 

<img width="2620" height="1658" alt="image" src="https://github.com/user-attachments/assets/ec0444bf-f55f-4128-ab7a-6006ec31700f" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File upload validation now uses HTML5 validation, improving reliability and browser-native error handling.
  * Validation errors for required uploads are shown alongside other form errors (outside the modal) for consistent display.
  * Help text and error messages for upload fields are rendered consistently after the upload control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->