### PR TITLE
Add validation for the import space with empty JSON

### DIFF
--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
@@ -38,6 +38,7 @@ module Decidim
         validate :slug_uniqueness
 
         validate :document_type_must_be_valid, if: :document
+        validate :document_must_have_content, if: :document
 
         def document_text
           @document_text ||= document&.download
@@ -76,6 +77,15 @@ module Decidim
           return unless OrganizationAssemblies.new(current_organization).query.where(slug:).where.not(id:).any?
 
           errors.add(:slug, :taken)
+        end
+
+        def document_must_have_content
+          return if document_text.blank?
+
+          parsed = JSON.parse(document_text)
+          errors.add(:document, :empty) if parsed.is_a?(Array) && parsed.empty?
+        rescue JSON::ParserError
+          errors.add(:document, :invalid_json)
         end
       end
     end

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_import_form.rb
@@ -38,7 +38,7 @@ module Decidim
         validate :slug_uniqueness
 
         validate :document_type_must_be_valid, if: :document
-        validate :document_must_have_content, if: :document
+        validate :document_must_have_content, if: -> { document.present? && errors[:document].none? }
 
         def document_text
           @document_text ||= document&.download

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -75,8 +75,8 @@ en:
           attributes:
             document:
               allowed_file_content_types: 'Invalid document type. Only files with the following extensions are allowed: %{types}.'
-              empty: 'The document is empty'
-              invalid_json: 'The document is not valid JSON'
+              empty: The document is empty
+              invalid_json: The document is not valid JSON
   activerecord:
     models:
       decidim/assembly:

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -75,6 +75,8 @@ en:
           attributes:
             document:
               allowed_file_content_types: 'Invalid document type. Only files with the following extensions are allowed: %{types}.'
+              empty: 'The document is empty'
+              invalid_json: 'The document is not valid JSON'
   activerecord:
     models:
       decidim/assembly:

--- a/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
+++ b/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
@@ -101,10 +101,10 @@ module Decidim
 
         context "when document has empty JSON array" do
           let(:document) do
-            Tempfile.new(["empty", ".json"]).tap do |file|
-              file.write("[]")
-              file.rewind
-            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+            file = Tempfile.new(["empty", ".json"])
+            file.write("[]")
+            file.rewind
+            upload_test_file(file.path, content_type: "application/json", return_blob: true)
           end
 
           it { is_expected.to be_invalid }
@@ -117,10 +117,10 @@ module Decidim
 
         context "when document has invalid JSON" do
           let(:document) do
-            Tempfile.new(["invalid", ".json"]).tap do |file|
-              file.write("{ invalid }")
-              file.rewind
-            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+            file = Tempfile.new(["invalid", ".json"])
+            file.write("{ invalid }")
+            file.rewind
+            upload_test_file(file.path, content_type: "application/json", return_blob: true)
           end
 
           it { is_expected.to be_invalid }

--- a/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
+++ b/decidim-assemblies/spec/forms/decidim/assemblies/admin/assembly_import_form_spec.rb
@@ -98,6 +98,38 @@ module Decidim
 
           it { is_expected.to be_invalid }
         end
+
+        context "when document has empty JSON array" do
+          let(:document) do
+            Tempfile.new(["empty", ".json"]).tap do |file|
+              file.write("[]")
+              file.rewind
+            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).to include("The document is empty")
+          end
+        end
+
+        context "when document has invalid JSON" do
+          let(:document) do
+            Tempfile.new(["invalid", ".json"]).tap do |file|
+              file.write("{ invalid }")
+              file.rewind
+            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).to include("The document is not valid JSON")
+          end
+        end
       end
     end
   end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
@@ -37,6 +37,7 @@ module Decidim
         validate :slug_uniqueness
 
         validate :document_type_must_be_valid, if: :document
+        validate :document_must_have_content, if: :document
 
         def document_text
           @document_text ||= document&.download
@@ -75,6 +76,15 @@ module Decidim
           return unless OrganizationParticipatoryProcesses.new(current_organization).query.where(slug:).where.not(id:).any?
 
           errors.add(:slug, :taken)
+        end
+
+        def document_must_have_content
+          return if document_text.blank?
+
+          parsed = JSON.parse(document_text)
+          errors.add(:document, :empty) if parsed.is_a?(Array) && parsed.empty?
+        rescue JSON::ParserError
+          errors.add(:document, :invalid_json)
         end
       end
     end

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_import_form.rb
@@ -37,7 +37,7 @@ module Decidim
         validate :slug_uniqueness
 
         validate :document_type_must_be_valid, if: :document
-        validate :document_must_have_content, if: :document
+        validate :document_must_have_content, if: -> { document.present? && errors[:document].none? }
 
         def document_text
           @document_text ||= document&.download

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -67,8 +67,8 @@ en:
           attributes:
             document:
               allowed_file_content_types: 'Invalid document type. Only files with the following extensions are allowed: %{types}'
-              empty: 'The document is empty'
-              invalid_json: 'The document is not valid JSON'
+              empty: The document is empty
+              invalid_json: The document is not valid JSON
     models:
       decidim/participatory_process_step_activated_event: Phase activated
       decidim/participatory_process_step_changed_event: Phase changed

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -67,6 +67,8 @@ en:
           attributes:
             document:
               allowed_file_content_types: 'Invalid document type. Only files with the following extensions are allowed: %{types}'
+              empty: 'The document is empty'
+              invalid_json: 'The document is not valid JSON'
     models:
       decidim/participatory_process_step_activated_event: Phase activated
       decidim/participatory_process_step_changed_event: Phase changed

--- a/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
@@ -101,10 +101,10 @@ module Decidim
 
         context "when document has empty JSON array" do
           let(:document) do
-            Tempfile.new(["empty", ".json"]).tap do |file|
-              file.write("[]")
-              file.rewind
-            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+            file = Tempfile.new(["empty", ".json"])
+            file.write("[]")
+            file.rewind
+            upload_test_file(file.path, content_type: "application/json", return_blob: true)
           end
 
           it { is_expected.to be_invalid }
@@ -117,10 +117,10 @@ module Decidim
 
         context "when document has invalid JSON" do
           let(:document) do
-            Tempfile.new(["invalid", ".json"]).tap do |file|
-              file.write("{ invalid }")
-              file.rewind
-            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+            file = Tempfile.new(["invalid", ".json"])
+            file.write("{ invalid }")
+            file.rewind
+            upload_test_file(file.path, content_type: "application/json", return_blob: true)
           end
 
           it { is_expected.to be_invalid }

--- a/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/decidim/participatory_processes/admin/participatory_process_import_form_spec.rb
@@ -98,6 +98,38 @@ module Decidim
 
           it { is_expected.to be_invalid }
         end
+
+        context "when document has empty JSON array" do
+          let(:document) do
+            Tempfile.new(["empty", ".json"]).tap do |file|
+              file.write("[]")
+              file.rewind
+            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).to include("The document is empty")
+          end
+        end
+
+        context "when document has invalid JSON" do
+          let(:document) do
+            Tempfile.new(["invalid", ".json"]).tap do |file|
+              file.write("{ invalid }")
+              file.rewind
+            end.then { |f| upload_test_file(f.path, content_type: "application/json", return_blob: true) }
+          end
+
+          it { is_expected.to be_invalid }
+
+          it "adds an error on document" do
+            form.valid?
+            expect(form.errors[:document]).to include("The document is not valid JSON")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Related to the bug with #16145, this is the other part. If you export a private process (before that PR) and you have a JSON with this format:

```json
[]
``` 

When you try to import it then you have an exception.

This PR adds a validation for this case. 

#### :pushpin: Related Issues
 
- Related to #16145 

#### Stacktrace

```
NoMethodError (undefined method 'organization' for nil):

/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:63:in 'Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#add_admins_as_followers'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:29:in 'block in Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#call'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/transaction.rb:616:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activesupport (7.2.3) lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/transaction.rb:613:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:361:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:431:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:30:in 'Decidim::Command#transaction'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:27:in 'Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#call'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:19:in 'Decidim::Command.call'
/workspaces/decidim/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_imports_controller.rb:20:in 'Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessImportsController#create'
actionpack (7.2.3) lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'
actionpack (7.2.3) lib/abstract_controller/base.rb:215:in 'AbstractController::Base#process_action'
actionpack (7.2.3) lib/action_controller/metal/rendering.rb:193:in 'ActionController::Rendering#process_action'
actionpack (7.2.3) lib/abstract_controller/callbacks.rb:261:in 'block in AbstractController::Callbacks#process_action'
activesupport (7.2.3) lib/active_support/callbacks.rb:121:in 'block in ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.3) lib/active_support/core_ext/time/zones.rb:65:in 'Time.use_zone'
/workspaces/decidim/decidim-core/app/controllers/concerns/decidim/use_organization_time_zone.rb:21:in 'Decidim::Admin::ApplicationController#use_organization_time_zone'
activesupport (7.2.3) lib/active_support/callbacks.rb:130:in 'block in ActiveSupport::Callbacks#run_callbacks'
i18n (1.14.8) lib/i18n.rb:354:in 'I18n::Base#with_locale'
/workspaces/decidim/decidim-core/app/controllers/concerns/decidim/locale_switcher.rb:25:in 'Decidim::Admin::ApplicationController#switch_locale'
activesupport (7.2.3) lib/active_support/callbacks.rb:130:in 'block in ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.3) lib/active_support/callbacks.rb:141:in 'ActiveSupport::Callbacks#run_callbacks'
actionpack (7.2.3) lib/abstract_controller/callbacks.rb:260:in 'AbstractController::Callbacks#process_action'
actionpack (7.2.3) lib/action_controller/metal/rescue.rb:27:in 'ActionController::Rescue#process_action'
actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:77:in 'block in ActionController::Instrumentation#process_action'
activesupport (7.2.3) lib/active_support/notifications.rb:210:in 'block in ActiveSupport::Notifications.instrument'
activesupport (7.2.3) lib/active_support/notifications/instrumenter.rb:58:in 'ActiveSupport::Notifications::Instrumenter#instrument'
activesupport (7.2.3) lib/active_support/notifications.rb:210:in 'ActiveSupport::Notifications.instrument'
actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:76:in 'ActionController::Instrumentation#process_action'
actionpack (7.2.3) lib/action_controller/metal/params_wrapper.rb:259:in 'ActionController::ParamsWrapper#process_action'
activerecord (7.2.3) lib/active_record/railties/controller_runtime.rb:39:in 'ActiveRecord::Railties::ControllerRuntime#process_action'
actionpack (7.2.3) lib/abstract_controller/base.rb:152:in 'AbstractController::Base#process'
actionview (7.2.3) lib/action_view/rendering.rb:40:in 'ActionView::Rendering#process'
actionpack (7.2.3) lib/action_controller/metal.rb:252:in 'ActionController::Metal#dispatch'
actionpack (7.2.3) lib/action_controller/metal.rb:335:in 'ActionController::Metal.dispatch'
actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:67:in 'ActionDispatch::Routing::RouteSet::Dispatcher#dispatch'
actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:50:in 'ActionDispatch::Routing::RouteSet::Dispatcher#serve'
actionpack (7.2.3) lib/action_dispatch/routing/mapper.rb:32:in 'block in <class:Constraints>'
actionpack (7.2.3) lib/action_dispatch/routing/mapper.rb:62:in 'ActionDispatch::Routing::Mapper::Constraints#serve'
actionpack (7.2.3) lib/action_dispatch/journey/router.rb:53:in 'block in ActionDispatch::Journey::Router#serve'
actionpack (7.2.3) lib/action_dispatch/journey/router.rb:133:in 'block in ActionDispatch::Journey::Router#find_routes'
actionpack (7.2.3) lib/action_dispatch/journey/router.rb:126:in 'Array#each'
```

#### Testing

1. Sign in as admin
2. Go to http://localhost:3000/admin/participatory_processes/imports
3. Import this file: 
[process-legacy-private.json](https://github.com/user-attachments/files/25417391/process-legacy-private.json)
4. (Before) see the exception
5. (After) see the error message 

### :camera: Screenshots 


<img width="894" height="1000" alt="image" src="https://github.com/user-attachments/assets/dda1c837-4149-4a7d-9509-5870659e5162" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import validation now rejects empty JSON arrays and malformed JSON for assemblies and participatory processes, surfacing clear errors.

* **Documentation**
  * New user-facing error messages added for empty and invalid JSON imports.

* **Tests**
  * Specs added to cover empty-array and invalid-JSON import scenarios, asserting appropriate error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->