### PR TITLE
Backport 'Make the process groups admin navigation consistent with others spaces' to v0.30

### DIFF
--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process_group.html.erb
@@ -1,3 +1,5 @@
+<% add_secondary_root_menu(:admin_participatory_process_group_menu) %>
+
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
     <% if allowed_to? :create, :process_group %>
@@ -8,17 +10,6 @@
         </span>
       <% end %>
     <% end %>
-    <div class="inline-block relative">
-      <%= button_tag id: "processes-menu-trigger", data: { component: "dropdown", target: "processes-dropdown-menu-settings" }, class: "dropdown__trigger button button__transparent" do %>
-        <span>
-          <%= t("menu.manage", scope: "decidim.admin") %>
-        </span>
-        <%= icon "arrow-down-s-line" %>
-      <% end %>
-      <div id="processes-dropdown-menu-settings" class="process-title-content-dropdown">
-        <%= dropdown_menu(:admin_participatory_process_group_menu).render %>
-      </div>
-    </div>
   </div>
 <% end %>
 

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -111,8 +111,8 @@ en:
       menu:
         participatory_process_groups: Process groups
         participatory_process_groups_submenu:
-          info: Info
-          landing_page: Landing page
+          info: About this process group
+          landing_page: Landing page layout
         participatory_processes: Processes
         participatory_processes_submenu:
           attachment_collections: Folders

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_groups_spec.rb
@@ -161,8 +161,9 @@ describe "Admin manages participatory process groups" do
         click_on "Edit"
       end
 
-      click_on "Manage"
-      click_on "Landing page"
+      within "#admin-sidebar-menu-settings" do
+        click_on "Landing page"
+      end
 
       expect(page).to have_content "Active content blocks"
     end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #16024 to v0.30

:hearts: Thank you!