### PR TITLE
Fix patch release command 

### DIFF
--- a/docs/modules/develop/pages/maintainers/releases.adoc
+++ b/docs/modules/develop/pages/maintainers/releases.adoc
@@ -115,7 +115,7 @@ The process is very similar from releasing a new Decidim version:
 [source,bash]
 ----
 gem install decidim-maintainers_toolbox
-decidim-releaser --github-token=(gh auth token) --version-type=patch
+decidim-releaser --github-token=$(gh auth token) --version-type=patch
 ----
 . This will create a Pull Request for the new release with title `Bump to vx.y.z version`. Wait for the tests to finish and check that everything is passing before releasing the version.
 NOTE: When you bump the version, the generator tests will fail because the gems and NPM packages have not been actually published yet (as in sent to rubygems/npm). You may see errors such as `No matching version found for @decidim/browserslist-config@~0.xx.y` in the CI logs. This should be fine as long as you have ensured that the generators tests passed in the previous commit.


### PR DESCRIPTION
#### :tophat: What? Why?
Patch release doesn't work on bash as the command is missing a $ within the github token. Upated the docs properly for when copying the command to run a patch release.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with improved GitHub token retrieval instructions. Changed examples from static placeholder values to dynamic command substitution for authentication tokens. The updated guidance provides clearer and more accurate direction for maintainers executing release processes, helping to ensure proper token handling and reducing potential configuration errors during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->