### PR TITLE
Show a warning message when the attachments URL are 404

### DIFF
--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -76,14 +76,22 @@ module Decidim
           next if url.blank?
 
           unless remote_file_exists?(url)
-            @warnings << I18n.t("decidim.assemblies.admin.imports.attachment_error", error: "Not found")
+            @warnings << I18n.t(
+              "decidim.assemblies.admin.imports.attachment_error",
+              title: attachment_title(file),
+              error: "Not found"
+            )
             next
           end
 
           begin
             file_tmp = URI.parse(url).open
           rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-            @warnings << I18n.t("decidim.assemblies.admin.imports.attachment_error", error: e.message)
+            @warnings << I18n.t(
+              "decidim.assemblies.admin.imports.attachment_error",
+              title: attachment_title(file),
+              error: e.message
+            )
             next
           end
 
@@ -147,6 +155,15 @@ module Decidim
         end
       rescue StandardError
         nil
+      end
+
+      def attachment_title(file)
+        title = file["title"]
+        return "" if title.blank?
+
+        return title unless title.is_a?(Hash)
+
+        title.values.find(&:present?) || ""
       end
 
       def import_hero_image(url)

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -72,9 +72,20 @@ module Decidim
         return if attachments["files"].nil?
 
         attachments["files"].map do |file|
-          next unless remote_file_exists?(file["remote_file_url"])
+          url = file["remote_file_url"]
+          next if url.blank?
 
-          file_tmp = URI.parse(file["remote_file_url"]).open
+          unless remote_file_exists?(url)
+            @warnings << I18n.t("decidim.assemblies.admin.imports.attachment_error", error: "Not found")
+            next
+          end
+
+          begin
+            file_tmp = URI.parse(url).open
+          rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+            @warnings << I18n.t("decidim.assemblies.admin.imports.attachment_error", error: e.message)
+            next
+          end
 
           Decidim.traceability.perform_action!("create", Attachment, @user) do
             attachment = Attachment.new(

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -86,7 +86,7 @@ module Decidim
 
           begin
             file_tmp = URI.parse(url).open
-          rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+          rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
             @warnings << I18n.t(
               "decidim.assemblies.admin.imports.attachment_error",
               title: attachment_title(file),

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -75,11 +75,12 @@ module Decidim
           url = file["remote_file_url"]
           next if url.blank?
 
-          unless remote_file_exists?(url)
+          error = remote_file_error(url)
+          if error.present?
             @warnings << I18n.t(
               "decidim.assemblies.admin.imports.attachment_error",
               title: attachment_title(file),
-              error: "Not found"
+              error:
             )
             next
           end
@@ -90,7 +91,7 @@ module Decidim
             @warnings << I18n.t(
               "decidim.assemblies.admin.imports.attachment_error",
               title: attachment_title(file),
-              error: e.message
+              error: format_error(e)
             )
             next
           end
@@ -143,7 +144,7 @@ module Decidim
         attachment_collection
       end
 
-      def remote_file_exists?(url)
+      def remote_file_error(url)
         return if url.nil?
 
         accepted = ["image", "application/pdf"]
@@ -151,10 +152,16 @@ module Decidim
         http_connection = Net::HTTP.new(url.host, url.port)
         http_connection.use_ssl = true if url.scheme == "https"
         http_connection.start do |http|
-          return http.head(url.request_uri)["Content-Type"].start_with?(*accepted)
+          response = http.head(url.request_uri)
+          content_type = response["Content-Type"]
+          return if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
+
+          message = response.message.presence || Rack::Utils::HTTP_STATUS_CODES[response.code.to_i]
+          message = message.presence || "Error"
+          return "#{response.code} #{message}"
         end
-      rescue StandardError
-        nil
+      rescue StandardError => e
+        format_error(e)
       end
 
       def attachment_title(file)
@@ -171,7 +178,7 @@ module Decidim
 
         @imported_assembly.attached_uploader(:hero_image).remote_url = url
       rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-        @warnings << I18n.t("decidim.assemblies.admin.imports.hero_image_error", error: e.message)
+        @warnings << I18n.t("decidim.assemblies.admin.imports.hero_image_error", error: format_error(e))
       end
 
       def import_banner_image(url)
@@ -179,7 +186,19 @@ module Decidim
 
         @imported_assembly.attached_uploader(:banner_image).remote_url = url
       rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-        @warnings << I18n.t("decidim.assemblies.admin.imports.banner_image_error", error: e.message)
+        @warnings << I18n.t("decidim.assemblies.admin.imports.banner_image_error", error: format_error(e))
+      end
+
+      def format_error(error)
+        return error.message unless error.respond_to?(:io) && error.io.respond_to?(:status)
+
+        status = error.io.status
+        return error.message if status.blank? || status.first.blank?
+
+        code = status[0]
+        message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
+        message = message.presence || error.message
+        "#{code} #{message}"
       end
     end
   end

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -154,11 +154,11 @@ module Decidim
         http_connection.start do |http|
           response = http.head(url.request_uri)
           content_type = response["Content-Type"]
-          return if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
+          next if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
 
           message = response.message.presence || Rack::Utils::HTTP_STATUS_CODES[response.code.to_i]
           message = message.presence || "Error"
-          return "#{response.code} #{message}"
+          next "#{response.code} #{message}"
         end
       rescue StandardError => e
         format_error(e)

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -280,6 +280,7 @@ en:
           highlighted_assemblies:
             max_results: Maximum amount of elements to show
         imports:
+          attachment_error: The attachment could not be imported due to an error. Error %{error}
           banner_image_error: The banner image could not be imported due to an error. Error %{error}
           hero_image_error: The hero image could not be imported due to an error. Error %{error}
         new_import:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -280,7 +280,7 @@ en:
           highlighted_assemblies:
             max_results: Maximum amount of elements to show
         imports:
-          attachment_error: The attachment could not be imported due to an error. Error %{error}
+          attachment_error: The attachment "%{title}" could not be imported due to an error. Error %{error}
           banner_image_error: The banner image could not be imported due to an error. Error %{error}
           hero_image_error: The hero image could not be imported due to an error. Error %{error}
         new_import:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -280,9 +280,9 @@ en:
           highlighted_assemblies:
             max_results: Maximum amount of elements to show
         imports:
-          attachment_error: The attachment "%{title}" could not be imported due to an error. Error %{error}
-          banner_image_error: The banner image could not be imported due to an error. Error %{error}
-          hero_image_error: The hero image could not be imported due to an error. Error %{error}
+          attachment_error: The attachment "%{title}" could not be imported (%{error}).
+          banner_image_error: The banner image could not be imported (%{error}).
+          hero_image_error: The hero image could not be imported (%{error}).
         new_import:
           accepted_types:
             json: JSON

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -271,6 +271,12 @@ module Decidim::Assemblies
             expect { importer.import_folders_and_attachments(attachments_data) }
               .not_to raise_error
           end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
+          end
         end
 
         context "when remote file is not accessible (500)" do
@@ -286,6 +292,26 @@ module Decidim::Assemblies
           it "does not raise an error" do
             expect { importer.import_folders_and_attachments(attachments_data) }
               .not_to raise_error
+          end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
+          end
+        end
+
+        context "when remote file is accessible but download fails" do
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url).to_return(status: 500)
+          end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
           end
         end
       end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -110,7 +110,7 @@ module Decidim::Assemblies
 
         it "collects a warning about the missing hero image" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported due to an error/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported \(404 Not Found\)\./i))
         end
       end
 
@@ -135,7 +135,7 @@ module Decidim::Assemblies
 
         it "collects a warning about the hero image import failure" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/hero image.*not.*imported/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported \(500 Internal Server Error\)\./i))
         end
       end
 
@@ -181,7 +181,7 @@ module Decidim::Assemblies
 
         it "collects a warning about the missing banner image" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/The banner image could not be imported due to an error/i))
+          expect(importer.warnings).to include(a_string_matching(/The banner image could not be imported \(404 Not Found\)\./i))
         end
       end
 
@@ -202,8 +202,8 @@ module Decidim::Assemblies
 
         it "collects warnings for both images" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/hero image/i))
-          expect(importer.warnings).to include(a_string_matching(/banner image/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported/i))
+          expect(importer.warnings).to include(a_string_matching(/The banner image could not be imported/i))
           expect(importer.warnings.length).to eq(2)
         end
       end
@@ -274,9 +274,7 @@ module Decidim::Assemblies
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(404 Not Found\)\./i))
           end
         end
 
@@ -297,9 +295,7 @@ module Decidim::Assemblies
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
 
@@ -312,9 +308,7 @@ module Decidim::Assemblies
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
       end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -276,6 +276,7 @@ module Decidim::Assemblies
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
 
@@ -298,6 +299,7 @@ module Decidim::Assemblies
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
 
@@ -312,6 +314,7 @@ module Decidim::Assemblies
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
       end

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -368,6 +368,7 @@ describe "Admin imports assembly" do
       within ".flash.warning" do
         expect(page).to have_content(/attachment could not be imported/i)
         expect(page).to have_content(/error/i)
+        expect(page).to have_content(/Eligendi praesentium/i)
       end
     end
   end

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -311,4 +311,64 @@ describe "Admin imports assembly" do
       end
     end
   end
+
+  context "when attachment URLs return 404" do
+    let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
+    let(:json_file) do
+      Tempfile.new(["assemblies", ".json"]).tap do |file|
+        file.write(json_data.to_json)
+        file.rewind
+      end
+    end
+    let(:uploaded_file) do
+      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+    end
+
+    before do
+      json_data.first["attachments"]["files"].each do |file|
+        file["remote_file_url"] = "http://example.com/missing-attachment.pdf"
+      end
+
+      stub_request(:head, "http://example.com/missing-attachment.pdf")
+        .to_return(status: 404, body: "Not Found")
+
+      stub_get_request_with_format(
+        "http://localhost:3000/uploads/decidim/assembly/hero_image/1/city.jpeg",
+        "image/jpeg"
+      )
+      stub_get_request_with_format(
+        "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg",
+        "image/jpeg"
+      )
+
+      within_admin_menu do
+        click_on "Import"
+      end
+
+      within ".import_assembly" do
+        fill_in_i18n(
+          :assembly_title,
+          "#assembly-title-tabs",
+          en: "Import assembly with 404 attachments",
+          es: "Importación de la asamblea",
+          ca: "Importació de l'asamblea"
+        )
+        fill_in :assembly_slug, with: "as-import-404-attachments"
+        check :assembly_import_attachments
+      end
+
+      dynamically_attach_file(:assembly_document, uploaded_file.path)
+      click_on "Import"
+    end
+
+    it "imports successfully and shows a warning about missing attachments" do
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Import assembly with 404 attachments")
+
+      within ".flash.warning" do
+        expect(page).to have_content(/attachment could not be imported/i)
+        expect(page).to have_content(/error/i)
+      end
+    end
+  end
 end

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -142,7 +142,7 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Import assembly with 404 hero")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported due to an error/i)
+        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -195,7 +195,7 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Import assembly with 404 banner")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The banner image could not be imported due to an error/i)
+        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -249,8 +249,8 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Import assembly with 404 images")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported due to an error/i)
-        expect(page).to have_content(/The banner image could not be imported due to an error/i)
+        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
+        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -306,8 +306,8 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Import assembly with long 404 images")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported due to an error/i)
-        expect(page).to have_content(/The banner image could not be imported due to an error/i)
+        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
+        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -366,9 +366,7 @@ describe "Admin imports assembly" do
       expect(page).to have_content("Import assembly with 404 attachments")
 
       within ".flash.warning" do
-        expect(page).to have_content(/attachment could not be imported/i)
-        expect(page).to have_content(/error/i)
-        expect(page).to have_content(/Eligendi praesentium/i)
+        expect(page).to have_content(/The attachment ".+" could not be imported \(404 Not Found\)\./i)
       end
     end
   end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -94,9 +94,20 @@ module Decidim
         return if attachments["files"].nil?
 
         attachments["files"].map do |file|
-          next unless remote_file_exists?(file["remote_file_url"])
+          url = file["remote_file_url"]
+          next if url.blank?
 
-          file_tmp = URI.parse(file["remote_file_url"]).open
+          unless remote_file_exists?(url)
+            @warnings << I18n.t("decidim.participatory_processes.admin.imports.attachment_error", error: "Not found")
+            next
+          end
+
+          begin
+            file_tmp = URI.parse(url).open
+          rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+            @warnings << I18n.t("decidim.participatory_processes.admin.imports.attachment_error", error: e.message)
+            next
+          end
 
           Decidim.traceability.perform_action!("create", Attachment, @user) do
             attachment = Attachment.new(

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -108,7 +108,7 @@ module Decidim
 
           begin
             file_tmp = URI.parse(url).open
-          rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+          rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
             @warnings << I18n.t(
               "decidim.participatory_processes.admin.imports.attachment_error",
               title: attachment_title(file),

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -98,14 +98,22 @@ module Decidim
           next if url.blank?
 
           unless remote_file_exists?(url)
-            @warnings << I18n.t("decidim.participatory_processes.admin.imports.attachment_error", error: "Not found")
+            @warnings << I18n.t(
+              "decidim.participatory_processes.admin.imports.attachment_error",
+              title: attachment_title(file),
+              error: "Not found"
+            )
             next
           end
 
           begin
             file_tmp = URI.parse(url).open
           rescue OpenURI::HTTPError, Errno::ENOENT, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-            @warnings << I18n.t("decidim.participatory_processes.admin.imports.attachment_error", error: e.message)
+            @warnings << I18n.t(
+              "decidim.participatory_processes.admin.imports.attachment_error",
+              title: attachment_title(file),
+              error: e.message
+            )
             next
           end
 
@@ -174,6 +182,15 @@ module Decidim
         end
       rescue StandardError
         nil
+      end
+
+      def attachment_title(file)
+        title = file["title"]
+        return "" if title.blank?
+
+        return title unless title.is_a?(Hash)
+
+        title.values.find(&:present?) || ""
       end
 
       def import_hero_image(url)

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -181,11 +181,11 @@ module Decidim
         http_connection.start do |http|
           response = http.head(url.request_uri)
           content_type = response["Content-Type"]
-          return if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
+          next if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
 
           message = response.message.presence || Rack::Utils::HTTP_STATUS_CODES[response.code.to_i]
           message = message.presence || "Error"
-          return "#{response.code} #{message}"
+          next "#{response.code} #{message}"
         end
       rescue StandardError => e
         format_error(e)

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -97,11 +97,12 @@ module Decidim
           url = file["remote_file_url"]
           next if url.blank?
 
-          unless remote_file_exists?(url)
+          error = remote_file_error(url)
+          if error.present?
             @warnings << I18n.t(
               "decidim.participatory_processes.admin.imports.attachment_error",
               title: attachment_title(file),
-              error: "Not found"
+              error:
             )
             next
           end
@@ -112,7 +113,7 @@ module Decidim
             @warnings << I18n.t(
               "decidim.participatory_processes.admin.imports.attachment_error",
               title: attachment_title(file),
-              error: e.message
+              error: format_error(e)
             )
             next
           end
@@ -170,7 +171,7 @@ module Decidim
         attachment_collection
       end
 
-      def remote_file_exists?(url)
+      def remote_file_error(url)
         return if url.nil?
 
         accepted = ["image", "application/pdf"]
@@ -178,10 +179,16 @@ module Decidim
         http_connection = Net::HTTP.new(url.host, url.port)
         http_connection.use_ssl = true if url.scheme == "https"
         http_connection.start do |http|
-          return http.head(url.request_uri)["Content-Type"].start_with?(*accepted)
+          response = http.head(url.request_uri)
+          content_type = response["Content-Type"]
+          return if response.is_a?(Net::HTTPSuccess) && content_type&.start_with?(*accepted)
+
+          message = response.message.presence || Rack::Utils::HTTP_STATUS_CODES[response.code.to_i]
+          message = message.presence || "Error"
+          return "#{response.code} #{message}"
         end
-      rescue StandardError
-        nil
+      rescue StandardError => e
+        format_error(e)
       end
 
       def attachment_title(file)
@@ -198,7 +205,7 @@ module Decidim
 
         @imported_process.attached_uploader(:hero_image).remote_url = url
       rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-        @warnings << I18n.t("decidim.participatory_processes.admin.imports.hero_image_error", error: e.message)
+        @warnings << I18n.t("decidim.participatory_processes.admin.imports.hero_image_error", error: format_error(e))
       end
 
       def import_group_hero_image(group, url)
@@ -206,7 +213,19 @@ module Decidim
 
         group.attached_uploader(:hero_image).remote_url = url
       rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-        @warnings << I18n.t("decidim.participatory_processes.admin.imports.hero_image_error", error: e.message)
+        @warnings << I18n.t("decidim.participatory_processes.admin.imports.hero_image_error", error: format_error(e))
+      end
+
+      def format_error(error)
+        return error.message unless error.respond_to?(:io) && error.io.respond_to?(:status)
+
+        status = error.io.status
+        return error.message if status.blank? || status.first.blank?
+
+        code = status[0]
+        message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
+        message = message.presence || error.message
+        "#{code} #{message}"
       end
     end
   end

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -491,8 +491,8 @@ en:
             max_results: Maximum amount of elements to show
             selection_criteria: Selection criteria
         imports:
-          attachment_error: The attachment "%{title}" could not be imported due to an error. Error %{error}
-          hero_image_error: The hero image could not be imported due to an error. Error %{error}
+          attachment_error: The attachment "%{title}" could not be imported (%{error}).
+          hero_image_error: The hero image could not be imported (%{error}).
         new_import:
           accepted_types:
             json: JSON

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -491,6 +491,7 @@ en:
             max_results: Maximum amount of elements to show
             selection_criteria: Selection criteria
         imports:
+          attachment_error: The attachment could not be imported due to an error. Error %{error}
           hero_image_error: The hero image could not be imported due to an error. Error %{error}
         new_import:
           accepted_types:

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -491,7 +491,7 @@ en:
             max_results: Maximum amount of elements to show
             selection_criteria: Selection criteria
         imports:
-          attachment_error: The attachment could not be imported due to an error. Error %{error}
+          attachment_error: The attachment "%{title}" could not be imported due to an error. Error %{error}
           hero_image_error: The hero image could not be imported due to an error. Error %{error}
         new_import:
           accepted_types:

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -349,6 +349,12 @@ module Decidim::ParticipatoryProcesses
             expect { importer.import_folders_and_attachments(attachments_data) }
               .not_to raise_error
           end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
+          end
         end
 
         context "when remote file is not accessible (500)" do
@@ -364,6 +370,26 @@ module Decidim::ParticipatoryProcesses
           it "does not raise an error" do
             expect { importer.import_folders_and_attachments(attachments_data) }
               .not_to raise_error
+          end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
+          end
+        end
+
+        context "when remote file is accessible but download fails" do
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url).to_return(status: 500)
+          end
+
+          it "collects a warning about the attachment import failure" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
+            expect(importer.warnings).to include(a_string_matching(/error/i))
           end
         end
       end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -354,6 +354,7 @@ module Decidim::ParticipatoryProcesses
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
 
@@ -376,6 +377,7 @@ module Decidim::ParticipatoryProcesses
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
 
@@ -390,6 +392,7 @@ module Decidim::ParticipatoryProcesses
             importer.import_folders_and_attachments(attachments_data)
             expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
             expect(importer.warnings).to include(a_string_matching(/error/i))
+            expect(importer.warnings).to include(a_string_matching(/Test File/i))
           end
         end
       end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -199,7 +199,7 @@ module Decidim::ParticipatoryProcesses
 
         it "collects a warning about the missing hero image" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported due to an error/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported \(404 Not Found\)\./i))
         end
       end
 
@@ -244,7 +244,7 @@ module Decidim::ParticipatoryProcesses
 
         it "collects a warning about the hero image import failure" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/hero image.*not.*imported/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported \(500 Internal Server Error\)\./i))
         end
       end
 
@@ -306,7 +306,7 @@ module Decidim::ParticipatoryProcesses
 
         it "collects a warning about the missing group hero image" do
           subject
-          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported due to an error/i))
+          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported \(404 Not Found\)\./i))
         end
       end
     end
@@ -352,9 +352,7 @@ module Decidim::ParticipatoryProcesses
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(404 Not Found\)\./i))
           end
         end
 
@@ -375,9 +373,7 @@ module Decidim::ParticipatoryProcesses
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
 
@@ -390,9 +386,7 @@ module Decidim::ParticipatoryProcesses
 
           it "collects a warning about the attachment import failure" do
             importer.import_folders_and_attachments(attachments_data)
-            expect(importer.warnings).to include(a_string_matching(/attachment could not be imported/i))
-            expect(importer.warnings).to include(a_string_matching(/error/i))
-            expect(importer.warnings).to include(a_string_matching(/Test File/i))
+            expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
       end

--- a/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
@@ -144,7 +144,7 @@ describe "Admin imports participatory process" do
       expect(page).to have_content("Import process with 404 hero")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported due to an error/i)
+        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -197,7 +197,7 @@ describe "Admin imports participatory process" do
       expect(page).to have_content("Import process with 404 group hero")
 
       within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported due to an error/i)
+        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -256,9 +256,7 @@ describe "Admin imports participatory process" do
       expect(page).to have_content("Import process with 404 attachments")
 
       within ".flash.warning" do
-        expect(page).to have_content(/attachment could not be imported/i)
-        expect(page).to have_content(/error/i)
-        expect(page).to have_content(/Possimus quia/i)
+        expect(page).to have_content(/The attachment ".+" could not be imported \(404 Not Found\)\./i)
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
@@ -258,6 +258,7 @@ describe "Admin imports participatory process" do
       within ".flash.warning" do
         expect(page).to have_content(/attachment could not be imported/i)
         expect(page).to have_content(/error/i)
+        expect(page).to have_content(/Possimus quia/i)
       end
     end
   end

--- a/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
@@ -201,4 +201,64 @@ describe "Admin imports participatory process" do
       end
     end
   end
+
+  context "when attachment URLs return 404" do
+    let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("participatory_processes.json"))) }
+    let(:json_file) do
+      Tempfile.new(["participatory_processes", ".json"]).tap do |file|
+        file.write(json_data.to_json)
+        file.rewind
+      end
+    end
+    let(:uploaded_file) do
+      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+    end
+
+    before do
+      json_data.first["attachments"]["files"].each do |file|
+        file["remote_file_url"] = "http://example.com/missing-attachment.pdf"
+      end
+
+      stub_request(:head, "http://example.com/missing-attachment.pdf")
+        .to_return(status: 404, body: "Not Found")
+
+      stub_get_request_with_format(
+        "http://localhost:3000/uploads/decidim/participatory_process/hero_image/1/city.jpeg",
+        "image/jpeg"
+      )
+      stub_get_request_with_format(
+        "http://localhost:3000/uploads/decidim/participatory_process_group/hero_image/1/city.jpeg",
+        "image/jpeg"
+      )
+
+      within_admin_menu do
+        click_on "Import"
+      end
+
+      within ".import_participatory_process" do
+        fill_in_i18n(
+          :participatory_process_title,
+          "#participatory_process-title-tabs",
+          en: "Import process with 404 attachments",
+          es: "Importación del proceso participativo",
+          ca: "Importació del procés participatiu"
+        )
+        fill_in :participatory_process_slug, with: "pp-import-404-attachments"
+        check :participatory_process_import_attachments
+      end
+
+      dynamically_attach_file(:participatory_process_document, uploaded_file.path)
+      click_on "Import"
+    end
+
+    it "imports successfully and shows a warning about missing attachments" do
+      expect(page).to have_content("successfully")
+      expect(page).to have_content("Import process with 404 attachments")
+
+      within ".flash.warning" do
+        expect(page).to have_content(/attachment could not be imported/i)
+        expect(page).to have_content(/error/i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As I mentioned in #16026, I found yet another bug in the import spaces flow. This is basically the same as the one in #16026, but this time with attachments: if the attachments don't exist, then we have an exception during the import process.

The proposed solution is by adding more warnings about this, so the admin can fix it afterwards. 

#### :pushpin: Related Issues
 
- Related to #16026 
 
#### Testing

1. Sign in as admin
2. Export an assembly
3. Change the URL of the attachments to an invalid URL
4. Import this assembly at http://localhost:3000/admin/assemblies/imports/new  - NOTE: do click in the "Import attachments" (as it is by default)
5. (Without the patch) see the exception
5. (With the patch) see the warning (and that the import still happens)

This is the assembly that I'm using for my local exploration:

[assemblies-bad.json](https://github.com/user-attachments/files/25175561/assemblies-bad.json)

### Stacktrace 

```
OpenURI::HTTPError (404 Not Found):

/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:393:in 'OpenURI.open_http'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:825:in 'URI::HTTP#buffer_open'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:233:in 'block in OpenURI.open_loop'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:231:in 'Kernel#catch'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:231:in 'OpenURI.open_loop'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:163:in 'OpenURI.open_uri'
/home/vscode/.local/share/mise/installs/ruby/3.4.7/lib/ruby/3.4.0/open-uri.rb:805:in 'OpenURI::OpenRead#open'
/workspaces/decidim/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb:77:in 'block in Decidim::Assemblies::AssemblyImporter#import_folders_and_attachments'
/workspaces/decidim/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb:74:in 'Array#map'
/workspaces/decidim/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb:74:in 'Decidim::Assemblies::AssemblyImporter#import_folders_and_attachments'
/workspaces/decidim/decidim-assemblies/app/commands/decidim/assemblies/admin/import_assembly.rb:45:in 'block (2 levels) in Decidim::Assemblies::Admin::ImportAssembly#import_assembly'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:64:in 'block (2 levels) in Decidim::Traceability#perform_action!'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.2.2) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.2.2) lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.2.2) lib/active_record/connection_handling.rb:296:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.2.2) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:63:in 'block in Decidim::Traceability#perform_action!'
paper_trail (16.0.0) lib/paper_trail/request.rb:85:in 'PaperTrail::Request.with'
paper_trail (16.0.0) lib/paper_trail.rb:81:in 'PaperTrail.request'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:62:in 'Decidim::Traceability#perform_action!'
``` 

### :camera: Screenshots

#### Before

<img width="1814" height="1011" alt="image" src="https://github.com/user-attachments/assets/2139cc24-9cea-4125-b7b0-466d4c9fec69" />

#### After 

<img width="1813" height="932" alt="image" src="https://github.com/user-attachments/assets/f4745a6f-84db-4198-8e1d-6072ad1d1cc1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Attachment and image imports now validate remote URLs, handle network/time-out errors gracefully, and display clear, consistent warning messages including status/details so imports continue despite problematic files.

* **Documentation**
  * Improved user-facing import error wording (hero/banner/attachment) for clearer, consistent messages that include the specific error detail.

* **Tests**
  * Added/updated tests covering attachment and image import failures (404, 500, download errors) to ensure precise warning messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->