### PR TITLE
Fix CommentSerializer NoMethodError when author is deleted

### DIFF
--- a/decidim-comments/lib/decidim/comments/comment_serializer.rb
+++ b/decidim-comments/lib/decidim/comments/comment_serializer.rb
@@ -14,8 +14,8 @@ module Decidim
           body: resource.body.values.first,
           locale: resource.body.keys.first,
           author: {
-            id: resource.author.id,
-            name: resource.author.name
+            id: resource.author.try(:id),
+            name: resource.author.try(:name)
           },
           alignment: resource.alignment,
           depth: resource.depth,

--- a/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
@@ -46,8 +46,12 @@ module Decidim
 
         context "when the author has been deleted" do
           let(:commentable) { create(:dummy_resource, :published) }
-          let(:comment) { create(:comment, commentable:, root_commentable: commentable, author: deleted_user) }
-          let(:deleted_user) { create(:user, :confirmed, :deleted, organization: commentable.organization) }
+          let(:comment) do
+            user = create(:user, :confirmed, organization: commentable.organization)
+            c = create(:comment, commentable:, root_commentable: commentable, author: user)
+            Decidim::User.where(id: user.id).delete_all
+            c.reload
+          end
 
           it "serializes without error" do
             expect { subject.serialize }.not_to raise_error

--- a/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/comment_serializer_spec.rb
@@ -43,6 +43,22 @@ module Decidim
         it "includes the root commentable's url" do
           expect(subject.serialize[:root_commentable_url]).to match(/http/)
         end
+
+        context "when the author has been deleted" do
+          let(:commentable) { create(:dummy_resource, :published) }
+          let(:comment) { create(:comment, commentable:, root_commentable: commentable, author: deleted_user) }
+          let(:deleted_user) { create(:user, :confirmed, :deleted, organization: commentable.organization) }
+
+          it "serializes without error" do
+            expect { subject.serialize }.not_to raise_error
+          end
+
+          it "returns nil for author fields" do
+            serialized = subject.serialize
+            expect(serialized[:author][:id]).to be_nil
+            expect(serialized[:author][:name]).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## What? Why?

`CommentSerializer#serialize` raises `NoMethodError: undefined method 'id' for nil:NilClass` when serializing comments whose author has been deleted. This crashes `OpenDataJob`, preventing open data export for the entire organization.

#13592 fixed the same issue for `ProposalSerializer`, `MeetingSerializer`, and `DebateSerializer`, but `CommentSerializer` was not included.

## Related Issues

Fixes #16120
Related to #13592

## Testing

1. Create a comment with a deleted user as author
2. Run `Decidim::Comments::CommentSerializer.new(comment).serialize`
3. Verify it returns without error, with `nil` author fields

Added spec: `comment_serializer_spec.rb` — "when the author has been deleted"

## Screenshots

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comments could fail to serialize if the original author's account was deleted. Comments now serialize safely and show unavailable author information (nil/blank) instead of causing errors.

* **Tests**
  * Added test coverage ensuring serialization behaves correctly for comments whose authors have been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->