### PR TITLE
Fix flaky spec with lockable on authentication

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -646,7 +646,22 @@ describe "Authentication" do
     end
 
     context "with lockable account" do
-      Devise.maximum_attempts = 3
+      around do |example|
+        original_maximum_attempts = Devise.maximum_attempts
+        original_unlock_strategy = Devise.unlock_strategy
+        original_lock_strategy = Devise.lock_strategy
+
+        Devise.maximum_attempts = 3
+        Devise.unlock_strategy = :email
+        Devise.lock_strategy = :failed_attempts
+
+        example.run
+      ensure
+        Devise.maximum_attempts = original_maximum_attempts
+        Devise.unlock_strategy = original_unlock_strategy
+        Devise.lock_strategy = original_lock_strategy
+      end
+
       let!(:maximum_attempts) { Devise.maximum_attempts }
 
       describe "when attempting to log in with failing password" do
@@ -693,7 +708,7 @@ describe "Authentication" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
               fill_in :session_user_password, with: "not-the-password"
-              perform_enqueued_jobs { find("*[type=submit]").click }
+              wait_enqueued_jobs { find("*[type=submit]").click }
             end
 
             expect(page).to have_content("Invalid")
@@ -712,7 +727,7 @@ describe "Authentication" do
         it "resends the unlock instructions" do
           within ".new_user" do
             fill_in :unlock_user_email, with: user.email
-            perform_enqueued_jobs { find("*[type=submit]").click }
+            wait_enqueued_jobs { find("*[type=submit]").click }
           end
 
           expect(page).to have_content("If your account exists")

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -708,7 +708,7 @@ describe "Authentication" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
               fill_in :session_user_password, with: "not-the-password"
-              wait_enqueued_jobs { find("*[type=submit]").click }
+              perform_enqueued_jobs { find("*[type=submit]").click }
             end
 
             expect(page).to have_content("Invalid")
@@ -727,7 +727,7 @@ describe "Authentication" do
         it "resends the unlock instructions" do
           within ".new_user" do
             fill_in :unlock_user_email, with: user.email
-            wait_enqueued_jobs { find("*[type=submit]").click }
+            perform_enqueued_jobs { find("*[type=submit]").click }
           end
 
           expect(page).to have_content("If your account exists")


### PR DESCRIPTION
#### :tophat: What? Why?

We have a flaky spec on `decidim-core/spec/system/authentication_spec.rb` related to the lockable feature from Devise

#### :pushpin: Related Issues

- https://github.com/decidim/decidim/actions/runs/21907882852/job/63253066327

#### Testing 

I could reproduce it (and the fix) with this: 

```bash
for i in $(seq 10); do echo "=== Run $i ===" && bin/rspec decidim-core/spec/system/authentication_spec.rb:692 --seed 51746 2>&1 ; done
``` 

### Stacktrace

```
......Coverage report generated for (1/3), (2/3) to /home/runner/work/decidim/decidim/coverage/coverage.xml.
Line Coverage: 55.3% (38419 / 69476)
2026-02-11 14:29:43 +0000 SEVERE: http://168.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:29:47 +0000 SEVERE: http://168.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:29:50 +0000 SEVERE: http://169.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:29:55 +0000 SEVERE: http://169.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:29:56 +0000 SEVERE: http://169.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
.........
1st Try error in ./spec/system/authentication_spec.rb:663:

expected: 1
     got: 0

(compared using ==)


RSpec::Retry: 2nd try ./spec/system/authentication_spec.rb:663
2026-02-11 14:30:03 +0000 SEVERE: http://170.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:30:05 +0000 SEVERE: http://170.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:30:07 +0000 SEVERE: http://170.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)

2nd Try error in ./spec/system/authentication_spec.rb:663:

expected: 1
     got: 0

(compared using ==)

RSpec::Retry: 3rd try ./spec/system/authentication_spec.rb:663
2026-02-11 14:30:11 +0000 SEVERE: http://171.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:30:15 +0000 SEVERE: http://171.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:30:16 +0000 SEVERE: http://171.lvh.me:5200/users/sign_in - Failed to load resource: the server responded with a status of 403 (Forbidden)
2026-02-11 14:30:22 +0000 SEVERE: http://174.lvh.me:5200/users/password - Failed to load resource: the server responded with a status of 403 (Forbidden)
F......D, [2026-02-11T14:30:30.126490 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
D, [2026-02-11T14:30:30.133160 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
...D, [2026-02-11T14:30:35.080994 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
D, [2026-02-11T14:30:35.087408 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
.D, [2026-02-11T14:30:37.521028 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
D, [2026-02-11T14:30:37.528766 #6833] DEBUG -- omniauth: (facebook) Setup endpoint detected, running now.
2026-02-11 14:31:14 +0000 SEVERE: http://200.lvh.me:5200/apply_password - Failed to load resource: the server responded with a status of 422 (Unprocessable Content)
..................

Failures:

  1) Authentication when a user is already registered with lockable account when attempting to log in with failing password locks the account when reached maximum failed attempts
     Failure/Error: expect(emails.count).to eq(1)

       expected: 1
            got: 0

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_with_lockable_account_when_attempting_to_log_in_with_failing_password_locks_the_account_when_reached_maximum_failed_attempts_960.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_with_lockable_account_when_attempting_to_log_in_with_failing_password_locks_the_account_when_reached_maximum_failed_attempts_960.html


     # ./spec/system/authentication_spec.rb:671:in 'block (6 levels) in <top (required)>'

```
### :camera: Screenshots

<img width="1680" height="943" alt="image" src="https://github.com/user-attachments/assets/140e1eea-b7d1-4397-89aa-880012e23eaf" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved lockable-account test setup by scoping authentication configuration within each example and restoring originals afterward, ensuring consistent setup/teardown and reducing cross-test interference. This makes tests more reliable and isolates configuration changes to individual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->