### PR TITLE
Add required field and validations to ContentBlockForm

### DIFF
--- a/decidim-admin/app/controllers/concerns/decidim/admin/content_blocks/landing_page_content_blocks.rb
+++ b/decidim-admin/app/controllers/concerns/decidim/admin/content_blocks/landing_page_content_blocks.rb
@@ -48,7 +48,7 @@ module Decidim
           def update
             enforce_permission_to_update_resource
 
-            @form = form(ContentBlockForm).from_params(params)
+            @form = form(ContentBlockForm).from_params(params, content_block:)
 
             UpdateContentBlock.call(@form, content_block, content_block_scope) do
               on(:ok) do

--- a/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletters_controller.rb
@@ -44,7 +44,7 @@ module Decidim
 
       def create
         enforce_permission_to :create, :newsletter
-        @form = form(NewsletterForm).from_params(params)
+        @form = form(NewsletterForm).from_params(params, content_block:)
         @form.images = images_block_context unless has_images_block_context?
 
         CreateNewsletter.call(@form, content_block) do
@@ -68,7 +68,7 @@ module Decidim
 
       def update
         enforce_permission_to(:update, :newsletter, newsletter:)
-        @form = form(NewsletterForm).from_params(params)
+        @form = form(NewsletterForm).from_params(params, content_block:)
         @form.images = images_block_context unless has_images_block_context?
 
         UpdateNewsletter.call(newsletter, @form) do

--- a/decidim-admin/app/forms/decidim/admin/content_block_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/content_block_form.rb
@@ -12,12 +12,39 @@ module Decidim
       attribute :settings, Object
       attribute :images, Hash
 
+      validate :validate_settings
+
       def map_model(model)
         self.images = model.images_container
       end
 
       def settings?
-        settings.manifest.settings.any?
+        return false unless settings.respond_to?(:manifest)
+
+        settings.manifest.attributes.any?
+      end
+
+      private
+
+      def validate_settings
+        coerce_settings if settings.respond_to?(:to_h) && !settings.respond_to?(:valid?)
+
+        return unless settings.respond_to?(:valid?)
+        return if settings.valid?
+
+        settings.errors.each do |error|
+          errors.add(:settings, error.message)
+        end
+      end
+
+      def coerce_settings
+        content_block = context[:content_block]
+        return unless content_block
+
+        self.settings = content_block.manifest.settings.schema.new(
+          settings.to_h,
+          content_block.organization.default_locale
+        )
       end
     end
   end

--- a/decidim-admin/spec/commands/decidim/admin/content_blocks/update_content_block_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/content_blocks/update_content_block_spec.rb
@@ -37,7 +37,10 @@ module Decidim::Admin::ContentBlocks
       }
     end
     let(:form) do
-      form_klass.from_params(form_params)
+      form_klass.from_params(form_params).with_context(
+        current_organization: content_block.organization,
+        content_block:
+      )
     end
 
     context "when the form is not valid" do

--- a/decidim-admin/spec/forms/decidim/admin/content_block_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/content_block_form_spec.rb
@@ -66,7 +66,7 @@ module Decidim
 
         it "adds errors to the settings attribute" do
           form.valid?
-          expect(form.errors[:settings]).to include(/cannot be blank|can't be blank/)
+          expect(form.errors[:settings]).to include(/cannot be blank/)
         end
       end
 

--- a/decidim-admin/spec/forms/decidim/admin/content_block_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/content_block_form_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Admin
+    describe ContentBlockForm do
+      subject { form }
+
+      let(:organization) { create(:organization) }
+      let(:manifest) do
+        Decidim::ContentBlockManifest.new.tap do |manifest|
+          manifest.name = :test_block
+          manifest.cell = "decidim/content_blocks/test_block"
+          manifest.public_name_key = "decidim.content_blocks.test_block.name"
+          manifest.settings do |settings|
+            settings.attribute :test_text, type: :text, translated: true, editor: true, required: true
+          end
+        end
+      end
+
+      let(:content_block) do
+        block = create(:content_block, organization:, scope_name: :homepage)
+        # Override the manifest lookup to use our test manifest
+        allow(block).to receive(:manifest).and_return(manifest)
+        allow(block).to receive(:manifest_name).and_return(:test_block)
+        block
+      end
+
+      let(:test_settings) do
+        {
+          "test_text_ca" => "",
+          "test_text_en" => "Test text en",
+          "test_text_es" => ""
+        }
+      end
+
+      let(:params) do
+        {
+          "settings" => test_settings,
+          "images" => {}
+        }
+      end
+
+      let(:form) do
+        described_class.from_params(params).with_context(
+          current_organization: organization,
+          content_block:
+        )
+      end
+
+      context "when everything is ok" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when a settings required attribute is missing in the default locale" do
+        let(:test_settings) do
+          {
+            "test_text_ca" => "Test text ca",
+            "test_text_en" => "",
+            "test_text_es" => "Test text es"
+          }
+        end
+
+        it { is_expected.not_to be_valid }
+
+        it "adds errors to the settings attribute" do
+          form.valid?
+          expect(form.errors[:settings]).to include(/cannot be blank|can't be blank/)
+        end
+      end
+
+      context "when only non-default locale has content" do
+        let(:test_settings) do
+          {
+            "test_text_ca" => "Test text ca",
+            "test_text_en" => "",
+            "test_text_es" => ""
+          }
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when settings is empty" do
+        let(:test_settings) { {} }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      describe "#settings?" do
+        it "returns true when settings has attributes" do
+          form.valid? # Trigger coercion
+          expect(form.settings?).to be true
+        end
+
+        context "when settings has no attributes" do
+          let(:manifest) do
+            Decidim::ContentBlockManifest.new.tap do |manifest|
+              manifest.name = :test_block
+              manifest.cell = "decidim/content_blocks/test_block"
+              manifest.public_name_key = "decidim.content_blocks.test_block.name"
+            end
+          end
+
+          it "returns false" do
+            form.valid? # Trigger coercion
+            expect(form.settings?).to be false
+          end
+        end
+      end
+
+      describe "coerce_settings" do
+        it "coerces settings to a schema object with default_locale" do
+          form.valid?
+          expect(form.settings).to respond_to(:valid?)
+          expect(form.settings.default_locale).to eq(organization.default_locale)
+        end
+      end
+    end
+  end
+end

--- a/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/content_blocks/registry_manager.rb
@@ -51,7 +51,7 @@ module Decidim
             content_block.settings_form_cell = "decidim/content_blocks/announcement_settings_form"
 
             content_block.settings do |settings|
-              settings.attribute :announcement, type: :text, translated: true, editor: true
+              settings.attribute :announcement, type: :text, translated: true, editor: true, required: true
             end
           end
 

--- a/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/announcement_settings_form/show.erb
@@ -1,5 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
   <div class="row column">
-    <%= settings_fields.translated :editor, :announcement, label: %>
+    <%= settings_fields.translated :editor, :announcement, label:, required: true %>
   </div>
 <% end %>

--- a/decidim-core/app/models/decidim/content_block.rb
+++ b/decidim-core/app/models/decidim/content_block.rb
@@ -36,7 +36,7 @@ module Decidim
     # Returns an object that responds to the settings defined in the content
     # block manifest.
     def settings
-      manifest.settings.schema.new(self[:settings])
+      manifest.settings.schema.new(self[:settings], organization&.default_locale)
     end
 
     def reload(*)

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
@@ -95,7 +95,7 @@ module Decidim
             content_block.settings_form_cell = "decidim/content_blocks/announcement_settings_form"
 
             content_block.settings do |settings|
-              settings.attribute :announcement, type: :text, translated: true, editor: true
+              settings.attribute :announcement, type: :text, translated: true, editor: true, required: true
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #16064, with @alecslupu and @carolromero noticed that the behavior of the content blocks forms have a problem: it doesn't allow to set some fields as required. This PR fixes that behaviour. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16127 (doesn't fix it as I still need to add the show logic change) 

#### Testing

Bug reproduction:

1. Implement this patch
```diff
diff --git a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
index 942f78582b..2c9bac109b 100644
--- a/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/content_blocks/registry_manager.rb
@@ -95,7 +95,7 @@ module Decidim
             content_block.settings_form_cell = "decidim/content_blocks/announcement_settings_form"

             content_block.settings do |settings|
-              settings.attribute :announcement, type: :text, translated: true, editor: true
+              settings.attribute :announcement, type: :text, translated: true, editor: true, required: true
             end
           end
```
2. Restart the server (as we're changing code non-autoloaded from `lib/`) 
3. Edit a landing page from Processes
4. Add an announcement content block
5. Edit it
6. Do not add anything 
7. Update it
8. See that you don't have a validation error

With the patch/PR:

0. Remove the patch for the bug from the previous step 
2. Restart the server (as we're changing code non-autoloaded from `lib/`) 
3. Edit a landing page from Processes
4. Add an announcement content block
5. Edit it
6. Do not add anything 
7. Update it
8. See the expected form error - it is respecting the validation

### :camera: Screenshots

<img width="1818" height="1006" alt="image" src="https://github.com/user-attachments/assets/e8de6e42-f38d-404c-819e-805bea4ab496" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error propagation for content block settings, including coercion into the settings schema and locale-aware handling.
  * Forms now receive content-block context during create/update (including newsletters) to ensure correct processing.
  * Announcement fields are now required on assembly and participatory process homepages.
  * Announcement label rendered as required in the settings form.

* **Tests**
  * Added comprehensive tests covering content block settings validation and coercion across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->