### PR TITLE
Fix caching issue in processes content block

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
@@ -28,7 +28,15 @@ module Decidim
       private
 
       def cache_hash
-        [I18n.locale, highlighted_spaces.map(&:cache_key_with_version)].join(Decidim.cache_key_separator)
+        [
+          I18n.locale,
+          highlighted_spaces.map do |space|
+            [
+              space.cache_key_with_version,
+              space.try(:active_step)&.cache_key_with_version
+            ].compact
+          end
+        ].flatten.join(Decidim.cache_key_separator)
       end
 
       def section_class

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
@@ -28,15 +28,7 @@ module Decidim
       private
 
       def cache_hash
-        [
-          I18n.locale,
-          highlighted_spaces.map do |space|
-            [
-              space.cache_key_with_version,
-              space.try(:active_step)&.cache_key_with_version
-            ].compact
-          end
-        ].flatten.join(Decidim.cache_key_separator)
+        [I18n.locale, highlighted_spaces.map(&:cache_key_with_version)].join(Decidim.cache_key_separator)
       end
 
       def section_class

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
@@ -11,7 +11,7 @@ module Decidim
 
     translatable_fields :title, :description
 
-    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess"
+    belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess", touch: true
     has_one :organization, through: :participatory_process
 
     alias participatory_space participatory_process

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
@@ -33,4 +33,38 @@ describe Decidim::ParticipatoryProcesses::ContentBlocks::HighlightedProcessesCel
       expect(subject).to have_css("a.card__grid", count: 8)
     end
   end
+
+  describe "#cache_hash" do
+    let(:processes) { create_list(:participatory_process, 2, :active, :with_steps, organization:) }
+
+    it "generates a unique hash" do
+      content_block.reload
+      old_hash = cell(content_block.cell, content_block).send(:cache_hash)
+      content_block.reload
+
+      expect(cell(content_block.cell, content_block).send(:cache_hash)).to eq(old_hash)
+    end
+
+    context "when participatory process active_step is updated" do
+      it "generates a different hash" do
+        old_hash = cell(content_block.cell, content_block).send(:cache_hash)
+        active_step = processes.first.active_step
+        active_step.update!(title: { en: "Updated title" })
+
+        expect(cell(content_block.cell, content_block).send(:cache_hash)).not_to eq(old_hash)
+      end
+    end
+
+    context "when current locale change" do
+      let(:alt_locale) { :ca }
+
+      before do
+        allow(I18n).to receive(:locale).and_return(alt_locale)
+      end
+
+      it "generates a different hash" do
+        expect(cell(content_block.cell, content_block).send(:cache_hash)).not_to match(/en$/)
+      end
+    end
+  end
 end

--- a/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
+++ b/decidim-participatory_processes/spec/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell_spec.rb
@@ -55,6 +55,19 @@ describe Decidim::ParticipatoryProcesses::ContentBlocks::HighlightedProcessesCel
       end
     end
 
+    context "when parent process is touched via step update" do
+      it "generates a different hash when process is touched" do
+        old_hash = cell(content_block.cell, content_block).send(:cache_hash)
+        process = processes.first
+
+        travel_to(1.second.from_now) do
+          process.update(updated_at: Time.current)
+        end
+
+        expect(cell(content_block.cell, content_block).send(:cache_hash)).not_to eq(old_hash)
+      end
+    end
+
     context "when current locale change" do
       let(:alt_locale) { :ca }
 

--- a/decidim-participatory_processes/spec/models/decidim/participatory_process_step_spec.rb
+++ b/decidim-participatory_processes/spec/models/decidim/participatory_process_step_spec.rb
@@ -116,6 +116,33 @@ module Decidim
           expect(other_step.position).to eq 0
         end
       end
+
+      context "when parent process is touched on step update" do
+        let(:participatory_process) { create(:participatory_process) }
+        let(:participatory_process_step) do
+          create(:participatory_process_step, participatory_process:)
+        end
+
+        it "touches the parent process" do
+          original_updated_at = participatory_process.updated_at
+
+          travel_to(1.second.from_now) do
+            participatory_process_step.save
+          end
+
+          expect(participatory_process.reload.updated_at).to be > original_updated_at
+        end
+
+        it "changes the process cache_key when step is updated" do
+          original_cache_key = participatory_process.cache_key_with_version
+
+          travel_to(1.second.from_now) do
+            participatory_process_step.save
+          end
+
+          expect(participatory_process.reload.cache_key_with_version).not_to eq(original_cache_key)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As explained on #15963, there's a caching issue in the "Highlighted Processes" content block of the homepage.

#### :pushpin: Related Issues
 
- Fixes #15963 

#### Testing

1. Enable caching locally with `bin/rails dev:cache`
2. Restart or start the rails server
3. Go to the homepage
4. Log in as admin
5. Edit the process that's visible in the homepage, add a new step, activate
6. Go back to the homepage
7. (Without the change) See that the step is the same as the one from step 3
8. (With the change) See that the step changes to the one from the step 5

### :camera: Screenshots


<img width="1654" height="914" alt="image" src="https://github.com/user-attachments/assets/4a0fe950-c05d-420a-9576-a094dbfdac0d" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation for participatory processes to ensure content changes in process steps are immediately reflected, preventing display of outdated information.

* **Tests**
  * Added comprehensive tests to verify proper cache behavior and parent process updates when steps are modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->