### PR TITLE
Fix count of valid questions types in survey

### DIFF
--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -48,6 +48,11 @@ module Decidim
         Decidim::Forms::QuestionnaireParticipants.new(self).count_participants
       end
 
+      # Public: Returns only the actual question types (excludes separators and title_and_description)
+      def question_types
+        questions.not_separator.not_title_and_description
+      end
+
       private
 
       # salt is used to generate secure hash in anonymous responses

--- a/decidim-forms/spec/models/decidim/forms/question_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/question_spec.rb
@@ -67,6 +67,32 @@ module Decidim
             expect(subject.class.not_conditioned).not_to include(question_conditioned)
           end
         end
+
+        describe "#not_separator" do
+          let(:question_separator) { create(:questionnaire_question, questionnaire:, question_type: "separator") }
+          let(:question_regular) { create(:questionnaire_question, questionnaire:, question_type: "short_response") }
+
+          it "excludes separator questions" do
+            expect(subject.class.not_separator).not_to include(question_separator)
+          end
+
+          it "includes regular questions" do
+            expect(subject.class.not_separator).to include(question_regular)
+          end
+        end
+
+        describe "#not_title_and_description" do
+          let(:question_title_desc) { create(:questionnaire_question, questionnaire:, question_type: "title_and_description") }
+          let(:question_regular) { create(:questionnaire_question, questionnaire:, question_type: "short_response") }
+
+          it "excludes title_and_description questions" do
+            expect(subject.class.not_title_and_description).not_to include(question_title_desc)
+          end
+
+          it "includes regular questions" do
+            expect(subject.class.not_title_and_description).to include(question_regular)
+          end
+        end
       end
 
       describe ".log_presenter_class_for" do

--- a/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
@@ -93,6 +93,28 @@ module Decidim
           end
         end
       end
+
+      describe "#question_types" do
+        let!(:question_separator) { create(:questionnaire_question, questionnaire:, question_type: "separator") }
+        let!(:question_title_desc) { create(:questionnaire_question, questionnaire:, question_type: "title_and_description") }
+        let!(:question_short_answer) { create(:questionnaire_question, questionnaire:, question_type: "short_response") }
+
+        it "returns only actual question types" do
+          expect(subject.question_types).to include(question_short_answer)
+        end
+
+        it "does not include separator questions" do
+          expect(subject.question_types).not_to include(question_separator)
+        end
+
+        it "does not include title_and_description questions" do
+          expect(subject.question_types).not_to include(question_title_desc)
+        end
+
+        it "returns the correct count" do
+          expect(subject.question_types.size).to eq(1)
+        end
+      end
     end
   end
 end

--- a/decidim-surveys/app/cells/decidim/surveys/survey_card_metadata_cell.rb
+++ b/decidim-surveys/app/cells/decidim/surveys/survey_card_metadata_cell.rb
@@ -31,7 +31,7 @@ module Decidim
       end
 
       def questions_count_item
-        text = "#{survey.questionnaire.questions.not_separator.size} #{t("questions", scope: "decidim.surveys.surveys.show")}"
+        text = "#{survey.questionnaire.question_types.size} #{t("questions", scope: "decidim.surveys.surveys.show")}"
 
         {
           text:,

--- a/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/surveys/index.html.erb
@@ -26,7 +26,7 @@
               <%= link_to decidim_sanitize_translated(survey.title), edit_survey_path(survey) %>
             </td>
             <td data-label="<%= t("models.survey.fields.questions", scope: "decidim.surveys") %>">
-              <%= survey.questionnaire.questions.not_separator.size %>
+              <%= survey.questionnaire.question_types.size %>
             </td>
             <td data-label="<%= t("models.survey.fields.responses", scope: "decidim.surveys") %>">
               <%= survey.questionnaire.count_participants %>

--- a/decidim-surveys/spec/cells/decidim/surveys/survey_card_metadata_cell_spec.rb
+++ b/decidim-surveys/spec/cells/decidim/surveys/survey_card_metadata_cell_spec.rb
@@ -47,7 +47,8 @@ module Decidim::Surveys
         questions_count = survey.questionnaire.question_types.size
         expect(subject.to_s).to include("#{questions_count} #{I18n.t("questions", scope: "decidim.surveys.surveys.show")}")
         expect(subject.to_s).to include("survey-line")
-        expect(questions_count).to eq(1)
+        # 3 from the factory + 1 question_regular from this spec
+        expect(questions_count).to eq(4)
       end
     end
   end

--- a/decidim-surveys/spec/cells/decidim/surveys/survey_card_metadata_cell_spec.rb
+++ b/decidim-surveys/spec/cells/decidim/surveys/survey_card_metadata_cell_spec.rb
@@ -39,10 +39,15 @@ module Decidim::Surveys
     end
 
     describe "questions_count_item" do
-      it "renders the correct number of questions and survey icon" do
-        questions_count = survey.questionnaire.questions.size
+      let!(:question_separator) { create(:questionnaire_question, questionnaire: survey.questionnaire, question_type: "separator") }
+      let!(:question_title_desc) { create(:questionnaire_question, questionnaire: survey.questionnaire, question_type: "title_and_description") }
+      let!(:question_regular) { create(:questionnaire_question, questionnaire: survey.questionnaire, question_type: "short_response") }
+
+      it "renders only the number of actual questions, excluding separators and title_and_description" do
+        questions_count = survey.questionnaire.question_types.size
         expect(subject.to_s).to include("#{questions_count} #{I18n.t("questions", scope: "decidim.surveys.surveys.show")}")
         expect(subject.to_s).to include("survey-line")
+        expect(questions_count).to eq(1)
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

When there's a question with "Separator" and "Title and description" elements, these are counted as questions in the surveys' admin table and in the frontend.

This PR fixes it by only counting the questions. 

#### :pushpin: Related Issues 

- Fixes https://github.com/decidim/decidim/issues/16200 

#### Testing

1. Sign in as admin
2. Create a question with 2 questions, 1 separator and 1 title and description
3. Save it 
4. Go to the index table in the admin
5. (Before) see that you have 3 questions
6. (After) see that you have 2 questions
7. Publish the survey
8. Go to the surveys list in the frontend
9. (Before) see that you have 3 questions
10. (After) see that you have 2 questions

### :camera: Screenshots

<img width="1850" height="996" alt="image" src="https://github.com/user-attachments/assets/f3cead89-3cf9-4ac3-baa4-015b4920c9d0" />

#### Before

<img width="1673" height="639" alt="image" src="https://github.com/user-attachments/assets/68c92732-2015-420d-9aee-2983c30946ae" />
<img width="1598" height="830" alt="image" src="https://github.com/user-attachments/assets/f7cad685-6139-40bb-9e27-166fff999d2c" />

#### After

<img width="1823" height="687" alt="image" src="https://github.com/user-attachments/assets/b5a0abe2-eda3-4b85-acc6-4a6f0d301f43" />
<img width="1773" height="726" alt="image" src="https://github.com/user-attachments/assets/ae7e7ac2-d638-4f40-ba40-f7e6d47968ff" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated question counts in survey displays and admin lists to exclude separator and title/description items, so counts reflect only actual questions.
* **Tests**
  * Added model and view specs to verify filtering logic and updated rendered count expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->