### PR TITLE
Avoid removing questions with "enter" key in surveys' admin

### DIFF
--- a/decidim-core/app/packs/src/decidim/confirm.js
+++ b/decidim-core/app/packs/src/decidim/confirm.js
@@ -169,7 +169,9 @@ export const initializeConfirm = () => {
     return handleDocumentEvent(ev, [
       Rails.linkClickSelector,
       Rails.buttonClickSelector,
-      Rails.formInputClickSelector
+      Rails.formInputClickSelector,
+      'button[data-confirm][type="button"]',
+      "form button[data-confirm]"
     ]);
   });
   document.addEventListener("change", (ev) => {
@@ -186,6 +188,11 @@ export const initializeConfirm = () => {
   document.addEventListener("turbo:load", function() {
     $(Rails.formInputClickSelector).on("click.confirm", (ev) => {
       handleConfirm(ev, getMatchingEventTarget(ev, Rails.formInputClickSelector));
+    });
+
+    // Handle button[type="button"] with data-confirm inside forms
+    $('button[data-confirm][type="button"]').on("click.confirm", (ev) => {
+      handleConfirm(ev, ev.currentTarget);
     });
   });
 };

--- a/decidim-core/app/packs/src/decidim/confirm.test.js
+++ b/decidim-core/app/packs/src/decidim/confirm.test.js
@@ -1,0 +1,225 @@
+/* global jest */
+
+jest.mock("src/decidim/refactor/moved/icon", () => () => "<svg></svg>");
+
+describe("Confirm dialog for button[type='button']", () => {
+  let mockRails = null;
+  let mockDecidim = null;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <div id="confirm-modal" style="display: none;">
+        <div data-dialog-title></div>
+        <div class="confirm-modal-icon"></div>
+        <div data-confirm-modal-content></div>
+        <button data-confirm-ok>Confirm</button>
+        <button data-confirm-cancel>Cancel</button>
+      </div>
+    `;
+
+    mockRails = {
+      linkClickSelector: "a[data-confirm]",
+      buttonClickSelector: "button[data-confirm]:not([form])",
+      formInputClickSelector: 'form button[type="submit"], form button:not([type])',
+      inputChangeSelector: "input[data-confirm], select[data-confirm]",
+      formSubmitSelector: "form[data-confirm]",
+      stopEverything: jest.fn(),
+      fire: jest.fn((el, event) => {
+        const evt = new CustomEvent(event);
+        el.dispatchEvent(evt);
+        return true;
+      }),
+      matches: function(element, selector) {
+        if (element instanceof Element) {
+          return element.matches(selector);
+        }
+        return false;
+      }
+    };
+
+    mockDecidim = {
+      currentDialogs: {
+        "confirm-modal": {
+          open: jest.fn(),
+          close: jest.fn()
+        }
+      }
+    };
+
+    window.Rails = mockRails;
+    window.Decidim = mockDecidim;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("selector matching for button[type='button'] with data-confirm", () => {
+    it("matches button[data-confirm][type='button'] selector", () => {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.setAttribute("data-confirm", "Are you sure?");
+
+      expect(button.matches('button[data-confirm][type="button"]')).toBe(true);
+    });
+
+    it("matches form button[data-confirm] selector", () => {
+      const form = document.createElement("form");
+      const button = document.createElement("button");
+      button.setAttribute("data-confirm", "Are you sure?");
+      form.appendChild(button);
+
+      expect(button.matches("form button[data-confirm]")).toBe(true);
+    });
+
+    it("does not match regular button without data-confirm", () => {
+      const button = document.createElement("button");
+      button.type = "button";
+
+      expect(button.matches('button[data-confirm][type="button"]')).toBe(false);
+    });
+
+    it("does not match button[type='submit'] with the type='button' selector", () => {
+      const button = document.createElement("button");
+      button.type = "submit";
+      button.setAttribute("data-confirm", "Are you sure?");
+
+      expect(button.matches('button[data-confirm][type="button"]')).toBe(false);
+    });
+
+    it("matches button[type='button'] inside form", () => {
+      document.body.innerHTML = `
+        <form>
+          <button type="button" data-confirm="Test message">Click me</button>
+        </form>
+      `;
+
+      const button = document.querySelector('button[type="button"]');
+      expect(button.matches('button[data-confirm][type="button"]')).toBe(true);
+      expect(button.matches("form button[data-confirm]")).toBe(true);
+    });
+
+    it("does not match button[type='button'] without data-confirm inside form", () => {
+      document.body.innerHTML = `
+        <form>
+          <button type="button">Click me</button>
+        </form>
+      `;
+
+      const button = document.querySelector('button[type="button"]');
+      expect(button.matches('button[data-confirm][type="button"]')).toBe(false);
+      expect(button.matches("form button[data-confirm]")).toBe(false);
+    });
+  });
+
+  describe("initializeConfirm - selectors registration", () => {
+    it("adds click event listener with proper selectors including button[type='button'] support", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+
+      initializeConfirm();
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith("click", expect.any(Function));
+    });
+
+    it("adds change event listener for input change selector", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+
+      initializeConfirm();
+
+      const changeHandlerCalls = addEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === "change"
+      );
+      expect(changeHandlerCalls.length).toBeGreaterThan(0);
+    });
+
+    it("adds submit event listener for form submit selector", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+
+      initializeConfirm();
+
+      const submitHandlerCalls = addEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === "submit"
+      );
+      expect(submitHandlerCalls.length).toBeGreaterThan(0);
+    });
+
+    it("adds turbo:load event listener for Foundation Abide compatibility", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      const addEventListenerSpy = jest.spyOn(document, "addEventListener");
+
+      initializeConfirm();
+
+      const turboLoadCalls = addEventListenerSpy.mock.calls.filter(
+        (call) => call[0] === "turbo:load"
+      );
+      expect(turboLoadCalls.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("handleDocumentEvent with button[type='button'] support", () => {
+    it("handles click on button[type='button'] with data-confirm and form attribute", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      document.body.innerHTML = `
+        <form id="my-form">
+          <button type="button" form="my-form" data-confirm="Are you sure?">Click me</button>
+        </form>
+      `;
+
+      const button = document.querySelector('button[type="button"]');
+      const openSpy = jest.spyOn(mockDecidim.currentDialogs["confirm-modal"], "open");
+
+      initializeConfirm();
+
+      button.click();
+
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it("handles click on button[type='button'] with data-confirm outside form", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      document.body.innerHTML = `
+        <button type="button" data-confirm="Are you sure?">Click me</button>
+      `;
+
+      const button = document.querySelector('button[type="button"]');
+      const openSpy = jest.spyOn(mockDecidim.currentDialogs["confirm-modal"], "open");
+
+      initializeConfirm();
+
+      button.click();
+
+      expect(openSpy).toHaveBeenCalled();
+    });
+
+    it("does not trigger confirm for button without data-confirm attribute", async () => {
+      const { initializeConfirm } = await import("src/decidim/confirm.js");
+
+      document.body.innerHTML = `
+        <form>
+          <button type="button">Click me</button>
+        </form>
+      `;
+
+      const button = document.querySelector('button[type="button"]');
+      const openSpy = jest.spyOn(mockDecidim.currentDialogs["confirm-modal"], "open");
+
+      initializeConfirm();
+
+      button.click();
+
+      expect(openSpy).not.toHaveBeenCalled();
+    });
+  });
+});
+
+/* dummy end */

--- a/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/questions/_question.html.erb
@@ -25,7 +25,7 @@
           </button>
 
           <% if editable %>
-            <button class="button button__xs button__transparent-secondary small alert remove-question button--title" data-confirm="<%= t("remove_question_confirm", scope: "decidim.elections.admin.questions.edit_questions") %>">
+            <button type="button" class="button button__xs button__transparent-secondary small alert remove-question button--title" data-confirm="<%= t("remove_question_confirm", scope: "decidim.elections.admin.questions.edit_questions") %>">
               <%= icon "delete-bin-line" %>
               <span class="hidden md:block"><%= t("remove", scope: "decidim.forms.admin.questionnaires.question") %></span>
             </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_question.html.erb
@@ -23,7 +23,7 @@
           </button>
 
           <% if editable %>
-            <button class="button button__xs button__transparent-secondary small alert remove-question button--title">
+            <button type="button" class="button button__xs button__transparent-secondary small alert remove-question button--title">
               <%= icon("delete-bin-line") %>
               <span class="hidden md:block"><%= t(".remove") %></span>
             </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_separator.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_separator.html.erb
@@ -12,7 +12,7 @@
 
       <div class="flex flex-row-reverse items-center gap-x-4 ml-auto">
         <% if editable %>
-          <button class="button button__xs button__transparent button__transparent-secondary small alert remove-question button--title">
+          <button type="button" class="button button__xs button__transparent button__transparent-secondary small alert remove-question button--title">
             <%= icon("delete-bin-line") %>
             <span class="hidden md:block"><%= t(".remove") %></span>
           </button>

--- a/decidim-forms/app/views/decidim/forms/admin/questionnaires/_title_and_description.html.erb
+++ b/decidim-forms/app/views/decidim/forms/admin/questionnaires/_title_and_description.html.erb
@@ -23,7 +23,7 @@
           </button>
 
           <% if editable %>
-            <button class="button button__xs button__transparent button__transparent-secondary small alert remove-question button--title">
+            <button type="button" class="button button__xs button__transparent button__transparent-secondary small alert remove-question button--title">
               <%= icon("delete-bin-line") %>
               <span class="hidden md:block"><%= t(".remove") %></span>
             </button>

--- a/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/poll/_question.html.erb
@@ -25,7 +25,7 @@
           </button>
 
           <% if editable %>
-            <button class="button button__xs button__transparent-secondary small alert remove-question button--title">
+            <button type="button" class="button button__xs button__transparent-secondary small alert remove-question button--title">
               <span class="hidden md:block"><%= t("remove", scope: "decidim.forms.admin.questionnaires.question") %></span>
             </button>
           <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

While working on #16254 and #16235, I noticed a mini-bug: when you're editing a surveys' questionnaire, and you're in an input field, if you press the "Enter" key, the first question is removed. 

This PR prevents it by adding the `type=button` attribute to the button element.

#### Testing

1. Sign in as admin
2. Edit a surveys' questionnaire
3. Press enter in any question in the first input
4. See that the first question isn't removed

### :camera: Screenshots

<img width="1639" height="983" alt="image" src="https://github.com/user-attachments/assets/cd00def4-523a-4315-b285-bcb346292343" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured "remove-question" buttons in admin interfaces no longer trigger unintended form submissions and correctly behave as standard buttons; confirmation prompts work for these buttons.

* **Tests**
  * Added tests validating confirmation dialog behavior for non-submitting buttons (including inside forms) to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->