### PR TITLE
Add anti-pattern check for usage of have_admin_callout (matcher strategy) - deprecated

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
@@ -4,7 +4,7 @@ require "decidim/dev/test/rspec_support/helpers"
 
 MIN_LENGTH_THRESHOLD = 12
 
-SINGLE_WORD_ANTIPATTERNS = %w(
+SINGLE_WORD_ANTI_PATTERNS = %w(
   successfully
   successfully.
   problem
@@ -47,7 +47,7 @@ RSpec::Matchers.define :have_admin_callout do |expected|
 
     if is_single_word && is_too_short
       raise <<~ERROR
-        Antipattern detected: Using generic single-word text "#{text}" in admin callout assertions.
+        Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.
 
         Problem: Generic single-word messages don't verify the actual feedback shown to users.
 
@@ -55,9 +55,9 @@ RSpec::Matchers.define :have_admin_callout do |expected|
       ERROR
     end
 
-    if is_single_word && SINGLE_WORD_ANTIPATTERNS.include?(stripped_text.downcase)
+    if is_single_word && SINGLE_WORD_ANTI_PATTERNS.include?(stripped_text.downcase)
       raise <<~ERROR
-        Antipattern detected: Using generic single-word text "#{text}" in admin callout assertions.
+        Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.
 
         Problem: Generic single-word messages don't verify the actual feedback shown to users.
         Single-word messages like "successfully" or "problem" are too vague.
@@ -70,7 +70,7 @@ RSpec::Matchers.define :have_admin_callout do |expected|
 
     if is_too_short
       raise <<~ERROR
-        Antipattern detected: Using very short text "#{text}" (#{stripped_text.length} chars) in admin callout assertions.
+        Anti-pattern detected: Using very short text "#{text}" (#{stripped_text.length} chars) in admin callout assertions.
 
         Problem: Very short messages are likely generic and don't provide meaningful feedback.
         Messages should be at least #{MIN_LENGTH_THRESHOLD} characters to convey useful information.

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
@@ -44,16 +44,6 @@ RSpec::Matchers.define :have_admin_callout do |expected|
     is_single_word = text.to_s.strip !~ /\s/
     is_too_short = stripped_text.length < MIN_LENGTH_THRESHOLD
 
-    if is_single_word && is_too_short
-      raise <<~ERROR
-        Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.
-
-        Problem: Generic single-word messages do not verify the actual feedback shown to users.
-
-        #{format_find_command(text)}
-      ERROR
-    end
-
     if is_single_word && SINGLE_WORD_ANTI_PATTERNS.include?(stripped_text.downcase)
       raise <<~ERROR
         Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
@@ -49,7 +49,7 @@ RSpec::Matchers.define :have_admin_callout do |expected|
       raise <<~ERROR
         Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.
 
-        Problem: Generic single-word messages don't verify the actual feedback shown to users.
+        Problem: Generic single-word messages do not verify the actual feedback shown to users.
 
         #{format_find_command(text)}
       ERROR
@@ -59,7 +59,7 @@ RSpec::Matchers.define :have_admin_callout do |expected|
       raise <<~ERROR
         Anti-pattern detected: Using generic single-word text "#{text}" in admin callout assertions.
 
-        Problem: Generic single-word messages don't verify the actual feedback shown to users.
+        Problem: Generic single-word messages do not verify the actual feedback shown to users.
         Single-word messages like "successfully" or "problem" are too vague.
 
         Example: "Meeting successfully published" is better than just "successfully"
@@ -72,7 +72,7 @@ RSpec::Matchers.define :have_admin_callout do |expected|
       raise <<~ERROR
         Anti-pattern detected: Using very short text "#{text}" (#{stripped_text.length} chars) in admin callout assertions.
 
-        Problem: Very short messages are likely generic and don't provide meaningful feedback.
+        Problem: Very short messages are likely generic and do not provide meaningful feedback.
         Messages should be at least #{MIN_LENGTH_THRESHOLD} characters to convey useful information.
 
         Examples of proper messages:

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
@@ -6,7 +6,6 @@ MIN_LENGTH_THRESHOLD = 12
 
 SINGLE_WORD_ANTI_PATTERNS = %w(
   successfully
-  successfully.
   problem
   error
   warning

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/admin_callout_matchers.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "decidim/dev/test/rspec_support/helpers"
+
+MIN_LENGTH_THRESHOLD = 12
+
+SINGLE_WORD_ANTIPATTERNS = %w(
+  successfully
+  successfully.
+  problem
+  error
+  warning
+  done
+  complete
+  finished
+  ok
+  okay
+  saved
+  updated
+  created
+  deleted
+  removed
+  published
+  unpublished
+).freeze
+
+RSpec::Matchers.define :have_admin_callout do |expected|
+  include Decidim::ComponentTestHelpers
+
+  match do |_page|
+    # Short-circuit for nil/symbols to avoid calling within_flash_messages
+    return true if expected.nil? || expected.is_a?(Symbol)
+
+    validate_text(expected)
+
+    within_flash_messages do
+      have_content expected
+    end
+  end
+
+  def validate_text(text)
+    return true if text.nil? || text.is_a?(Symbol)
+
+    stripped_text = text.to_s.gsub(/[[:punct:]]/, "")
+    is_single_word = text.to_s.strip !~ /\s/
+    is_too_short = stripped_text.length < MIN_LENGTH_THRESHOLD
+
+    if is_single_word && is_too_short
+      raise <<~ERROR
+        Antipattern detected: Using generic single-word text "#{text}" in admin callout assertions.
+
+        Problem: Generic single-word messages don't verify the actual feedback shown to users.
+
+        #{format_find_command(text)}
+      ERROR
+    end
+
+    if is_single_word && SINGLE_WORD_ANTIPATTERNS.include?(stripped_text.downcase)
+      raise <<~ERROR
+        Antipattern detected: Using generic single-word text "#{text}" in admin callout assertions.
+
+        Problem: Generic single-word messages don't verify the actual feedback shown to users.
+        Single-word messages like "successfully" or "problem" are too vague.
+
+        Example: "Meeting successfully published" is better than just "successfully"
+
+        #{format_find_command(text)}
+      ERROR
+    end
+
+    if is_too_short
+      raise <<~ERROR
+        Antipattern detected: Using very short text "#{text}" (#{stripped_text.length} chars) in admin callout assertions.
+
+        Problem: Very short messages are likely generic and don't provide meaningful feedback.
+        Messages should be at least #{MIN_LENGTH_THRESHOLD} characters to convey useful information.
+
+        Examples of proper messages:
+          - "Meeting successfully published"
+          - "Budget successfully created."
+          - "There was a problem saving the form"
+          - "Your changes have been saved successfully"
+
+        #{format_find_command(text)}
+      ERROR
+    end
+
+    true
+  end
+
+  def format_find_command(text)
+    <<~COMMAND
+
+      To find similar instances:
+        grep -r 'have_admin_callout.*#{text}' --include="*.rb" decidim-*/
+    COMMAND
+  end
+
+  failure_message do
+    @failure_message || super()
+  end
+
+  diffable
+end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/helpers.rb
@@ -53,12 +53,6 @@ module Decidim
       expect(page).to have_css(".main-bar #trigger-dropdown-account")
     end
 
-    def have_admin_callout(text)
-      within_flash_messages do
-        have_content text
-      end
-    end
-
     def stub_get_request_with_format(rq_url, rs_format)
       stub_request(:get, rq_url)
         .with(

--- a/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
+++ b/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
@@ -149,5 +149,51 @@ RSpec.describe "have_admin_callout matcher" do
         end.to raise_error(/Meeting successfully published/)
       end
     end
+
+    context "boundary cases" do
+      it "validates 12 characters without raising" do
+        expect do
+          matcher = have_admin_callout("123456789012")
+          matcher.send(:validate_text, "123456789012")
+        end.not_to raise_error
+      end
+
+      it "fails for 11 characters" do
+        expect do
+          matcher = have_admin_callout("12345678901")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Anti-pattern detected/)
+      end
+    end
+
+    context "valid strings pass validation" do
+      it "validates 'Meeting successfully published' without raising" do
+        expect do
+          matcher = have_admin_callout("Meeting successfully published")
+          matcher.send(:validate_text, "Meeting successfully published")
+        end.not_to raise_error
+      end
+
+      it "validates 'Budget successfully created' without raising" do
+        expect do
+          matcher = have_admin_callout("Budget successfully created")
+          matcher.send(:validate_text, "Budget successfully created")
+        end.not_to raise_error
+      end
+
+      it "validates 'There was a problem saving the form' without raising" do
+        expect do
+          matcher = have_admin_callout("There was a problem saving the form")
+          matcher.send(:validate_text, "There was a problem saving the form")
+        end.not_to raise_error
+      end
+
+      it "validates 'Your changes have been saved successfully' without raising" do
+        expect do
+          matcher = have_admin_callout("Your changes have been saved successfully")
+          matcher.send(:validate_text, "Your changes have been saved successfully")
+        end.not_to raise_error
+      end
+    end
   end
 end

--- a/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
+++ b/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "have_admin_callout matcher" do
+  describe "antipattern detection" do
+    context "with single-word antipatterns" do
+      it "fails for 'successfully'" do
+        expect do
+          matcher = have_admin_callout("successfully")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'problem'" do
+        expect do
+          matcher = have_admin_callout("problem")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'error'" do
+        expect do
+          matcher = have_admin_callout("error")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'warning'" do
+        expect do
+          matcher = have_admin_callout("warning")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'Done' (capitalized)" do
+        expect do
+          matcher = have_admin_callout("Done")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'OK'" do
+        expect do
+          matcher = have_admin_callout("OK")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'created'" do
+        expect do
+          matcher = have_admin_callout("created")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'updated'" do
+        expect do
+          matcher = have_admin_callout("updated")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'deleted'" do
+        expect do
+          matcher = have_admin_callout("deleted")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'published'" do
+        expect do
+          matcher = have_admin_callout("published")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'unpublished'" do
+        expect do
+          matcher = have_admin_callout("unpublished")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+    end
+
+    context "with very short strings" do
+      it "fails for 5-character strings like 'Error'" do
+        expect do
+          matcher = have_admin_callout("Error")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for strings with punctuation like 'Error!'" do
+        expect do
+          matcher = have_admin_callout("Error!")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for short multi-word strings like 'Error now'" do
+        expect do
+          matcher = have_admin_callout("Error now")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+
+      it "fails for 'Bad data'" do
+        expect do
+          matcher = have_admin_callout("Bad data")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Antipattern detected/)
+      end
+    end
+
+    context "edge cases" do
+      it "does not fail for nil" do
+        expect do
+          matcher = have_admin_callout(nil)
+          matcher.matches?(Object.new)
+        end.not_to raise_error
+      end
+
+      it "does not fail for symbols" do
+        expect do
+          matcher = have_admin_callout(:some_symbol)
+          matcher.matches?(Object.new)
+        end.not_to raise_error
+      end
+
+      it "provides helpful error messages with grep command" do
+        expect do
+          matcher = have_admin_callout("successfully")
+          matcher.matches?(Object.new)
+        end.to raise_error(/grep.*have_admin_callout.*successfully/)
+      end
+
+      it "mentions minimum length threshold in error message" do
+        expect do
+          matcher = have_admin_callout("Bad data")
+          matcher.matches?(Object.new)
+        end.to raise_error(/12.*characters/)
+      end
+
+      it "provides example replacements in error message" do
+        expect do
+          matcher = have_admin_callout("successfully")
+          matcher.matches?(Object.new)
+        end.to raise_error(/Meeting successfully published/)
+      end
+    end
+  end
+end

--- a/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
+++ b/decidim-dev/spec/lib/decidim/dev/admin_callout_matchers_spec.rb
@@ -3,83 +3,83 @@
 require "spec_helper"
 
 RSpec.describe "have_admin_callout matcher" do
-  describe "antipattern detection" do
-    context "with single-word antipatterns" do
+  describe "anti-pattern detection" do
+    context "with single-word anti-patterns" do
       it "fails for 'successfully'" do
         expect do
           matcher = have_admin_callout("successfully")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'problem'" do
         expect do
           matcher = have_admin_callout("problem")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'error'" do
         expect do
           matcher = have_admin_callout("error")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'warning'" do
         expect do
           matcher = have_admin_callout("warning")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'Done' (capitalized)" do
         expect do
           matcher = have_admin_callout("Done")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'OK'" do
         expect do
           matcher = have_admin_callout("OK")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'created'" do
         expect do
           matcher = have_admin_callout("created")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'updated'" do
         expect do
           matcher = have_admin_callout("updated")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'deleted'" do
         expect do
           matcher = have_admin_callout("deleted")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'published'" do
         expect do
           matcher = have_admin_callout("published")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'unpublished'" do
         expect do
           matcher = have_admin_callout("unpublished")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
     end
 
@@ -88,28 +88,28 @@ RSpec.describe "have_admin_callout matcher" do
         expect do
           matcher = have_admin_callout("Error")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for strings with punctuation like 'Error!'" do
         expect do
           matcher = have_admin_callout("Error!")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for short multi-word strings like 'Error now'" do
         expect do
           matcher = have_admin_callout("Error now")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
 
       it "fails for 'Bad data'" do
         expect do
           matcher = have_admin_callout("Bad data")
           matcher.matches?(Object.new)
-        end.to raise_error(/Antipattern detected/)
+        end.to raise_error(/Anti-pattern detected/)
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While giving an eye to #15994, I found the usage of this antipattern: 

>       expect(page).to have_admin_callout("successfully")

This is something that is well extended in the codebase, and it actually can also ignore a minor bug in the process: as the spec was copy and pasted, the flash can also be copy pasted and we can be showing a wrong message in the flash (something like "Meeting successfully updated" when it should really be a Proposal). 

As this is really extended through the codebase, I think we should introduce a rubocop or a failure in the CI for this. I think just adding the failure in the matcher is the cleanest way of doing it. 

#### :pushpin: Related Issues

- Related to #15994 

#### Testing

1. (Before) Do a search for this string in the codebase
``` 
grep -r 'have_admin_callout."successfully' --include="*.rb" decidim-*/ | wc -l
206
```
2. Apply the patch
3. (After) Do the search and see it on 0


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for admin callout validation covering antipatterns, length rules, edge cases, and helpful failure messages.

* **Chores**
  * Replaced the previous admin-callout test helper with a stricter validation matcher that enforces clearer admin notification wording and provides actionable guidance when messages are too short or ambiguous.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->