### PR TITLE
Gracefully handle the exception with newsletters' message encryption

### DIFF
--- a/decidim-admin/app/controllers/decidim/admin/newsletter_templates_controller.rb
+++ b/decidim-admin/app/controllers/decidim/admin/newsletter_templates_controller.rb
@@ -18,6 +18,8 @@ module Decidim
         email = NewsletterMailer.newsletter(current_user, fake_newsletter, true)
         Premailer::Rails::Hook.perform(email)
         render html: email.html_part.body.decoded.html_safe
+      rescue ActiveSupport::MessageEncryptor::InvalidMessage
+        render :preview_error, layout: false
       end
 
       private

--- a/decidim-admin/app/views/decidim/admin/newsletter_templates/preview_error.html.erb
+++ b/decidim-admin/app/views/decidim/admin/newsletter_templates/preview_error.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>" dir="<%= rtl_direction %>">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><%= t(".error_title") %></title>
+    <%= stylesheet_pack_tag "decidim_core", "decidim_admin", media: "all" %>
+    <%= javascript_pack_tag "decidim_core", "decidim_admin", defer: false %>
+  </head>
+  <body class="p-8">
+    <%= cell("decidim/announcement", { title: t(".error_title"), body: t(".error") }, callout_class: "alert") %>
+  </body>
+</html>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -808,6 +808,9 @@ en:
         show:
           preview: 'Preview template: %{template_name}'
           use_template: Use this template
+        preview_error:
+          error_title: Preview Error
+          error: 'The newsletter preview could not be generated due to an encryption error. This usually happens when the SECRET_KEY_BASE environment variable has changed after the SMTP settings were saved. To fix this issue, please go to the System panel, navigate to the organization settings, and re-save the SMTP configuration. This will re-encrypt the credentials with the current secret key.'
       newsletters:
         confirm_recipients:
           email: Email

--- a/decidim-admin/spec/system/admin_manages_newsletter_templates_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletter_templates_spec.rb
@@ -66,5 +66,32 @@ describe "Admin manages newsletter templates" do
 
     it_behaves_like "working newsletter template iframe", :basic_only_text
     it_behaves_like "working newsletter template iframe", :image_text_cta
+
+    context "when there is an encryption error with SMTP settings" do
+      let(:organization) do
+        create(
+          :organization,
+          name: { en: "Test organization" },
+          smtp_settings: {
+            "from" => "test@example.org",
+            "user_name" => "test",
+            "encrypted_password" => Decidim::AttributeEncryptor.encrypt("password")
+          }
+        )
+      end
+
+      it "shows an error message when decryption fails" do
+        # Simulate an encryption error by stubbing the decrypt method
+        allow(Decidim::AttributeEncryptor).to receive(:decrypt).and_raise(
+          ActiveSupport::MessageEncryptor::InvalidMessage
+        )
+
+        visit decidim_admin.preview_newsletter_template_path(:basic_only_text)
+
+        expect(page).to have_content("newsletter preview could not be generated")
+        expect(page).to have_content("encryption error")
+        expect(page).to have_content("SECRET_KEY_BASE")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

As we discussed at #16103, there's a problem with Rails and a bug that shows when you have a SECRET_KEY_BASE environment variable and the local secret from `tmp/`. We cannot solve programmatically and it shouldn't happen, but if it happens or an installation messed up their SECRET_KEY_BASE and have problems with the SMTP credentials, then we should at least handle gracefully this error.

This PR does that, showing a "friendly" error message instead of an scary exception (or 500 error in production).  

#### :pushpin: Related Issues 

- Related to #16103

#### Testing

0. Define a SECRET_KEY_BASE env var with a `bin/rails secret`
1. Create a development app with this 
2. Change this env var
3. Restart the server
4. Sign in as admin
5. Go to http://localhost:3000/admin/newsletter_templates?locale=en 
6. See the error 

### :camera: Screenshots

#### Before

<img width="1366" height="1472" alt="image" src="https://github.com/user-attachments/assets/a52b159c-6770-45a5-b00a-eb1996edc3ff" />

#### After 

<img width="1263" height="873" alt="image" src="https://github.com/user-attachments/assets/787c2f9b-0911-4e40-ae58-3e03763a4b14" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Newsletter template preview now includes enhanced error handling for encryption-related issues, gracefully managing failures that previously resulted in system crashes. When preview generation encounters encryption configuration problems, users now receive clear, localized error messages with helpful guidance and troubleshooting hints to resolve the issue, significantly improving reliability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->