### PR TITLE
Fix CSRF error on login pages

### DIFF
--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -9,6 +9,8 @@ module Decidim
 
       before_action :check_sign_in_enabled, only: :create
 
+      rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_referer_or_path
+
       def create
         super do |user|
           if user.admin?
@@ -44,8 +46,13 @@ module Decidim
 
       private
 
+      def redirect_to_referer_or_path
+        set_flash_message(:alert, "csrf_token", scope: "devise.failure")
+        redirect_to redirect_back(fallback_location: root_path) && return
+      end
+
       def check_sign_in_enabled
-        redirect_to new_user_session_path unless current_organization.sign_in_enabled?
+        redirect_to new_user_session_path && return unless current_organization.sign_in_enabled?
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -52,7 +52,7 @@ module Decidim
       end
 
       def check_sign_in_enabled
-        redirect_to new_user_session_path && return unless current_organization.sign_in_enabled?
+        redirect_to new_user_session_path unless current_organization.sign_in_enabled?
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/sessions_controller.rb
@@ -48,7 +48,7 @@ module Decidim
 
       def redirect_to_referer_or_path
         set_flash_message(:alert, "csrf_token", scope: "devise.failure")
-        redirect_to redirect_back(fallback_location: root_path) && return
+        redirect_back(fallback_location: root_path) && return
       end
 
       def check_sign_in_enabled

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1807,6 +1807,7 @@ en:
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:
       already_authenticated: You are already signed in.
+      csrf_token: Unable to verify your request. Please retry.
       inactive: Your account is not activated yet.
       invalid: Invalid %{authentication_keys} or password.
       invited: You have a pending invitation, accept it to finish creating your account.

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -34,6 +34,13 @@ describe "Authentication" do
     visit decidim.root_path
   end
 
+  around do |example|
+    previous_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    example.run
+    ActionController::Base.allow_forgery_protection = previous_value
+  end
+
   describe "Create an account" do
     around do |example|
       perform_enqueued_jobs { example.run }
@@ -472,6 +479,25 @@ describe "Authentication" do
 
         expect(page).to have_content("Logged in successfully")
         expect_current_user_to_be(user)
+      end
+
+      context "when CSRF token is invalid" do
+        it "displays error when email is empty" do
+          click_on("Log in", match: :first)
+          within "#session_new_user" do
+            fill_in :session_user_email, with: user.email
+            fill_in :session_user_password, with: "DfyvHn425mYAy2HL"
+          end
+
+          page.driver.browser.manage.delete_all_cookies
+          expect(page.driver.browser.manage.all_cookies).to be_empty
+
+          within "#session_new_user" do
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_content("Unable to verify your request. Please retry.")
+        end
       end
 
       context "when email validation is triggered in the log in form" do

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -37,8 +37,11 @@ describe "Authentication" do
   around do |example|
     previous_value = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true
-    example.run
-    ActionController::Base.allow_forgery_protection = previous_value
+    begin
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = previous_value
+    end
   end
 
   describe "Create an account" do
@@ -482,7 +485,7 @@ describe "Authentication" do
       end
 
       context "when CSRF token is invalid" do
-        it "displays error when email is empty" do
+        it "displays a retry error" do
           click_on("Log in", match: :first)
           within "#session_new_user" do
             fill_in :session_user_email, with: user.email

--- a/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
@@ -10,9 +10,16 @@ module Decidim
 
         helper Decidim::DecidimFormHelper
 
+        rescue_from ActionController::InvalidAuthenticityToken, with: :redirect_to_referer_or_path
+
         layout "decidim/system/login"
 
         private
+
+        def redirect_to_referer_or_path
+          set_flash_message(:alert, "csrf_token", scope: "devise.failure")
+          redirect_to redirect_back(fallback_location: root_path) && return
+        end
 
         def current_organization; end
       end

--- a/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/devise/sessions_controller.rb
@@ -18,7 +18,7 @@ module Decidim
 
         def redirect_to_referer_or_path
           set_flash_message(:alert, "csrf_token", scope: "devise.failure")
-          redirect_to redirect_back(fallback_location: root_path) && return
+          redirect_back(fallback_location: root_path)
         end
 
         def current_organization; end

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -12,8 +12,11 @@ describe "Sessions" do
   around do |example|
     previous_value = ActionController::Base.allow_forgery_protection
     ActionController::Base.allow_forgery_protection = true
-    example.run
-    ActionController::Base.allow_forgery_protection = previous_value
+    begin
+      example.run
+    ensure
+      ActionController::Base.allow_forgery_protection = previous_value
+    end
   end
 
   before do
@@ -45,7 +48,7 @@ describe "Sessions" do
   end
 
   context "when the csrf token is expired" do
-    it "clears cookies and shows an error message" do
+    it "displays a retry error message" do
       within ".new_admin" do
         fill_in :admin_email, with: "admin@example.org"
         fill_in :admin_password, with: "decidim123456789"

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -9,6 +9,13 @@ describe "Sessions" do
                    password_confirmation: "decidim123456789")
   end
 
+  around do |example|
+    previous_value = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+    example.run
+    ActionController::Base.allow_forgery_protection = previous_value
+  end
+
   before do
     visit decidim_system.root_path
   end
@@ -34,6 +41,24 @@ describe "Sessions" do
       end
 
       expect(page).to have_no_content("Dashboard")
+    end
+  end
+
+  context "when the csrf token is expired" do
+    it "clears cookies and shows an error message" do
+      within ".new_admin" do
+        fill_in :admin_email, with: "admin@example.org"
+        fill_in :admin_password, with: "decidim123456789"
+      end
+
+      page.driver.browser.manage.delete_all_cookies
+      expect(page.driver.browser.manage.all_cookies).to be_empty
+
+      within ".new_admin" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("Unable to verify your request. Please retry.")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
if you authenticate to Decidim instance, when you are lacking activity you get to be logout. If a long period of time passes, when you try to authenticate you get a `ActionController::InvalidAuthenticityToken` even if you fill in the correct credentials. 
This PR fixes this

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #9451

#### Testing
##### Scenario 1
1. Visit the login  user page `/users/sign_in`
2. On your console, remove any session cookies ( ex: _session_id cookie ) 
3. Without refreshing the page fill in email / pass 
4. Click submit
5. See error 
6. Apply patch
7. Repeat steps 1,2,3,4 
8. See there is a friendly message 


##### Scenario 2
1. Visit the login  user page `/system/admins/sign_in`
2. repeat steps 2 to 8 from Scenario 1

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="762" height="586" alt="image" src="https://github.com/user-attachments/assets/41b3407f-1fdb-4002-b3df-0fc48617903d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CSRF token handling during sign-in to detect invalid/expired tokens, show a clear error ("Unable to verify your request. Please retry.") and redirect users back or to the homepage.
* **Tests**
  * Added system tests covering invalid/expired CSRF token scenarios for account creation and login to ensure proper error messaging and redirection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->