### PR TITLE
Fix flaky spec in initiatives' ephemeral workflows

### DIFF
--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -143,7 +143,7 @@ describe "Initiative signing with ephemeral workflows" do
               click_on "Validate your data"
               # Wait for the page to update with success message
               expect(page).to have_content("You have signed the initiative", wait: 10)
-            end.to change { Decidim::Authorization.where(user: user, name: "dummy_authorization_handler").count }.by(1)
+            end.to change { Decidim::Authorization.where(user:, name: "dummy_authorization_handler").count }.by(1)
           end
         end
       end

--- a/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb
@@ -135,11 +135,15 @@ describe "Initiative signing with ephemeral workflows" do
           end
 
           it "an authorization is created" do
-            sleep 1
-            user = Decidim::User.ephemeral.last
+            # Ensure ephemeral user exists before we start counting authorizations
+            expect(Decidim::User.ephemeral.count).to be >= 1
+            user = Decidim::User.ephemeral.order(:created_at).last
+
             expect do
               click_on "Validate your data"
-            end.to change(Decidim::Authorization.where(user:, name: "dummy_authorization_handler"), :count).by(1)
+              # Wait for the page to update with success message
+              expect(page).to have_content("You have signed the initiative", wait: 10)
+            end.to change { Decidim::Authorization.where(user: user, name: "dummy_authorization_handler").count }.by(1)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

While working wtih #15895, I found some flakys in initiatives specs. This PR solves one of them, related to the `decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb` file. 

#### :pushpin: Related Issues

- Related to #15895 (can't find the exact CI log with the error message, but it is reproducible at least in my local environment) 

#### Testing

It is failing in 13 out of 25 runs here:

```
for i in $(seq 25); do echo "=== Run $i ===" && bin/rspec decidim-initiatives/spec/system/initiative_signing_ephemeral_workflows_spec.rb:137 --seed 37197 2>&1 ; done
```

### Stacktrace

``` 

=== Run 23 ===
Run options: include {locations: {"./spec/system/initiative_signing_ephemeral_workflows_spec.rb" => [137]}}

Randomized with seed 37197

Initiative signing with ephemeral workflows
  when the workflow collects personal data
    and an authorization handler form is defined
      behaves like creating an authorization
        when the user fills its personal accepting tos and submits the form
          an authorization is created (FAILED - 1)

Failures:

  1) Initiative signing with ephemeral workflows when the workflow collects personal data and an authorization handler form is defined behaves like creating an authorization when the user fills its personal accepting tos and submits the form an authorization is created
     Failure/Error:
       expect do
         click_on "Validate your data"
       end.to change(Decidim::Authorization.where(user:, name: "dummy_authorization_handler"), :count).by(1)

       expected `Decidim::Authorization::ActiveRecord_Relation#count` to have changed by 1, but was changed by 0

     [Screenshot Image]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_initiative_signing_with_ephemeral_workflows_when_the_workflow_collects_personal_data_and_an_authorization_handler_form_is_defined_behaves_like_creating_an_authorization_when_the__535.png

     [Screenshot HTML]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_initiative_signing_with_ephemeral_workflows_when_the_workflow_collects_personal_data_and_an_authorization_handler_form_is_defined_behaves_like_creating_an_authorization_when_the__535.html




     Shared Example Group: "creating an authorization" called from ./spec/system/initiative_signing_ephemeral_workflows_spec.rb:148
     # ./spec/system/initiative_signing_ephemeral_workflows_spec.rb:142:in 'block (6 levels) in <top (required)>'

Top 1 slowest examples (7.32 seconds, 74.1% of total time):
  Initiative signing with ephemeral workflows when the workflow collects personal data and an authorization handler form is defined behaves like creating an authorization when the user fills its personal accepting tos and submits the form an authorization is created
    7.32 seconds ./spec/system/initiative_signing_ephemeral_workflows_spec.rb:137

Finished in 9.88 seconds (files took 5.19 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/initiative_signing_ephemeral_workflows_spec.rb:137 # Initiative signing with ephemeral workflows when the workflow collects personal data and an authorization handler form is defined behaves like creating an authorization when the user fills its personal accepting tos and submits the form an authorization is created
```
 

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of initiative signing workflow tests by making ephemeral user selection deterministic, waiting for the UI success message before asserting, and verifying authorization counts against the specific user and action to reduce timing- and concurrency-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->