### PR TITLE
Do not show withdrawn links if there aren't any

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -124,7 +124,9 @@ module Decidim
       end
 
       def withdrawn_meetings?
-        @withdrawn_meetings ||= Meeting.where(component: current_component).published.not_hidden.withdrawn.visible_for(current_user).exists?
+        return @withdrawn_meetings if defined?(@withdrawn_meetings)
+
+        @withdrawn_meetings = Meeting.where(component: current_component).published.not_hidden.withdrawn.visible_for(current_user).exists?
       end
 
       def registration_qr_code_image

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -18,7 +18,7 @@ module Decidim
       include Decidim::AttachmentsHelper
       include Decidim::SanitizeHelper
 
-      helper_method :meetings, :meeting, :registration, :registration_qr_code_image, :search, :tab_panel_items
+      helper_method :meetings, :meeting, :registration, :registration_qr_code_image, :search, :tab_panel_items, :withdrawn_meetings?
 
       before_action :add_additional_csp_directives, only: [:show]
 
@@ -121,6 +121,10 @@ module Decidim
 
       def registration
         @registration ||= meeting.registrations.find_by(user: current_user)
+      end
+
+      def withdrawn_meetings?
+        @withdrawn_meetings ||= Meeting.where(component: current_component).published.not_hidden.withdrawn.visible_for(current_user).exists?
       end
 
       def registration_qr_code_image

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -126,7 +126,7 @@ module Decidim
       def withdrawn_meetings?
         return @withdrawn_meetings if defined?(@withdrawn_meetings)
 
-        @withdrawn_meetings = Meeting.where(component: current_component).published.not_hidden.withdrawn.visible_for(current_user).exists?
+        @withdrawn_meetings ||= search_base_collection.withdrawn.exists?
       end
 
       def registration_qr_code_image
@@ -136,12 +136,7 @@ module Decidim
       end
 
       def search_collection
-        Meeting
-          .where(component: current_component)
-          .published
-          .not_hidden
-          .or(MeetingLink.find_meetings(component: current_component))
-          .visible_for(current_user)
+        search_base_collection
           .with_availability(
             filter_params[:with_availability]
           )
@@ -149,6 +144,15 @@ module Decidim
             :component,
             attachments: :file_attachment
           )
+      end
+
+      def search_base_collection
+        Meeting
+          .where(component: current_component)
+          .published
+          .not_hidden
+          .or(MeetingLink.find_meetings(component: current_component))
+          .visible_for(current_user)
       end
 
       def meeting_form

--- a/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/shared/_meetings.html.erb
@@ -27,7 +27,7 @@
 <% if component.present? %>
   <% if params.dig("filter", "with_availability").present? && params["filter"]["with_availability"] == "withdrawn" %>
     <%= link_to t("decidim.meetings.meetings.index.see_all"), meetings_path("filter[with_availability]" => nil), class: "button button__sm button__text-secondary" %>
-  <% else %>
+  <% elsif withdrawn_meetings? %>
     <%= link_to t("decidim.meetings.meetings.index.see_all_withdrawn"), meetings_path("filter[with_availability]" => "withdrawn"), class: "button button__sm button__text-secondary" %>
   <% end %>
 <% end %>

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -146,7 +146,7 @@ describe "Explore meetings", :slow do
 
     context "when checking withdrawn meetings" do
       context "when there are no withdrawn meetings" do
-        let!(:meeting) { create_list(:meeting, 3, :published, component:) }
+        let!(:non_withdrawn_meetings) { create_list(:meeting, 3, :published, component:) }
 
         it "does not show the withdrawn link" do
           visit_component

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -148,16 +148,10 @@ describe "Explore meetings", :slow do
       context "when there are no withdrawn meetings" do
         let!(:meeting) { create_list(:meeting, 3, :published, component:) }
 
-        before do
+        it "does not show the withdrawn link" do
           visit_component
-          click_on "See all withdrawn meetings"
-        end
 
-        it "shows an empty page with a message" do
-          expect(page).to have_content("No meetings match your search criteria or there is not any meeting scheduled.")
-          within ".flash.info", match: :first do
-            expect(page).to have_content("You are viewing the list of meetings withdrawn by their authors.")
-          end
+          expect(page).to have_no_link("See all withdrawn meetings")
         end
       end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -176,7 +176,7 @@ describe "Explore meetings", :slow do
         let!(:linked_withdrawn_meeting) { create(:meeting, :withdrawn, :published, component: linked_component) }
 
         before do
-          create(:meeting_link, meeting: linked_withdrawn_meeting, component: component)
+          create(:meeting_link, meeting: linked_withdrawn_meeting, component:)
           visit_component
         end
 

--- a/decidim-meetings/spec/system/explore_meetings_spec.rb
+++ b/decidim-meetings/spec/system/explore_meetings_spec.rb
@@ -170,6 +170,20 @@ describe "Explore meetings", :slow do
           end
         end
       end
+
+      context "when there are withdrawn linked meetings" do
+        let(:linked_component) { create(:meeting_component, participatory_space:) }
+        let!(:linked_withdrawn_meeting) { create(:meeting, :withdrawn, :published, component: linked_component) }
+
+        before do
+          create(:meeting_link, meeting: linked_withdrawn_meeting, component: component)
+          visit_component
+        end
+
+        it "shows the withdrawn link" do
+          expect(page).to have_link("See all withdrawn meetings")
+        end
+      end
     end
 
     context "with hidden meetings" do

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -16,7 +16,7 @@ module Decidim
       include Paginable
       include Decidim::AttachmentsHelper
 
-      helper_method :proposal_presenter, :form_presenter, :tab_panel_items
+      helper_method :proposal_presenter, :form_presenter, :tab_panel_items, :withdrawn_proposals?
 
       before_action :authenticate_user!, only: [:new, :create]
       before_action :ensure_is_draft, only: [:preview, :publish, :edit_draft, :update_draft, :destroy_draft]
@@ -231,6 +231,10 @@ module Decidim
 
       def proposal_presenter
         @proposal_presenter ||= present(@proposal)
+      end
+
+      def withdrawn_proposals?
+        @withdrawn_proposals ||= Proposal.where(component: current_component).published.not_hidden.withdrawn.exists?
       end
 
       def form_proposal_params

--- a/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/decidim-proposals/app/controllers/decidim/proposals/proposals_controller.rb
@@ -234,7 +234,9 @@ module Decidim
       end
 
       def withdrawn_proposals?
-        @withdrawn_proposals ||= Proposal.where(component: current_component).published.not_hidden.withdrawn.exists?
+        return @withdrawn_proposals if defined?(@withdrawn_proposals)
+
+        @withdrawn_proposals = Proposal.where(component: current_component).published.not_hidden.withdrawn.exists?
       end
 
       def form_proposal_params

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposals.html.erb
@@ -26,6 +26,6 @@
 
 <% if params.dig("filter", "with_availability").present? && params["filter"]["with_availability"] == "withdrawn" %>
   <%= link_to t("decidim.proposals.proposals.index.see_all"), proposals_path("filter[with_availability]" => nil), class: "button button__sm button__text-secondary" %>
-<% else %>
+<% elsif withdrawn_proposals? %>
   <%= link_to t("decidim.proposals.proposals.index.see_all_withdrawn"), proposals_path(filter: { with_availability: "withdrawn", with_any_state: [] }), class: "button button__sm button__text-secondary" %>
 <% end %>

--- a/decidim-proposals/spec/system/index_proposals_spec.rb
+++ b/decidim-proposals/spec/system/index_proposals_spec.rb
@@ -36,16 +36,10 @@ describe "Index proposals" do
     context "when there are no withdrawn proposals" do
       let!(:proposals) { create_list(:proposal, 3, component:) }
 
-      before do
+      it "does not show the withdrawn link" do
         visit_component
-        click_on "See all withdrawn proposals"
-      end
 
-      it "shows an empty page with a message" do
-        expect(page).to have_content("There are no proposals with this criteria.")
-        within ".flash.warning" do
-          expect(page).to have_content("You are viewing the list of proposals withdrawn by their authors.")
-        end
+        expect(page).to have_no_link("See all withdrawn proposals")
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

If there aren't any withdrawn meetings nor proposals we still show the link. This PR fixes this by not showing the link. 

#### :pushpin: Related Issues 
- Fixes #16035 

#### Testing

1. Go to a proposals index page in a space
2. If you don't have any withdrawn proposals (the default in seeds), you will not see the link
3. Create a proposal
4. Withdraw it
5. Go back to the index page
6. See the link in the bottom

And the same for meetings

### :camera: Screenshots
 
<img width="871" height="503" alt="image" src="https://github.com/user-attachments/assets/d7e5ed5a-2f1e-4f96-849b-5f083dde8557" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "See all withdrawn" link now appears only when withdrawn meetings or proposals actually exist for the current component (including linked withdrawn meetings), preventing navigation to empty pages.

* **Testing**
  * Updated and added system tests to assert the withdrawn link is absent when none exist and present when withdrawn items are linked to the component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->