### PR TITLE
Devcontainers: caches and .env file introduction

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -7,8 +7,6 @@ services:
       dockerfile: .devcontainer/Dockerfile
     volumes:
     - ../:/workspaces/decidim:cached
-    - bundle-cache:/usr/local/bundle
-    - node-modules-cache:/workspaces/decidim/node_modules
     ports:
       - "${DEVCONTAINER_APP_PORT:-3000}:3000"
     command: sleep infinity
@@ -36,6 +34,4 @@ services:
 volumes:
   redis-data:
   postgres-data:
-  bundle-cache:
-  node-modules-cache:
 

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,6 +9,9 @@ services:
     - ../:/workspaces/decidim:cached
     ports:
       - "${DEVCONTAINER_APP_PORT:-3000}:3000"
+    env_file:
+      - path: ../.env
+        required: false
     command: sleep infinity
     depends_on:
       - redis

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "workspaceFolder": "/workspaces/decidim",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/rails/devcontainer/features/bundler-cache:1.0.1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
       "moby": false
     },

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ schema.json
 .yardoc
 .rspec-failures
 .rbenv-vars
+.env
 # Sublime Text 3 indexing file: .tags
 .tags
 # Vim swap files


### PR DESCRIPTION
#### :tophat: What? Why?

While working with devcontainers exclusively, I found a couple of issues/needs: 

1. Bundler cache wan't working correctly
2. NPM cache had some permissions errors
3. I had no clean-way of defining multiple Env Vars

#### :pushpin: Related Issues

- Related to #15887 

#### Testing

##### Bundler cache

Check out the output when running `bin/devcontainer rebuild`. When the development_app is created, it should have some of the packages cached

##### NPM cache

Run 

```
bin/devcontainer fish
npm install hello-world
npm install -g pnpm
```

After `bin/devcontainer rebuild` with this and without this patch. 

Without this patch, you'll have permissions errors

##### Env Vars

1. Create a .env file with this;

```env
DECIDIM_AVAILABLE_LOCALES="en,es,ca"
```

2. Run `bin/devcontainer rebuild`

3. See that the generated app only have these locales

You can also check that this file is optional by not creating this and running `bin/devcontainer rebuild` - it should work as before 

### Screenshot

(From the env vars)

<img width="2660" height="1728" alt="image" src="https://github.com/user-attachments/assets/3368d708-4492-4a08-a5f2-a838cc3387e5" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development container setup with improved bundler caching to reduce build times.
  * Enhanced development environment configuration to support optional environment variable loading.
  * Updated git configuration to exclude environment variable files from version control.
  * Streamlined container volume management for more efficient development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->