### PR TITLE
Be smart with the 'most commented' sorting option

### DIFF
--- a/decidim-debates/app/controllers/decidim/debates/orderable.rb
+++ b/decidim-debates/app/controllers/decidim/debates/orderable.rb
@@ -14,11 +14,25 @@ module Decidim
         private
 
         def available_orders
-          @available_orders ||= %w(random recent commented updated)
+          @available_orders ||= possible_orders
+        end
+
+        def possible_orders
+          @possible_orders ||= begin
+            possible_orders = %w(random recent updated)
+            possible_orders << "commented" if most_commented_order_available?
+            possible_orders
+          end
         end
 
         def default_order
           "updated"
+        end
+
+        def most_commented_order_available?
+          return @most_commented_order_available if defined?(@most_commented_order_available)
+
+          @most_commented_order_available = Decidim::Debates::Debate.most_commented_available?(current_component)
         end
 
         def reorder(debates)

--- a/decidim-debates/app/controllers/decidim/debates/orderable.rb
+++ b/decidim-debates/app/controllers/decidim/debates/orderable.rb
@@ -20,7 +20,7 @@ module Decidim
         def possible_orders
           @possible_orders ||= begin
             possible_orders = %w(random recent updated)
-            possible_orders << "commented" if most_commented_order_available?
+            possible_orders << "most_commented" if most_commented_order_available?
             possible_orders
           end
         end
@@ -39,7 +39,7 @@ module Decidim
           case order
           when "recent"
             debates.order(created_at: :desc)
-          when "commented"
+          when "most_commented"
             debates.order(comments_count: :desc)
           when "updated"
             debates.order(updated_at: :desc)

--- a/decidim-debates/app/models/decidim/debates/debate.rb
+++ b/decidim-debates/app/models/decidim/debates/debate.rb
@@ -236,6 +236,15 @@ module Decidim
       # Create the :search_text ransacker alias for searching from both of these.
       ransacker_i18n_multi :search_text, [:title, :description]
 
+      def self.most_commented_available?(component)
+        return false unless component.settings.comments_enabled?
+
+        where(component:)
+          .not_hidden
+          .where("comments_count > 0")
+          .exists?
+      end
+
       def self.ransackable_scopes(_auth_object = nil)
         [:with_any_state, :with_any_origin, :with_any_taxonomies]
       end

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -157,8 +157,8 @@ en:
           create: Create
           title: Create new debate
         orders:
-          most_commented: Most commented
           label: Order debates by
+          most_commented: Most commented
           random: Random order
           recent: Most recent
           updated: Recently updated

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -157,7 +157,7 @@ en:
           create: Create
           title: Create new debate
         orders:
-          commented: Most commented
+          most_commented: Most commented
           label: Order debates by
           random: Random order
           recent: Most recent

--- a/decidim-debates/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-debates/spec/controllers/concerns/orderable_spec.rb
@@ -35,8 +35,8 @@ module Decidim
         context "with comments disabled" do
           let(:comments_enabled) { false }
 
-          it "does not show commented option to sort" do
-            expect(view.available_orders).not_to include("commented")
+          it "does not show most_commented option to sort" do
+            expect(view.available_orders).not_to include("most_commented")
           end
         end
 
@@ -44,12 +44,12 @@ module Decidim
           let(:comments_enabled) { true }
           let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
 
-          it "shows commented option to sort" do
-            expect(view.available_orders).to include("commented")
+          it "shows most_commented option to sort" do
+            expect(view.available_orders).to include("most_commented")
           end
         end
 
-        context "with or without comments and commented availability" do
+        context "with or without comments and most_commented availability" do
           let!(:debate_without_comments) { create(:debate, component:) }
           let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
           let(:comments_enabled) { true }
@@ -59,14 +59,14 @@ module Decidim
               debate_with_comments.update!(comments_count: 0)
             end
 
-            it "does not show commented option to sort" do
-              expect(view.available_orders).not_to include("commented")
+            it "does not show most_commented option to sort" do
+              expect(view.available_orders).not_to include("most_commented")
             end
           end
 
           context "when there are debates with comments" do
-            it "shows commented option to sort" do
-              expect(view.available_orders).to include("commented")
+            it "shows most_commented option to sort" do
+              expect(view.available_orders).to include("most_commented")
             end
           end
         end

--- a/decidim-debates/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-debates/spec/controllers/concerns/orderable_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Debates
+    class OrderableFakeController < Decidim::ApplicationController
+      include Orderable
+    end
+
+    describe OrderableFakeController do
+      let(:participatory_process) { create(:participatory_process, :with_steps) }
+      let(:active_step_id) { participatory_process.active_step.id }
+      let(:component) { create(:component, :with_one_step, participatory_space: participatory_process, manifest_name: "debates") }
+      let(:component_settings) do
+        double(
+          comments_enabled?: comments_enabled
+        )
+      end
+      let(:current_settings) do
+        double(:current_settings,
+               comments_enabled?: comments_enabled)
+      end
+      let(:comments_enabled) { nil }
+      let(:view) { controller.view_context }
+
+      before do
+        allow(controller).to receive(:component_settings).and_return(component_settings)
+        allow(controller).to receive(:current_settings).and_return(current_settings)
+        allow(controller).to receive(:current_participatory_space).and_return(participatory_process)
+        allow(controller).to receive(:current_component).and_return(component)
+      end
+
+      describe "#available_orders" do
+        context "with comments disabled" do
+          let(:comments_enabled) { false }
+
+          it "does not show commented option to sort" do
+            expect(view.available_orders).not_to include("commented")
+          end
+        end
+
+        context "with comments enabled" do
+          let(:comments_enabled) { true }
+          let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+
+          it "shows commented option to sort" do
+            expect(view.available_orders).to include("commented")
+          end
+        end
+
+        context "with or without comments and commented availability" do
+          let!(:debate_without_comments) { create(:debate, component:) }
+          let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+          let(:comments_enabled) { true }
+
+          context "when there are no debates with comments" do
+            before do
+              debate_with_comments.update!(comments_count: 0)
+            end
+
+            it "does not show commented option to sort" do
+              expect(view.available_orders).not_to include("commented")
+            end
+          end
+
+          context "when there are debates with comments" do
+            it "shows commented option to sort" do
+              expect(view.available_orders).to include("commented")
+            end
+          end
+        end
+      end
+
+      describe "#most_commented_order_available?" do
+        let!(:debate_without_comments) { create(:debate, component:) }
+        let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+
+        context "when comments are disabled" do
+          let(:component) { create(:debates_component, :with_comments_disabled) }
+
+          it "returns false" do
+            expect(controller.send(:most_commented_order_available?)).to be false
+          end
+        end
+
+        context "when comments are enabled" do
+          context "when there are debates with only zero comments" do
+            before do
+              debate_with_comments.update!(comments_count: 0)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_commented_order_available?)).to be false
+            end
+          end
+
+          context "when there are debates with comments" do
+            it "returns true" do
+              expect(controller.send(:most_commented_order_available?)).to be true
+            end
+          end
+
+          context "when debates are hidden" do
+            before do
+              create(:moderation, reportable: debate_with_comments, hidden_at: Time.current)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_commented_order_available?)).to be false
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-debates/spec/models/decidim/debates/debate_spec.rb
+++ b/decidim-debates/spec/models/decidim/debates/debate_spec.rb
@@ -131,9 +131,7 @@ describe Decidim::Debates::Debate do
     context "when the debate has been closed" do
       let(:debate) { build(:debate, :participant_author, :closed) }
 
-      # Even though the debate is closed, the administrator can still post comments
-      # ("Comments are currently disabled, only administrators can reply or post new ones")
-      it { is_expected.to be_truthy}
+      it { is_expected.to be_falsey }
     end
   end
 

--- a/decidim-debates/spec/models/decidim/debates/debate_spec.rb
+++ b/decidim-debates/spec/models/decidim/debates/debate_spec.rb
@@ -131,7 +131,50 @@ describe Decidim::Debates::Debate do
     context "when the debate has been closed" do
       let(:debate) { build(:debate, :participant_author, :closed) }
 
-      it { is_expected.to be_falsey }
+      it { is_expected.not_to be_accepts_new_comments }
+    end
+  end
+
+  describe ".most_commented_available?" do
+    let(:component) { create(:debates_component) }
+
+    context "when comments are disabled" do
+      let(:component) { create(:debates_component, :with_comments_disabled) }
+      let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+
+      it "returns false" do
+        expect(described_class.most_commented_available?(component)).to be false
+      end
+    end
+
+    context "when comments are enabled" do
+      context "when there are no debates with comments" do
+        let!(:debate_without_comments) { create(:debate, component:) }
+
+        it "returns false" do
+          expect(described_class.most_commented_available?(component)).to be false
+        end
+      end
+
+      context "when there are debates with comments" do
+        let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+
+        it "returns true" do
+          expect(described_class.most_commented_available?(component)).to be true
+        end
+      end
+
+      context "when debates are hidden" do
+        let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+
+        before do
+          create(:moderation, reportable: debate_with_comments, hidden_at: Time.current)
+        end
+
+        it "returns false" do
+          expect(described_class.most_commented_available?(component)).to be false
+        end
+      end
     end
   end
 end

--- a/decidim-debates/spec/models/decidim/debates/debate_spec.rb
+++ b/decidim-debates/spec/models/decidim/debates/debate_spec.rb
@@ -133,7 +133,7 @@ describe Decidim::Debates::Debate do
 
       # Even though the debate is closed, the administrator can still post comments
       # ("Comments are currently disabled, only administrators can reply or post new ones")
-      it { is_expected.to be_accepts_new_comments }
+      it { is_expected.to be_truthy}
     end
   end
 

--- a/decidim-debates/spec/models/decidim/debates/debate_spec.rb
+++ b/decidim-debates/spec/models/decidim/debates/debate_spec.rb
@@ -131,7 +131,9 @@ describe Decidim::Debates::Debate do
     context "when the debate has been closed" do
       let(:debate) { build(:debate, :participant_author, :closed) }
 
-      it { is_expected.not_to be_accepts_new_comments }
+      # Even though the debate is closed, the administrator can still post comments
+      # ("Comments are currently disabled, only administrators can reply or post new ones")
+      it { is_expected.to be_accepts_new_comments }
     end
   end
 

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -89,6 +89,79 @@ describe "Explore debates" do
       end
     end
 
+    context "when there are no debates with comments" do
+      let!(:debates) { create_list(:debate, 3, component:) }
+
+      before do
+        visit_component
+      end
+
+      it "does not show 'commented' sorting option" do
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          expect(page).to have_no_content("Most commented")
+        end
+      end
+    end
+
+    shared_examples "ordering debates by selected option" do |selected_option|
+      let(:first_debate_title) { translated(first_debate.title) }
+      let(:last_debate_title) { translated(last_debate.title) }
+      before do
+        visit_component
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          click_on(selected_option)
+        end
+      end
+
+      it "lists the debates ordered by selected option" do
+        expect(page).to have_css("[id^='debate']:first-child", text: first_debate_title)
+        expect(page).to have_css("[id^='debate']:last-child", text: last_debate_title)
+      end
+    end
+
+    context "when ordering by 'recent'" do
+      let!(:old_debate) { create(:debate, component:, created_at: 1.day.ago) }
+      let!(:new_debate) { create(:debate, component:, created_at: Time.current) }
+      let(:first_debate) { new_debate }
+      let(:last_debate) { old_debate }
+
+      it_behaves_like "ordering debates by selected option", "Most recent"
+    end
+
+    context "when ordering by 'updated'" do
+      let!(:old_debate) { create(:debate, component:, updated_at: 1.day.ago) }
+      let!(:new_debate) { create(:debate, component:, updated_at: Time.current) }
+      let(:first_debate) { new_debate }
+      let(:last_debate) { old_debate }
+
+      it_behaves_like "ordering debates by selected option", "Recently updated"
+    end
+
+    context "when ordering by 'commented'" do
+      let!(:debate_without_comments) { create(:debate, component:, comments_count: 0) }
+      let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
+      let(:first_debate) { debate_with_comments }
+      let(:last_debate) { debate_without_comments }
+
+      before do
+        visit_component
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          click_on("Most commented")
+        end
+      end
+
+      it "lists the debates ordered by selected option" do
+        expect(page).to have_css("[id^='debate']:first-child", text: translated(debate_with_comments.title))
+        expect(page).to have_css("[id^='debate']:last-child", text: translated(debate_without_comments.title))
+      end
+    end
+
     context "when there are open debates" do
       let(:debates) { nil }
       let!(:open_debate) do

--- a/decidim-debates/spec/system/explore_debates_spec.rb
+++ b/decidim-debates/spec/system/explore_debates_spec.rb
@@ -96,7 +96,7 @@ describe "Explore debates" do
         visit_component
       end
 
-      it "does not show 'commented' sorting option" do
+      it "does not show 'most_commented' sorting option" do
         within ".order-by" do
           expect(page).to have_css("div.order-by a", text: "Random")
           page.find("a", text: "Random").click
@@ -141,7 +141,7 @@ describe "Explore debates" do
       it_behaves_like "ordering debates by selected option", "Recently updated"
     end
 
-    context "when ordering by 'commented'" do
+    context "when ordering by 'most_commented'" do
       let!(:debate_without_comments) { create(:debate, component:, comments_count: 0) }
       let!(:debate_with_comments) { create(:debate, component:, comments_count: 5) }
       let(:first_debate) { debate_with_comments }

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -23,7 +23,7 @@ module Decidim
             possible_orders = %w(random recent)
             possible_orders << "most_voted" if most_voted_order_available?
             possible_orders << "most_liked" if current_settings.likes_enabled?
-            possible_orders << "most_commented" if component_settings.comments_enabled?
+            possible_orders << "most_commented" if most_commented_order_available?
             possible_orders << "most_followed"
             possible_orders << "with_more_authors" if with_more_authors_order_available?
             possible_orders
@@ -57,6 +57,12 @@ module Decidim
           return @with_more_authors_order_available if defined?(@with_more_authors_order_available)
 
           @with_more_authors_order_available = Decidim::Proposals::Proposal.with_more_authors_available?(current_component)
+        end
+
+        def most_commented_order_available?
+          return @most_commented_order_available if defined?(@most_commented_order_available)
+
+          @most_commented_order_available = Decidim::Proposals::Proposal.most_commented_available?(current_component)
         end
 
         def order_by_votes?

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -174,6 +174,17 @@ module Decidim
           .exists?
       end
 
+      def self.most_commented_available?(component)
+        return false unless component.settings.comments_enabled?
+
+        where(component:)
+          .published
+          .not_hidden
+          .not_withdrawn
+          .where("comments_count > 0")
+          .exists?
+      end
+
       acts_as_list scope: :decidim_component_id
 
       searchable_fields({

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -36,12 +36,14 @@ Decidim.register_component(:proposals) do |component|
 
   POSSIBLE_SORT_ORDERS = %w(automatic random recent most_liked most_voted most_commented most_followed with_more_authors).freeze
   WITH_MORE_AUTHORS_ORDER = "with_more_authors"
+  MOST_COMMENTED_ORDER = "most_commented"
 
   sort_order_choices = lambda do |context|
     component = context[:component]
     orders = POSSIBLE_SORT_ORDERS.dup
 
-    return orders.excluding(WITH_MORE_AUTHORS_ORDER) unless component && Decidim::Proposals::Proposal.with_more_authors_available?(component)
+    orders = orders.excluding(WITH_MORE_AUTHORS_ORDER) unless component && Decidim::Proposals::Proposal.with_more_authors_available?(component)
+    orders = orders.excluding(MOST_COMMENTED_ORDER) unless component && Decidim::Proposals::Proposal.most_commented_available?(component)
 
     orders
   end

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -56,6 +56,7 @@ module Decidim
         context "when step has default_sort_order" do
           let(:component_default_sort_order) { "random" }
           let(:step_default_sort_order) { "most_commented" }
+          let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
 
           it "use it instead of component's" do
             expect(controller.send(:default_order)).to eq("most_commented")
@@ -119,8 +120,18 @@ module Decidim
             let(:default_sort_order) { "most_commented" }
             let(:comments_enabled) { true }
 
-            it "default_order is most_commented" do
-              expect(controller.send(:default_order)).to eq(default_sort_order)
+            context "when there are no proposals with comments" do
+              it "defaults to random" do
+                expect(controller.send(:default_order)).to eq("random")
+              end
+            end
+
+            context "when there are proposals with comments" do
+              let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+              it "default_order is most_commented" do
+                expect(controller.send(:default_order)).to eq(default_sort_order)
+              end
             end
           end
 
@@ -200,6 +211,7 @@ module Decidim
 
         context "with comments enabled" do
           let(:comments_enabled) { true }
+          let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
 
           it "shows most_commented option to sort" do
             expect(view.available_orders).to include("most_commented")
@@ -211,6 +223,28 @@ module Decidim
 
           it "does not show most_commented option to sort" do
             expect(view.available_orders).not_to include("most_commented")
+          end
+        end
+
+        context "with or without comments and most_commented availability" do
+          let!(:proposal_without_comments) { create(:proposal, component:) }
+          let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+          let(:comments_enabled) { true }
+
+          context "when there are no proposals with comments" do
+            before do
+              proposal_with_comments.update!(comments_count: 0)
+            end
+
+            it "does not show most_commented option to sort" do
+              expect(view.available_orders).not_to include("most_commented")
+            end
+          end
+
+          context "when there are proposals with comments" do
+            it "shows most_commented option to sort" do
+              expect(view.available_orders).to include("most_commented")
+            end
           end
         end
 
@@ -275,6 +309,57 @@ module Decidim
 
           it "returns false" do
             expect(controller.send(:with_more_authors_order_available?)).to be false
+          end
+        end
+      end
+
+      describe "#most_commented_order_available?" do
+        let!(:proposal_without_comments) { create(:proposal, component:) }
+        let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+        context "when comments are disabled" do
+          let(:component) { create(:proposal_component, :with_comments_disabled) }
+
+          it "returns false" do
+            expect(controller.send(:most_commented_order_available?)).to be false
+          end
+        end
+
+        context "when comments are enabled" do
+          context "when there are proposals with only zero comments" do
+            before do
+              proposal_with_comments.update!(comments_count: 0)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_commented_order_available?)).to be false
+            end
+          end
+
+          context "when there are proposals with comments" do
+            it "returns true" do
+              expect(controller.send(:most_commented_order_available?)).to be true
+            end
+          end
+
+          context "when proposals are not published" do
+            before do
+              proposal_with_comments.update!(published_at: nil)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_commented_order_available?)).to be false
+            end
+          end
+
+          context "when proposals are hidden" do
+            before do
+              create(:moderation, reportable: proposal_with_comments, hidden_at: Time.current)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_commented_order_available?)).to be false
+            end
           end
         end
       end

--- a/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/component_spec.rb
@@ -245,6 +245,24 @@ describe "Proposals component" do # rubocop:disable RSpec/DescribeClass
           expect(default_sort_order_container).to have_content("With more authors")
         end
       end
+
+      context "when there are no proposals with comments" do
+        it "does not include most_commented" do
+          expect(default_sort_order_container).to have_no_content("Most commented")
+        end
+      end
+
+      context "when there are proposals with comments" do
+        let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+        before do
+          visit edit_component_path
+        end
+
+        it "includes most_commented" do
+          expect(default_sort_order_container).to have_content("Most commented")
+        end
+      end
     end
   end
 

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -82,6 +82,61 @@ module Decidim
         end
       end
 
+      describe ".most_commented_available?" do
+        let(:component) { create(:proposal_component) }
+
+        context "when comments are disabled" do
+          let(:component) { create(:proposal_component, :with_comments_disabled) }
+          let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+          it "returns false" do
+            expect(described_class.most_commented_available?(component)).to be false
+          end
+        end
+
+        context "when comments are enabled" do
+          context "when there are no proposals with comments" do
+            let!(:proposal_without_comments) { create(:proposal, component:) }
+
+            it "returns false" do
+              expect(described_class.most_commented_available?(component)).to be false
+            end
+          end
+
+          context "when there are proposals with comments" do
+            let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+            it "returns true" do
+              expect(described_class.most_commented_available?(component)).to be true
+            end
+          end
+
+          context "when proposals are not published" do
+            let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+            before do
+              proposal_with_comments.update!(published_at: nil)
+            end
+
+            it "returns false" do
+              expect(described_class.most_commented_available?(component)).to be false
+            end
+          end
+
+          context "when proposals are hidden" do
+            let!(:proposal_with_comments) { create(:proposal, component:, comments_count: 5) }
+
+            before do
+              create(:moderation, reportable: proposal_with_comments, hidden_at: Time.current)
+            end
+
+            it "returns false" do
+              expect(described_class.most_commented_available?(component)).to be false
+            end
+          end
+        end
+      end
+
       it "has a votes association returning proposal votes" do
         expect(subject.votes.count).to eq(0)
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -664,6 +664,22 @@ describe "Proposals" do
       end
     end
 
+    context "when there are no proposals with comments" do
+      let!(:proposals) { create_list(:proposal, 3, component:) }
+
+      before do
+        visit_component
+      end
+
+      it "does not show 'most_commented' ordering option" do
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          expect(page).to have_no_content("Most commented")
+        end
+      end
+    end
+
     context "when searching proposals" do
       let!(:proposals) do
         [


### PR DESCRIPTION
#### :tophat: What? Why?

This is a follow-up to #16104, this time implementing this change for the "Most commented" sorting option

#### :pushpin: Related Issues

- Related to #16104
- Related to https://github.com/decidim/decidim/issues/9397 (not closing it, as I'll handle the other options after this is merged) 

#### Testing

2. Apply this patch
3. Go to the backend an create a new Proposals comment
4. See that you don't have the "Most commented" sorting option in the Default sorting selection
5. Create the component
6. Go to the fronted, see that you don't have the "Most commented" sorting option in the index page
7. Create a new proposal
8. Leave a comment
9. Go to the configuration form of the proposal, see that you have the "Most commented" sorting option in the Default sorting selection
6. Go to the fronted, see that you have the "Most commented" sorting option in the index page 

### :camera: Screenshots

#### Without comments

<img width="767" height="802" alt="image" src="https://github.com/user-attachments/assets/40e78665-fb3f-4147-8836-4d7f5ecd47b0" />
<img width="788" height="627" alt="image" src="https://github.com/user-attachments/assets/b47782fe-63a3-48c5-8d58-f3ef29284a72" />

#### With comments

<img width="800" height="799" alt="image" src="https://github.com/user-attachments/assets/7c2aba9b-5ce1-4e18-bf4d-48f7d3550aa3" />
<img width="797" height="694" alt="image" src="https://github.com/user-attachments/assets/3ef699de-91c3-4067-941e-e4ed01a0b08f" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Most commented" sort option for proposals and debates; shown only when comments are enabled and there are items with comments.
* **Localization**
  * "Most commented" label preserved in locales.
* **Behavior Changes**
  * Ordering logic updated to expose the new option conditionally; default orders unchanged.
* **Tests**
  * Expanded unit, controller and system tests covering visibility and ordering with varying comment and moderation states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->