### PR TITLE
Fix markup and UX between the spaces imports

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
@@ -1,6 +1,10 @@
 <div class="form__wrapper">
   <div class="card pt-4" id="assemblies">
     <div class="card-section">
+      <div class="row column mb-4">
+        <%= cell("decidim/announcement", { body: t("decidim.assemblies.admin.new_import.help_html") }, callout_class: "info") %>
+      </div>
+
       <div class="row column">
         <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
       </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div class="row column">
-        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary" %>
+        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary", help_i18n_scope: "decidim.forms.file_help.import_file", help_i18n_messages: ["message_1"] %>
       </div>
 
       <div class="card-divider">

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/_form.html.erb
@@ -1,34 +1,34 @@
-<%= append_javascript_pack_tag "decidim_assemblies_admin" %>
-
 <div class="form__wrapper">
   <div class="card pt-4" id="assemblies">
     <div class="card-section">
       <div class="row column">
         <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
       </div>
+
       <div class="row column">
         <%= form.text_field :slug, help_text: t(".slug_help_html", url: decidim_form_slug_url(:assemblies, form.object.slug)) %>
       </div>
+
       <div class="row column">
-        <%= form.upload :document, button_class: "button button__sm button__transparent-secondary" %>
+        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary" %>
       </div>
-      <div class="row column">
-        <div class="card">
-          <div class="card-divider">
-            <legend><%= t("assembly_imports.new.select", scope: "decidim.admin") %></legend>
+
+      <div class="card-divider">
+        <div class="card-title">
+          <%= t("assembly_imports.new.select", scope: "decidim.admin") %>
+        </div>
+      </div>
+      <div class="card-section">
+        <div class="row">
+          <div class="columns">
+            <%= form.check_box :import_attachments %>
           </div>
-          <div class="card-section">
-            <div class="row">
-              <div class="columns">
-                <%= form.check_box :import_attachments %>
-              </div>
-              <div class="columns">
-                <%= form.check_box :import_components %>
-              </div>
-            </div>
+          <div class="columns">
+            <%= form.check_box :import_components %>
           </div>
         </div>
       </div>
+
     </div>
   </div>
 </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/new.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assembly_imports/new.html.erb
@@ -1,4 +1,5 @@
 <% add_decidim_page_title(t("assembly_imports.new.title", scope: "decidim.admin")) %>
+
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t("assembly_imports.new.title", scope: "decidim.admin") %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -282,6 +282,7 @@ en:
         new_import:
           accepted_types:
             json: JSON
+          help_html: This import feature allows you to create a new assembly from an exported JSON file. You can export an assembly from another organization or from this same organization. The imported assembly will include its settings, components, and attachments (if selected).
       assemblies:
         description:
           area_name: Area

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -269,6 +269,7 @@ en:
             slug_help_html: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         assembly_imports:
           form:
+            document_legend: Add a document
             slug_help_html: 'URL slugs are used to generate the URLs that point to this assembly. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         assembly_members:
           form:

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -11,6 +11,18 @@ describe "Admin imports assembly" do
     visit decidim_admin_assemblies.assemblies_path
   end
 
+  context "when viewing the import page" do
+    before do
+      within_admin_menu do
+        click_on "Import"
+      end
+    end
+
+    it "displays the import help text" do
+      expect(page).to have_content("This import feature allows you to create a new assembly from an exported JSON file")
+    end
+  end
+
   context "when importing the assembly with basic fields" do
     before do
       stub_get_request_with_format(

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1053,9 +1053,6 @@ en:
           explanation: 'Guidance for file:'
           message_1: Has to be an image or a document.
           message_2: If it is an image, it preferably be a landscape image that does not have any text. The platform crops the image.
-        import_file:
-          explanation: 'Guidance for import file:'
-          message_1: Has to be a JSON document downloaded through the export feature.
         icon:
           explanation: 'Guidance for icon:'
           message_1: Has to be a square image.
@@ -1064,6 +1061,9 @@ en:
           explanation: 'Guidance for image:'
           message_1: Preferably a landscape image that does not have any text.
           message_2: The service crops the image.
+        import_file:
+          explanation: 'Guidance for import file:'
+          message_1: Has to be a JSON document downloaded through the export feature.
       file_validation:
         allowed_file_extensions: 'Allowed file extensions: %{extensions}'
         max_file_dimension: 'Maximum file dimensions: %{resolution} pixels'

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1053,6 +1053,9 @@ en:
           explanation: 'Guidance for file:'
           message_1: Has to be an image or a document.
           message_2: If it is an image, it preferably be a landscape image that does not have any text. The platform crops the image.
+        import_file:
+          explanation: 'Guidance for import file:'
+          message_1: Has to be a JSON document downloaded through the export feature.
         icon:
           explanation: 'Guidance for icon:'
           message_1: Has to be a square image.

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
@@ -14,7 +14,7 @@
       </div>
 
       <div class="row column">
-        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary" %>
+        <%= form.upload :document, label: t(".document_legend"), button_class: "button button__sm button__transparent-secondary", help_i18n_scope: "decidim.forms.file_help.import_file", help_i18n_messages: ["message_1"] %>
       </div>
 
       <div class="card-divider">

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card pt-4" id="processes">
     <div class="card-section">
       <div class="row column">
-        <%= form.translated :text_field, :title, autofocus: true %>
+        <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
       </div>
 
       <div class="row column">
@@ -32,7 +32,6 @@
         </div>
       </div>
 
-      </div>
     </div>
   </div>
 </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_imports/_form.html.erb
@@ -1,6 +1,10 @@
 <div class="form__wrapper">
   <div class="card pt-4" id="processes">
     <div class="card-section">
+      <div class="row column mb-4">
+        <%= cell("decidim/announcement", { body: t("decidim.participatory_processes.admin.new_import.help_html") }, callout_class: "info") %>
+      </div>
+
       <div class="row column">
         <%= form.translated :text_field, :title, autofocus: true, aria: { label: :title } %>
       </div>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -493,6 +493,7 @@ en:
         new_import:
           accepted_types:
             json: JSON
+          help_html: This import feature allows you to create a new participatory process from an exported JSON file. You can export a process from another organization or from this same organization. The imported process will include its settings, components, and attachments (if selected).
         participatory_process_duplicates:
           form:
             slug_help_html: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'

--- a/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
@@ -11,6 +11,18 @@ describe "Admin imports participatory process" do
     visit decidim_admin_participatory_processes.participatory_processes_path
   end
 
+  context "when viewing the import page" do
+    before do
+      within_admin_menu do
+        click_on "Import"
+      end
+    end
+
+    it "displays the import help text" do
+      expect(page).to have_content("This import feature allows you to create a new participatory process from an exported JSON file")
+    end
+  end
+
   context "with context" do
     before "Imports the process with the basic fields" do
       within_admin_menu do


### PR DESCRIPTION
#### :tophat: What? Why?

Related to the latest problems in the import spaces forms, this PR fixes a couple of things that I found:

1. Make the markup consistent between the two spaces (aria labels, JS tags, labels)
2. Fix the help text in the modal to talk about the JSON file and not about images 
3. Add a help text with an announcement info 

#### Testing

1. Go to http://localhost:3000/admin/participatory_processes/imports/new
2. Go to http://localhost:3000/admin/assemblies/imports/new
3. Both forms should be similar 

### :camera: Screenshots

#### Before

<img width="1617" height="694" alt="image" src="https://github.com/user-attachments/assets/82a7e3db-6562-4519-bd4e-1b322ef4016c" />
<img width="1743" height="695" alt="image" src="https://github.com/user-attachments/assets/ed6fb9d1-59c8-46fd-bd38-b81b2f09a3c2" />

#### After

<img width="1757" height="649" alt="image" src="https://github.com/user-attachments/assets/6be6bd92-157d-4ec0-8667-b2fd0dc8b6c7" />
<img width="1624" height="716" alt="image" src="https://github.com/user-attachments/assets/0ca4780f-ed95-463d-a79a-311e9e682a44" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Streamlined assembly and participatory process import forms with simplified layout and informational callouts
  * Added localized help text and labels for document upload fields across import interfaces
  * Improved accessibility for form fields (better labels/attributes)

* **Tests**
  * Added system tests to verify import page help text displays correctly for both modules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->