### PR TITLE
Fix to allow locale-specific `user_name` placement in mobile greeting

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_mobile_account.html.erb
@@ -31,7 +31,7 @@
       </div>
     <% end %>
 
-    <p class="h3 mt-2"><%= t("decidim.block_user_mailer.notify.hello") %>&nbsp;<%= current_user.name %></p>
+    <p class="h3 mt-2"><%= t("layouts.decidim.header.mobile_account_greeting", user_name: current_user.name) %></p>
 
     <ul>
       <%= render partial: "layouts/decidim/header/main_links_dropdown" %>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2136,6 +2136,7 @@ en:
         confirm_title_close_ephemeral_session: Before leaving this page…
         log_in: Log in
         main_menu: Main menu
+        mobile_account_greeting: Hello, %{user_name}
         user_menu: User menu
       impersonation_warning:
         close_session: Close session


### PR DESCRIPTION
#### :tophat: What? Why?

This PR makes the mobile account greeting fully translatable by moving `user_name` placement into the locale string.

Previously, the view rendered `Hello,` and `current_user.name` separately, which fixed the word order in the template.
With this fix, the view passes `user_name` to I18n and the English translation is updated to `Hello, %{user_name}`.

This allows each locale to control where the username appears in the sentence.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing

1. Sign in with a user account.
2. Open the mobile account menu/header.
3. Confirm the greeting shows the user name correctly (e.g. `Hello, John Doe` in English).
4. Switch locale (if available) and confirm username position can be adjusted via translation, not template concatenation.

### :camera: Screenshots

In English (`Hello, %{user_name}`):

<img width="433" height="284" alt="dropdown-hello-en" src="https://github.com/user-attachments/assets/45ae68ca-3178-4346-ae83-c7b131d7f742" />

In Japanese (`%{user_name}-san, konnichiha`):

<img width="429" height="286" alt="dropdown-hello-ja" src="https://github.com/user-attachments/assets/91dcdd53-0ab5-448e-bbf8-791eb7ca9fa6" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile account header now shows a personalized, localized greeting that includes the user's name instead of a generic message.
  * Added an English translation entry for the new greeting so it displays correctly for English-language users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->