### PR TITLE
Fix flaky spec in initiatives' filters

### DIFF
--- a/decidim-initiatives/spec/system/filter_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/filter_initiatives_spec.rb
@@ -75,11 +75,15 @@ describe "Filter Initiatives", :slow do
           click_filter_item scoped_type1.scope_name[I18n.locale.to_s]
         end
 
+        # Wait for the scope filter to be applied and the page to update
+        expect(page).to have_css(".card__grid", count: 2)
+
         within "#dropdown-menu-order" do
           click_on "Most commented"
         end
 
-        expect(page).to have_css(".card__grid[id^='initiative']", count: 2)
+        # Wait for both filter and ordering to be applied
+        expect(page).to have_css(".card__grid[id^='initiative']", count: 2, wait: 10)
         expect(page).to have_css(".card__grid[id^='initiative']:first-child", text: translated(first_initiative.title))
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While working wtih #15895, I found some flakys in initiatives specs. This PR solves one of them, related to the `decidim-initiatives/spec/system/filter_initiatives_spec.rb` file. 

#### :pushpin: Related Issues

- Related to #15895 (can't find the exact CI log with the error message, but it is reproducible at least in my local environment) 

#### Testing

It is failing in 3 out of 10 runs here:

```
for i in $(seq 10); do echo "=== Run $i ===" && bin/rspec decidim-initiatives/spec/system/filter_initiatives_spec.rb:82 --seed 30150 2>&1 ; done
```

### Stacktrace

``` 
=== Run 8 ===
Run options: include {locations: {"./spec/system/filter_initiatives_spec.rb" => [82]}}

Randomized with seed 30150

Filter Initiatives
  when filtering initiatives by SCOPE
    when selecting one scope
      can be ordered by most commented after filtering (FAILED - 1)

Failures:

  1) Filter Initiatives when filtering initiatives by SCOPE when selecting one scope can be ordered by most commented after filtering
     Failure/Error: expect(page).to have_css(".card__grid[id^='initiative']", count: 2)
       expected to find visible css ".card__grid[id^='initiative']" 2 times, found 4 matches: "<script>alert(\"initiative_title\");</script> Error voluptatem quis. 40\n16 Feb → 17 Jun\n0 1000\nOpen", "<script>alert(\"initiative_title\");</script> Hic itaque dolorem. 50\n16 Feb → 17 Jun\n0 1000\nOpen", "<script>alert(\"initiative_title\");</script> Quia autem sapiente. 61\n16 Feb → 17 Jun\n0 1000\nOpen", "<script>alert(\"initiative_title\");</script> Corporis eum autem. 71\n16 Feb → 17 Jun\n0 1000\nOpen"

     [Screenshot Image]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_filter_initiatives_when_filtering_initiatives_by_scope_when_selecting_one_scope_can_be_ordered_by_most_commented_after_filtering_654.png

     [Screenshot HTML]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_filter_initiatives_when_filtering_initiatives_by_scope_when_selecting_one_scope_can_be_ordered_by_most_commented_after_filtering_654.html




     # ./spec/system/filter_initiatives_spec.rb:82:in 'block (4 levels) in <top (required)>'
     # /workspaces/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <main>'
     # /workspaces/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in 'block (2 levels) in <main>'

Top 1 slowest examples (35.35 seconds, 93.4% of total time):
  Filter Initiatives when filtering initiatives by SCOPE when selecting one scope can be ordered by most commented after filtering
    35.35 seconds ./spec/system/filter_initiatives_spec.rb:73

Finished in 37.85 seconds (files took 4.37 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/filter_initiatives_spec.rb:73 # Filter Initiatives when filtering initiatives by SCOPE when selecting one scope can be ordered by most commented after filtering

Randomized with seed 30150
```
 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of initiative filtering system tests with enhanced synchronization handling to ensure accurate results during dynamic UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->