### PR TITLE
Fix component menu hidden feature for all the spaces

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -14,7 +14,10 @@ module Decidim
 
       # Items to display in the navigation of an assembly
       def assembly_nav_items(participatory_space)
-        components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))
+        components = participatory_space
+                     .components
+                     .published.or(Decidim::Component.where(id: try(:current_component)))
+                     .where(visible: true)
 
         [
           *(if participatory_space.members_public_page?

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -195,7 +195,16 @@ shared_examples "manage assembly components" do
     context "when the component is published" do
       let(:published_at) { Time.current }
 
+      before do
+        create(:content_block, organization:, scope_name: :assembly_homepage, manifest_name: :main_data, scoped_resource_id: assembly.id)
+      end
+
       it "hides the component from the menu" do
+        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        expect(page).to have_content translated(component.name)
+
+        visit decidim_admin_assemblies.components_path(assembly)
+
         within ".component-#{component.id}" do
           find("button[data-controller='dropdown']").click
           click_on "Hide"
@@ -205,6 +214,9 @@ shared_examples "manage assembly components" do
           find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
+
+        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -201,7 +201,7 @@ shared_examples "manage assembly components" do
 
       it "hides the component from the menu" do
         visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
-        expect(page).to have_content translated(component.name)
+        expect(page).to have_content decidim_escape_translated(component.name)
 
         visit decidim_admin_assemblies.components_path(assembly)
 
@@ -216,7 +216,7 @@ shared_examples "manage assembly components" do
         end
 
         visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
-        expect(page).to have_no_content translated(component.name)
+        expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end
 

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -214,8 +214,8 @@ describe "Assemblies" do
 
         it "shows the components" do
           within ".participatory-space__nav-container" do
-            expect(page).to have_content(translated(proposals_component.name, locale: :en))
-            expect(page).to have_no_content(translated(meetings_component.name, locale: :en))
+            expect(page).to have_content(decidim_escape_translated(proposals_component.name))
+            expect(page).to have_no_content(decidim_escape_translated(meetings_component.name))
           end
         end
       end

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -28,7 +28,11 @@ module Decidim
           end
 
           meeting_components = participatory_space.components.published.where(manifest_name: "meetings")
-          other_components = participatory_space.components.published.where.not(manifest_name: "meetings")
+          other_components = participatory_space
+                             .components
+                             .published
+                             .where.not(manifest_name: "meetings")
+                             .where(visible: true)
 
           meeting_components.each do |component|
             next unless Decidim::Meetings::Meeting.where(component:).published.not_hidden.visible_for(current_user).exists?

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -27,7 +27,11 @@ module Decidim
             }
           end
 
-          meeting_components = participatory_space.components.published.where(manifest_name: "meetings")
+          meeting_components = participatory_space
+                               .components
+                               .published
+                               .where(manifest_name: "meetings")
+                               .where(visible: true)
           other_components = participatory_space
                              .components
                              .published

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -196,6 +196,11 @@ shared_examples "manage conference components" do
       let(:published_at) { Time.current }
 
       it "hides the component from the menu" do
+        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        expect(page).to have_content decidim_escape_translated(component.name)
+
+        visit decidim_admin_conferences.components_path(conference)
+
         within ".component-#{component.id}" do
           find("button[data-controller='dropdown']").click
           click_on "Hide"
@@ -205,6 +210,9 @@ shared_examples "manage conference components" do
           find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
+
+        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end
 

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -8,7 +8,7 @@
     <% model.each do |item| %>
       <li role="menuitem">
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>
-          <%= item[:name] %>
+          <%= decidim_escape_translated(item[:name]) %>
           <%= icon "arrow-right-line" %>
         <% end %>
       </li>

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -6,7 +6,10 @@ module Decidim
     module InitiativesHelper
       # Items to display in the navigation of an initiative
       def initiative_nav_items(participatory_space)
-        components = participatory_space.components.published.or(Decidim::Component.where(id: try(:current_component)))
+        components = participatory_space
+                     .components
+                     .published.or(Decidim::Component.where(id: try(:current_component)))
+                     .where(visible: true)
 
         components.map do |component|
           {

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -212,7 +212,7 @@ describe "Admin manages initiative components" do
 
       it "hides the component from the menu" do
         visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
-        expect(page).to have_content translated(component.name)
+        expect(page).to have_content decidim_escape_translated(component.name)
 
         visit decidim_admin_initiatives.components_path(initiative)
 
@@ -227,7 +227,7 @@ describe "Admin manages initiative components" do
         end
 
         visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
-        expect(page).to have_no_content translated(component.name)
+        expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -211,6 +211,11 @@ describe "Admin manages initiative components" do
       let(:published_at) { Time.current }
 
       it "hides the component from the menu" do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+        expect(page).to have_content translated(component.name)
+
+        visit decidim_admin_initiatives.components_path(initiative)
+
         within ".component-#{component.id}" do
           find("button[data-controller='dropdown']").click
           click_on "Hide"
@@ -220,6 +225,9 @@ describe "Admin manages initiative components" do
           find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
+
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -247,15 +247,15 @@ describe "Initiative" do
 
       it "shows the components" do
         within ".participatory-space__nav-container" do
-          expect(page).to have_content(translated(meetings_component.name, locale: :en))
-          expect(page).to have_no_content(translated(unpublished_proposals_component.name, locale: :en))
-          expect(page).to have_content(translated(blogs_component.name, locale: :en))
+          expect(page).to have_content(decidim_escape_translated(meetings_component.name))
+          expect(page).to have_no_content(decidim_escape_translated(unpublished_proposals_component.name))
+          expect(page).to have_content(decidim_escape_translated(blogs_component.name))
         end
       end
 
       it "allows visiting the components" do
         within ".participatory-space__nav-container" do
-          click_on translated(meetings_component.name, locale: :en)
+          click_on decidim_escape_translated(meetings_component.name)
         end
 
         expect(page).to have_css('[id^="meetings__meeting"]', count: 3)
@@ -315,7 +315,7 @@ describe "Initiative" do
 
       it "has special permissions to create posts" do
         within ".participatory-space__nav-container" do
-          click_on translated(blogs_component.name, locale: :en)
+          click_on decidim_escape_translated(blogs_component.name)
         end
 
         expect(page).to have_content("New post")
@@ -323,7 +323,7 @@ describe "Initiative" do
 
       it "has special permissions to create meetings" do
         within ".participatory-space__nav-container" do
-          click_on translated(meetings_component.name, locale: :en)
+          click_on decidim_escape_translated(meetings_component.name)
         end
 
         expect(page).to have_content("New meeting")

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -321,7 +321,7 @@ shared_examples "manage process components" do
 
       it "hides the component from the menu" do
         visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
-        expect(page).to have_content translated(component.name)
+        expect(page).to have_content decidim_escape_translated(component.name)
 
         visit decidim_admin_participatory_processes.components_path(participatory_process)
 
@@ -336,7 +336,7 @@ shared_examples "manage process components" do
         end
 
         visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
-        expect(page).to have_no_content translated(component.name)
+        expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end
 

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -315,7 +315,16 @@ shared_examples "manage process components" do
     context "when the component is published" do
       let(:published_at) { Time.current }
 
+      before do
+        create(:content_block, organization:, scope_name: :participatory_process_homepage, manifest_name: :main_data, scoped_resource_id: participatory_process.id)
+      end
+
       it "hides the component from the menu" do
+        visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
+        expect(page).to have_content translated(component.name)
+
+        visit decidim_admin_participatory_processes.components_path(participatory_process)
+
         within ".component-#{component.id}" do
           find("button[data-controller='dropdown']").click
           click_on "Hide"
@@ -325,6 +334,9 @@ shared_examples "manage process components" do
           find("button[data-controller='dropdown']").click
           expect(page).to have_css("a", text: "Unpublish")
         end
+
+        visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -274,8 +274,8 @@ describe "Participatory Processes" do
 
           it "shows the components" do
             within ".participatory-space__nav-container" do
-              expect(page).to have_content(translated(proposals_component.name, locale: :en))
-              expect(page).to have_no_content(translated(meetings_component.name, locale: :en))
+              expect(page).to have_content(decidim_escape_translated(proposals_component.name))
+              expect(page).to have_no_content(decidim_escape_translated(meetings_component.name))
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When the components' menu hidden feature was introduced, it was done with two things: 

- it only works in processes
- it lacked the specs to actually check that the components are indeed hidden

This PR makes it work for the other spaces (assemblies, conferences, and initiatives) and add the specs to actually check this. 

#### :pushpin: Related Issues 

- Fixes #15491

#### Testing

1. Go to any space (assemblies, conferences, and initiatives) 
2. Create a component and publish it
3. Change the visibility to "Menu Hidden"
4. See the component is still visible in the front end.

### :camera: Screenshots 

#### Before 

<img width="1846" height="924" alt="image" src="https://github.com/user-attachments/assets/a11fbc3a-88a1-4c92-bce0-865fafa18ce9" />

#### After

<img width="1841" height="918" alt="image" src="https://github.com/user-attachments/assets/628cb6ba-da03-4ff7-a965-c1f9eab3c56b" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components can be hidden from public views and navigation across assemblies, conferences, initiatives, and participatory processes.

* **Bug Fixes**
  * Navigation and public pages now only include components marked as visible.

* **Tests**
  * Front-end tests extended to verify component visibility on public pages before and after hiding.

* **Security**
  * Navigation labels now use safe escaping to prevent unsafe content rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->