### PR TITLE
Fix transparent checkbox for assembly on edit

### DIFF
--- a/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/controller.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/controller.js
@@ -50,10 +50,6 @@ export default class extends Controller {
 
     if (isTransparentCheckbox) {
       isTransparentCheckbox.disabled = (enabledPrivateSpace === false);
-
-      if (isTransparentCheckbox.checked) {
-        isTransparentCheckbox.checked = false;
-      }
     }
 
     if (specialFeatures) {

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -135,6 +135,22 @@ describe "Admin manages assemblies" do
         expect(src).to be_blob_url(hero_blob)
       end
     end
+
+    describe "when the assembly is transparent" do
+      let!(:assembly3) { create(:assembly, :private, :transparent, organization:) }
+
+      before do
+        visit decidim_admin_assemblies.assemblies_path
+      end
+
+      it "shows the transparent checkbox correctly" do
+        within "tr", text: translated(assembly3.title) do
+          click_on translated(assembly3.title)
+        end
+
+        expect(page).to have_checked_field("assembly_is_transparent")
+      end
+    end
   end
 
   context "when managing parent assemblies" do

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -135,10 +135,6 @@ describe "Admin manages assemblies" do
     describe "when the assembly is transparent" do
       let!(:assembly3) { create(:assembly, :private, :transparent, organization:) }
 
-      before do
-        visit decidim_admin_assemblies.assemblies_path
-      end
-
       it "shows the transparent checkbox correctly" do
         within "tr", text: translated(assembly3.title) do
           click_on translated(assembly3.title)

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -111,7 +111,7 @@ describe "Admin manages assemblies" do
       visit decidim_admin_assemblies.assemblies_path
     end
 
-    it "update a participatory process without images does not delete them" do
+    it "update an assembly without images does not delete them" do
       within "tr", text: translated(assembly3.title) do
         click_on translated(assembly3.title)
       end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -116,10 +116,6 @@ describe "Admin manages assemblies" do
         click_on translated(assembly3.title)
       end
 
-      within_admin_sidebar_menu do
-        click_on "About this assembly"
-      end
-
       select(decidim_sanitize_translated(taxonomy.name), from: "taxonomies-#{taxonomy_filter.id}")
 
       click_on "Update"


### PR DESCRIPTION
#### :tophat: What? Why?

When saving a private and transparent assembly, the checkbox isn't shown correctly on the edit form.

This PR fixes it. 

#### :pushpin: Related Issues
 
- Related to #15895 
 
#### Testing

1. Sign in as admin
2. Edit an assembly and make it private and transparent
3. Edit this same assembly
4. (Before) see that the checkbox for "is transparent' isn't checked
4. (After) see that the checkbox for "is transparent' is checked

### :camera: Screenshots

#### Before

<img width="737" height="424" alt="image" src="https://github.com/user-attachments/assets/09d0bc62-ed00-4156-8bd5-854985f22cbd" />

#### After

<img width="939" height="455" alt="image" src="https://github.com/user-attachments/assets/cc24e130-970c-46c8-bdb7-f2188128d9fa" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the transparency checkbox was being automatically unchecked when toggling related visibility/private options; assemblies now retain their transparent setting even when the control is disabled.

* **Tests**
  * Added/updated system tests to verify transparency behavior across view and edit flows, confirming the transparency checkbox displays and preserves the correct state during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->