### PR TITLE
Remove 'free text' option from sorting questions' responses options

### DIFF
--- a/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
@@ -22,6 +22,7 @@ export default function createEditableForm() {
   const matrixRowRemoveFieldButtonSelector = ".remove-matrix-row";
   const addMatrixRowButtonSelector = ".add-matrix-row";
   const maxChoicesWrapperSelector = ".questionnaire-question-max-choices";
+  const responseOptionFreeTextSelector = ".questionnaire-question-response-option-free-text";
 
   const displayConditionFieldSelector = ".questionnaire-question-display-condition";
   const displayConditionsWrapperSelector = ".questionnaire-question-display-conditions";
@@ -335,7 +336,10 @@ export default function createEditableForm() {
     const dynamicFieldsMatrixRows = dynamicFieldsForMatrixRows[fieldId];
 
     const onQuestionTypeChange = () => {
-      if (isMultipleChoiceOption($fieldQuestionTypeSelect.val())) {
+      const $currentField = $fieldQuestionTypeSelect.parents(fieldSelector);
+      const questionType = $fieldQuestionTypeSelect.val();
+
+      if (isMultipleChoiceOption(questionType)) {
         const nOptions = $fieldQuestionTypeSelect.parents(fieldSelector).find(responseOptionFieldSelector).length;
 
         if (nOptions === 0) {
@@ -351,6 +355,12 @@ export default function createEditableForm() {
           dynamicFieldsMatrixRows._addField();
           dynamicFieldsMatrixRows._addField();
         }
+      }
+
+      if (questionType === "sorting") {
+        $currentField.find(responseOptionFreeTextSelector).hide();
+      } else {
+        $currentField.find(responseOptionFreeTextSelector).show();
       }
     };
 

--- a/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
@@ -358,9 +358,9 @@ export default function createEditableForm() {
       }
 
       if (questionType === "sorting") {
-        $currentField.find(responseOptionFreeTextSelector).hide();
+        $currentField.find(responseOptionFreeTextSelector).addClass("hidden");
       } else {
-        $currentField.find(responseOptionFreeTextSelector).show();
+        $currentField.find(responseOptionFreeTextSelector).removeClass("hidden");
       }
     };
 

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_response_option.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_response_option.html.erb
@@ -26,8 +26,7 @@
       %>
     </div>
 
-    <% unless question.question_type == "sorting" %>
-      <div class="row column questionnaire-question-response-option-free-text">
+    <div class="row column questionnaire-question-response-option-free-text">
         <%=
           form.check_box(
             :free_text,
@@ -36,7 +35,6 @@
           )
         %>
       </div>
-    <% end %>
   </div>
 
   <% if response_option.persisted? %>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_response_option.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_response_option.html.erb
@@ -26,15 +26,17 @@
       %>
     </div>
 
-    <div class="row column">
-      <%=
-        form.check_box(
-          :free_text,
-          label: t(".free_text"),
-          disabled: !questionnaire.questions_editable?
-        )
-      %>
-    </div>
+    <% unless question.question_type == "sorting" %>
+      <div class="row column questionnaire-question-response-option-free-text">
+        <%=
+          form.check_box(
+            :free_text,
+            label: t(".free_text"),
+            disabled: !questionnaire.questions_editable?
+          )
+        %>
+      </div>
+    <% end %>
   </div>
 
   <% if response_option.persisted? %>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -414,7 +414,7 @@ shared_examples_for "add questions" do
       expect(page).to have_css("input[type=checkbox][id$=_free_text]")
 
       select "Sorting", from: "Type"
-      expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: true)
+      expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: :visible)
     end
 
     it_behaves_like "updating the max choices selector according to the configured options"

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -412,9 +412,55 @@ shared_examples_for "add questions" do
 
       select "Single option", from: "Type"
       expect(page).to have_css("input[type=checkbox][id$=_free_text]")
+
+      select "Sorting", from: "Type"
+      expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
     end
 
     it_behaves_like "updating the max choices selector according to the configured options"
+  end
+
+  context "when adding a sorting question" do
+    before do
+      click_on "Add question"
+
+      expand_all_questions
+
+      within ".questionnaire-question" do
+        fill_in find_nested_form_field_locator("body_en"), with: "This is a sorting question"
+        select "Single option", from: "Type"
+      end
+    end
+
+    it "does not display the free text option when switching to sorting type" do
+      within ".questionnaire-question" do
+        expect(page).to have_css("input[type=checkbox][id$=_free_text]")
+
+        select "Sorting", from: "Type"
+
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+      end
+    end
+
+    it "shows the free text option when switching back from sorting to single option" do
+      within ".questionnaire-question" do
+        select "Sorting", from: "Type"
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+
+        select "Single option", from: "Type"
+        expect(page).to have_css("input[type=checkbox][id$=_free_text]")
+      end
+    end
+
+    it "hides free text option when switching from multiple option to sorting" do
+      within ".questionnaire-question" do
+        select "Multiple option", from: "Type"
+        expect(page).to have_css("input[type=checkbox][id$=_free_text]")
+
+        select "Sorting", from: "Type"
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+      end
+    end
   end
 
   context "when adding a matrix question" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -414,7 +414,7 @@ shared_examples_for "add questions" do
       expect(page).to have_css("input[type=checkbox][id$=_free_text]")
 
       select "Sorting", from: "Type"
-      expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+      expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
     end
 
     it_behaves_like "updating the max choices selector according to the configured options"
@@ -438,14 +438,14 @@ shared_examples_for "add questions" do
 
         select "Sorting", from: "Type"
 
-        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
       end
     end
 
     it "shows the free text option when switching back from sorting to single option" do
       within ".questionnaire-question" do
         select "Sorting", from: "Type"
-        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
 
         select "Single option", from: "Type"
         expect(page).to have_css("input[type=checkbox][id$=_free_text]")
@@ -458,7 +458,7 @@ shared_examples_for "add questions" do
         expect(page).to have_css("input[type=checkbox][id$=_free_text]")
 
         select "Sorting", from: "Type"
-        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]")
+        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
       end
     end
   end

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -414,7 +414,7 @@ shared_examples_for "add questions" do
       expect(page).to have_css("input[type=checkbox][id$=_free_text]")
 
       select "Sorting", from: "Type"
-      expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
+      expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: true)
     end
 
     it_behaves_like "updating the max choices selector according to the configured options"
@@ -438,14 +438,14 @@ shared_examples_for "add questions" do
 
         select "Sorting", from: "Type"
 
-        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: :visible)
       end
     end
 
     it "shows the free text option when switching back from sorting to single option" do
       within ".questionnaire-question" do
         select "Sorting", from: "Type"
-        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: :visible)
 
         select "Single option", from: "Type"
         expect(page).to have_css("input[type=checkbox][id$=_free_text]")
@@ -458,7 +458,7 @@ shared_examples_for "add questions" do
         expect(page).to have_css("input[type=checkbox][id$=_free_text]")
 
         select "Sorting", from: "Type"
-        expect(page).not_to have_css("input[type=checkbox][id$=_free_text]", visible: true)
+        expect(page).to have_no_css("input[type=checkbox][id$=_free_text]", visible: :visible)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When configuring a survey or a form with a question type of "sorting", the responses option have the option of "free text", but this isn't used in the frontend. 

The problem is that "free text" shouldn't be available in the admin panel for these kind of questions (see #15820), so this PR removes this option. 

#### :pushpin: Related Issues
 
- Fixes #15820

#### Testing

1. Create a new survey
2. Create a new question type of type "Sorting"
3. See that you don't have the "Free text" checkbox in the responses options
4. Save it 
5. Open the question again 
6. See that you still don't have the "Free text" checkbox in the responses options
7. Remove the question
8. Create a new question with the question type to other (like "Short response")
9. Save it
10. Change it to question type of type "Sorting"
6. See that you still don't have the "Free text" checkbox in the responses options

### :camera: Screenshots

#### Before
<img width="1447" height="924" alt="image" src="https://github.com/user-attachments/assets/42bc3058-0b45-45e6-93ea-a850c7f6d382" />

#### After
<img width="1313" height="844" alt="image" src="https://github.com/user-attachments/assets/25129244-c0e8-4c57-8e13-d3e2bc4c3000" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free-text response input now conditionally displays based on question type—hidden for sorting questions, visible for others; existing behavior preserved when switching types.

* **Style**
  * Added a CSS hook/class around the free-text option to support consistent UI styling.

* **Tests**
  * Added tests verifying free-text visibility when switching between question types (includes duplicated test contexts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->