### PR TITLE
Fix survey export exporting wrong survey 

### DIFF
--- a/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/responses/index.html.erb
@@ -4,7 +4,7 @@
   <h1 class="item_show__header-title">
     <%= t ".title", total: @total %>
     <% if @survey.questionnaire.responses.any? %>
-      <%= export_dropdown(current_component, @survey.questionnaire.id) if allowed_to? :export_responses, :questionnaire %>
+      <%= export_dropdown(current_component, @survey.id) if allowed_to? :export_responses, :questionnaire %>
     <% end %>
   </h1>
 </div>

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -54,8 +54,8 @@ Decidim.register_component(:surveys) do |component|
   end
 
   component.exports :survey_user_responses do |exports|
-    exports.collection do |f|
-      survey = Decidim::Surveys::Survey.find_by(component: f)
+    exports.collection do |component, user, survey_id|
+      survey = Decidim::Surveys::Survey.find(survey_id)
       Decidim::Forms::QuestionnaireUserResponses.for(survey.questionnaire)
     end
 

--- a/decidim-surveys/lib/decidim/surveys/component.rb
+++ b/decidim-surveys/lib/decidim/surveys/component.rb
@@ -54,7 +54,7 @@ Decidim.register_component(:surveys) do |component|
   end
 
   component.exports :survey_user_responses do |exports|
-    exports.collection do |component, user, survey_id|
+    exports.collection do |_component, _user, survey_id|
       survey = Decidim::Surveys::Survey.find(survey_id)
       Decidim::Forms::QuestionnaireUserResponses.for(survey.questionnaire)
     end

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -25,9 +25,8 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
     end
 
     let(:component) { create(:surveys_component) }
-    let(:component2) { create(:surveys_component) }
     let(:survey) { create(:survey, component: component) }
-    let(:survey2) { create(:survey, component: component2) }
+    let(:survey2) { create(:survey, component: component) }
     let!(:survey_responses) { create_list(:response, 3, questionnaire: survey.questionnaire) }
     let!(:other_survey_responses) { create_list(:response, 4, questionnaire: survey2.questionnaire) }
     let(:organization) { component.participatory_space.organization }

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -25,8 +25,8 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
     end
 
     let(:component) { create(:surveys_component) }
-    let(:survey) { create(:survey, component: component) }
-    let(:survey2) { create(:survey, component: component) }
+    let(:survey) { create(:survey, component:) }
+    let(:survey2) { create(:survey, component:) }
     let!(:survey_responses) { create_list(:response, 3, questionnaire: survey.questionnaire) }
     let!(:other_survey_responses) { create_list(:response, 4, questionnaire: survey2.questionnaire) }
     let(:organization) { component.participatory_space.organization }

--- a/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
+++ b/decidim-surveys/spec/lib/decidim/surveys/component_spec.rb
@@ -13,4 +13,32 @@ describe "Surveys component" do # rubocop:disable RSpec/DescribeClass
       expect { subject.manifest.run_hooks(:copy, old_component: component, new_component:) }.not_to raise_error
     end
   end
+
+  describe "component exports" do
+    subject do
+      component
+        .manifest
+        .export_manifests
+        .find { |manifest| manifest.name == :survey_user_responses }
+        &.collection
+        &.call(component, user, survey2.id)
+    end
+
+    let(:component) { create(:surveys_component) }
+    let(:component2) { create(:surveys_component) }
+    let(:survey) { create(:survey, component: component) }
+    let(:survey2) { create(:survey, component: component2) }
+    let!(:survey_responses) { create_list(:response, 3, questionnaire: survey.questionnaire) }
+    let!(:other_survey_responses) { create_list(:response, 4, questionnaire: survey2.questionnaire) }
+    let(:organization) { component.participatory_space.organization }
+
+    context "when the user is an admin" do
+      let!(:user) { create(:user, admin: true, organization:) }
+
+      it "exports responses only for the requested survey" do
+        expect(subject.count).to eq(4)
+        expect(subject.flatten.map(&:id)).to match_array(other_survey_responses.map(&:id))
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
After https://github.com/decidim/decidim/issues/13152 Exports for surveys were exporting the wrong survey. This was because they were found on the manifest with `.find_by(component:)` so that surveys that belonged to the same component always returned the first instance.

#### :pushpin: Related Issues
- Fixes #16029 
- Mind that this will also affect this one: https://github.com/decidim/decidim/commit/f57ce9fad43b78100a7ab78fc537edb6baa975ec as this also calls `.find_by(component:)` but this PR doesn't cover it
- will need backporting to 0.30 and 0.31
- tangentially related to https://github.com/decidim/decidim/issues/15443 

#### Testing
*Describe the best way to test or validate your PR.*

1. Go to admin -> processes -> pick a participatory process with a surveys component. Should have more than one survey and the surveys should be answered
2. Pick the second survey within the survey.
3. Click Export, pick any format
4. From the front-office (not admin panel) go to My account -> My Data
5. Click on the export

Shows an empty file if the first survey has no answers or the answers of the first survey. After fix, correct file is shown. 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
URL to this button changes `resource_id` from `questionnaire.id` to `survey.id`
<img width="259" height="211" alt="image" src="https://github.com/user-attachments/assets/8e8a9227-3793-4b6b-a909-560826537da6" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Exported admin responses are now correctly scoped to the selected survey; export control targets the survey itself.
* **Tests**
  * Added tests to confirm exports include only responses for the specified survey and that exported response IDs match that survey.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->