### PR TITLE
Fix line in the account mobile menu

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -237,10 +237,6 @@ header {
           @apply text-md;
         }
 
-        .main-bar {
-          @apply border-b border-gray;
-        }
-
         .main-bar__avatar {
           @apply w-12 h-12;
         }


### PR DESCRIPTION
#### :tophat: What? Why?

On a new review by @decidim/product on the menu, we found a minor bug: a line that shouldn't be there. This PR fixes it. 

#### :pushpin: Related Issues

- Related to  #15683 and #15299

#### Testing

1. Log in 
2. Use a responsive viewport to kick in the mobile UI 
3. Open the Account menu
4. (Before this patch) see the line
5. (After the patch) see that you don't have the line

### :camera: Screenshots

#### Before
<img width="988" height="1316" alt="image" src="https://github.com/user-attachments/assets/de274f32-a222-4c0f-8483-f297b618a2d5" />


#### After
<img width="926" height="1284" alt="image" src="https://github.com/user-attachments/assets/e78037d0-7525-4de7-92f6-a38da11f43c8" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the bottom border from the main navigation bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->