### PR TITLE
Fix importing attachments within processes/assemblies

### DIFF
--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -84,27 +84,24 @@ module Decidim
             next
           end
 
-          begin
-            file_tmp = URI.parse(url).open
-          rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-            @warnings << I18n.t(
-              "decidim.assemblies.admin.imports.attachment_error",
-              title: attachment_title(file),
-              error: format_error(e)
-            )
-            next
-          end
-
           Decidim.traceability.perform_action!("create", Attachment, @user) do
             attachment = Attachment.new(
               title: file["title"],
               description: file["description"],
-              content_type: file_tmp.content_type,
               attached_to: @imported_assembly,
               weight: file["weight"],
-              file: file_tmp, # Define attached_to before this
-              file_size: file_tmp.size
+              content_type: fetch_content_type(url)
             )
+            begin
+              attachment.attached_uploader(:file).remote_url = url
+            rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+              @warnings << I18n.t(
+                "decidim.assemblies.admin.imports.attachment_error",
+                title: attachment_title(file),
+                error: format_error(e)
+              )
+              next
+            end
             attachment.create_attachment_collection(file["attachment_collection"])
             attachment.save!
             attachment
@@ -198,6 +195,22 @@ module Decidim
         message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
         message = message.presence || error.message
         "#{code} #{message}"
+      end
+
+      def fetch_content_type(url)
+        return nil if url.blank?
+
+        uri = URI.parse(url)
+        http_connection = Net::HTTP.new(uri.host, uri.port)
+        http_connection.use_ssl = true if uri.scheme == "https"
+        http_connection.start do |http|
+          response = http.head(uri.request_uri)
+          return nil unless response.is_a?(Net::HTTPSuccess)
+
+          response["Content-Type"]&.split(";")&.first
+        end
+      rescue StandardError
+        nil
       end
     end
   end

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -89,11 +89,11 @@ module Decidim
               title: file["title"],
               description: file["description"],
               attached_to: @imported_assembly,
-              weight: file["weight"],
-              content_type: fetch_content_type(url)
+              weight: file["weight"]
             )
             begin
               attachment.attached_uploader(:file).remote_url = url
+              attachment.set_content_type_and_size
             rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
               @warnings << I18n.t(
                 "decidim.assemblies.admin.imports.attachment_error",
@@ -195,22 +195,6 @@ module Decidim
         message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
         message = message.presence || error.message
         "#{code} #{message}"
-      end
-
-      def fetch_content_type(url)
-        return nil if url.blank?
-
-        uri = URI.parse(url)
-        http_connection = Net::HTTP.new(uri.host, uri.port)
-        http_connection.use_ssl = true if uri.scheme == "https"
-        http_connection.start do |http|
-          response = http.head(uri.request_uri)
-          return nil unless response.is_a?(Net::HTTPSuccess)
-
-          response["Content-Type"]&.split(";")&.first
-        end
-      rescue StandardError
-        nil
       end
     end
   end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -311,6 +311,114 @@ module Decidim::Assemblies
             expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
+
+        context "when remote file is accessible and downloadable (PDF)" do
+          let(:remote_file_url) { "http://example.com/document.pdf" }
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "successfully imports the attachment" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+          end
+
+          it "attaches the file to the assembly" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file).to be_attached
+            expect(attachment.file.filename.to_s).to eq("document.pdf")
+          end
+
+          it "sets the content type automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.content_type).to eq("application/pdf")
+          end
+
+          it "sets the file size automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file_size).to be_present
+          end
+
+          it "has no warnings" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to be_empty
+          end
+        end
+
+        context "when remote file is accessible and downloadable (image)" do
+          let(:remote_file_url) { "http://example.com/image.jpg" }
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("city.jpeg")))
+          end
+
+          it "successfully imports the attachment" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+          end
+
+          it "attaches the file to the assembly" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file).to be_attached
+          end
+
+          it "sets the content type automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.content_type).to eq("image/jpeg")
+          end
+
+          it "has no warnings" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to be_empty
+          end
+        end
+
+        context "when remote file URL is blank" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => ""
+                }
+              ],
+              "attachment_collections" => []
+            }
+          end
+
+          it "does not create any attachments" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::Attachment, :count)
+          end
+        end
+
+        context "when files array is nil" do
+          let(:attachments_data) do
+            {
+              "files" => nil,
+              "attachment_collections" => []
+            }
+          end
+
+          it "does not create any attachments" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::Attachment, :count)
+          end
+        end
       end
     end
   end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -106,27 +106,24 @@ module Decidim
             next
           end
 
-          begin
-            file_tmp = URI.parse(url).open
-          rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-            @warnings << I18n.t(
-              "decidim.participatory_processes.admin.imports.attachment_error",
-              title: attachment_title(file),
-              error: format_error(e)
-            )
-            next
-          end
-
           Decidim.traceability.perform_action!("create", Attachment, @user) do
             attachment = Attachment.new(
               title: file["title"],
               description: file["description"],
-              content_type: file_tmp.content_type,
               attached_to: @imported_process,
               weight: file["weight"],
-              file: file_tmp, # Define attached_to before this
-              file_size: file_tmp.size
+              content_type: fetch_content_type(url)
             )
+            begin
+              attachment.attached_uploader(:file).remote_url = url
+            rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
+              @warnings << I18n.t(
+                "decidim.participatory_processes.admin.imports.attachment_error",
+                title: attachment_title(file),
+                error: format_error(e)
+              )
+              next
+            end
             attachment.create_attachment_collection(file["attachment_collection"])
             attachment.save!
             attachment
@@ -225,6 +222,22 @@ module Decidim
         message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
         message = message.presence || error.message
         "#{code} #{message}"
+      end
+
+      def fetch_content_type(url)
+        return nil if url.blank?
+
+        uri = URI.parse(url)
+        http_connection = Net::HTTP.new(uri.host, uri.port)
+        http_connection.use_ssl = true if uri.scheme == "https"
+        http_connection.start do |http|
+          response = http.head(uri.request_uri)
+          return nil unless response.is_a?(Net::HTTPSuccess)
+
+          response["Content-Type"]&.split(";")&.first
+        end
+      rescue StandardError
+        nil
       end
     end
   end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -111,11 +111,11 @@ module Decidim
               title: file["title"],
               description: file["description"],
               attached_to: @imported_process,
-              weight: file["weight"],
-              content_type: fetch_content_type(url)
+              weight: file["weight"]
             )
             begin
               attachment.attached_uploader(:file).remote_url = url
+              attachment.set_content_type_and_size
             rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
               @warnings << I18n.t(
                 "decidim.participatory_processes.admin.imports.attachment_error",
@@ -222,22 +222,6 @@ module Decidim
         message = status[1].presence || Rack::Utils::HTTP_STATUS_CODES[code.to_i]
         message = message.presence || error.message
         "#{code} #{message}"
-      end
-
-      def fetch_content_type(url)
-        return nil if url.blank?
-
-        uri = URI.parse(url)
-        http_connection = Net::HTTP.new(uri.host, uri.port)
-        http_connection.use_ssl = true if uri.scheme == "https"
-        http_connection.start do |http|
-          response = http.head(uri.request_uri)
-          return nil unless response.is_a?(Net::HTTPSuccess)
-
-          response["Content-Type"]&.split(";")&.first
-        end
-      rescue StandardError
-        nil
       end
     end
   end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -387,6 +387,114 @@ module Decidim::ParticipatoryProcesses
             expect(importer.warnings).to include(a_string_matching(/The attachment "Test File" could not be imported \(500 Internal Server Error\)\./i))
           end
         end
+
+        context "when remote file is accessible and downloadable (PDF)" do
+          let(:remote_file_url) { "http://example.com/document.pdf" }
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "successfully imports the attachment" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+          end
+
+          it "attaches the file to the process" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file).to be_attached
+            expect(attachment.file.filename.to_s).to eq("document.pdf")
+          end
+
+          it "sets the content type automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.content_type).to eq("application/pdf")
+          end
+
+          it "sets the file size automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file_size).to be_present
+          end
+
+          it "has no warnings" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to be_empty
+          end
+        end
+
+        context "when remote file is accessible and downloadable (image)" do
+          let(:remote_file_url) { "http://example.com/image.jpg" }
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("city.jpeg")))
+          end
+
+          it "successfully imports the attachment" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+          end
+
+          it "attaches the file to the process" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.file).to be_attached
+          end
+
+          it "sets the content type automatically" do
+            importer.import_folders_and_attachments(attachments_data)
+            attachment = Decidim::Attachment.last
+            expect(attachment.content_type).to eq("image/jpeg")
+          end
+
+          it "has no warnings" do
+            importer.import_folders_and_attachments(attachments_data)
+            expect(importer.warnings).to be_empty
+          end
+        end
+
+        context "when remote file URL is blank" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => ""
+                }
+              ],
+              "attachment_collections" => []
+            }
+          end
+
+          it "does not create any attachments" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::Attachment, :count)
+          end
+        end
+
+        context "when files array is nil" do
+          let(:attachments_data) do
+            {
+              "files" => nil,
+              "attachment_collections" => []
+            }
+          end
+
+          it "does not create any attachments" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::Attachment, :count)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Yet another fix related to the export/import feature in spaces. 

This time the problem is when the attachments are actually available (i.e. a status code 200). There's an error with the TMP file that we have as content type, when `ActiveStorage` actually needs a Content Type for these files to be imported.

#### :pushpin: Related Issues

- Fixes #10180 

#### Testing

0. Sign in as admin
1. Export a process or assembly
2. Go to http://localhost:3000/admin/participatory_processes/imports/new
3. Fill a title, a slug and upload that JSON
4. (Before this PR) there's an exception
5. (After this PR) the process is imported correctly

### Stacktrace

```
ArgumentError (Could not find or build blob: expected attachable, got #<Tempfile:/tmp/open-uri20260224-57523-krhegm>):

activestorage (7.2.3) lib/active_storage/attached/changes/create_one.rb:112:in 'ActiveStorage::Attached::Changes::CreateOne#find_or_build_blob'
activestorage (7.2.3) lib/active_storage/attached/changes/create_one.rb:20:in 'ActiveStorage::Attached::Changes::CreateOne#blob'
activestorage (7.2.3) lib/active_storage/attached/changes/create_one.rb:12:in 'ActiveStorage::Attached::Changes::CreateOne#initialize'
activestorage (7.2.3) lib/active_storage/attached/model.rb:121:in 'Class#new'
activestorage (7.2.3) lib/active_storage/attached/model.rb:121:in 'Decidim::Attachment::GeneratedAssociationMethods#file='
activemodel (7.2.3) lib/active_model/attribute_assignment.rb:48:in 'Kernel#public_send'
activemodel (7.2.3) lib/active_model/attribute_assignment.rb:48:in 'ActiveModel::AttributeAssignment#_assign_attribute'
activerecord (7.2.3) lib/active_record/attribute_assignment.rb:17:in 'block in ActiveRecord::AttributeAssignment#_assign_attributes'
activerecord (7.2.3) lib/active_record/attribute_assignment.rb:9:in 'Hash#each'
activerecord (7.2.3) lib/active_record/attribute_assignment.rb:9:in 'ActiveRecord::AttributeAssignment#_assign_attributes'
activemodel (7.2.3) lib/active_model/attribute_assignment.rb:34:in 'ActiveModel::AttributeAssignment#assign_attributes'
activemodel (7.2.3) lib/active_model/api.rb:81:in 'ActiveModel::API#initialize'
activerecord (7.2.3) lib/active_record/core.rb:470:in 'ActiveRecord::Core#initialize'
activerecord (7.2.3) lib/active_record/inheritance.rb:76:in 'Class#new'
activerecord (7.2.3) lib/active_record/inheritance.rb:76:in 'ActiveRecord::Inheritance::ClassMethods#new'
/workspaces/decidim/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb:121:in 'block (2 levels) in Decidim::ParticipatoryProcesses::ParticipatoryProcessImporter#import_folders_and_attachments'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:64:in 'block (2 levels) in Decidim::Traceability#perform_action!'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:63:in 'block in Decidim::Traceability#perform_action!'
paper_trail (16.0.0) lib/paper_trail/request.rb:85:in 'PaperTrail::Request.with'
paper_trail (16.0.0) lib/paper_trail.rb:81:in 'PaperTrail.request'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:62:in 'Decidim::Traceability#perform_action!'
/workspaces/decidim/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb:120:in 'block in Decidim::ParticipatoryProcesses::ParticipatoryProcessImporter#import_folders_and_attachments'
/workspaces/decidim/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb:95:in 'Array#map'
/workspaces/decidim/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb:95:in 'Decidim::ParticipatoryProcesses::ParticipatoryProcessImporter#import_folders_and_attachments'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:46:in 'block (2 levels) in Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#import_participatory_process'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:64:in 'block (2 levels) in Decidim::Traceability#perform_action!'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:63:in 'block in Decidim::Traceability#perform_action!'
paper_trail (16.0.0) lib/paper_trail/request.rb:85:in 'PaperTrail::Request.with'
paper_trail (16.0.0) lib/paper_trail.rb:81:in 'PaperTrail.request'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:62:in 'Decidim::Traceability#perform_action!'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:43:in 'block in Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#import_participatory_process'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:41:in 'Array#each'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:41:in 'Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#import_participatory_process'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:28:in 'block in Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#call'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/transaction.rb:616:in 'block in ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activesupport (7.2.3) lib/active_support/concurrency/null_lock.rb:9:in 'ActiveSupport::Concurrency::NullLock#synchronize'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/transaction.rb:613:in 'ActiveRecord::ConnectionAdapters::TransactionManager#within_new_transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:361:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:431:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:233:in 'ActiveRecord::Transactions::ClassMethods#transaction'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:30:in 'Decidim::Command#transaction'
/workspaces/decidim/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/import_participatory_process.rb:27:in 'Decidim::ParticipatoryProcesses::Admin::ImportParticipatoryProcess#call'
/workspaces/decidim/decidim-core/lib/decidim/command.rb:19:in 'Decidim::Command.call'
/workspaces/decidim/decidim-participatory_processes/app/controllers/decidim/participatory_processes/admin/participatory_process_imports_controller.rb:20:in 'Decidim::ParticipatoryProcesses::Admin::ParticipatoryProcessImportsController#create'
```

### :camera: Screenshots

<img width="1120" height="589" alt="image" src="https://github.com/user-attachments/assets/827b98cc-eb28-4208-8fc3-50470c49ee08" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote file imports now assign remote URLs, derive content type/size from responses, and gracefully catch network/download errors—logging attachment warnings and skipping failed files.

* **Tests**
  * Added tests for successful PDF/image remote imports, plus edge cases for blank or nil file references and content-type/size validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->