### PR TITLE
Fix export buttons in Initiatives

### DIFF
--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -1,7 +1,7 @@
 <div class="relative">
   <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="<%= dropdown_id(filters) %>">
     <% if filters.present? %>
-      <%= t("actions.export-selection", scope: "decidim.admin") %>
+      <%= t("actions.export_selection", scope: "decidim.admin") %>
     <% else %>
       <%= t("actions.export", scope: "decidim.admin") %>
     <% end %>

--- a/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
+++ b/decidim-admin/app/views/decidim/admin/exports/_dropdown.html.erb
@@ -3,7 +3,7 @@
     <% if filters.present? %>
       <%= t("actions.export_selection", scope: "decidim.admin") %>
     <% else %>
-      <%= t("actions.export", scope: "decidim.admin") %>
+      <%= t("actions.export_all", scope: "decidim.admin") %>
     <% end %>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -190,7 +190,8 @@ en:
           </ul>
           If you change your mind, you can restore it later.
         export: Export
-        export-selection: Export selection
+        export_all: Export all
+        export_selection: Export selection
         import: Import
         member:
           new: New member

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/exports/_dropdown.html.erb
@@ -2,9 +2,9 @@
 <div class="relative">
   <button class="button button__sm button__transparent-secondary" data-controller="dropdown" data-target="dropdown-exports-<%= menu_id %>-<%= dropdown_id(collection_ids) %>">
     <% if collection_ids.present? %>
-      <%= t("actions.export-selection", scope: "decidim.admin") %>
+      <%= t("actions.export_selection", scope: "decidim.admin") %>
     <% else %>
-      <%= t("actions.export", scope: "decidim.admin") %>
+      <%= t("actions.export_all", scope: "decidim.admin") %>
     <% end %>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-down-s-line" %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -5,7 +5,9 @@
       <%= t("decidim.admin.titles.initiatives") %>
 
       <% if allowed_to? :export, :initiatives %>
-        <%= export_dropdowns(query) %>
+        <div class="flex align-middle gap-x-4 ml-auto">
+          <%= export_dropdowns(query) %>
+        </div>
       <% end %>
     </h1>
   </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -5,7 +5,7 @@
       <%= t("decidim.admin.titles.initiatives") %>
 
       <% if allowed_to? :export, :initiatives %>
-        <div class="flex align-middle gap-x-4 ml-auto">
+        <div class="flex items-center gap-x-4 ml-auto">
           <%= export_dropdowns(query) %>
         </div>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Into the admin section, when i access the initiative page if i select a filter the page shows 2 export button and they don't seem to be related.

This PR fixes them by clarifying what these two buttons do.

#### :pushpin: Related Issues
 
- Fixes #15931

#### Testing

1. Sign in as admin
2. Go to the Initiatives admin 
3. Filter for any criteria
4. See the buttons at the top of the table

### :camera: Screenshots

#### Before

<img width="2076" height="764" alt="image" src="https://github.com/user-attachments/assets/d079da8f-46bd-44dc-91bc-b0c21c5d8804" />

#### After

<img width="2050" height="630" alt="image" src="https://github.com/user-attachments/assets/ef2f56a2-9df3-4782-a222-4aaa5b544bc8" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified export options by introducing distinct button labels: "Export all" and "Export selection" so the intended action is clearer.

* **UI/UX**
  * Adjusted layout and spacing of export controls for improved alignment and visual consistency across admin lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->