### PR TITLE
Fix elections' manual start checkbox on edit

### DIFF
--- a/decidim-elections/app/packs/src/decidim/elections/admin/election_form.js
+++ b/decidim-elections/app/packs/src/decidim/elections/admin/election_form.js
@@ -35,4 +35,5 @@ document.addEventListener("turbo:load", () => {
   });
 
   setManualStart();
+  toggleManualStart();
 });

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -81,6 +81,32 @@ describe "Admin manages elections" do
     it_behaves_like "having a rich text editor", "new_election", "full"
   end
 
+  describe "manual start checkbox persistence" do
+    it "hides start date fields when returning to form with manual start checked" do
+      within "tr", text: translated(election.title) do
+        find("button[data-controller='dropdown']").click
+        click_on "Edit election"
+      end
+
+      within ".edit_election" do
+        check "Manual start"
+        expect(page).to have_no_field("election_start_at_date")
+        expect(page).to have_no_field("election_start_at_time")
+      end
+
+      click_on "Questions"
+      expect(page).to have_content("Questions")
+
+      click_on "Main"
+
+      within ".edit_election" do
+        expect(page).to have_checked_field("Manual start")
+        expect(page).to have_no_field("election_start_at_date")
+        expect(page).to have_no_field("election_start_at_time")
+      end
+    end
+  end
+
   describe "updating an election" do
     it "updates an election" do
       within "tr", text: translated(election.title) do


### PR DESCRIPTION
#### :tophat: What? Why?

When editing an election with "Manual start", you can still see the "start time" when editing this election.

This PR fixes that.

#### :pushpin: Related Issues
 
- Fixes #15345 

#### Testing

1. Sign in as admin
2. Create an election with "manual start" checkbox
3. Save it
4. Edit it and see the "start time" 
5. (Before) you still have it visible
6. (After) the "start time" is hidden (as it is when clicking the checkbox)

### :camera: Screenshots

#### Before

<img width="1673" height="1056" alt="image" src="https://github.com/user-attachments/assets/0536b9ba-3d13-46e8-a845-2488b0be43c6" />

#### After

<img width="1781" height="1161" alt="image" src="https://github.com/user-attachments/assets/d321f524-bb27-4f7c-8220-86da1247c41b" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed manual start checkbox UI state initialization to properly show/hide start date and time fields.
  * Ensured checkbox state and field visibility persist when navigating between form tabs in the election editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->