### PR TITLE
Move announcement for spaces to Content Block

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -9,7 +9,7 @@ module Decidim
         fetch_file_attributes :hero_image, :banner_image
 
         fetch_form_attributes :title, :subtitle, :weight, :slug, :description, :short_description,
-                              :promoted, :taxonomizations, :parent, :announcement, :organization,
+                              :promoted, :taxonomizations, :parent, :organization,
                               :private_space, :developer_group, :local_area, :target, :participatory_scope,
                               :participatory_structure, :meta_scope, :purpose_of_action,
                               :composition, :creation_date, :created_by, :created_by_other,

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/duplicate_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/duplicate_assembly.rb
@@ -58,7 +58,6 @@ module Decidim
             participatory_scope: @assembly.participatory_scope,
             participatory_structure: @assembly.participatory_structure,
             meta_scope: @assembly.meta_scope,
-            announcement: @assembly.announcement,
             taxonomies: @assembly.taxonomies
           )
         end

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
@@ -13,7 +13,7 @@ module Decidim
                               :target, :participatory_scope, :participatory_structure, :meta_scope,
                               :purpose_of_action, :composition, :creation_date, :created_by,
                               :created_by_other, :duration, :included_at, :closing_date, :closing_date_reason,
-                              :internal_organisation, :has_members, :is_transparent, :special_features, :twitter_handler, :announcement,
+                              :internal_organisation, :has_members, :is_transparent, :special_features, :twitter_handler,
                               :facebook_handler, :instagram_handler, :youtube_handler, :github_handler, :weight
 
         private

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -31,7 +31,6 @@ module Decidim
         translatable_attribute :subtitle, String
         translatable_attribute :target, String
         translatable_attribute :title, String
-        translatable_attribute :announcement, Decidim::Attributes::RichText
 
         attribute :created_by, String
         attribute :facebook_handler, String

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -54,8 +54,7 @@ module Decidim
             youtube_handler: attributes["youtube_handler"],
             github_handler: attributes["github_handler"],
             created_by: attributes["created_by"],
-            meta_scope: attributes["meta_scope"],
-            announcement: attributes["announcement"]
+            meta_scope: attributes["meta_scope"]
           )
           @imported_assembly.attached_uploader(:hero_image).remote_url = attributes["remote_hero_image_url"] if attributes["remote_hero_image_url"].present?
           @imported_assembly.attached_uploader(:banner_image).remote_url = attributes["remote_banner_image_url"] if attributes["remote_banner_image_url"].present?

--- a/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
@@ -13,7 +13,6 @@ module Decidim
             subtitle: resource.subtitle,
             remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(resource).hero_image_url,
             remote_banner_image_url: Decidim::Assemblies::AssemblyPresenter.new(resource).banner_image_url,
-            announcement: resource.announcement,
             developer_group: resource.developer_group,
             local_area: resource.local_area,
             meta_scope: resource.meta_scope,

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -48,9 +48,6 @@
         <%= form.translated :editor, :internal_organisation, aria: { label: :internal_organisation } %>
       </div>
 
-      <div class="row column">
-        <%= form.translated :editor, :announcement, help_text: t(".announcement_help") %>
-      </div>
     </div>
   </div>
   <div class="card" data-controller="accordion" id="accordion-duration">

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -246,7 +246,6 @@ en:
       admin:
         assemblies:
           form:
-            announcement_help: The text you enter here will be shown to the user right below the assembly information.
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration
             duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.
@@ -386,7 +385,6 @@ en:
     open_data:
       help:
         assemblies:
-          announcement: The announcement (callout) information
           area: The area of the assembly
           assembly_type: The type of the assembly
           closing_date: The closing date of the assembly

--- a/decidim-assemblies/db/data/20260210195653_move_announcement_to_content_block_on_assemblies.rb
+++ b/decidim-assemblies/db/data/20260210195653_move_announcement_to_content_block_on_assemblies.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class MoveAnnouncementToContentBlockOnAssemblies < ActiveRecord::Migration[7.2]
+  class Assembly < ApplicationRecord
+    self.table_name = "decidim_assemblies"
+  end
+
+  class ContentBlock < ApplicationRecord
+    self.table_name = "decidim_content_blocks"
+  end
+
+  def up
+    Assembly.find_each do |assembly|
+      announcement = assembly.announcement
+      next if announcement.blank? || announcement == {}
+
+      content_block = ContentBlock.find_or_initialize_by(
+        decidim_organization_id: assembly.decidim_organization_id,
+        scope_name: :assembly_homepage,
+        manifest_name: :announcement,
+        scoped_resource_id: assembly.id
+      )
+
+      settings = announcement.each_with_object({}) do |(locale, value), acc|
+        next if locale.to_s == "machine_translations"
+
+        acc["announcement_#{locale}"] = value
+      end
+
+      next if settings.empty?
+
+      content_block.settings = (content_block.settings || {}).merge(settings)
+      content_block.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/decidim-assemblies/lib/decidim/api/assembly_type.rb
+++ b/decidim-assemblies/lib/decidim/api/assembly_type.rb
@@ -17,7 +17,6 @@ module Decidim
 
       description "An assembly"
 
-      field :announcement, Decidim::Core::TranslatedFieldType, "Highlighted announcement for this assembly", null: true
       field :banner_image, String, "The banner image for this assembly", null: true
       field :children, [Decidim::Assemblies::AssemblyType, { null: true }], "Children of this assembly", null: false
       field :children_count, Integer, "Number of children assemblies", null: true

--- a/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
@@ -48,6 +48,11 @@ module Decidim
           Decidim.content_blocks.register(:assembly_homepage, :announcement) do |content_block|
             content_block.cell = "decidim/content_blocks/participatory_space_announcement"
             content_block.public_name_key = "decidim.content_blocks.announcement.name"
+            content_block.settings_form_cell = "decidim/content_blocks/announcement_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :announcement, type: :text, translated: true, editor: true
+            end
           end
 
           Decidim.content_blocks.register(:assembly_homepage, :main_data) do |content_block|

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -67,7 +67,6 @@ module Decidim::Assemblies
         instagram_handler: "lorem",
         youtube_handler: "lorem",
         github_handler: "lorem",
-        announcement: { en: "announcement_lorem" }
       )
     end
     let(:invalid) { false }

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -66,7 +66,7 @@ module Decidim::Assemblies
         facebook_handler: "lorem",
         instagram_handler: "lorem",
         youtube_handler: "lorem",
-        github_handler: "lorem",
+        github_handler: "lorem"
       )
     end
     let(:invalid) { false }

--- a/decidim-assemblies/spec/commands/duplicate_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/duplicate_assembly_spec.rb
@@ -56,7 +56,6 @@ module Decidim::Assemblies
         expect(new_assembly.target).to eq(old_assembly.target)
         expect(new_assembly.participatory_scope).to eq(old_assembly.participatory_scope)
         expect(new_assembly.meta_scope).to eq(old_assembly.meta_scope)
-        expect(new_assembly.announcement).to eq(old_assembly.announcement)
         expect(new_assembly.taxonomies).to eq(old_assembly.taxonomies)
       end
 

--- a/decidim-assemblies/spec/commands/update_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_spec.rb
@@ -63,7 +63,6 @@ module Decidim::Assemblies
             instagram_handler: my_assembly.instagram_handler,
             youtube_handler: my_assembly.youtube_handler,
             github_handler: my_assembly.github_handler,
-            announcement: my_assembly.announcement,
             taxonomies: [taxonomy.id, taxonomizations.first.taxonomy.id]
           }.merge(attachment_params)
         }

--- a/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
+++ b/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
@@ -46,7 +46,7 @@ describe MoveAnnouncementToContentBlockOnAssemblies do
         expect(content_block.settings.to_h).not_to have_key("announcement_machine_translations")
       end
 
-      it "does not change an existing active block" do
+      it "preserves published state while updating settings on an existing active block" do
         content_block = create(
           :content_block,
           organization:,

--- a/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
+++ b/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./db/data/20260210195653_move_announcement_to_content_block_on_assemblies"
+
+describe MoveAnnouncementToContentBlockOnAssemblies do
+  let(:migrator) do
+    described_class.new.tap do |m|
+      m.verbose = false
+    end
+  end
+
+  describe "#up" do
+    let(:organization) { create(:organization) }
+
+    context "when the assembly has announcement content" do
+      let!(:assembly) { create(:assembly, organization:) }
+
+      before do
+        assembly.update_column(
+          :announcement,
+          {
+            "en" => "Important announcement",
+            "es" => "Anuncio importante",
+            "machine_translations" => { "ca" => "Avis" }
+          }
+        )
+      end
+
+      it "creates an inactive announcement content block with settings" do
+        expect do
+          migrator.migrate(:up)
+        end.to change(Decidim::ContentBlock, :count).by(1)
+
+        content_block = Decidim::ContentBlock.find_by(
+          organization:,
+          scope_name: :assembly_homepage,
+          manifest_name: :announcement,
+          scoped_resource_id: assembly.id
+        )
+
+        expect(content_block).to be_present
+        expect(content_block).not_to be_published
+        expect(content_block.settings["announcement_en"]).to eq("Important announcement")
+        expect(content_block.settings["announcement_es"]).to eq("Anuncio importante")
+        expect(content_block.settings.to_h).not_to have_key("announcement_machine_translations")
+      end
+
+      it "does not change an existing active block" do
+        content_block = create(
+          :content_block,
+          organization:,
+          scope_name: :assembly_homepage,
+          manifest_name: :announcement,
+          scoped_resource_id: assembly.id,
+          published_at: Time.current,
+          settings: { "announcement_en" => "Old" }
+        )
+
+        migrator.migrate(:up)
+
+        expect(content_block.reload).to be_published
+        expect(content_block.settings["announcement_en"]).to eq("Important announcement")
+      end
+    end
+
+    context "when the assembly has no announcement content" do
+      let!(:assembly) { create(:assembly, organization:) }
+
+      before do
+        assembly.update_column(:announcement, {})
+      end
+
+      it "does not create a content block" do
+        expect { migrator.migrate(:up) }.not_to change(Decidim::ContentBlock, :count)
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migrator.migrate(:down) }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
+++ b/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
@@ -22,7 +22,7 @@ describe MoveAnnouncementToContentBlockOnAssemblies do
           {
             "en" => "Important announcement",
             "es" => "Anuncio importante",
-            "machine_translations" => { "ca" => "Avis" }
+            "machine_translations" => { "ca" => "Avís" }
           }
         )
       end

--- a/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
+++ b/decidim-assemblies/spec/db/data/move_announcement_to_content_block_on_assemblies_spec.rb
@@ -17,6 +17,7 @@ describe MoveAnnouncementToContentBlockOnAssemblies do
       let!(:assembly) { create(:assembly, organization:) }
 
       before do
+        # rubocop:disable Rails/SkipsModelValidations
         assembly.update_column(
           :announcement,
           {
@@ -25,6 +26,7 @@ describe MoveAnnouncementToContentBlockOnAssemblies do
             "machine_translations" => { "ca" => "Avís" }
           }
         )
+        # rubocop:enable Rails/SkipsModelValidations
       end
 
       it "creates an inactive announcement content block with settings" do
@@ -68,7 +70,7 @@ describe MoveAnnouncementToContentBlockOnAssemblies do
       let!(:assembly) { create(:assembly, organization:) }
 
       before do
-        assembly.update_column(:announcement, {})
+        assembly.update_column(:announcement, {}) # rubocop:disable Rails/SkipsModelValidations
       end
 
       it "does not create a content block" do

--- a/decidim-assemblies/spec/forms/assembly_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_form_spec.rb
@@ -96,13 +96,6 @@ module Decidim
         let(:instagram_handler) { "lorem" }
         let(:youtube_handler) { "lorem" }
         let(:github_handler) { "lorem" }
-        let(:announcement) do
-          {
-            en: "Announcement",
-            es: "Anuncio",
-            ca: "Anunci"
-          }
-        end
         let(:parent_id) { nil }
         let(:assembly_id) { nil }
         let(:root_taxonomy) { create(:taxonomy, organization:) }
@@ -159,9 +152,6 @@ module Decidim
               "github_handler" => github_handler,
               "weight" => weight,
               "parent_id" => parent_id,
-              "announcement_en" => announcement[:en],
-              "announcement_es" => announcement[:es],
-              "announcement_ca" => announcement[:ca],
               "taxonomies" => [taxonomies.first.id, taxonomies.second.id]
             }
           }
@@ -337,8 +327,7 @@ module Decidim
                 youtube_handler: assembly.youtube_handler,
                 github_handler: assembly.github_handler,
                 weight: assembly.weight,
-                parent_id: child_assembly,
-                announcement: assembly.announcement
+                parent_id: child_assembly
               }
             }
           end
@@ -391,8 +380,7 @@ module Decidim
                 youtube_handler: assembly.youtube_handler,
                 github_handler: assembly.github_handler,
                 weight: assembly.weight,
-                parent_id: grandchild_assembly,
-                announcement: assembly.announcement
+                parent_id: grandchild_assembly
               }
             }
           end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
@@ -52,7 +52,6 @@ module Decidim::Assemblies
         expect(serialized).to include(youtube_handler: resource.youtube_handler)
         expect(serialized).to include(github_handler: resource.github_handler)
         expect(serialized).to include(created_by_other: resource.created_by_other)
-        expect(serialized).to include(announcement: resource.announcement)
       end
 
       context "when assembly has area" do

--- a/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
@@ -14,10 +14,10 @@ shared_examples "manage assemblies announcements" do
   end
 
   def fill_announcement_editor(values)
-    if page.has_css?("#content_block_settings_announcement-tabs")
+    if page.has_css?("#content_block-settings--announcement-tabs")
       fill_in_i18n_editor(
         :content_block_settings_announcement,
-        "#content_block_settings_announcement-tabs",
+        "#content_block-settings--announcement-tabs",
         values
       )
     else

--- a/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
+++ b/decidim-assemblies/spec/shared/assembly_announcements_examples.rb
@@ -1,25 +1,42 @@
 # frozen_string_literal: true
 
 shared_examples "manage assemblies announcements" do
-  it "can customize a general announcement for the assembly" do
-    within("tr", text: translated(assembly.title)) do
-      find("button[data-controller='dropdown']").click
-      click_on "Edit"
-    end
+  let(:announcement_assembly) { assembly }
+  let!(:content_block) do
+    create(
+      :content_block,
+      organization:,
+      scope_name: :assembly_homepage,
+      manifest_name: :announcement,
+      scoped_resource_id: announcement_assembly.id,
+      published_at: Time.current
+    )
+  end
 
-    fill_in_i18n_editor(
-      :assembly_announcement,
-      "#assembly-announcement-tabs",
+  def fill_announcement_editor(values)
+    if page.has_css?("#content_block_settings_announcement-tabs")
+      fill_in_i18n_editor(
+        :content_block_settings_announcement,
+        "#content_block_settings_announcement-tabs",
+        values
+      )
+    else
+      fill_in_editor("content_block_settings_announcement_en", with: values.fetch(:en))
+    end
+  end
+
+  it "can customize a general announcement for the assembly" do
+    visit decidim_admin_assemblies.edit_assembly_landing_page_content_block_path(announcement_assembly, content_block)
+
+    fill_announcement_editor(
       en: "An important announcement",
       es: "Un aviso muy importante",
       ca: "Un avís molt important"
     )
 
-    within ".edit_assembly" do
-      find("*[type=submit]").click
-    end
+    click_on "Update"
 
-    expect(page).to have_admin_callout("Assembly successfully updated.")
+    expect(page).to have_content("Active content blocks")
     visit decidim_admin_assemblies.assemblies_path
 
     if defined?(parent_assembly) && !parent_assembly.nil?
@@ -29,7 +46,7 @@ shared_examples "manage assemblies announcements" do
     end
 
     new_window = window_opened_by do
-      within "tr", text: translated(assembly.title) do
+      within "tr", text: translated(announcement_assembly.title) do
         find("button[data-controller='dropdown']").click
         click_on "Preview"
       end

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -6,7 +6,7 @@ shared_examples "manage assemblies" do
     let(:image3_path) { Decidim::Dev.asset(image3_filename) }
 
     let(:assembly_parent_id_options) { page.find_by_id("assembly_parent_id").find_all("option").map(&:value) }
-    let(:attributes) { attributes_for(:assembly, :with_content_blocks, organization:, blocks_manifests: [:announcement]) }
+    let(:attributes) { attributes_for(:assembly, :with_content_blocks, organization:) }
 
     before do
       within("tr", text: translated(assembly.title)) do
@@ -28,7 +28,6 @@ shared_examples "manage assemblies" do
         fill_in_i18n_editor(:assembly_purpose_of_action, "#assembly-purpose_of_action-tabs", **attributes[:purpose_of_action].except("machine_translations"))
         fill_in_i18n_editor(:assembly_composition, "#assembly-composition-tabs", **attributes[:composition].except("machine_translations"))
         fill_in_i18n_editor(:assembly_internal_organisation, "#assembly-internal_organisation-tabs", **attributes[:internal_organisation].except("machine_translations"))
-        fill_in_i18n_editor(:assembly_announcement, "#assembly-announcement-tabs", **attributes[:announcement].except("machine_translations"))
         fill_in_i18n_editor(:assembly_closing_date_reason, "#assembly-closing_date_reason-tabs", **attributes[:closing_date_reason].except("machine_translations"))
 
         fill_in_i18n(:assembly_participatory_scope, "#assembly-participatory_scope-tabs", **attributes[:participatory_scope].except("machine_translations"))

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -48,14 +48,14 @@ describe "Admin manages assemblies" do
 
     let(:image2_filename) { "city2.jpeg" }
     let(:image2_path) { Decidim::Dev.asset(image2_filename) }
-    let(:attributes) { attributes_for(:assembly, :with_content_blocks, organization:, blocks_manifests: [:announcement]) }
+    let(:attributes) { attributes_for(:assembly, :with_content_blocks, organization:) }
     let(:last_assembly) { Decidim::Assembly.last }
 
     before do
       click_on "New assembly"
     end
 
-    %w(purpose_of_action composition description short_description announcement internal_organisation).each do |field|
+    %w(purpose_of_action composition description short_description internal_organisation).each do |field|
       it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='assembly-#{field}-tabs']", "full"
     end
 
@@ -71,7 +71,6 @@ describe "Admin manages assemblies" do
         fill_in_i18n_editor(:assembly_purpose_of_action, "#assembly-purpose_of_action-tabs", **attributes[:purpose_of_action].except("machine_translations"))
         fill_in_i18n_editor(:assembly_composition, "#assembly-composition-tabs", **attributes[:composition].except("machine_translations"))
         fill_in_i18n_editor(:assembly_internal_organisation, "#assembly-internal_organisation-tabs", **attributes[:internal_organisation].except("machine_translations"))
-        fill_in_i18n_editor(:assembly_announcement, "#assembly-announcement-tabs", **attributes[:announcement].except("machine_translations"))
         fill_in_i18n_editor(:assembly_closing_date_reason, "#assembly-closing_date_reason-tabs", **attributes[:closing_date_reason].except("machine_translations"))
 
         fill_in_i18n(:assembly_participatory_scope, "#assembly-participatory_scope-tabs", **attributes[:participatory_scope].except("machine_translations"))
@@ -140,7 +139,7 @@ describe "Admin manages assemblies" do
 
   context "when managing parent assemblies" do
     let(:parent_assembly) { nil }
-    let!(:assembly) { create(:assembly, :with_content_blocks, organization:, blocks_manifests: [:announcement]) }
+    let!(:assembly) { create(:assembly, :with_content_blocks, organization:) }
 
     before do
       switch_to_host(organization.host)
@@ -161,7 +160,7 @@ describe "Admin manages assemblies" do
 
   context "when navigating child assemblies" do
     let!(:parent_assembly) { create(:assembly, organization:) }
-    let!(:child_assembly) { create(:assembly, :with_content_blocks, organization:, parent: parent_assembly, blocks_manifests: [:announcement]) }
+    let!(:child_assembly) { create(:assembly, :with_content_blocks, organization:, parent: parent_assembly) }
     let(:assembly) { child_assembly }
 
     before do

--- a/decidim-assemblies/spec/types/assembly_type_spec.rb
+++ b/decidim-assemblies/spec/types/assembly_type_spec.rb
@@ -336,13 +336,6 @@ module Decidim
         end
       end
 
-      describe "announcement" do
-        let(:query) { '{ announcement { translation(locale: "en")}}' }
-
-        it "returns all the required fields" do
-          expect(response["announcement"]["translation"]).to eq(model.announcement["en"])
-        end
-      end
     end
   end
 end

--- a/decidim-assemblies/spec/types/assembly_type_spec.rb
+++ b/decidim-assemblies/spec/types/assembly_type_spec.rb
@@ -335,7 +335,6 @@ module Decidim
           expect(response["githubHandler"]).to eq(model.github_handler)
         end
       end
-
     end
   end
 end

--- a/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
@@ -1,5 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
   <div class="row column">
-    <%= settings_fields.translated :editor, :announcement, label: label %>
+    <%= settings_fields.translated :editor, :announcement, label: %>
   </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
@@ -1,0 +1,5 @@
+<% form.fields_for :settings, form.object.settings do |settings_fields| %>
+  <div class="row column">
+    <%= settings_fields.translated :editor, :announcement, label: label %>
+  </div>
+<% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form_cell.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  module ContentBlocks
+    class AnnouncementSettingsFormCell < Decidim::ViewModel
+      alias form model
+
+      def content_block
+        options[:content_block]
+      end
+
+      def label
+        I18n.t("decidim.content_blocks.announcement.body")
+      end
+    end
+  end
+end

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_announcement_cell.rb
@@ -3,8 +3,6 @@
 module Decidim
   module ContentBlocks
     class ParticipatorySpaceAnnouncementCell < BaseCell
-      delegate :announcement, to: :resource
-
       def show
         return if announcement_cell.blank_content?
 
@@ -12,7 +10,7 @@ module Decidim
       end
 
       def announcement_cell
-        @announcement_cell ||= cell("decidim/announcement", announcement)
+        @announcement_cell ||= cell("decidim/announcement", model.settings.announcement)
       end
     end
   end

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -579,6 +579,7 @@ en:
     contact: Contact
     content_blocks:
       announcement:
+        body: Announcement text
         name: Announcement
       cta:
         name: Image, text and Call To Action button

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/create_participatory_process.rb
@@ -9,7 +9,7 @@ module Decidim
         fetch_file_attributes :hero_image
 
         fetch_form_attributes :organization, :title, :subtitle, :weight, :slug, :description,
-                              :short_description, :promoted, :taxonomizations, :announcement,
+                              :short_description, :promoted, :taxonomizations,
                               :has_members, :private_space, :developer_group, :local_area, :target,
                               :participatory_scope, :participatory_structure, :meta_scope, :start_date, :end_date,
                               :participatory_process_group

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/update_participatory_process.rb
@@ -11,8 +11,7 @@ module Decidim
         fetch_form_attributes :title, :subtitle, :weight, :slug, :promoted,
                               :taxonomizations, :has_members, :private_space, :developer_group, :local_area,
                               :target, :participatory_scope, :participatory_structure,
-                              :meta_scope, :start_date, :end_date, :participatory_process_group,
-                              :announcement
+                              :meta_scope, :start_date, :end_date, :participatory_process_group
 
         protected
 

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -13,7 +13,6 @@ module Decidim
 
         mimic :participatory_process
 
-        translatable_attribute :announcement, Decidim::Attributes::RichText
         translatable_attribute :description, Decidim::Attributes::RichText
         translatable_attribute :developer_group, String
         translatable_attribute :local_area, String

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/open_data_participatory_process_serializer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/open_data_participatory_process_serializer.rb
@@ -11,7 +11,6 @@ module Decidim
             url: EngineRouter.main_proxy(resource).participatory_process_url(resource),
             subtitle: resource.subtitle,
             remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(resource).hero_image_url,
-            announcement: resource.announcement,
             start_date: resource.start_date,
             end_date: resource.end_date,
             developer_group: resource.developer_group,

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -39,7 +39,6 @@ module Decidim
             meta_scope: attributes["meta_scope"],
             start_date: attributes["start_date"],
             end_date: attributes["end_date"],
-            announcement: attributes["announcement"],
             private_space: attributes["private_space"],
             participatory_process_group: process_group
           )

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -35,9 +35,6 @@
         <%= form.translated :editor, :description, resource_mentionable: true, aria: { label: :description } %>
       </div>
 
-      <div class="row column">
-        <%= form.translated :editor, :announcement, help_text: t(".announcement_help") %>
-      </div>
     </div>
   </div>
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -342,7 +342,6 @@ en:
     open_data:
       help:
         participatory_processes:
-          announcement: The announcement (callout) information
           area: The area where the process is taking place
           component_settings: The component settings of the process
           created_at: The date this space was created
@@ -508,7 +507,6 @@ en:
             slug_help_html: 'URL slugs are used to generate the URLs that point to this process. Only accepts letters, numbers and dashes, and must start with a letter. Example: %{url}'
         participatory_processes:
           form:
-            announcement_help: The text you enter here will be shown to the user right below the process information.
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration
             has_members_help: You will be able to create and publish members

--- a/decidim-participatory_processes/db/data/20260210195709_move_announcement_to_content_block_on_participatory_processes.rb
+++ b/decidim-participatory_processes/db/data/20260210195709_move_announcement_to_content_block_on_participatory_processes.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class MoveAnnouncementToContentBlockOnParticipatoryProcesses < ActiveRecord::Migration[7.2]
+  class ParticipatoryProcess < ApplicationRecord
+    self.table_name = "decidim_participatory_processes"
+  end
+
+  class ContentBlock < ApplicationRecord
+    self.table_name = "decidim_content_blocks"
+  end
+
+  def up
+    ParticipatoryProcess.find_each do |participatory_process|
+      announcement = participatory_process.announcement
+      next if announcement.blank? || announcement == {}
+
+      content_block = ContentBlock.find_or_initialize_by(
+        decidim_organization_id: participatory_process.decidim_organization_id,
+        scope_name: :participatory_process_homepage,
+        manifest_name: :announcement,
+        scoped_resource_id: participatory_process.id
+      )
+
+      settings = announcement.each_with_object({}) do |(locale, value), acc|
+        next if locale.to_s == "machine_translations"
+
+        acc["announcement_#{locale}"] = value
+      end
+
+      next if settings.empty?
+
+      content_block.settings = (content_block.settings || {}).merge(settings)
+      content_block.save!
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
+++ b/decidim-participatory_processes/lib/decidim/api/participatory_process_type.rb
@@ -15,7 +15,6 @@ module Decidim
 
       description "A participatory process"
 
-      field :announcement, Decidim::Core::TranslatedFieldType, "Highlighted announcement for this participatory process.", null: true
       field :description, Decidim::Core::TranslatedFieldType, "The description of this participatory process.", null: true
       field :developer_group, Decidim::Core::TranslatedFieldType, "The promoter group of this participatory process.", null: true
       field :end_date, Decidim::Core::DateType, "This participatory process' end date.", null: true

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
@@ -92,6 +92,11 @@ module Decidim
           Decidim.content_blocks.register(:participatory_process_homepage, :announcement) do |content_block|
             content_block.cell = "decidim/content_blocks/participatory_space_announcement"
             content_block.public_name_key = "decidim.content_blocks.announcement.name"
+            content_block.settings_form_cell = "decidim/content_blocks/announcement_settings_form"
+
+            content_block.settings do |settings|
+              settings.attribute :announcement, type: :text, translated: true, editor: true
+            end
           end
 
           Decidim.content_blocks.register(:participatory_process_homepage, :main_data) do |content_block|

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -45,7 +45,7 @@ module Decidim::ParticipatoryProcesses
         taxonomizations:,
         errors:,
         related_process_ids:,
-        participatory_process_group:,
+        participatory_process_group:
       )
     end
     let(:invalid) { false }

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_spec.rb
@@ -46,7 +46,6 @@ module Decidim::ParticipatoryProcesses
         errors:,
         related_process_ids:,
         participatory_process_group:,
-        announcement: { en: "message" }
       )
     end
     let(:invalid) { false }

--- a/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
@@ -17,6 +17,7 @@ describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
       let!(:participatory_process) { create(:participatory_process, organization:) }
 
       before do
+        # rubocop:disable Rails/SkipsModelValidations
         participatory_process.update_column(
           :announcement,
           {
@@ -25,6 +26,7 @@ describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
             "machine_translations" => { "ca" => "Avís" }
           }
         )
+        # rubocop:enable Rails/SkipsModelValidations
       end
 
       it "creates an inactive announcement content block with settings" do
@@ -68,7 +70,7 @@ describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
       let!(:participatory_process) { create(:participatory_process, organization:) }
 
       before do
-        participatory_process.update_column(:announcement, {})
+        participatory_process.update_column(:announcement, {}) # rubocop:disable Rails/SkipsModelValidations
       end
 
       it "does not create a content block" do

--- a/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
@@ -46,7 +46,7 @@ describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
         expect(content_block.settings.to_h).not_to have_key("announcement_machine_translations")
       end
 
-      it "does not change an existing active block" do
+      it "preserves published_at while updating settings on an existing active block" do
         content_block = create(
           :content_block,
           organization:,

--- a/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
@@ -22,7 +22,7 @@ describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
           {
             "en" => "Important announcement",
             "es" => "Anuncio importante",
-            "machine_translations" => { "ca" => "Avs" }
+            "machine_translations" => { "ca" => "Avís" }
           }
         )
       end

--- a/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/db/data/move_announcement_to_content_block_on_participatory_processes_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "./db/data/20260210195709_move_announcement_to_content_block_on_participatory_processes"
+
+describe MoveAnnouncementToContentBlockOnParticipatoryProcesses do
+  let(:migrator) do
+    described_class.new.tap do |m|
+      m.verbose = false
+    end
+  end
+
+  describe "#up" do
+    let(:organization) { create(:organization) }
+
+    context "when the process has announcement content" do
+      let!(:participatory_process) { create(:participatory_process, organization:) }
+
+      before do
+        participatory_process.update_column(
+          :announcement,
+          {
+            "en" => "Important announcement",
+            "es" => "Anuncio importante",
+            "machine_translations" => { "ca" => "Avs" }
+          }
+        )
+      end
+
+      it "creates an inactive announcement content block with settings" do
+        expect do
+          migrator.migrate(:up)
+        end.to change(Decidim::ContentBlock, :count).by(1)
+
+        content_block = Decidim::ContentBlock.find_by(
+          organization:,
+          scope_name: :participatory_process_homepage,
+          manifest_name: :announcement,
+          scoped_resource_id: participatory_process.id
+        )
+
+        expect(content_block).to be_present
+        expect(content_block).not_to be_published
+        expect(content_block.settings["announcement_en"]).to eq("Important announcement")
+        expect(content_block.settings["announcement_es"]).to eq("Anuncio importante")
+        expect(content_block.settings.to_h).not_to have_key("announcement_machine_translations")
+      end
+
+      it "does not change an existing active block" do
+        content_block = create(
+          :content_block,
+          organization:,
+          scope_name: :participatory_process_homepage,
+          manifest_name: :announcement,
+          scoped_resource_id: participatory_process.id,
+          published_at: Time.current,
+          settings: { "announcement_en" => "Old" }
+        )
+
+        migrator.migrate(:up)
+
+        expect(content_block.reload).to be_published
+        expect(content_block.settings["announcement_en"]).to eq("Important announcement")
+      end
+    end
+
+    context "when the process has no announcement content" do
+      let!(:participatory_process) { create(:participatory_process, organization:) }
+
+      before do
+        participatory_process.update_column(:announcement, {})
+      end
+
+      it "does not create a content block" do
+        expect { migrator.migrate(:up) }.not_to change(Decidim::ContentBlock, :count)
+      end
+    end
+  end
+
+  describe "#down" do
+    it "raises ActiveRecord::IrreversibleMigration" do
+      expect { migrator.migrate(:down) }.to raise_error(ActiveRecord::IrreversibleMigration)
+    end
+  end
+end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/open_data_participatory_process_serializer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/open_data_participatory_process_serializer_spec.rb
@@ -22,7 +22,6 @@ module Decidim::ParticipatoryProcesses
         expect(serialized).to include(reference: resource.reference)
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
-        expect(serialized).to include(announcement: resource.announcement)
         expect(serialized).to include(start_date: resource.start_date)
         expect(serialized).to include(end_date: resource.end_date)
         expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -33,7 +33,6 @@ module Decidim::ParticipatoryProcesses
           "meta_scope" => Decidim::Faker::Localized.sentence(word_count: 3),
           "start_date" => "2022-08-01",
           "end_date" => "2023-08-01",
-          "announcement" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
           "private_space" => false,
           "participatory_process_group" => group_data
         }
@@ -62,7 +61,6 @@ module Decidim::ParticipatoryProcesses
         expect(subject.meta_scope).to eq(import_data["meta_scope"])
         expect(subject.start_date).to eq(Date.parse(import_data["start_date"]))
         expect(subject.end_date).to eq(Date.parse(import_data["end_date"]))
-        expect(subject.announcement).to eq(import_data["announcement"])
         expect(subject.private_space).to eq(import_data["private_space"])
         expect(subject.participatory_process_group).to be_a(Decidim::ParticipatoryProcessGroup)
       end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_serializer_spec.rb
@@ -20,7 +20,6 @@ module Decidim::ParticipatoryProcesses
         expect(serialized).to include(slug: resource.slug)
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
-        expect(serialized).to include(announcement: resource.announcement)
         expect(serialized).to include(start_date: resource.start_date)
         expect(serialized).to include(end_date: resource.end_date)
         expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)

--- a/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_processes_examples.rb
@@ -108,7 +108,6 @@ shared_examples "manage processes examples" do
       fill_in_i18n(:participatory_process_subtitle, "#participatory_process-subtitle-tabs", **attributes[:subtitle].except("machine_translations"))
       fill_in_i18n_editor(:participatory_process_short_description, "#participatory_process-short_description-tabs", **attributes[:short_description].except("machine_translations"))
       fill_in_i18n_editor(:participatory_process_description, "#participatory_process-description-tabs", **attributes[:description].except("machine_translations"))
-      fill_in_i18n_editor(:participatory_process_announcement, "#participatory_process-announcement-tabs", **attributes[:announcement].except("machine_translations"))
       fill_in_i18n(:participatory_process_developer_group, "#participatory_process-developer_group-tabs", **attributes[:developer_group].except("machine_translations"))
       fill_in_i18n(:participatory_process_local_area, "#participatory_process-local_area-tabs", **attributes[:local_area].except("machine_translations"))
       fill_in_i18n(:participatory_process_meta_scope, "#participatory_process-meta_scope-tabs", **attributes[:meta_scope].except("machine_translations"))

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -14,10 +14,10 @@ shared_examples "manage processes announcements" do
   end
 
   def fill_announcement_editor(values)
-    if page.has_css?("#content_block_settings_announcement-tabs")
+    if page.has_css?("#content_block-settings--announcement-tabs")
       fill_in_i18n_editor(
         :content_block_settings_announcement,
-        "#content_block_settings_announcement-tabs",
+        "#content_block-settings--announcement-tabs",
         values
       )
     else
@@ -26,10 +26,10 @@ shared_examples "manage processes announcements" do
   end
 
   def clear_announcement_editor(locales)
-    if page.has_css?("#content_block_settings_announcement-tabs")
+    if page.has_css?("#content_block-settings--announcement-tabs")
       clear_i18n_editor(
         :content_block_settings_announcement,
-        "#content_block_settings_announcement-tabs",
+        "#content_block-settings--announcement-tabs",
         locales
       )
     else

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -1,30 +1,54 @@
 # frozen_string_literal: true
 
 shared_examples "manage processes announcements" do
-  let!(:participatory_process) { create(:participatory_process, :with_content_blocks, organization:, blocks_manifests: [:announcement], announcement: {}) }
+  let(:participatory_process) { create(:participatory_process, :with_content_blocks, organization:, blocks_manifests: [], announcement: {}) }
+  let!(:content_block) do
+    create(
+      :content_block,
+      organization:,
+      scope_name: :participatory_process_homepage,
+      manifest_name: :announcement,
+      scoped_resource_id: participatory_process.id,
+      published_at: Time.current
+    )
+  end
+
+  def fill_announcement_editor(values)
+    if page.has_css?("#content_block_settings_announcement-tabs")
+      fill_in_i18n_editor(
+        :content_block_settings_announcement,
+        "#content_block_settings_announcement-tabs",
+        values
+      )
+    else
+      fill_in_editor("content_block_settings_announcement_en", with: values.fetch(:en))
+    end
+  end
+
+  def clear_announcement_editor(locales)
+    if page.has_css?("#content_block_settings_announcement-tabs")
+      clear_i18n_editor(
+        :content_block_settings_announcement,
+        "#content_block_settings_announcement-tabs",
+        locales
+      )
+    else
+      clear_editor("content_block_settings_announcement_en")
+    end
+  end
 
   it "can customize a general announcement for the process" do
-    within "tr", text: translated(participatory_process.title) do
-      click_on translated(participatory_process.title)
-    end
+    visit decidim_admin_participatory_processes.edit_participatory_process_landing_page_content_block_path(participatory_process, content_block)
 
-    within_admin_sidebar_menu do
-      click_on "About this process"
-    end
-
-    fill_in_i18n_editor(
-      :participatory_process_announcement,
-      "#participatory_process-announcement-tabs",
+    fill_announcement_editor(
       en: "An important announcement",
       es: "Un aviso muy importante",
       ca: "Un avís molt important"
     )
 
-    within ".edit_participatory_process" do
-      find("*[type=submit]").click
-    end
+    click_on "Update"
 
-    expect(page).to have_admin_callout("Participatory process successfully updated.")
+    expect(page).to have_content("Active content blocks")
 
     visit decidim_admin_participatory_processes.participatory_processes_path
 
@@ -41,23 +65,10 @@ shared_examples "manage processes announcements" do
   end
 
   it "remove announcement element if announcement body is empty" do
-    within "tr", text: translated(participatory_process.title) do
-      click_on translated(participatory_process.title)
-    end
+    visit decidim_admin_participatory_processes.edit_participatory_process_landing_page_content_block_path(participatory_process, content_block)
+    clear_announcement_editor(%i[en es ca])
 
-    within_admin_sidebar_menu do
-      click_on "About this process"
-    end
-
-    find_by_id("participatory_process-announcement-tabs").click
-    send_keys("T")
-    send_keys(:backspace)
-
-    within ".edit_participatory_process" do
-      find("*[type=submit]").click
-    end
-
-    expect(page).to have_admin_callout("Participatory process successfully updated.")
+    click_on "Update"
 
     visit decidim_admin_participatory_processes.participatory_processes_path
 

--- a/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
+++ b/decidim-participatory_processes/spec/shared/process_announcements_examples.rb
@@ -66,7 +66,7 @@ shared_examples "manage processes announcements" do
 
   it "remove announcement element if announcement body is empty" do
     visit decidim_admin_participatory_processes.edit_participatory_process_landing_page_content_block_path(participatory_process, content_block)
-    clear_announcement_editor(%i[en es ca])
+    clear_announcement_editor([:en, :es, :ca])
 
     click_on "Update"
 

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
@@ -65,7 +65,7 @@ describe "Admin manages participatory processes", versioning: true do
       click_on "New process"
     end
 
-    %w(short_description description announcement).each do |field|
+    %w(short_description description).each do |field|
       it_behaves_like "having a rich text editor for field", ".tabs-content[data-tabs-content='participatory_process-#{field}-tabs']", "full"
     end
     it_behaves_like "having no taxonomy filters defined"
@@ -76,8 +76,6 @@ describe "Admin manages participatory processes", versioning: true do
         fill_in_i18n(:participatory_process_subtitle, "#participatory_process-subtitle-tabs", **attributes[:subtitle].except("machine_translations"))
         fill_in_i18n_editor(:participatory_process_short_description, "#participatory_process-short_description-tabs", **attributes[:short_description].except("machine_translations"))
         fill_in_i18n_editor(:participatory_process_description, "#participatory_process-description-tabs", **attributes[:description].except("machine_translations"))
-        fill_in_i18n_editor(:participatory_process_announcement, "#participatory_process-announcement-tabs", **attributes[:announcement].except("machine_translations"))
-
         fill_in_i18n(:participatory_process_developer_group, "#participatory_process-developer_group-tabs", **attributes[:developer_group].except("machine_translations"))
         fill_in_i18n(:participatory_process_local_area, "#participatory_process-local_area-tabs", **attributes[:local_area].except("machine_translations"))
         fill_in_i18n(:participatory_process_meta_scope, "#participatory_process-meta_scope-tabs", **attributes[:meta_scope].except("machine_translations"))

--- a/decidim-participatory_processes/spec/types/integration_schema_spec.rb
+++ b/decidim-participatory_processes/spec/types/integration_schema_spec.rb
@@ -16,10 +16,6 @@ describe "Decidim::Api::QueryType" do
   let(:participatory_process_query) do
     %(
       participatoryProcess {
-        announcement{
-          translation(locale: "#{locale}")
-          locales
-        }
         attachments{
           url
           type
@@ -170,13 +166,6 @@ describe "Decidim::Api::QueryType" do
   let(:components) { [] }
   let!(:participatory_process_response) do
     {
-      "announcement" => {
-        "locales" => (
-          participatory_process.announcement.keys.excluding("machine_translations") +
-          participatory_process.announcement["machine_translations"].keys
-        ).sort,
-        "translation" => participatory_process.announcement[locale]
-      },
       "attachments" => [],
       "categories" => [],
       "components" => components,

--- a/decidim-participatory_processes/spec/types/participatory_process_type_spec.rb
+++ b/decidim-participatory_processes/spec/types/participatory_process_type_spec.rb
@@ -170,14 +170,6 @@ module Decidim
         end
       end
 
-      describe "announcement" do
-        let(:query) { '{ announcement { translation(locale: "en")}}' }
-
-        it "returns all the required fields" do
-          expect(response["announcement"]["translation"]).to eq(model.announcement["en"])
-        end
-      end
-
       describe "steps" do
         let!(:step) { create(:participatory_process_step, participatory_process: model) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

As explained at #16064, right now the set-up of the Announcement content block is a bit weird because historical reasons:

1. You need to define the text at the Assembly or Process general form
2. You need to enable the Content block in the Landing page layout

These two pages are separated and aren't intuitive.

This PR moves the editor to the content block editor.

#### :pushpin: Related Issues

- Fixes #16064 

#### Testing

#### For existing content blocks

0. Before the patch
1. Sign in as admin
2. Edit an assembly, add an announcement
3. Go to the landing page editor, activate the "Announcement" content block 
4. Apply this patch
5. Run the data migration
6. Go to the Assembly form, see that you don't have the announcement there
3. Go to the landing page editor, see that you have the text in the "Announcement" content block 

### :camera: Screenshots
  
<img width="1804" height="976" alt="image" src="https://github.com/user-attachments/assets/4ad2392f-1285-42cc-8c3d-92ca0221059c" />

<img width="1745" height="875" alt="image" src="https://github.com/user-attachments/assets/21cc168c-d393-49e6-851e-d58c822a282e" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Announcements are now managed via content blocks with a dedicated announcement settings form and editor.

* **Data Migration**
  * New migration moves existing assembly and participatory process announcements into content blocks to preserve content.

* **User-facing Changes**
  * Announcement inputs removed from assembly and participatory process admin forms and public exports; announcements are edited via content block workflows.

* **Tests**
  * Added and updated tests covering migration and the new content-block announcement flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->