### PR TITLE
Change header breadcrumb color to match primary color

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -420,7 +420,7 @@ header {
       @apply block lg:hidden w-full z-20;
 
       &__dropdown-trigger {
-        @apply flex items-center justify-between text-black;
+        @apply flex items-center justify-between text-white;
 
         svg {
           @apply w-6 h-6 fill-current;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -323,11 +323,11 @@ header {
     @apply container h-full flex justify-between items-center sm:relative last-of-type:[&>svg]:hidden;
 
     &__container {
-      @apply bg-white relative h-14 flex justify-between;
+      @apply bg-primary relative h-14 flex justify-between;
     }
 
     &__breadcrumb-desktop {
-      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-black gap-x-2;
+      @apply hidden lg:flex justify-between items-center [&>*]:text-md [&>*]:text-white gap-x-2;
 
       .no-interactive {
         @apply font-normal px-0;

--- a/decidim-core/app/packs/stylesheets/decidim/_layout.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_layout.scss
@@ -6,7 +6,7 @@
   }
 
   [data-content] {
-    @apply relative flex flex-col flex-1 border-t-neutral-100 border-t;
+    @apply relative flex flex-col flex-1;
   }
 }
 

--- a/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_follow_space_menu_bar_button.html.erb
@@ -1,7 +1,7 @@
 <%= content_for :participatory_space_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary") %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent") %>
 <% end %>
 
 <%= content_for :participatory_space_mobile_actions do %>
-  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent-secondary", mobile: true) %>
+  <%= cell("decidim/follow_button", participatory_space, button_classes: "button button__sm button__transparent", mobile: true) %>
 <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
@@ -5,7 +5,7 @@
   <% next if item.blank? %>
 
   <% item_label = translated_attribute(item[:label]) %>
-  <span aria-hidden="true"><%= icon "arrow-right-s-line" %></span>
+  <span aria-hidden="true"><%= icon "arrow-right-s-line", class: "fill-white" %></span>
   <%= link_to_if(item[:url].present? && !is_active_link?(item[:url], :exclusive), item_label, item[:url], class: "menu-bar__breadcrumb-desktop__dropdown-wrapper menu-bar__breadcrumb-desktop__dropdown-trigger", "aria-current": (item[:active] ? "page" : nil)) do %>
     <%# This block is executed if the condition is false %>
     <%= content_tag :span, item_label, class: "menu-bar__breadcrumb-desktop__dropdown-trigger no-interactive", tabindex: "0", "aria-current": (item[:active] ? "page" : nil) %>


### PR DESCRIPTION
#### :tophat: What? Why?

After the changes on the breadcrumb, the next mini-change is to do the background color match the primary color. This PR does that.

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/16280 

#### Testing

1. Go to a page with breadcrumb
2. See the color change 

### :camera: Screenshots

#### Before

<img width="1846" height="631" alt="image" src="https://github.com/user-attachments/assets/570978a6-c33c-4f47-9092-f1104445e49d" />
<img width="522" height="644" alt="image" src="https://github.com/user-attachments/assets/93f810d4-a57e-4f17-bab1-c49abe4a5c1e" />

#### After
<img width="1852" height="820" alt="image" src="https://github.com/user-attachments/assets/dd781547-4f82-4cb0-99a4-80cdda126ba1" />
<img width="576" height="654" alt="image" src="https://github.com/user-attachments/assets/94e6b071-b808-41dd-a1f9-2afe7b783b99" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated header background color and breadcrumb text styling for improved visual consistency
  * Refined button appearance in navigation menu
  * Enhanced icon styling in breadcrumb navigation
  * Removed top border from main content area for cleaner layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->