### PR TITLE
Fix for editing a meeting page from related process

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
@@ -43,7 +43,7 @@
   <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.meetings") %>">
     <% if is_linked %>
       <%= t("index.linked_meeting_warning_html", href: Decidim::ResourceLocatorPresenter.new(meeting).edit, name: present(meeting).space_title, scope: "decidim.meetings.admin.meetings") %>
-  <% else %>
+    <% else %>
       <%= render partial: "decidim/meetings/admin/meetings/meeting_actions", locals: { meeting:, view: } %>
     <% end %>
   </td>

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meeting-tr.html.erb
@@ -3,7 +3,7 @@
 <tr data-id="<%= meeting.id %>">
   <td class="!text-left" data-label="<%= t("models.meeting.fields.title", scope: "decidim.meetings") %>">
     <% if allowed_to? :update, :meeting, meeting: meeting %>
-      <%= link_to present(meeting).title(html_escape: true), edit_meeting_path(meeting) %>
+      <%= link_to present(meeting).title(html_escape: true), Decidim::ResourceLocatorPresenter.new(meeting).edit %>
     <% else %>
       <%= present(meeting).title(html_escape: true) %><br>
     <% end %>
@@ -42,8 +42,8 @@
 
   <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.meetings") %>">
     <% if is_linked %>
-      <%= t("index.linked_meeting_warning_html", href: edit_meeting_path(meeting), name: present(meeting).space_title, scope: "decidim.meetings.admin.meetings") %>
-    <% else %>
+      <%= t("index.linked_meeting_warning_html", href: Decidim::ResourceLocatorPresenter.new(meeting).edit, name: present(meeting).space_title, scope: "decidim.meetings.admin.meetings") %>
+  <% else %>
       <%= render partial: "decidim/meetings/admin/meetings/meeting_actions", locals: { meeting:, view: } %>
     <% end %>
   </td>

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
@@ -23,6 +23,21 @@ describe "Admin manages meetings" do
       expect(page).to have_css("tbody tr:first-child", text: Decidim::Meetings::MeetingPresenter.new(other_meeting).title)
       expect(page).to have_css("tbody tr:last-child", text: Decidim::Meetings::MeetingPresenter.new(meeting).title)
     end
+
+    it "redirects to the proper edit meeting page, outside the linked meeting" do
+      expect(resource_locator(meeting).admin_index).to include(current_path)
+
+      within "tr", text: Decidim::Meetings::MeetingPresenter.new(other_meeting).title do
+        expect(page).to have_content("This meeting must be edited from")
+        click_on translated(other_participatory_space.title)
+      end
+
+      expect(page).to have_no_content("You are not authorized to perform this action.")
+      expect(page).to have_current_path(resource_locator(other_meeting).edit)
+      click_on "Update"
+
+      expect(page).to have_current_path(resource_locator(other_meeting).admin_index)
+    end
   end
 
   describe "linking a meeting" do
@@ -44,6 +59,7 @@ describe "Admin manages meetings" do
 
       expect do
         click_on "Update"
+        sleep 1
       end.to change { meeting.meeting_links.count }.by(1)
     end
   end

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_links_spec.rb
@@ -32,7 +32,6 @@ describe "Admin manages meetings" do
         click_on translated(other_participatory_space.title)
       end
 
-      expect(page).to have_no_content("You are not authorized to perform this action.")
       expect(page).to have_current_path(resource_locator(other_meeting).edit)
       click_on "Update"
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am fixing the edit resource link for linked meetings.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #16089

#### Testing
1. Login as Admin 
2. In Space A, create Meeting A
3. Link Meeting A to Space B using MeetingLink (so Meeting A refers to Space B).
4. Visit the Space B 
5. See the linked meeting
6. Click the meeting name / Space name 
7. **Before**: You get a "You are not authorized ... "
8. **After**: You are able to edit the meeting (being redirected to the other space).

### :camera: Screenshots

<img width="1408" height="183" alt="image" src="https://github.com/user-attachments/assets/b125ae8a-54a1-4981-bf97-7c9cf0ccbf42" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated how meeting edit links are generated to ensure consistent, reliable navigation from meeting rows and warning notices.

* **Tests**
  * Added a system test confirming linked-meeting navigation, edit flow, and return to the admin meetings index after updates (includes handling asynchronous update timing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->