### PR TITLE
Hide redundant single-option checkbox tree filters

### DIFF
--- a/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
+++ b/decidim-core/app/helpers/decidim/check_boxes_tree_helper.rb
@@ -41,6 +41,12 @@ module Decidim
       def tree_node?
         is_a?(TreeNode)
       end
+
+      # Returns true when the tree has only one flat option,
+      # making the filter redundant (equivalent to selecting "All")
+      def single_option?
+        node.is_a?(Array) && node.size == 1 && node.first.is_a?(TreePoint)
+      end
     end
 
     # struct for leafs of checkboxes trees

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -34,6 +34,7 @@
       <% end %>
 
       <% filter_sections.each do |f| %>
+        <% next if f[:collection].is_a?(Decidim::CheckBoxesTreeHelper::TreeNode) && f[:collection].single_option? %>
         <%= form.collection_filter(**f) %>
       <% end %>
 

--- a/decidim-core/spec/helpers/decidim/check_boxes_tree_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/check_boxes_tree_helper_spec.rb
@@ -100,6 +100,77 @@ module Decidim
       end
     end
 
+    describe "TreeNode#single_option?" do
+      let(:root_point) { Decidim::CheckBoxesTreeHelper::TreePoint.new("", "All") }
+
+      context "when node has a single TreePoint child" do
+        let(:tree) do
+          Decidim::CheckBoxesTreeHelper::TreeNode.new(
+            root_point,
+            [Decidim::CheckBoxesTreeHelper::TreePoint.new("only_option", "Only option")]
+          )
+        end
+
+        it "returns true" do
+          expect(tree.single_option?).to be true
+        end
+      end
+
+      context "when node has multiple TreePoint children" do
+        let(:tree) do
+          Decidim::CheckBoxesTreeHelper::TreeNode.new(
+            root_point,
+            [
+              Decidim::CheckBoxesTreeHelper::TreePoint.new("option1", "Option 1"),
+              Decidim::CheckBoxesTreeHelper::TreePoint.new("option2", "Option 2")
+            ]
+          )
+        end
+
+        it "returns false" do
+          expect(tree.single_option?).to be false
+        end
+      end
+
+      context "when node has a single TreeNode child (nested filter)" do
+        let(:tree) do
+          Decidim::CheckBoxesTreeHelper::TreeNode.new(
+            root_point,
+            [
+              Decidim::CheckBoxesTreeHelper::TreeNode.new(
+                Decidim::CheckBoxesTreeHelper::TreePoint.new("nested", "Nested"),
+                []
+              )
+            ]
+          )
+        end
+
+        it "returns false" do
+          expect(tree.single_option?).to be false
+        end
+      end
+
+      context "when node is nil" do
+        let(:tree) do
+          Decidim::CheckBoxesTreeHelper::TreeNode.new(root_point)
+        end
+
+        it "returns false" do
+          expect(tree.single_option?).to be false
+        end
+      end
+
+      context "when node is an empty array" do
+        let(:tree) do
+          Decidim::CheckBoxesTreeHelper::TreeNode.new(root_point, [])
+        end
+
+        it "returns false" do
+          expect(tree.single_option?).to be false
+        end
+      end
+    end
+
     describe "#filter_global_scopes_values" do
       let(:root) { helper.filter_global_scopes_values }
       let(:leaf) { helper.filter_global_scopes_values.leaf }


### PR DESCRIPTION
## Summary

- Add `TreeNode#single_option?` method that returns `true` when a checkbox tree has only one flat option (a single `TreePoint` child), making the filter equivalent to "All"
- Skip rendering such redundant filters in `_filters.html.erb`
- Add specs covering all edge cases for `single_option?`

### Affected filters

This applies to **flat** filters where the only children are `TreePoint`s:

| Filter | Condition | Child type |
|--------|-----------|------------|
| Proposal state | 0 ProposalStates (only `state_not_published` remains) | TreePoint |
| Meeting type | Only 1 type | TreePoint |
| Directory space type | Only 1 participatory space type | TreePoint |

### Unaffected filters (by design)

Nested filters where children are wrapped in `TreeNode` are intentionally unaffected, because even with a single item, "All" (no tag) vs "specific item" produces different results:

| Filter | Reason |
|--------|--------|
| Taxonomy | Each item wrapped in TreeNode |
| Scope | Each item wrapped in TreeNode |
| Area | Each item wrapped in TreeNode |
| Origin | Always has 2+ TreePoints |

## Test plan

- [ ] Run `bundle exec rspec decidim-core/spec/helpers/decidim/check_boxes_tree_helper_spec.rb`
- [ ] Verify proposal filters hide state filter when no ProposalStates exist
- [ ] Verify taxonomy/scope/area filters still show with a single item

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Redundant filters with only a single option are now automatically hidden from the filter interface, creating a cleaner and more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->