### PR TITLE
Fix focus guard related bugs

### DIFF
--- a/decidim-core/app/cells/decidim/report_button/already_reported_modal.erb
+++ b/decidim-core/app/cells/decidim/report_button/already_reported_modal.erb
@@ -1,7 +1,7 @@
 <%= decidim_modal id: modal_id, class: "flag-modal" do %>
   <div data-dialog-container>
     <%= icon "flag-line" %>
-    <h2 tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_modal.title") %></h2>
+    <h2 id="dialog-title-<%= modal_id %>" tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_modal.title") %></h2>
     <div>
       <div class="form__wrapper flag-modal__form">
         <p class="flag-modal__form-description"><%= t("decidim.shared.flag_modal.already_reported") %></p>

--- a/decidim-core/app/cells/decidim/report_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_button/flag_modal.erb
@@ -2,7 +2,7 @@
   <%= decidim_form_for report_form, builder:, url: report_path, method: :post, html: { id: nil, data: { controller: "report-form" } } do |f| %>
     <div data-dialog-container>
       <%= icon "flag-line" %>
-      <h2 tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_modal.title") %></h2>
+      <h2 id="dialog-title-<%= modal_id %>" tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_modal.title") %></h2>
       <div>
         <div class="form__wrapper flag-modal__form">
           <p id="dialog-desc-<%= modal_id %>" class="flag-modal__form-description"><%= t("decidim.shared.flag_modal.description") %></p>

--- a/decidim-core/app/cells/decidim/report_user_button/already_reported_modal.erb
+++ b/decidim-core/app/cells/decidim/report_user_button/already_reported_modal.erb
@@ -1,7 +1,7 @@
 <%= decidim_modal id: modal_id, class: "flag-user-modal" do %>
   <div data-dialog-container>
     <%= icon "flag-line" %>
-    <h2 tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_user_modal.title") %></h2>
+    <h2 id="dialog-title-<%= modal_id %>" tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_user_modal.title") %></h2>
     <div>
       <div class="form__wrapper flag-modal__form">
         <p class="flag-modal__form-description"><%= t("decidim.shared.flag_user_modal.already_reported") %></p>

--- a/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
+++ b/decidim-core/app/cells/decidim/report_user_button/flag_modal.erb
@@ -2,7 +2,7 @@
   <%= decidim_form_for report_form, builder:, url: report_path, method: :post, html: { id: nil, data: { controller: "report-form" } } do |f| %>
     <div data-dialog-container>
       <%= icon "flag-line" %>
-      <h2 tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_user_modal.title") %></h2>
+      <h2 id="dialog-title-<%= modal_id %>" tabindex="-1" data-dialog-title><%= t("decidim.shared.flag_user_modal.title") %></h2>
       <div>
         <div class="form__wrapper flag-modal__form">
           <p class="flag-modal__form-description"><%= t("decidim.shared.flag_user_modal.description") %></p>

--- a/decidim-core/app/cells/decidim/share_text_widget/modal.erb
+++ b/decidim-core/app/cells/decidim/share_text_widget/modal.erb
@@ -1,6 +1,6 @@
 <%= decidim_modal id: "socialShare", class: "share-modal" do %>
   <div data-dialog-container>
-    <h2 tabindex="-1" data-dialog-title><%= t("share", scope: "decidim.shared.share_modal") %></h2>
+    <h2 id="dialog-title-socialShare" tabindex="-1" data-dialog-title><%= t("share", scope: "decidim.shared.share_modal") %></h2>
 
     <div>
 

--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -8,6 +8,13 @@ import Dialogs from "a11y-dialog-component";
  * @return {void}
  */
 const createDialog = (component) => {
+  const getFocusableElements = (container) => {
+    const selectors = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])";
+    return Array.from(container.querySelectorAll(selectors)).filter(
+      (el) => el.offsetParent !== null
+    );
+  };
+
   const {
     dataset: { dialog, ...attrs }
   } = component;
@@ -29,11 +36,33 @@ const createDialog = (component) => {
     backdropSelector: `[data-dialog="${dialog}"]`,
     enableAutoFocus: false,
     onOpen: (params, trigger) => {
+      const keyHandler = (event) => {
+        if (event.key !== "Tab") {
+          return;
+        }
+        const focusable = getFocusableElements(params);
+        if (focusable.length === 0) {
+          return;
+        }
+        if (event.shiftKey && document.activeElement === focusable[0]) {
+          event.preventDefault();
+          focusable[focusable.length - 1].focus({ preventScroll: true });
+        } else if (!event.shiftKey && document.activeElement === focusable[focusable.length - 1]) {
+          event.preventDefault();
+          focusable[0].focus({ preventScroll: true });
+        }
+      };
+      params._focusTrapHandler = keyHandler;
+      params.addEventListener("keydown", keyHandler);
       setFocusOnTitle(params);
       window.focusGuard.trap(params, trigger);
       params.dispatchEvent(new CustomEvent("open.dialog"));
     },
     onClose: (params) => {
+      if (params._focusTrapHandler) {
+        params.removeEventListener("keydown", params._focusTrapHandler);
+        Reflect.deleteProperty(params, "_focusTrapHandler");
+      }
       window.focusGuard.disable();
       params.dispatchEvent(new CustomEvent("close.dialog"));
     },

--- a/decidim-core/app/packs/src/decidim/a11y.test.js
+++ b/decidim-core/app/packs/src/decidim/a11y.test.js
@@ -48,6 +48,12 @@ describe("a11y dialog focus trap", () => {
     });
 
     it("handles Tab key", () => {
+      const selectors = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])";
+      const tabbableElements = Array.from(dialogEl.querySelectorAll(selectors)).filter(
+        (el) => el.offsetParent !== null || el.offsetParent !== undefined
+      );
+      tabbableElements[tabbableElements.length - 1].focus();
+
       const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true });
       const preventDefault = jest.fn();
       event.preventDefault = preventDefault;

--- a/decidim-core/app/packs/src/decidim/a11y.test.js
+++ b/decidim-core/app/packs/src/decidim/a11y.test.js
@@ -1,0 +1,73 @@
+import { createDialog } from "src/decidim/a11y"
+
+describe("a11y dialog focus trap", () => {
+  const dialogHtml = `
+    <button id="open-btn" data-dialog-open="testDialog">Open</button>
+    <div id="test-dialog" data-dialog="testDialog">
+      <div data-dialog-container>
+        <h2 id="dialog-title-testDialog" tabindex="-1" data-dialog-title>Test Dialog</h2>
+        <a href="#">Link 1</a>
+        <button>Button 1</button>
+        <input type="text" />
+        <button>Button 2</button>
+        <a href="#">Link 2</a>
+      </div>
+      <div data-dialog-actions>
+        <button data-dialog-close="testDialog">Close</button>
+      </div>
+    </div>
+  `;
+
+  beforeEach(() => {
+    document.body.innerHTML = dialogHtml;
+    window.Decidim = {
+      currentDialogs: {}
+    };
+    window.focusGuard = {
+      trap: jest.fn(),
+      disable: jest.fn()
+    };
+  });
+
+  describe("keydown handler", () => {
+    let dialogEl;
+
+    beforeEach(() => {
+      const component = document.querySelector("[data-dialog]");
+      createDialog(component);
+      dialogEl = document.querySelector("[data-dialog='testDialog']");
+      // Get the dialog from Decidim.currentDialogs and open it
+      const dialog = window.Decidim.currentDialogs.testDialog;
+      dialog.open();
+    });
+
+    it("adds keydown handler on open", () => {
+      expect(dialogEl._focusTrapHandler).toBeDefined();
+    });
+
+    it("handles Tab key", () => {
+      const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true });
+      const preventDefault = jest.fn();
+      event.preventDefault = preventDefault;
+
+      dialogEl.dispatchEvent(event);
+
+      expect(preventDefault).toHaveBeenCalled();
+    });
+  });
+
+  describe("onClose cleanup", () => {
+    it("removes the keydown handler on close", () => {
+      const component = document.querySelector("[data-dialog]");
+      createDialog(component);
+      const dialogEl = document.querySelector("[data-dialog='testDialog']");
+
+      const dialog = window.Decidim.currentDialogs.testDialog;
+      dialog.open();
+      expect(dialogEl._focusTrapHandler).toBeDefined();
+
+      dialog.close();
+      expect(dialogEl._focusTrapHandler).toBeUndefined();
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/a11y.test.js
+++ b/decidim-core/app/packs/src/decidim/a11y.test.js
@@ -1,3 +1,5 @@
+/* global jest */
+
 import { createDialog } from "src/decidim/a11y"
 
 describe("a11y dialog focus trap", () => {
@@ -30,7 +32,7 @@ describe("a11y dialog focus trap", () => {
   });
 
   describe("keydown handler", () => {
-    let dialogEl;
+    let dialogEl = null;
 
     beforeEach(() => {
       const component = document.querySelector("[data-dialog]");

--- a/decidim-core/app/packs/src/decidim/a11y.test.js
+++ b/decidim-core/app/packs/src/decidim/a11y.test.js
@@ -50,7 +50,7 @@ describe("a11y dialog focus trap", () => {
     it("handles Tab key", () => {
       const selectors = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])";
       const tabbableElements = Array.from(dialogEl.querySelectorAll(selectors)).filter(
-        (el) => el.offsetParent !== null || el.offsetParent !== undefined
+        (el) => el.offsetParent || el.offsetParent === null
       );
       tabbableElements[tabbableElements.length - 1].focus();
 

--- a/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.js
+++ b/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.js
@@ -78,16 +78,16 @@ export default class FocusGuard {
 
     let target = null;
     if (guard.dataset.position === "start") {
-      // Focus at the start guard, so focus the first focusable element after that
-      for (let ind = 0; ind < visibleNodes.length; ind += 1) {
+      // Focus at the start guard, so focus the last focusable element (cycle forward to end)
+      for (let ind = visibleNodes.length - 1; ind >= 0; ind -= 1) {
         if (!this.isFocusGuard(visibleNodes[ind]) && this.isFocusable(visibleNodes[ind])) {
           target = visibleNodes[ind];
           break;
         }
       }
     } else {
-      // Focus at the end guard, so focus the first focusable element after that
-      for (let ind = visibleNodes.length - 1; ind >= 0; ind -= 1) {
+      // Focus at the end guard, so focus the first focusable element (cycle back to start)
+      for (let ind = 0; ind < visibleNodes.length; ind += 1) {
         if (!this.isFocusGuard(visibleNodes[ind]) && this.isFocusable(visibleNodes[ind])) {
           target = visibleNodes[ind];
           break;


### PR DESCRIPTION
## :tophat: What? Why?

While checking out #15285, I saw different errors in the focus guard implementation. This PR fixes them. 

(While recording the videos some of them may have background music, sorry about that!!) 

## :pushpin: Related Issues
 
- Fixes #15285 

## Testing

### Bug 1. Report modal without focus

1. Sign in as a participant
2. Go to the actions meatball menu in a Proposal, report this proposal
3. (Bug) see that the focus isn't directly in the modal, you need to click in the modal to be focused there

[Kooha-2026-02-25-12-07-38.webm](https://github.com/user-attachments/assets/74c59e31-c5ff-4e0f-acde-4cf9a25aa6bf)

#### The fix

[Kooha-2026-02-25-12-19-30.webm](https://github.com/user-attachments/assets/f6677b41-cb3e-4f56-8fdf-6e5df0706109)


### Bug 2. Focus cycle doesn't work on some modals (and scrolls in the background) 

In some modals (such as Report or Share) when you arrive to the final element (a button) the tab doesn't get you back to the first element.

Also focus on the last element on these modals get you scrolled on the background page

1. Go to a proposal show page
2. Click in the Share button to open the modal
3. Click tab several times
4. (Bug) See that you don't go back to the beggining  

[Kooha-2026-02-25-12-08-03.webm](https://github.com/user-attachments/assets/2b6efbf4-4b24-4b95-8fba-9d6b66e228ac)

#### The fix

[Kooha-2026-02-25-12-19-53.webm](https://github.com/user-attachments/assets/76ec7769-0135-4f6e-996c-d25134b5faf0)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Dialog titles now include stable IDs to improve screen reader labeling and DOM targeting.
* **Bug Fixes**
  * Improved keyboard focus trapping and wrap-around behavior in modal dialogs to prevent focus escape and ensure predictable Tab/Shift+Tab cycling.
* **Tests**
  * Added unit tests covering dialog focus trapping, keyboard interaction, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->