### PR TITLE
Add a validation and increase the amounts for budgets

### DIFF
--- a/decidim-budgets/app/forms/decidim/budgets/admin/budget_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/budget_form.rb
@@ -16,7 +16,7 @@ module Decidim
 
         validates :title, translatable_presence: true
         validates :weight, numericality: { greater_than_or_equal_to: 0 }
-        validates :total_budget, numericality: { greater_than: 0 }
+        validates :total_budget, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 9_223_372_036_854_775_807 }
       end
     end
   end

--- a/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
+++ b/decidim-budgets/app/forms/decidim/budgets/admin/project_form.rb
@@ -26,7 +26,7 @@ module Decidim
 
         validates :title, translatable_presence: true
         validates :description, translatable_presence: true
-        validates :budget_amount, presence: true, numericality: { greater_than: 0 }
+        validates :budget_amount, presence: true, numericality: { only_integer: true, greater_than: 0, less_than_or_equal_to: 9_223_372_036_854_775_807 }
         validates :address, geocoding: true, if: ->(form) { form.has_address? && !form.geocoded? }
 
         validate :notify_missing_attachment_if_errored

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -11,4 +11,3 @@ class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
     change_column :decidim_budgets_projects, :budget_amount, :integer
   end
 end
-end

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
+  def change
+    change_column :decidim_budgets_budgets, :total_budget, :bigint
+    change_column :decidim_budgets_projects, :budget_amount, :bigint
+  end
+end

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -9,12 +9,12 @@ class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
   def down
     budget_overflow = select_value(<<~SQL.squish)
       SELECT 1 FROM decidim_budgets_budgets
-      WHERE total_budget > 2147483647
+      WHERE total_budget > 2147483647 OR total_budget < -2147483648
       LIMIT 1
     SQL
     project_overflow = select_value(<<~SQL.squish)
       SELECT 1 FROM decidim_budgets_projects
-      WHERE budget_amount > 2147483647
+      WHERE budget_amount > 2147483647 OR budget_amount < -2147483648
       LIMIT 1
     SQL
 

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -18,9 +18,7 @@ class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
       LIMIT 1
     SQL
 
-    if budget_overflow || project_overflow
-      raise ActiveRecord::IrreversibleMigration, "Cannot safely convert bigint budgets back to integer: out-of-range values exist"
-    end
+    raise ActiveRecord::IrreversibleMigration, "Cannot safely convert bigint budgets back to integer: out-of-range values exist" if budget_overflow || project_overflow
 
     change_column :decidim_budgets_budgets, :total_budget, :integer
     change_column :decidim_budgets_projects, :budget_amount, :integer

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
-  def change
+  def up
     change_column :decidim_budgets_budgets, :total_budget, :bigint
     change_column :decidim_budgets_projects, :budget_amount, :bigint
   end
+
+  def down
+    change_column :decidim_budgets_budgets, :total_budget, :integer
+    change_column :decidim_budgets_projects, :budget_amount, :integer
+  end
+end
 end

--- a/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
+++ b/decidim-budgets/db/migrate/20250912110213_change_budget_columns_to_bigint.rb
@@ -7,6 +7,21 @@ class ChangeBudgetColumnsToBigint < ActiveRecord::Migration[7.1]
   end
 
   def down
+    budget_overflow = select_value(<<~SQL.squish)
+      SELECT 1 FROM decidim_budgets_budgets
+      WHERE total_budget > 2147483647
+      LIMIT 1
+    SQL
+    project_overflow = select_value(<<~SQL.squish)
+      SELECT 1 FROM decidim_budgets_projects
+      WHERE budget_amount > 2147483647
+      LIMIT 1
+    SQL
+
+    if budget_overflow || project_overflow
+      raise ActiveRecord::IrreversibleMigration, "Cannot safely convert bigint budgets back to integer: out-of-range values exist"
+    end
+
     change_column :decidim_budgets_budgets, :total_budget, :integer
     change_column :decidim_budgets_projects, :budget_amount, :integer
   end

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/budget_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/budget_form_spec.rb
@@ -53,4 +53,22 @@ describe Decidim::Budgets::Admin::BudgetForm do
 
     it { is_expected.not_to be_valid }
   end
+
+  describe "when total_budget is negative" do
+    let(:total_budget) { -1 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when total_budget is too large" do
+    let(:total_budget) { 9_223_372_036_854_775_808 }
+
+    it { is_expected.not_to be_valid }
+  end
+
+  describe "when total_budget is at the maximum allowed value" do
+    let(:total_budget) { 9_223_372_036_854_775_807 }
+
+    it { is_expected.to be_valid }
+  end
 end

--- a/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
+++ b/decidim-budgets/spec/forms/decidim/budgets/admin/project_form_spec.rb
@@ -100,6 +100,24 @@ module Decidim::Budgets
       it { is_expected.not_to be_valid }
     end
 
+    describe "when budget_amount is negative" do
+      let(:budget_amount) { -1 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when budget_amount is too large" do
+      let(:budget_amount) { 9_223_372_036_854_775_808 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when budget_amount is at the maximum allowed value" do
+      let(:budget_amount) { 9_223_372_036_854_775_807 }
+
+      it { is_expected.to be_valid }
+    end
+
     context "with proposals" do
       subject { described_class.from_model(project).with_context(context) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

If you add a really big number in budgets' amounts, you have a 500 error. 

The problem is that we don't have validations there, so this PR adds them (both at the budgets and the projects levels). 

On the other hand, I noticed that with the current column type (`int`) the maximum number is "just" `2147483647`.

This looks like a lot (`2_147_483_647` EUR is lots of moneys!!) but it would depend in the currency: in JPY (japans' yen) it is "only" 11M EUR, and taking into account that the [whole PB in Paris was nearly 100M EUR](https://www.participatorybudgeting.org/pbparis/), I prefer to be optimistic with this number 😄 

So, I propose to also change this column type to `bigint`, so the number is 9_223_372_036_854_775_807. Converting this from JPY to EUR would be 49 trillion EUR, so that will not be problem (for now!)

#### :pushpin: Related Issues
 
- Fixes #15018

#### Testing

0. Sign in as admin
1. Create or edit a budget or a project and change the amount to 214748364711111111111111111111111 
2. (Before the patch) See an exception
3. (After the patch) See a validation error

#### Stacktrace

```
ActiveModel::RangeError (2147483647111111 is out of range for ActiveModel::Type::Integer with limit 4 bytes):

activemodel (7.2.3) lib/active_model/type/integer.rb:95:in 'ActiveModel::Type::Integer#ensure_in_range'
activemodel (7.2.3) lib/active_model/type/integer.rb:71:in 'ActiveModel::Type::Integer#serialize_cast_value'
activemodel (7.2.3) lib/active_model/type/serialize_cast_value.rb:31:in 'ActiveModel::Type::SerializeCastValue.serialize'
activemodel (7.2.3) lib/active_model/attribute.rb:208:in 'ActiveModel::Attribute::FromUser#_value_for_database'
activemodel (7.2.3) lib/active_model/attribute.rb:57:in 'ActiveModel::Attribute#value_for_database'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/quoting.rb:227:in 'block in ActiveRecord::ConnectionAdapters::Quoting#type_casted_binds'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/quoting.rb:225:in 'Array#map'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/quoting.rb:225:in 'ActiveRecord::ConnectionAdapters::Quoting#type_casted_binds'
activerecord (7.2.3) lib/active_record/connection_adapters/postgresql_adapter.rb:896:in 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#exec_no_cache'
activerecord (7.2.3) lib/active_record/connection_adapters/postgresql_adapter.rb:877:in 'ActiveRecord::ConnectionAdapters::PostgreSQLAdapter#execute_and_clear'
activerecord (7.2.3) lib/active_record/connection_adapters/postgresql/database_statements.rb:79:in 'ActiveRecord::ConnectionAdapters::PostgreSQL::DatabaseStatements#exec_delete'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:208:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#update'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/query_cache.rb:27:in 'ActiveRecord::ConnectionAdapters::AbstractAdapter#update'
activerecord (7.2.3) lib/active_record/persistence.rb:280:in 'block in ActiveRecord::Persistence::ClassMethods#_update_record'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/persistence.rb:279:in 'ActiveRecord::Persistence::ClassMethods#_update_record'
activerecord (7.2.3) lib/active_record/persistence.rb:887:in 'ActiveRecord::Persistence#_update_row'
activerecord (7.2.3) lib/active_record/locking/optimistic.rb:93:in 'ActiveRecord::Locking::Optimistic#_update_row'
activerecord (7.2.3) lib/active_record/persistence.rb:909:in 'ActiveRecord::Persistence#_update_record'
activerecord (7.2.3) lib/active_record/attribute_methods/dirty.rb:234:in 'ActiveRecord::AttributeMethods::Dirty#_update_record'
activerecord (7.2.3) lib/active_record/callbacks.rb:449:in 'block (2 levels) in ActiveRecord::Callbacks#_update_record'
activerecord (7.2.3) lib/active_record/timestamp.rb:140:in 'ActiveRecord::Timestamp#record_update_timestamps'
activerecord (7.2.3) lib/active_record/callbacks.rb:449:in 'block in ActiveRecord::Callbacks#_update_record'
activesupport (7.2.3) lib/active_support/callbacks.rb:110:in 'ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.3) lib/active_support/callbacks.rb:914:in 'ActiveRecord::Base#_run_update_callbacks'
activerecord (7.2.3) lib/active_record/callbacks.rb:449:in 'ActiveRecord::Callbacks#_update_record'
activerecord (7.2.3) lib/active_record/timestamp.rb:122:in 'ActiveRecord::Timestamp#_update_record'
activerecord (7.2.3) lib/active_record/persistence.rb:896:in 'ActiveRecord::Persistence#create_or_update'
activerecord (7.2.3) lib/active_record/callbacks.rb:441:in 'block in ActiveRecord::Callbacks#create_or_update'
activesupport (7.2.3) lib/active_support/callbacks.rb:121:in 'block in ActiveSupport::Callbacks#run_callbacks'
activerecord (7.2.3) lib/active_record/autosave_association.rb:372:in 'ActiveRecord::AutosaveAssociation#around_save_collection_association'
activesupport (7.2.3) lib/active_support/callbacks.rb:130:in 'block in ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.3) lib/active_support/callbacks.rb:141:in 'ActiveSupport::Callbacks#run_callbacks'
activesupport (7.2.3) lib/active_support/callbacks.rb:914:in 'ActiveRecord::Base#_run_save_callbacks'
activerecord (7.2.3) lib/active_record/callbacks.rb:441:in 'ActiveRecord::Callbacks#create_or_update'
activerecord (7.2.3) lib/active_record/timestamp.rb:127:in 'ActiveRecord::Timestamp#create_or_update'
activerecord (7.2.3) lib/active_record/persistence.rb:426:in 'ActiveRecord::Persistence#save!'
activerecord (7.2.3) lib/active_record/validations.rb:54:in 'ActiveRecord::Validations#save!'
activerecord (7.2.3) lib/active_record/transactions.rb:366:in 'block in ActiveRecord::Transactions#save!'
activerecord (7.2.3) lib/active_record/transactions.rb:418:in 'block (2 levels) in ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:414:in 'block in ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:410:in 'ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/transactions.rb:366:in 'ActiveRecord::Transactions#save!'
activerecord (7.2.3) lib/active_record/suppressor.rb:56:in 'ActiveRecord::Suppressor#save!'
activerecord (7.2.3) lib/active_record/persistence.rb:581:in 'block in ActiveRecord::Persistence#update!'
activerecord (7.2.3) lib/active_record/transactions.rb:418:in 'block (2 levels) in ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:414:in 'block in ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
activerecord (7.2.3) lib/active_record/connection_handling.rb:298:in 'ActiveRecord::ConnectionHandling#with_connection'
activerecord (7.2.3) lib/active_record/transactions.rb:410:in 'ActiveRecord::Transactions#with_transaction_returning_status'
activerecord (7.2.3) lib/active_record/persistence.rb:579:in 'ActiveRecord::Persistence#update!'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:95:in 'block in Decidim::Traceability#update!'
/workspaces/decidim/decidim-core/app/services/decidim/traceability.rb:64:in 'block (2 levels) in Decidim::Traceability#perform_action!'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/database_statements.rb:359:in 'ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction'
activerecord (7.2.3) lib/active_record/transactions.rb:234:in 'block in ActiveRecord::Transactions::ClassMethods#transaction'
activerecord (7.2.3) lib/active_record/connection_adapters/abstract/connection_pool.rb:425:in 'ActiveRecord::ConnectionAdapters::ConnectionPool#with_connection'
```

### :camera: Screenshots

<img width="1774" height="970" alt="image" src="https://github.com/user-attachments/assets/3b59d19c-c79f-4eec-8728-e7689c3e8c64" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Budget fields now require positive whole numbers and are capped at the 64-bit signed integer maximum to prevent invalid or excessively large entries.

* **Chores**
  * Database integer columns for budget fields converted to support larger values with safeguards for safe rollback.

* **Tests**
  * Added boundary tests for negative, zero, maximum, and out-of-range budget values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->