### PR TITLE
Fix flaky spec in budgets' `download_open_data_files_spec.rb`

### DIFF
--- a/decidim-budgets/spec/system/download_open_data_files_spec.rb
+++ b/decidim-budgets/spec/system/download_open_data_files_spec.rb
@@ -7,6 +7,22 @@ require "decidim/core/test/shared_examples/download_open_data_shared_examples"
 describe "Download Open Data files", download: true do
   let(:organization) { create(:organization) }
 
+  before do
+    I18n.backend.reload!
+    I18n.backend.store_translations(
+      :en,
+      decidim: {
+        open_data: {
+          help: {
+            projects: {
+              test_field: "Test field for projects serializer subscription"
+            }
+          }
+        }
+      }
+    )
+  end
+
   include_context "when downloading open data files"
 
   it "lets the users download open data files" do


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am fixing the budgets pipeline that has started to fail with the following error: 

<img width="1360" height="659" alt="image" src="https://github.com/user-attachments/assets/9283540c-b296-457b-a7d3-a935d8ee1dc9" />

Since this is a test field, we cannot add it to the I18n files.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16095 (a failing pipeline)

#### Testing
1. Run the budgets pipeline several times.. See it consistently passes 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced open data download test coverage with additional localization data to support testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->