### PR TITLE
Be smart with the 'with more authors' sorting option

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -24,7 +24,8 @@ module Decidim
             possible_orders << "most_voted" if most_voted_order_available?
             possible_orders << "most_liked" if current_settings.likes_enabled?
             possible_orders << "most_commented" if component_settings.comments_enabled?
-            possible_orders << "most_followed" << "with_more_authors"
+            possible_orders << "most_followed"
+            possible_orders << "with_more_authors" if with_more_authors_order_available?
             possible_orders
           end
         end
@@ -50,6 +51,12 @@ module Decidim
 
         def most_voted_order_available?
           current_settings.votes_enabled? && !current_settings.votes_hidden?
+        end
+
+        def with_more_authors_order_available?
+          return @with_more_authors_order_available if defined?(@with_more_authors_order_available)
+
+          @with_more_authors_order_available = Decidim::Proposals::Proposal.with_more_authors_available?(current_component)
         end
 
         def order_by_votes?

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -165,6 +165,14 @@ module Decidim
           .where(decidim_proposals_evaluation_assignments: { evaluator_role_id: evaluator_roles })
       end
 
+      def self.with_more_authors_available?(component)
+        where(component: component)
+          .published
+          .not_hidden
+          .where("coauthorships_count > 1")
+          .exists?
+      end
+
       acts_as_list scope: :decidim_component_id
 
       searchable_fields({

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -166,7 +166,7 @@ module Decidim
       end
 
       def self.with_more_authors_available?(component)
-        where(component: component)
+        where(component:)
           .published
           .not_hidden
           .where("coauthorships_count > 1")

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -169,6 +169,7 @@ module Decidim
         where(component:)
           .published
           .not_hidden
+          .not_withdrawn
           .where("coauthorships_count > 1")
           .exists?
       end

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -35,6 +35,16 @@ Decidim.register_component(:proposals) do |component|
   component.permissions_class_name = "Decidim::Proposals::Permissions"
 
   POSSIBLE_SORT_ORDERS = %w(automatic random recent most_liked most_voted most_commented most_followed with_more_authors).freeze
+  WITH_MORE_AUTHORS_ORDER = "with_more_authors"
+
+  sort_order_choices = lambda do |context|
+    component = context[:component]
+    orders = POSSIBLE_SORT_ORDERS.dup
+
+    return orders.excluding(WITH_MORE_AUTHORS_ORDER) unless component && Decidim::Proposals::Proposal.with_more_authors_available?(component)
+
+    orders
+  end
 
   component.settings(:global) do |settings|
     settings.attribute :taxonomy_filters, type: :taxonomy_filters
@@ -47,7 +57,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :threshold_per_proposal, type: :integer, default: 0, required: true
     settings.attribute :can_accumulate_votes_beyond_threshold, type: :boolean, default: false
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
-    settings.attribute :default_sort_order, type: :select, default: "automatic", choices: ->(_context) { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, default: "automatic", choices: ->(context) { sort_order_choices.call(context) }
     settings.attribute :official_proposals_enabled, type: :boolean, default: true
     settings.attribute :comments_enabled, type: :boolean, default: true
     settings.attribute :comments_max_length, type: :integer, required: true
@@ -81,7 +91,7 @@ Decidim.register_component(:proposals) do |component|
     settings.attribute :proposal_answering_enabled, type: :boolean, default: true
     settings.attribute :publish_answers_immediately, type: :boolean, default: true
     settings.attribute :answers_with_costs, type: :boolean, default: false
-    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: ->(_context) { POSSIBLE_SORT_ORDERS }
+    settings.attribute :default_sort_order, type: :select, include_blank: true, choices: ->(context) { sort_order_choices.call(context) }
     settings.attribute :amendment_creation_enabled, type: :boolean, default: true
     settings.attribute :amendment_reaction_enabled, type: :boolean, default: true
     settings.attribute :amendment_promotion_enabled, type: :boolean, default: true

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -214,7 +214,7 @@ module Decidim
           end
         end
 
-        context "with_more_authors availability" do
+        context "with or without coauthors and with_more_authors availability" do
           let!(:proposal_with_single_author) { create(:proposal, component:) }
           let!(:proposal_with_coauthors) { create(:proposal, component:) }
           let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -251,7 +251,6 @@ module Decidim
             expect(controller.send(:with_more_authors_order_available?)).to be false
           end
         end
-        end
 
         context "when there are proposals with coauthors" do
           it "returns true" do

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -242,25 +242,15 @@ module Decidim
         let!(:proposal_with_coauthors) { create(:proposal, component:) }
         let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
 
-        context "when there are no proposals with coauthors" do
+        context "when there are proposals with only single author" do
           before do
-            proposal_with_coauthors.destroy
+            coauthorships.each(&:destroy)
           end
 
           it "returns false" do
             expect(controller.send(:with_more_authors_order_available?)).to be false
           end
         end
-
-        context "when there are proposals with only single author" do
-          before do
-            coauthorships.each(&:destroy)
-            proposal_with_coauthors.destroy
-          end
-
-          it "returns false" do
-            expect(controller.send(:with_more_authors_order_available?)).to be false
-          end
         end
 
         context "when there are proposals with coauthors" do

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -55,10 +55,10 @@ module Decidim
 
         context "when step has default_sort_order" do
           let(:component_default_sort_order) { "random" }
-          let(:step_default_sort_order) { "with_more_authors" }
+          let(:step_default_sort_order) { "most_commented" }
 
           it "use it instead of component's" do
-            expect(controller.send(:default_order)).to eq("with_more_authors")
+            expect(controller.send(:default_order)).to eq("most_commented")
           end
         end
 
@@ -101,7 +101,7 @@ module Decidim
           describe "recent" do
             let(:default_sort_order) { "recent" }
 
-            it "default_order is random" do
+            it "default_order is recent" do
               expect(controller.send(:default_order)).to eq(default_sort_order)
             end
           end
@@ -110,7 +110,7 @@ module Decidim
             let(:default_sort_order) { "most_liked" }
             let(:likes_enabled) { true }
 
-            it "default_order is random" do
+            it "default_order is most_liked" do
               expect(controller.send(:default_order)).to eq(default_sort_order)
             end
           end
@@ -119,7 +119,7 @@ module Decidim
             let(:default_sort_order) { "most_commented" }
             let(:comments_enabled) { true }
 
-            it "default_order is random" do
+            it "default_order is most_commented" do
               expect(controller.send(:default_order)).to eq(default_sort_order)
             end
           end
@@ -127,7 +127,7 @@ module Decidim
           describe "most_followed" do
             let(:default_sort_order) { "most_followed" }
 
-            it "default_order is random" do
+            it "default_order is most_followed" do
               expect(controller.send(:default_order)).to eq(default_sort_order)
             end
           end
@@ -135,8 +135,19 @@ module Decidim
           describe "with_more_authors" do
             let(:default_sort_order) { "with_more_authors" }
 
-            it "default_order is random" do
-              expect(controller.send(:default_order)).to eq(default_sort_order)
+            context "when there are no proposals with coauthors" do
+              it "defaults to random" do
+                expect(controller.send(:default_order)).to eq("random")
+              end
+            end
+
+            context "when there are proposals with coauthors" do
+              let!(:proposal_with_coauthors) { create(:proposal, component:) }
+              let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+              it "default_order is with_more_authors" do
+                expect(controller.send(:default_order)).to eq(default_sort_order)
+              end
             end
           end
         end
@@ -200,6 +211,81 @@ module Decidim
 
           it "does not show most_commented option to sort" do
             expect(view.available_orders).not_to include("most_commented")
+          end
+        end
+
+        context "with_more_authors availability" do
+          let!(:proposal_with_single_author) { create(:proposal, component:) }
+          let!(:proposal_with_coauthors) { create(:proposal, component:) }
+          let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+          context "when there are no proposals with coauthors" do
+            before do
+              proposal_with_coauthors.destroy
+            end
+
+            it "does not show with_more_authors option to sort" do
+              expect(view.available_orders).not_to include("with_more_authors")
+            end
+          end
+
+          context "when there are proposals with coauthors" do
+            it "shows with_more_authors option to sort" do
+              expect(view.available_orders).to include("with_more_authors")
+            end
+          end
+        end
+      end
+
+      describe "#with_more_authors_order_available?" do
+        let!(:proposal_with_single_author) { create(:proposal, component:) }
+        let!(:proposal_with_coauthors) { create(:proposal, component:) }
+        let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+        context "when there are no proposals with coauthors" do
+          before do
+            proposal_with_coauthors.destroy
+          end
+
+          it "returns false" do
+            expect(controller.send(:with_more_authors_order_available?)).to be false
+          end
+        end
+
+        context "when there are proposals with only single author" do
+          before do
+            coauthorships.each(&:destroy)
+            proposal_with_coauthors.destroy
+          end
+
+          it "returns false" do
+            expect(controller.send(:with_more_authors_order_available?)).to be false
+          end
+        end
+
+        context "when there are proposals with coauthors" do
+          it "returns true" do
+            expect(controller.send(:with_more_authors_order_available?)).to be true
+          end
+        end
+
+        context "when proposals are not published" do
+          before do
+            proposal_with_coauthors.update!(published_at: nil)
+          end
+
+          it "returns false" do
+            expect(controller.send(:with_more_authors_order_available?)).to be false
+          end
+        end
+
+        context "when proposals are hidden" do
+          before do
+            create(:moderation, reportable: proposal_with_coauthors, hidden_at: Time.current)
+          end
+
+          it "returns false" do
+            expect(controller.send(:with_more_authors_order_available?)).to be false
           end
         end
       end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -219,6 +219,33 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
         end
       end
     end
+
+    describe "default_sort_order choices" do
+      let(:default_sort_order_container) { page.all(".default_sort_order_container").first }
+
+      before do
+        visit edit_component_path
+      end
+
+      context "when there are no proposals with coauthors" do
+        it "does not include with_more_authors" do
+          expect(default_sort_order_container).to have_no_content("With more authors")
+        end
+      end
+
+      context "when there are proposals with coauthors" do
+        let!(:proposal_with_coauthors) { create(:proposal, component:) }
+        let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+        before do
+          visit edit_component_path
+        end
+
+        it "includes with_more_authors" do
+          expect(default_sort_order_container).to have_content("With more authors")
+        end
+      end
+    end
   end
 
   describe "proposals exporter" do

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -35,6 +35,53 @@ module Decidim
         include_examples "counts commentators as newsletter participants"
       end
 
+      describe ".with_more_authors_available?" do
+        let(:component) { create(:proposal_component) }
+
+        context "when there are no proposals with coauthors" do
+          let!(:proposal_with_single_author) { create(:proposal, component:) }
+
+          it "returns false" do
+            expect(described_class.with_more_authors_available?(component)).to be false
+          end
+        end
+
+        context "when there are proposals with coauthors" do
+          let!(:proposal_with_coauthors) { create(:proposal, component:) }
+          let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+          it "returns true" do
+            expect(described_class.with_more_authors_available?(component)).to be true
+          end
+        end
+
+        context "when proposals are not published" do
+          let!(:proposal_with_coauthors) { create(:proposal, component:) }
+          let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+          before do
+            proposal_with_coauthors.update!(published_at: nil)
+          end
+
+          it "returns false" do
+            expect(described_class.with_more_authors_available?(component)).to be false
+          end
+        end
+
+        context "when proposals are hidden" do
+          let!(:proposal_with_coauthors) { create(:proposal, component:) }
+          let!(:coauthorships) { create_list(:coauthorship, 2, coauthorable: proposal_with_coauthors) }
+
+          before do
+            create(:moderation, reportable: proposal_with_coauthors, hidden_at: Time.current)
+          end
+
+          it "returns false" do
+            expect(described_class.with_more_authors_available?(component)).to be false
+          end
+        end
+      end
+
       it "has a votes association returning proposal votes" do
         expect(subject.votes.count).to eq(0)
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -648,6 +648,22 @@ describe "Proposals" do
       end
     end
 
+    context "when there are no proposals with coauthors" do
+      let!(:proposals) { create_list(:proposal, 3, component:) }
+
+      before do
+        visit_component
+      end
+
+      it "does not show 'with_more_authors' ordering option" do
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          expect(page).to have_no_content("With more authors")
+        end
+      end
+    end
+
     context "when searching proposals" do
       let!(:proposals) do
         [


### PR DESCRIPTION
#### :tophat: What? Why?

When a proposal component doesn't have coauthors, we still have the option "with more authors" for sorting them, both in the frontend and in the admin panel (in the "Default sorting" option).

This PR changes it, so this option is a bit smart: it only appears when there are proposals with coauthors.

#### :pushpin: Related Issues
 
- Related to #9397  (not closing it, as I'll handle the other options after this is merged)
 
#### Testing

1. Apply this patch
2. Go to the frontend and search for a proposals components index 
3. See that you don't have the coauthors option
4. Go to the admin, edit settings of this component
5. See that you don't have the coauthors option in the "Default sorting" field
6. Make a proposal with a coauthor - with open another browser and login with user 2
6.1. Go to a proposal from a participant (user 2)
6.2. Leave a comment with user 1
6.3. With user 2, go to this comment and search for hte option "Mark as co-author"
6.3. Go to the Notifications of user 1, accept the petition to become a co-author
6.4. Check hat the proposal has co-authors:
<img width="612" height="390" alt="image" src="https://github.com/user-attachments/assets/88e416e9-8fa7-4062-b36f-c4ec03481447" />
<img width="2412" height="1402" alt="image" src="https://github.com/user-attachments/assets/18749f9b-2ece-409b-bf1b-81edf4549ecd" />


Now, rec-check 2, 3, 4 and 5: 

7. Go to the frontend and search for a proposals components index 
8. See that you have the coauthors option
9. Go to the admin, edit settings of this component
10. See that you have the coauthors option in the "Default sorting" field

### :camera: Screenshots

#### with proposals without coauthors

<img width="2446" height="1500" alt="image" src="https://github.com/user-attachments/assets/243f0c8e-137c-40ea-a972-0bb3aeae29ff" />
<img width="1236" height="539" alt="image" src="https://github.com/user-attachments/assets/537f5de0-3cea-4c20-bf8a-6561e43065e1" />
 
#### with proposals with coauthors

<img width="2002" height="950" alt="image" src="https://github.com/user-attachments/assets/ba54db9c-28d8-4e3e-b05e-caf3ade3211d" />
<img width="1143" height="795" alt="image" src="https://github.com/user-attachments/assets/cc636822-c6d1-4fab-8629-219aebfeb65f" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "With more authors" sort option is now dynamic: shown and selectable only when coauthored proposals exist; otherwise hidden and the listing falls back to the appropriate default (e.g., Random).
  * "Most followed" sorting remains consistently available.

* **Tests**
  * Expanded unit, controller, view, and system tests to validate availability, default selection, and UI visibility of the "With more authors" option across proposal states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->