### PR TITLE
Fix visual links missing from milestones

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/result_show/milestones.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_show/milestones.erb
@@ -12,7 +12,7 @@
           <%= l milestone.entry_date, format: :decidim_short %>
         </div>
         <% if translated_attribute(milestone.description).present? %>
-          <div>
+          <div class="editor-content">
             <%= decidim_sanitize_translated(milestone.description) %>
           </div>
         <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
The `editor-content` class element was missing from the milestones show, allowing for links to properly display their properties (blue underline) within the description section. 

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/15845

#### Testing
1. Login 
2. Find a space with accountability configured
3. Create a result
4. Within that result click the 3 dots and create a milestone with whatever name you link
5. In the description add a link to website to something written in the WYSIWYG editor
6. Press save 
7. Head to the front end and find that Result
8. See the milestone in that result with the proper link within the description displaying properly.

### :camera: Screenshots
<img width="844" height="511" alt="image" src="https://github.com/user-attachments/assets/39e0daa1-bfed-4496-8809-eb3bd2021aca" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved milestone description presentation with enhanced visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->