### PR TITLE
Remove unused field `enable_participatory_space_filters` on organizations

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/update_organization.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_organization.rb
@@ -10,7 +10,7 @@ module Decidim
       fetch_form_attributes :name, :description, :default_locale, :reference_prefix, :time_zone, :twitter_handler,
                             :facebook_handler, :instagram_handler, :youtube_handler, :github_handler, :badges_enabled,
                             :comments_max_length, :enable_machine_translations, :admin_terms_of_service_body,
-                            :rich_text_editor_in_public_views, :enable_participatory_space_filters, :official_url,
+                            :rich_text_editor_in_public_views, :official_url,
                             :enable_omnipresent_banner, :omnipresent_banner_url, :omnipresent_banner_title,
                             :omnipresent_banner_short_description
 

--- a/decidim-admin/app/forms/decidim/admin/organization_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/organization_form.rb
@@ -20,7 +20,6 @@ module Decidim
       attribute :rich_text_editor_in_public_views, Boolean
       attribute :enable_machine_translations, Boolean
       attribute :machine_translation_display_priority, String
-      attribute :enable_participatory_space_filters, Boolean
 
       attribute :twitter_handler, String
       attribute :facebook_handler, String

--- a/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
@@ -12,10 +12,6 @@
       <%= form.check_box :badges_enabled %>
     </div>
 
-    <div class="row column">
-      <%= form.check_box :enable_participatory_space_filters %>
-    </div>
-
     <% if Decidim.config.enable_machine_translations %>
       <div class="row column">
         <%= form.check_box :enable_machine_translations %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -56,7 +56,6 @@ en:
         description: Description
         enable_machine_translations: Enable machine translations
         enable_omnipresent_banner: Show omnipresent banner
-        enable_participatory_space_filters: Enable participatory space filters
         facebook_handler: Facebook handler
         favicon: Icon
         force_authentication: Force authentication

--- a/decidim-core/db/migrate/20260217152425_remove_enable_participatory_space_filters_from_decidim_organizations.rb
+++ b/decidim-core/db/migrate/20260217152425_remove_enable_participatory_space_filters_from_decidim_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveEnableParticipatorySpaceFiltersFromDecidimOrganizations < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :decidim_organizations, :enable_participatory_space_filters, :boolean
+  end
+end

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -155,7 +155,6 @@ FactoryBot.define do
       }
     end
     file_upload_settings { Decidim::OrganizationSettings.default(:upload) }
-    enable_participatory_space_filters { true }
     content_security_policy do
       {
         "default-src" => "localhost:* #{host}:*",


### PR DESCRIPTION
#### :tophat: What? Why?

We have an unused field (I think) since the redesign. This PR removes it.

#### :pushpin: Related Issues

- Fixes #14620 

#### Testing

1. Sign in as admin
2. Go to  http://localhost:3000/admin/organization/edit
3. Scroll to the "Extra features" card 
4. See the checkboxes

### :camera: Screenshots

#### Before

<img width="1548" height="740" alt="image" src="https://github.com/user-attachments/assets/e93df3bc-1a2b-43a1-b659-602216416bad" />

#### After

<img width="1780" height="796" alt="image" src="https://github.com/user-attachments/assets/eea96182-3a0c-40ea-9c9d-e01250c56343" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the participatory space filters configuration option from organization administration settings. The feature flag and related interface elements have been disabled and the underlying database support has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->