### PR TITLE
Fix long names and components counter in admin

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_sidebar-menu.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_sidebar-menu.scss
@@ -29,7 +29,7 @@
     }
 
     a > span:first-child {
-      @apply truncate;
+      @apply min-w-0 whitespace-normal break-words;
     }
 
     ul {

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_sidebar-menu.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_sidebar-menu.scss
@@ -4,7 +4,7 @@
   &__item {
     a,
     &-disabled {
-      @apply gap-x-2 p-2 flex items-center text-sm truncate border border-gray-5 rounded;
+      @apply gap-x-2 p-2 flex items-center text-sm border border-gray-5 rounded;
 
       > svg {
         @apply w-4 h-4 flex-none text-gray fill-current;
@@ -25,7 +25,11 @@
     }
 
     & .component-counter {
-      @apply ml-auto inline-flex items-center justify-center w-5 h-5 text-xs font-semibold rounded-full bg-background-4 border-secondary;
+      @apply flex-shrink-0 ml-auto inline-flex items-center justify-center w-5 h-5 text-xs font-semibold rounded-full bg-background-4 border-secondary;
+    }
+
+    a > span:first-child {
+      @apply truncate;
     }
 
     ul {


### PR DESCRIPTION
#### :tophat: What? Why?
During a QA of the association team this week, we detected that the Nightly components sidebar in a space were breaking the components counter when the title of the component is reeeeaaaalllyy long. 

This PR fixes it by making it multiline. 

#### :pushpin: Related Issues
 
- Fixes #16196 

#### Testing

0. Log in as admin
1. Create a component with a really long title, for instance: "Proposals with a really long title and not showing the counter"
2. Save it
3. See the component sidebar
4. (Before) the counter and the full title wasn't visible
5. (After) the counter and the full title is visible 

### :camera: Screenshots

#### Before
<img width="812" height="586" alt="image" src="https://github.com/user-attachments/assets/6e4adc7b-a2f7-4604-84be-ecab9b61a934" />


#### After

<img width="1059" height="734" alt="image" src="https://github.com/user-attachments/assets/376d8b3e-192c-4110-95a6-98bbae79a97d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved sidebar menu layout: adjusted spacing and padding for clearer item presentation.
  * Enabled wrapping for sidebar item text to prevent overflow and improve readability.
  * Stabilized counter layout so item counters display consistently alongside labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->