### PR TITLE
Fix conference JumpTo button

### DIFF
--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
@@ -36,7 +36,7 @@
     @apply divide-y divide-white [&>li]:py-3.5 first:[&>li]:pt-0 last:[&>li]:pb-0;
 
     &-container {
-      @apply ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-stretch;
+      @apply mt-2 ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-stretch;
 
       [id*="dropdown-menu"] {
         @apply mx-0;

--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
@@ -100,3 +100,7 @@
     }
   }
 }
+
+[data-target="dropdown-menu-conference"] {
+  @apply md:hidden;
+}

--- a/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
+++ b/decidim-conferences/app/packs/stylesheets/decidim/conferences/_conference.scss
@@ -99,6 +99,10 @@
       @apply text-lg text-gray-2;
     }
   }
+
+  &__section {
+    @apply md:pt-0;
+  }
 }
 
 [data-target="dropdown-menu-conference"] {

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -42,7 +42,7 @@ edit_link(
 
     <%= participatory_space_floating_help %>
 
-    <section class="content-block">
+    <section class="content-block conference__section">
       <h2 class="h2 decorator"><%= t("conferences.show.introduction", scope: "decidim") %></h2>
       <div class="content-block__description editor-content">
         <%= decidim_sanitize_editor_admin translated_attribute(current_participatory_space.short_description) %>

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,10 +1,10 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-open-md="true">
+  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
-  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav">
+  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav" aria-hidden="true">
     <% model.each do |item| %>
       <li role="menuitem">
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>

--- a/decidim-core/app/packs/stylesheets/decidim/_participatory_spaces.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_participatory_spaces.scss
@@ -99,7 +99,7 @@
     @apply divide-y divide-white [&>li]:py-3.5 first:[&>li]:pt-0 last:[&>li]:pb-0;
 
     &-container {
-      @apply mb-20 ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-start;
+      @apply mb-8 ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-start;
 
       [id*="dropdown-menu"] {
         @apply mx-0;

--- a/decidim-core/app/packs/stylesheets/decidim/_participatory_spaces.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_participatory_spaces.scss
@@ -99,7 +99,7 @@
     @apply divide-y divide-white [&>li]:py-3.5 first:[&>li]:pt-0 last:[&>li]:pb-0;
 
     &-container {
-      @apply ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-start;
+      @apply mb-20 ml-0 md:ml-6 bg-primary p-3 md:p-6 rounded w-full md:w-auto self-start;
 
       [id*="dropdown-menu"] {
         @apply mx-0;


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am fixing a visual issue within conferences page, where the "jump to" button in conference page is being displayed when it should not. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15296

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
**Before**
<img width="1430" height="358" alt="image" src="https://github.com/user-attachments/assets/9275adf7-4701-4a4d-907c-4050355f446b" />

**After**
<img width="1473" height="401" alt="image" src="https://github.com/user-attachments/assets/77922758-3db3-4b5f-9d6f-945086d21944" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted navigation spacing across conference and participatory space layouts and added styling for the conference intro section.
  * Updated conference dropdown to be hidden on medium and larger screens.

* **Accessibility**
  * Improved dropdown markup to better support screen readers (added relevant accessibility attributes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->