### PR TITLE
Make the process groups admin navigation consistent with others spaces

### DIFF
--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
@@ -1,3 +1,5 @@
+<% add_secondary_root_menu(:admin_participatory_process_group_menu) %>
+
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
     <% if allowed_to? :create, :process_group %>
@@ -8,17 +10,6 @@
         </span>
       <% end %>
     <% end %>
-    <div class="inline-block relative">
-      <%= button_tag id: "processes-menu-trigger", data: { controller: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
-        <span>
-          <%= t("menu.manage", scope: "decidim.admin") %>
-        </span>
-        <%= icon "arrow-down-s-line" %>
-      <% end %>
-      <div id="processes-dropdown-menu-settings" class="process-title-content-dropdown">
-        <%= dropdown_menu(:admin_participatory_process_group_menu).render %>
-      </div>
-    </div>
   </div>
 <% end %>
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
       menu:
         participatory_process_groups: Process groups
         participatory_process_groups_submenu:
-          info: Info
+          info: About this process group
           landing_page: Landing page layout
         participatory_processes: Processes
         participatory_processes_submenu:

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
@@ -162,8 +162,9 @@ describe "Admin manages participatory process groups" do
         click_on "Edit"
       end
 
-      click_on "Manage"
-      click_on "Landing page"
+      within "#admin-sidebar-menu-settings" do
+        click_on "Landing page"
+      end
 
       expect(page).to have_content "Active content blocks"
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing the Process Groups feature last week, we noticed that the UI pattern in how the navigation works here doesn't correspond with the rest of the admin: the navigation works with the right-top button, and it is expected to have it in the sidebar.

This PR fixes that\

#### Testing

1. Sign in as admin
2. Go to the admin panel
3. Go to a process group
4. See the navigation

### :camera: Screenshots

#### Before

<img width="2714" height="1428" alt="image" src="https://github.com/user-attachments/assets/8deecc87-5223-4929-ba7a-a94f149f3abf" />

#### After

<img width="2750" height="1198" alt="image" src="https://github.com/user-attachments/assets/f7ce7c0c-ed2d-4caf-bfb5-98090d86e9f9" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Simplified the admin participatory process group interface by removing the processes dropdown menu from the breadcrumb area.
  * Updated the admin menu label from "Info" to "About this process group" for improved clarity and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->