### PR TITLE
Prevent taxonomy importer from removing custom component settings

### DIFF
--- a/decidim-core/lib/decidim/maintenance/taxonomy_importer.rb
+++ b/decidim-core/lib/decidim/maintenance/taxonomy_importer.rb
@@ -85,7 +85,7 @@ module Decidim
           component = GlobalID::Locator.locate(component_id)
           if component
             begin
-              component.update!(settings: { taxonomy_filters: [filter.id.to_s] })
+              component.update!(settings: component.settings.to_h.merge(taxonomy_filters: [filter.id.to_s]))
               result[:components_assigned][filter.internal_name[organization.default_locale]] ||= []
               result[:components_assigned][filter.internal_name[organization.default_locale]] << component_id
             rescue ActiveRecord::RecordInvalid

--- a/decidim-core/spec/lib/maintenance/taxonomy_importer_spec.rb
+++ b/decidim-core/spec/lib/maintenance/taxonomy_importer_spec.rb
@@ -167,6 +167,19 @@ module Decidim::Maintenance
         end
       end
 
+      context "when component has existing settings" do
+        before do
+          component.update!(settings: { comments_enabled: false })
+        end
+
+        it "preserves existing settings when assigning taxonomy filters" do
+          expect(component.reload.settings.comments_enabled).to be(false)
+          subject.import!
+          expect(component.reload.settings[:taxonomy_filters]).to eq([filter.id.to_s])
+          expect(component.settings.comments_enabled).to be(false)
+        end
+      end
+
       context "when a filter already exists" do
         let!(:root_taxonomy) { create(:taxonomy, organization:, name: { organization.default_locale => "New root taxonomy" }) }
         let!(:filter) { create(:taxonomy_filter, root_taxonomy:, participatory_space_manifests: ["participatory_processes"]) }


### PR DESCRIPTION
#### :tophat: What? Why?

Prevent taxonomy importer from removing custom component settings when assigning the `taxonomy_filters`.

#### :pushpin: Related Issues

- Fixes #15986

#### Testing

1. From a `development_app` with Decidim 0.29.x, create a Proposals component with `participatory_texts_enabled: true` (or any other non-default setting).
2. Upgrade Decidim from version 0.29.x to 0.30.x.
3. Run the upgrade commands as documented in the release notes. Then, make and import the taxonomy plan:

  ```bash
  bin/rails decidim:taxonomies:make_plan
  bin/rails decidim:taxonomies:import_all_plans
  ```

4. Check the component settings and see we keep the `participatory_texts_enabled: true`.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Importing taxonomy filters now preserves any existing component settings instead of overwriting them, preventing loss of prior configuration.

* **Tests**
  * Added/expanded tests to ensure existing component settings remain intact when taxonomy filters are imported, and that taxonomy filters are applied as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->