### PR TITLE
Fix notifications flaky specs

### DIFF
--- a/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
+++ b/decidim-core/spec/services/decidim/notifications_digest_sending_decider_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 describe Decidim::NotificationsDigestSendingDecider do
   subject { described_class }
 
+  before { travel_to(Time.now.utc.noon) }
+
   context "with a user who has never received a notifications digest mail" do
     let(:user) { build(:user, notifications_sending_frequency: :daily, digest_sent_at: nil) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
Sometimes, the CI pipeline fails during nights with the following error. This PR fixes the issue. One of the questions is if the spec is broken, or the problem relies on the implementation, considering that an AI module assessed that it can happen in production.
- The logic is calendar‑day based (<= (time - 1.day).end_of_day), not “last 24 hours.”
- If a digest was sent shortly before midnight (e.g., 23:57) and the next run happens just after midnight, that timestamp is still “on the previous day,” so it qualifies and can be sent again within minutes.
- If you want a strict 24‑hour window, the implementation needs to change.
- If the intent is a strict “last 24 hours / last 7 days” window, I’d change the thresholds to compare against the exact time delta instead of end_of_day:
  - Daily: user.digest_sent_at <= time - 1.day
  - Weekly: user.digest_sent_at <= time - 1.week

A failing workflow would be https://github.com/decidim/decidim/actions/runs/21693698043/job/62559429041

```
Failures:

  1) Decidim::NotificationsDigestSendingDecider when frequency is set to daily with a user who has received a notifications digest mail in the same day must_notify? returns false
     Failure/Error: expect(subject.must_notify?(user, current_time)).to be(false)

       expected false
            got true
     # ./spec/services/decidim/notifications_digest_sending_decider_spec.rb:35:in `block (5 levels) in <top (required)>'
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Run the spec on develop see it passes 
2. Add on line 7 the following ` before { travel_to(Time.now.utc.midnight) }` to simulate midnight 
3. Run the specs.
4. See that only one spec is failing "# Decidim::NotificationsDigestSendingDecider when frequency is set to daily with a user who has received a notifications digest mail in the same day must_notify? returns false"
5. Apply patch, or change on your previously added line to `before { travel_to(Time.now.utc.noon) }` 
6. Run the specs
7. See everything is running ok

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to ensure consistent time-based test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->