### PR TITLE
Fix export for private spaces

### DIFF
--- a/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/participatory_space.rb
@@ -44,8 +44,8 @@ Decidim.register_participatory_space(:assemblies) do |participatory_space|
   end
 
   participatory_space.exports :assemblies do |export|
-    export.collection do |participatory_space, _user|
-      Decidim::Assembly.public_spaces.includes(:attachment_collections).where(id: participatory_space)
+    export.collection do |participatory_space, user|
+      Decidim::Assembly.visible_for(user).includes(:attachment_collections).where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-assemblies/spec/lib/decidim/exporters/export_manifest_spec.rb
+++ b/decidim-assemblies/spec/lib/decidim/exporters/export_manifest_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters::ExportManifest do
+    describe "Assembly export collection" do
+      let(:organization) { create(:organization) }
+      let(:admin) { create(:user, :admin, :confirmed, organization:) }
+      let(:assembly) { create(:assembly, organization:) }
+      let(:export_manifest) { assembly.manifest.export_manifests.find { |m| m.name == :assemblies } }
+
+      describe "with private non-transparent assemblies" do
+        let!(:private_assembly) { create(:assembly, :private, :opaque, organization:) }
+
+        context "when user is an admin" do
+          it "includes private non-transparent assemblies" do
+            collection = export_manifest.collection.call(private_assembly, admin)
+            expect(collection).to include(private_assembly)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes private non-transparent assemblies" do
+            collection = export_manifest.collection.call(private_assembly, nil)
+            expect(collection).not_to include(private_assembly)
+          end
+        end
+      end
+
+      describe "with private transparent assemblies" do
+        let!(:transparent_assembly) { create(:assembly, :private, :transparent, organization:) }
+
+        context "when user is an admin" do
+          it "includes private transparent assemblies" do
+            collection = export_manifest.collection.call(transparent_assembly, admin)
+            expect(collection).to include(transparent_assembly)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "includes private transparent assemblies" do
+            collection = export_manifest.collection.call(transparent_assembly, nil)
+            expect(collection).to include(transparent_assembly)
+          end
+        end
+      end
+
+      describe "with unpublished assemblies" do
+        let!(:unpublished_assembly) { create(:assembly, :unpublished, organization:) }
+
+        context "when user is an admin" do
+          it "includes unpublished assemblies" do
+            collection = export_manifest.collection.call(unpublished_assembly, admin)
+            expect(collection).to include(unpublished_assembly)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes unpublished assemblies" do
+            collection = export_manifest.collection.call(unpublished_assembly, nil)
+            expect(collection).not_to include(unpublished_assembly)
+          end
+        end
+      end
+
+      describe "with public published assemblies" do
+        let!(:public_assembly) { create(:assembly, organization:) }
+
+        it "includes public published assemblies for admin" do
+          collection = export_manifest.collection.call(public_assembly, admin)
+          expect(collection).to include(public_assembly)
+        end
+
+        it "includes public published assemblies for open data" do
+          collection = export_manifest.collection.call(public_assembly, nil)
+          expect(collection).to include(public_assembly)
+        end
+      end
+    end
+  end
+end

--- a/decidim-conferences/lib/decidim/conferences/participatory_space.rb
+++ b/decidim-conferences/lib/decidim/conferences/participatory_space.rb
@@ -49,8 +49,9 @@ Decidim.register_participatory_space(:conferences) do |participatory_space|
   end
 
   participatory_space.exports :conferences do |export|
-    export.collection do |participatory_space, _user|
-      Decidim::Conference.public_spaces.includes(:taxonomies, :attachment_collections).where(id: participatory_space)
+    export.collection do |participatory_space, user|
+      scope = user.present? ? Decidim::Conference.all : Decidim::Conference.public_spaces
+      scope.includes(:taxonomies, :attachment_collections).where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-conferences/spec/lib/decidim/exporters/export_manifest_spec.rb
+++ b/decidim-conferences/spec/lib/decidim/exporters/export_manifest_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters::ExportManifest do
+    describe "Conference export collection" do
+      let(:organization) { create(:organization) }
+      let(:admin) { create(:user, :admin, :confirmed, organization:) }
+      let(:conference) { create(:conference, organization:) }
+      let(:export_manifest) { conference.manifest.export_manifests.find { |m| m.name == :conferences } }
+
+      describe "with unpublished conferences" do
+        let!(:unpublished_conference) { create(:conference, :unpublished, organization:) }
+
+        context "when user is an admin" do
+          it "includes unpublished conferences" do
+            collection = export_manifest.collection.call(unpublished_conference, admin)
+            expect(collection).to include(unpublished_conference)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes unpublished conferences" do
+            collection = export_manifest.collection.call(unpublished_conference, nil)
+            expect(collection).not_to include(unpublished_conference)
+          end
+        end
+      end
+
+      describe "with published conferences" do
+        let!(:published_conference) { create(:conference, organization:) }
+
+        it "includes published conferences for admin" do
+          collection = export_manifest.collection.call(published_conference, admin)
+          expect(collection).to include(published_conference)
+        end
+
+        it "includes published conferences for open data" do
+          collection = export_manifest.collection.call(published_conference, nil)
+          expect(collection).to include(published_conference)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/export_participatory_space_job.rb
+++ b/decidim-core/app/jobs/decidim/export_participatory_space_job.rb
@@ -11,7 +11,7 @@ module Decidim
         manifest.name == name.to_sym
       end
 
-      collection = export_manifest.collection.call(participatory_space)
+      collection = export_manifest.collection.call(participatory_space, user)
       serializer = export_manifest.serializer
 
       export_data = Decidim::Exporters.find_exporter(format).new(collection, serializer).export

--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -118,7 +118,7 @@ module Decidim
 
     def data_for_participatory_space(export_manifest)
       collection = participatory_spaces.filter { |space| space.manifest.name == export_manifest.manifest.name }.flat_map do |participatory_space|
-        export_manifest.collection.call(participatory_space)
+        export_manifest.collection.call(participatory_space, nil)
       end
 
       serializer = export_manifest.open_data_serializer.nil? ? export_manifest.serializer : export_manifest.open_data_serializer

--- a/decidim-core/spec/jobs/decidim/export_participatory_space_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/export_participatory_space_job_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::ExportParticipatorySpaceJob do
+  subject { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:admin) { create(:user, :admin, :confirmed, organization:) }
+  let(:participatory_process) { create(:participatory_process, organization:) }
+  let(:export_manifest) { participatory_process.manifest.export_manifests.find { |m| m.name == :participatory_processes } }
+
+  before do
+    # Stub mailer to avoid actually sending emails
+    mailer_double = double(deliver_later: true)
+    allow(Decidim::ExportMailer).to receive(:export).and_return(mailer_double)
+  end
+
+  describe "exporting private processes" do
+    let(:private_process) { create(:participatory_process, :private, organization:) }
+
+    it "includes private processes when user is an admin" do
+      collection = export_manifest.collection.call(private_process, admin)
+      expect(collection).to include(private_process)
+    end
+
+    it "excludes private processes when user is nil (open data)" do
+      collection = export_manifest.collection.call(private_process, nil)
+      expect(collection).not_to include(private_process)
+    end
+  end
+
+  describe "exporting unpublished processes" do
+    let(:unpublished_process) { create(:participatory_process, :unpublished, organization:) }
+
+    it "includes unpublished processes when user is an admin" do
+      collection = export_manifest.collection.call(unpublished_process, admin)
+      expect(collection).to include(unpublished_process)
+    end
+
+    it "excludes unpublished processes when user is nil (open data)" do
+      collection = export_manifest.collection.call(unpublished_process, nil)
+      expect(collection).not_to include(unpublished_process)
+    end
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/participatory_space.rb
@@ -55,8 +55,9 @@ Decidim.register_participatory_space(:initiatives) do |participatory_space|
   ]
 
   participatory_space.exports :initiatives do |export|
-    export.collection do |participatory_space, _user|
-      Decidim::Initiative.public_spaces.where(id: participatory_space)
+    export.collection do |participatory_space, user|
+      scope = user.present? ? Decidim::Initiative.all : Decidim::Initiative.public_spaces
+      scope.where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-initiatives/spec/lib/decidim/exporters/export_manifest_spec.rb
+++ b/decidim-initiatives/spec/lib/decidim/exporters/export_manifest_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters::ExportManifest do
+    describe "Initiative export collection" do
+      let(:organization) { create(:organization) }
+      let(:admin) { create(:user, :admin, :confirmed, organization:) }
+      let(:initiative) { create(:initiative, organization:) }
+      let(:export_manifest) { initiative.manifest.export_manifests.find { |m| m.name == :initiatives } }
+
+      describe "with unpublished initiatives" do
+        let!(:unpublished_initiative) { create(:initiative, :created, organization:) }
+
+        context "when user is an admin" do
+          it "includes unpublished initiatives" do
+            collection = export_manifest.collection.call(unpublished_initiative, admin)
+            expect(collection).to include(unpublished_initiative)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes unpublished initiatives" do
+            collection = export_manifest.collection.call(unpublished_initiative, nil)
+            expect(collection).not_to include(unpublished_initiative)
+          end
+        end
+      end
+
+      describe "with published initiatives" do
+        let!(:published_initiative) { create(:initiative, organization:) }
+
+        it "includes published initiatives for admin" do
+          collection = export_manifest.collection.call(published_initiative, admin)
+          expect(collection).to include(published_initiative)
+        end
+
+        it "includes published initiatives for open data" do
+          collection = export_manifest.collection.call(published_initiative, nil)
+          expect(collection).to include(published_initiative)
+        end
+      end
+    end
+  end
+end

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/participatory_space.rb
@@ -40,8 +40,8 @@ Decidim.register_participatory_space(:participatory_processes) do |participatory
   end
 
   participatory_space.exports :participatory_processes do |export|
-    export.collection do |participatory_space, _user|
-      Decidim::ParticipatoryProcess.public_spaces.where(id: participatory_space)
+    export.collection do |participatory_space, user|
+      Decidim::ParticipatoryProcess.visible_for(user).where(id: participatory_space)
     end
 
     export.include_in_open_data = true

--- a/decidim-participatory_processes/spec/lib/decidim/exporters/export_manifest_spec.rb
+++ b/decidim-participatory_processes/spec/lib/decidim/exporters/export_manifest_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe Exporters::ExportManifest do
+    describe "Participatory Process export collection" do
+      let(:organization) { create(:organization) }
+      let(:admin) { create(:user, :admin, :confirmed, organization:) }
+      let(:participatory_process) { create(:participatory_process, organization:) }
+      let(:export_manifest) { participatory_process.manifest.export_manifests.find { |m| m.name == :participatory_processes } }
+
+      describe "with private processes" do
+        let!(:private_process) { create(:participatory_process, :private, organization:) }
+
+        context "when user is an admin" do
+          it "includes private processes" do
+            collection = export_manifest.collection.call(private_process, admin)
+            expect(collection).to include(private_process)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes private processes" do
+            collection = export_manifest.collection.call(private_process, nil)
+            expect(collection).not_to include(private_process)
+          end
+        end
+      end
+
+      describe "with unpublished processes" do
+        let!(:unpublished_process) { create(:participatory_process, :unpublished, organization:) }
+
+        context "when user is an admin" do
+          it "includes unpublished processes" do
+            collection = export_manifest.collection.call(unpublished_process, admin)
+            expect(collection).to include(unpublished_process)
+          end
+        end
+
+        context "when user is nil (open data)" do
+          it "excludes unpublished processes" do
+            collection = export_manifest.collection.call(unpublished_process, nil)
+            expect(collection).not_to include(unpublished_process)
+          end
+        end
+      end
+
+      describe "with public published processes" do
+        let!(:public_process) { create(:participatory_process, organization:) }
+
+        it "includes public published processes for admin" do
+          collection = export_manifest.collection.call(public_process, admin)
+          expect(collection).to include(public_process)
+        end
+
+        it "includes public published processes for open data" do
+          collection = export_manifest.collection.call(public_process, nil)
+          expect(collection).to include(public_process)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #15895 I found yet another bug related to the export/import feature.

This case was introduced by me 😄 - during the Open Data improvement project, I broke the export for private spaces. This PR fixes it.

#### :pushpin: Related Issues
 
- Related to #15895 
- Related to https://github.com/decidim/decidim/pull/13313 

#### Testing

1. Sign in as admin
2. Edit a process
3. Click in the "Private process" checkbox and click in Update 
4. Go to the admin index process list: http://localhost:3000/admin/participatory_processes
5. In actions, click the Export option
6. Go to letter opener, http://localhost:3000/letter_opener 
7. Click in the DOWNLOAD link in the last email
8. Open the zip, open the JSON 
9. (Before) see that it is an empty JSON
10. (After) see that you have the contents of the space

### :camera: Screenshots

<img width="844" height="721" alt="image" src="https://github.com/user-attachments/assets/e375d1d6-592e-407d-abd8-9818ab7fa111" />
<img width="780" height="429" alt="image" src="https://github.com/user-attachments/assets/4e8aefa5-d4aa-4343-be58-8799ca8c00f2" />

#### Before

<img width="958" height="529" alt="image" src="https://github.com/user-attachments/assets/d0bfa96f-da70-4a11-9f5d-0567baccfa62" />

#### After

<img width="962" height="581" alt="image" src="https://github.com/user-attachments/assets/f86e45aa-d4cd-41d9-acf1-908e5b38e3a4" />

:hearts: Thank you!
