### PR TITLE
Fix showing announcement content block with only the default locale

### DIFF
--- a/decidim-core/app/cells/decidim/announcement_cell.rb
+++ b/decidim-core/app/cells/decidim/announcement_cell.rb
@@ -72,7 +72,7 @@ module Decidim
     end
 
     def clean_announcement
-      return if announcement.is_a?(Hash) && announcement.values.any?(&:empty?)
+      return if announcement.is_a?(Hash) && announcement.values.all?(&:blank?)
 
       clean(announcement)
     end

--- a/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/announcement_cell_spec.rb
@@ -43,5 +43,15 @@ module Decidim
         expect(html).to have_text("My announcement")
       end
     end
+
+    context "when passing a translations hash with some empty locales" do
+      let(:announcement) { { en: "My announcement", ca: "" } }
+
+      it "renders the card" do
+        html = cell("decidim/announcement", announcement).call
+        expect(html).to have_css("div.flash[data-announcement]")
+        expect(html).to have_text("My announcement")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the code and the review for https://github.com/decidim/decidim/issues/16064, we noticed a weird behavior about announcements: you need to fill all the locales to actually be shown. 

#### :pushpin: Related Issues
 
- Fixes #16127 

#### Testing

0. With an organization with multiple locales and with the default locale being English
1. Sign in as admin
2. Go to the landing page editor of a process
3. Add an announcement content block
4. Activate it
5. Edit it and fill **only** the English locale
6. (Before) see that you don't have it in the public page
7. (After) see that you have it in the public page, and changing the locale to other, such as Spanish, you still see the same message (as other forms do)

### :camera: Screenshots

<img width="1113" height="409" alt="image" src="https://github.com/user-attachments/assets/e007dccf-0baf-460e-8ec8-d274547eccca" />
<img width="1029" height="340" alt="image" src="https://github.com/user-attachments/assets/b81700ff-e888-4a72-8118-81b98ce0e709" />
<img width="1141" height="604" alt="image" src="https://github.com/user-attachments/assets/ed4496c7-00f4-4947-bdb9-4c1d0207357e" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multilingual announcements with partial translations. Announcements now display correctly when some language translations contain text while others are empty, while fully blank announcements continue to be filtered appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->