### PR TITLE
Fix can_participate? into ParticipatoryProcessStep

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -42,37 +42,54 @@ shared_examples "manage attachments examples" do
       end
     end
 
-    it "can add attachments without a collection to a process" do
-      click_on "New attachment"
+    context "when creating an attachment" do
+      before do
+        click_on "New attachment"
 
-      within ".new_attachment" do
-        fill_in_i18n(
-          :attachment_title,
-          "#attachment-title-tabs",
-          en: "Very Important Document",
-          es: "Documento Muy Importante",
-          ca: "Document Molt Important"
-        )
+        within ".new_attachment" do
+          fill_in_i18n(
+            :attachment_title,
+            "#attachment-title-tabs",
+            en: "Very Important Document",
+            es: "Documento Muy Importante",
+            ca: "Document Molt Important"
+          )
 
-        fill_in_i18n(
-          :attachment_description,
-          "#attachment-description-tabs",
-          en: "This document contains important information",
-          es: "Este documento contiene información importante",
-          ca: "Aquest document conté informació important"
-        )
+          fill_in_i18n(
+            :attachment_description,
+            "#attachment-description-tabs",
+            en: "This document contains important information",
+            es: "Este documento contiene información importante",
+            ca: "Aquest document conté informació important"
+          )
+        end
+
+        dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
       end
 
-      dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
+      it "can be added without a collection to a process" do
+        within ".new_attachment" do
+          find("*[type=submit]").click
+        end
 
-      within ".new_attachment" do
-        find("*[type=submit]").click
+        expect(page).to have_admin_callout("successfully")
+
+        within "#attachments table" do
+          expect(page).to have_text("Very Important Document")
+        end
       end
 
-      expect(page).to have_admin_callout("successfully")
+      it "the notifications are properly displayed" do
+        create(:follow, user:, followable: attached_to)
 
-      within "#attachments table" do
-        expect(page).to have_text("Very Important Document")
+        within ".new_attachment" do
+          find("*[type=submit]").click
+        end
+
+        wait_enqueued_jobs do
+          visit decidim.notifications_path
+          expect(page).to have_content("A new document has been added to")
+        end
       end
     end
 

--- a/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_attachments_examples.rb
@@ -42,54 +42,37 @@ shared_examples "manage attachments examples" do
       end
     end
 
-    context "when creating an attachment" do
-      before do
-        click_on "New attachment"
+    it "can add attachments without a collection to a process" do
+      click_on "New attachment"
 
-        within ".new_attachment" do
-          fill_in_i18n(
-            :attachment_title,
-            "#attachment-title-tabs",
-            en: "Very Important Document",
-            es: "Documento Muy Importante",
-            ca: "Document Molt Important"
-          )
+      within ".new_attachment" do
+        fill_in_i18n(
+          :attachment_title,
+          "#attachment-title-tabs",
+          en: "Very Important Document",
+          es: "Documento Muy Importante",
+          ca: "Document Molt Important"
+        )
 
-          fill_in_i18n(
-            :attachment_description,
-            "#attachment-description-tabs",
-            en: "This document contains important information",
-            es: "Este documento contiene información importante",
-            ca: "Aquest document conté informació important"
-          )
-        end
-
-        dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
+        fill_in_i18n(
+          :attachment_description,
+          "#attachment-description-tabs",
+          en: "This document contains important information",
+          es: "Este documento contiene información importante",
+          ca: "Aquest document conté informació important"
+        )
       end
 
-      it "can be added without a collection to a process" do
-        within ".new_attachment" do
-          find("*[type=submit]").click
-        end
+      dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
 
-        expect(page).to have_admin_callout("successfully")
-
-        within "#attachments table" do
-          expect(page).to have_text("Very Important Document")
-        end
+      within ".new_attachment" do
+        find("*[type=submit]").click
       end
 
-      it "the notifications are properly displayed" do
-        create(:follow, user:, followable: attached_to)
+      expect(page).to have_admin_callout("successfully")
 
-        within ".new_attachment" do
-          find("*[type=submit]").click
-        end
-
-        wait_enqueued_jobs do
-          visit decidim.notifications_path
-          expect(page).to have_content("A new document has been added to")
-        end
+      within "#attachments table" do
+        expect(page).to have_text("Very Important Document")
       end
     end
 

--- a/decidim-assemblies/spec/system/admin/admin_manages_assembly_attachments_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assembly_attachments_spec.rb
@@ -17,5 +17,44 @@ describe "Admin manages assembly attachments" do
     end
   end
 
-  it_behaves_like "manage attachments examples"
+  it_behaves_like "manage attachments examples" do
+    context "when checking notifications" do
+      it "successfully displays the notification" do
+        create(:follow, user:, followable: attached_to)
+
+        click_on "New attachment"
+
+        within ".new_attachment" do
+          fill_in_i18n(
+            :attachment_title,
+            "#attachment-title-tabs",
+            en: "Very Important Document",
+            es: "Documento Muy Importante",
+            ca: "Document Molt Important"
+          )
+
+          fill_in_i18n(
+            :attachment_description,
+            "#attachment-description-tabs",
+            en: "This document contains important information",
+            es: "Este documento contiene información importante",
+            ca: "Aquest document conté informació important"
+          )
+        end
+
+        dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
+
+        within ".new_attachment" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        wait_enqueued_jobs do
+          visit decidim.notifications_path
+          expect(page).to have_content("A new document has been added to")
+        end
+      end
+    end
+  end
 end

--- a/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
+++ b/decidim-participatory_processes/app/models/decidim/participatory_process_step.rb
@@ -9,6 +9,8 @@ module Decidim
     include Traceable
     include Loggable
 
+    delegate :can_participate?, to: :participatory_process
+
     translatable_fields :title, :description
 
     belongs_to :participatory_process, foreign_key: "decidim_participatory_process_id", class_name: "Decidim::ParticipatoryProcess", touch: true

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_attachments_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_attachments_spec.rb
@@ -5,5 +5,44 @@ require "spec_helper"
 describe "Admin manages participatory process attachments" do
   include_context "when admin administrating a participatory process"
 
-  it_behaves_like "manage process attachments examples"
+  it_behaves_like "manage process attachments examples" do
+    context "when checking notifications" do
+      it "successfully displays the notification" do
+        create(:follow, user:, followable: attached_to)
+
+        click_on "New attachment"
+
+        within ".new_attachment" do
+          fill_in_i18n(
+            :attachment_title,
+            "#attachment-title-tabs",
+            en: "Very Important Document",
+            es: "Documento Muy Importante",
+            ca: "Document Molt Important"
+          )
+
+          fill_in_i18n(
+            :attachment_description,
+            "#attachment-description-tabs",
+            en: "This document contains important information",
+            es: "Este documento contiene información importante",
+            ca: "Aquest document conté informació important"
+          )
+        end
+
+        dynamically_attach_file(:attachment_file, Decidim::Dev.asset("Exampledocument.pdf"))
+
+        within ".new_attachment" do
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout("successfully")
+
+        wait_enqueued_jobs do
+          visit decidim.notifications_path
+          expect(page).to have_content("A new document has been added to")
+        end
+      end
+    end
+  end
 end

--- a/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
@@ -33,6 +33,25 @@ describe "Participatory Process Steps" do
       end
     end
 
+    context "when activating a step" do
+      let!(:user) { create(:user, :confirmed, organization:) }
+      let!(:follow) { create(:follow, user:, followable: participatory_process) }
+
+      before do
+        participatory_process.steps.first.update!(active: true)
+        Decidim::ParticipatoryProcesses::Admin::ActivateParticipatoryProcessStep.call(steps.last, user)
+        login_as user, scope: :user
+        switch_to_host(organization.host)
+      end
+
+      it "activates the step" do
+        wait_enqueued_jobs do
+          visit decidim.notifications_path
+          expect(page).to have_content("phase is now active for")
+        end
+      end
+    end
+
     it "lists all the steps" do
       visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale, display_steps: true)
 

--- a/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_process_steps_spec.rb
@@ -44,7 +44,7 @@ describe "Participatory Process Steps" do
         switch_to_host(organization.host)
       end
 
-      it "activates the step" do
+      it "triggers a notification" do
         wait_enqueued_jobs do
           visit decidim.notifications_path
           expect(page).to have_content("phase is now active for")


### PR DESCRIPTION
#### :tophat: What? Why?
While i was trying to check the issue fixed by #15950 i went to the notifications path and i got served with an error, caused by activation of a new ParticipatoryProcessStep. This Step was activated when i have locally tested #15988

Additionally i am adding a spec for the work done in #15950. 

<img width="1290" height="458" alt="image" src="https://github.com/user-attachments/assets/5c2a2db3-6fe4-4ea7-8182-32c063ecf0e7" />

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15950
- Related to #15988
- Fixes #?

#### Testing
1. Login as admin
2. Visit the Participatory process frontend site & make sure you follow it 
3. Visit a **participatory process in admin** 
4. Create a new ParticipatoryProcessStep & activate 
5. Visit the frontend site 
6. Go to your notifications 
7. See error 
8. Apply patch 
9. See error is gone

To validate the spec, switch to this branch, edit the Attachment work and revert the work done in #15950, then run: `./bin/rspec decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_attachments_spec.rb`

You should see an error similar with the above. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Participatory process steps can directly access participation eligibility from their parent process.

* **Tests**
  * Added system tests covering notifications when participatory process steps are activated.
  * Added system tests verifying notifications after attachments are added to participatory processes and assemblies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->