### PR TITLE
Fix allow admins deleting attachments with links

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -3,6 +3,7 @@
 shared_examples "manage attachments examples" do
   context "when processing attachments" do
     let!(:attachment) { create(:attachment, attached_to:, attachment_collection:) }
+    let!(:attachment_with_link) { create(:attachment, :with_link, attached_to:, attachment_collection:) }
 
     before do
       visit current_path
@@ -180,6 +181,17 @@ shared_examples "manage attachments examples" do
       expect(page).to have_admin_callout("successfully")
 
       expect(page).to have_no_content(translated(attachment.title, locale: :en))
+    end
+
+    it "can delete an attachment with a link" do
+      within "tr", text: translated(attachment_with_link.title) do
+        find("button[data-controller='dropdown']").click
+        accept_confirm { click_on "Delete" }
+      end
+
+      expect(page).to have_admin_callout("successfully")
+
+      expect(page).to have_no_content(translated(attachment_with_link.title, locale: :en))
     end
 
     it "can update an attachment" do

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -189,7 +189,7 @@ shared_examples "manage attachments examples" do
         accept_confirm { click_on "Delete" }
       end
 
-      expect(page).to have_admin_callout("successfully")
+      expect(page).to have_admin_callout("Attachment destroyed successfully")
 
       expect(page).to have_no_content(translated(attachment_with_link.title, locale: :en))
     end

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -9,7 +9,7 @@ module Decidim
     include Traceable
 
     before_save :set_content_type_and_size, if: :attached?
-    before_validation :set_link_content_type_and_size, if: :link?
+    before_validation :set_link_content_type_and_size, if: :editable_link?
 
     translatable_fields :title, :description
     belongs_to :attachment_collection, class_name: "Decidim::AttachmentCollection", optional: true
@@ -67,6 +67,13 @@ module Decidim
     # Returns Boolean.
     def link?
       link.present?
+    end
+
+    # Whether this attachment is a link that can be edited or not.
+    #
+    # Returns Boolean.
+    def editable_link?
+      !destroyed? && !frozen? && link?
     end
 
     # Whether this attachment has a file or not.


### PR DESCRIPTION
#### :tophat: What? Why?

This PR
* Prevents calling the `set_link_content_type_and_size` callback of the `Decidim::Attachment` model if the instance is not editable because is in frozen state or destroyed.
* This change allows admins to delete attachments with links from the admin panel 
* Adds a test to check the fix.

#### :pushpin: Related Issues

- Fixes decidim/decidim#15993



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when deleting attachments that contain links and ensured clear success feedback.
  * Avoided unnecessary metadata processing for non-editable link attachments to reduce validation issues.

* **Tests**
  * Added end-to-end tests validating deletion of attachments with links and confirming their removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->