### PR TITLE
Fix showing end dates when meetings have multiple dates

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -138,7 +138,15 @@
     &-month,
     &-day,
     &-year {
-      @apply inline-flex items-center justify-evenly empty:[&>div]:hidden;
+      @apply inline-flex items-center justify-center empty:[&>div]:hidden;
+    }
+
+    &--wide {
+      @apply w-24;
+    }
+
+    &-separator {
+      @apply mx-2 font-normal text-sm;
     }
   }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_cards.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cards.scss
@@ -116,7 +116,7 @@
   }
 
   &__calendar {
-    @apply w-14 flex flex-col justify-start rounded overflow-hidden bg-background text-center;
+    @apply w-20 flex flex-col justify-start rounded overflow-hidden bg-background text-center;
 
     /* overwrite defaults */
     &-list__reset {
@@ -132,7 +132,7 @@
     }
 
     &-year {
-      @apply text-black text-xs;
+      @apply text-black text-xs mb-0.5;
     }
 
     &-month,
@@ -141,12 +141,12 @@
       @apply inline-flex items-center justify-center empty:[&>div]:hidden;
     }
 
-    &--wide {
-      @apply w-24;
-    }
-
     &-separator {
       @apply mx-2 font-normal text-sm;
+    }
+
+    .card__list-content {
+      @apply mt-0.5;
     }
   }
 

--- a/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/dates_and_map/show.erb
@@ -1,14 +1,18 @@
 <div class="meeting__calendar-container">
   <div class="meeting__calendar meeting__calendar__lg">
     <div class="meeting__calendar-month mb-4">
-      <p><%= l(start_time, format: !same_month? ? "%b" : "%B") %></p>
-      <p class="meeting__calendar-separator"><%= "-" if !same_month? %></p>
-      <p><%= l(end_time, format: "%b") if !same_month? %></p>
+      <p><%= l(start_time, format: same_month? ? "%B" : "%b") %></p>
+      <% unless same_month? %>
+        <p class="meeting__calendar-separator">-</p>
+        <p><%= l(end_time, format: "%b") %></p>
+      <% end %>
     </div>
     <div class="meeting__calendar-day">
       <p><%= l(start_time, format: "%d") %></p>
-      <p class="meeting__calendar-separator"><%= "-" if !same_day? || !same_month? %></p>
-      <p><%= l(end_time, format: "%d") if !same_day? || !same_month? %></p>
+      <% unless same_day? && same_month? %>
+        <p class="meeting__calendar-separator">-</p>
+        <p><%= l(end_time, format: "%d") %></p>
+      <% end %>
     </div>
     <div class="meeting__calendar-year">
       <p><%= year %></p>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
@@ -1,5 +1,19 @@
-<time class="card__calendar" datetime="<%= meeting.start_time.iso8601 %>">
-  <span class="card__calendar-month"><%= l(meeting.start_time, format: "%b") %></span>
-  <span class="card__calendar-day"><%= l(meeting.start_time, format: "%d") %></span>
-  <span class="card__calendar-year"><%= l(meeting.start_time, format: "%Y") %></span>
+<time class="card__calendar <%= "card__calendar--wide" unless same_day? && same_month? %>" datetime="<%= meeting.start_time.iso8601 %>">
+  <span class="card__calendar-month">
+    <p><%= l(meeting.start_time, format: same_month? ? "%B" : "%b") %></p>
+    <% unless same_month? %>
+      <p class="meeting__calendar-separator">-</p>
+      <p><%= l(meeting.end_time, format: "%b") %></p>
+    <% end %>
+  </span>
+  <span class="card__calendar-day">
+    <p><%= l(meeting.start_time, format: "%d") %></p>
+    <% unless same_day? && same_month? %>
+      <p class="card__calendar-separator">-</p>
+      <p><%= l(meeting.end_time, format: "%d") %></p>
+    <% end %>
+  </span>
+  <span class="card__calendar-year">
+    <p><%= l(meeting.start_time, format: "%Y") %></p>
+  </span>
 </time>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
@@ -2,7 +2,7 @@
   <span class="card__calendar-month">
     <p><%= l(meeting.start_time, format: same_month? ? "%B" : "%b") %></p>
     <% unless same_month? %>
-      <p class="meeting__calendar-separator">-</p>
+      <p class="card__calendar-separator">-</p>
       <p><%= l(meeting.end_time, format: "%b") %></p>
     <% end %>
   </span>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l/image.erb
@@ -1,4 +1,4 @@
-<time class="card__calendar <%= "card__calendar--wide" unless same_day? && same_month? %>" datetime="<%= meeting.start_time.iso8601 %>">
+<time class="card__calendar" datetime="<%= meeting.start_time.iso8601 %>">
   <span class="card__calendar-month">
     <p><%= l(meeting.start_time, format: same_month? ? "%B" : "%b") %></p>
     <% unless same_month? %>

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -39,13 +39,13 @@ module Decidim
       def same_month?
         return true if meeting.end_time.blank?
 
-        meeting.start_time.month == meeting.end_time.month
+        meeting.start_time.year == meeting.end_time.year && meeting.start_time.month == meeting.end_time.month
       end
 
       def same_day?
         return true if meeting.end_time.blank?
 
-        meeting.start_time.day == meeting.end_time.day
+        meeting.start_time.to_date == meeting.end_time.to_date
       end
 
       def metadata_cell

--- a/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
+++ b/decidim-meetings/app/cells/decidim/meetings/meeting_l_cell.rb
@@ -36,6 +36,18 @@ module Decidim
         @current_space ||= current_component.participatory_space
       end
 
+      def same_month?
+        return true if meeting.end_time.blank?
+
+        meeting.start_time.month == meeting.end_time.month
+      end
+
+      def same_day?
+        return true if meeting.end_time.blank?
+
+        meeting.start_time.day == meeting.end_time.day
+      end
+
       def metadata_cell
         "decidim/meetings/meeting_card_metadata"
       end

--- a/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
+++ b/decidim-meetings/app/packs/stylesheets/decidim/meetings/_item.scss
@@ -35,11 +35,11 @@
     &-month,
     &-day,
     &-year {
-      @apply inline-flex items-center justify-evenly empty:[&>p]:hidden;
+      @apply inline-flex items-center justify-center empty:[&>p]:hidden;
     }
 
     &-separator {
-      @apply mx-2 font-normal text-sm;
+      @apply mx-4 font-normal text-sm;
     }
 
     &__lg {

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -29,10 +29,6 @@ module Decidim::Meetings
         expect(subject).to have_css(".card__calendar-year", text: "2020")
       end
 
-      it "does not show wide calendar class" do
-        expect(subject).to have_no_css(".card__calendar--wide")
-      end
-
       it "does not show separator" do
         expect(subject).to have_no_css(".card__calendar-separator")
       end
@@ -55,10 +51,6 @@ module Decidim::Meetings
 
       it "does not show month separator" do
         expect(subject).to have_css(".card__calendar-month", text: "October")
-      end
-
-      it "shows wide calendar class" do
-        expect(subject).to have_css(".card__calendar--wide")
       end
     end
 
@@ -83,10 +75,6 @@ module Decidim::Meetings
 
       it "shows month separator" do
         expect(subject).to have_css(".card__calendar-separator")
-      end
-
-      it "shows wide calendar class" do
-        expect(subject).to have_css(".card__calendar--wide")
       end
     end
 

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -28,6 +28,82 @@ module Decidim::Meetings
       it "shows the start time's year" do
         expect(subject).to have_css(".card__calendar-year", text: "2020")
       end
+
+      it "does not show wide calendar class" do
+        expect(subject).not_to have_css(".card__calendar--wide")
+      end
+
+      it "does not show separator" do
+        expect(subject).not_to have_css(".meeting__calendar-separator")
+      end
+    end
+
+    context "when meeting spans multiple days in the same month" do
+      let!(:meeting) { create(:meeting, :published, start_time: Time.new(2020, 10, 15, 10, 0, 0, 0), end_time: Time.new(2020, 10, 17, 12, 0, 0, 0)) }
+
+      it "shows the start day" do
+        expect(subject).to have_css(".card__calendar-day", text: "15")
+      end
+
+      it "shows the end day" do
+        expect(subject).to have_css(".card__calendar-day", text: "17")
+      end
+
+      it "shows the separator" do
+        expect(subject).to have_css(".meeting__calendar-separator")
+      end
+
+      it "does not show month separator" do
+        expect(subject).to have_css(".card__calendar-month", text: "October")
+      end
+
+      it "shows wide calendar class" do
+        expect(subject).to have_css(".card__calendar--wide")
+      end
+    end
+
+    context "when meeting spans multiple months" do
+      let!(:meeting) { create(:meeting, :published, start_time: Time.new(2020, 10, 15, 10, 0, 0, 0), end_time: Time.new(2020, 11, 17, 12, 0, 0, 0)) }
+
+      it "shows the start month" do
+        expect(subject).to have_css(".card__calendar-month", text: "Oct")
+      end
+
+      it "shows the end month" do
+        expect(subject).to have_css(".card__calendar-month", text: "Nov")
+      end
+
+      it "shows the start day" do
+        expect(subject).to have_css(".card__calendar-day", text: "15")
+      end
+
+      it "shows the end day" do
+        expect(subject).to have_css(".card__calendar-day", text: "17")
+      end
+
+      it "shows month separator" do
+        expect(subject).to have_css(".meeting__calendar-separator")
+      end
+
+      it "shows wide calendar class" do
+        expect(subject).to have_css(".card__calendar--wide")
+      end
+    end
+
+    context "when meeting has no end time" do
+      let!(:meeting) { create(:meeting, :published, start_time: Time.new(2020, 10, 15, 10, 0, 0, 0), end_time: nil) }
+
+      it "shows the start time's month" do
+        expect(subject).to have_css(".card__calendar-month", text: "October")
+      end
+
+      it "shows the start time's day" do
+        expect(subject).to have_css(".card__calendar-day", text: "15")
+      end
+
+      it "does not show separator" do
+        expect(subject).not_to have_css(".meeting__calendar-separator")
+      end
     end
 
     context "when title contains special html entities" do

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -30,11 +30,11 @@ module Decidim::Meetings
       end
 
       it "does not show wide calendar class" do
-        expect(subject).not_to have_css(".card__calendar--wide")
+        expect(subject).to have_no_css(".card__calendar--wide")
       end
 
       it "does not show separator" do
-        expect(subject).not_to have_css(".meeting__calendar-separator")
+        expect(subject).to have_no_css(".meeting__calendar-separator")
       end
     end
 
@@ -102,7 +102,7 @@ module Decidim::Meetings
       end
 
       it "does not show separator" do
-        expect(subject).not_to have_css(".meeting__calendar-separator")
+        expect(subject).to have_no_css(".meeting__calendar-separator")
       end
     end
 

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -34,7 +34,7 @@ module Decidim::Meetings
       end
 
       it "does not show separator" do
-        expect(subject).to have_no_css(".meeting__calendar-separator")
+        expect(subject).to have_no_css(".card__calendar-separator")
       end
     end
 
@@ -50,7 +50,7 @@ module Decidim::Meetings
       end
 
       it "shows the separator" do
-        expect(subject).to have_css(".meeting__calendar-separator")
+        expect(subject).to have_css(".card__calendar-separator")
       end
 
       it "does not show month separator" do
@@ -82,7 +82,7 @@ module Decidim::Meetings
       end
 
       it "shows month separator" do
-        expect(subject).to have_css(".meeting__calendar-separator")
+        expect(subject).to have_css(".card__calendar-separator")
       end
 
       it "shows wide calendar class" do


### PR DESCRIPTION
#### :tophat: What? Why?

When a meeting has multiple dates (i.e. the end date doesn't match with the day/month of the start date), then we don't show the end date in the card view (like in the content blocks or in the index page).

This PR fixes this, and does two minor related changes:

- clean-up the logic used for this in the show page, as it was not idiomatic in my opinion (or saying it in another way, a bit ugly)
- make the margins/separations a bit less 

#### :pushpin: Related Issues

- Fixes #9801 

#### Testing

1. Scroll in the homepage with the "Upcoming meetings" content block (enabled by default in the seeds)
2. Go to http://localhost:3000/meetings/ 

### :camera: Screenshots

#### Before

<img width="801" height="529" alt="image" src="https://github.com/user-attachments/assets/1f06e852-7bef-46da-8a73-ba86dca1b100" />
<img width="764" height="831" alt="image" src="https://github.com/user-attachments/assets/506d4c22-136f-4afd-bfa4-696a24e14629" />
<img width="781" height="508" alt="image" src="https://github.com/user-attachments/assets/f0298244-2c11-4470-921d-de58cf7020b0" />

#### After

<img width="822" height="462" alt="image" src="https://github.com/user-attachments/assets/690f41a0-60d6-4f1e-a2ff-1d4bb97cbe16" />
<img width="802" height="914" alt="image" src="https://github.com/user-attachments/assets/76b4c37c-80ec-41d7-88a8-21f21477974f" />
<img width="832" height="513" alt="image" src="https://github.com/user-attachments/assets/3c475ac7-4f9e-410b-ad74-91f92dbd86b2" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter meeting date display: full month names when spanning months, abbreviated otherwise; end dates and separators shown only when different from starts; markup updated for clearer conditional rendering.

* **Style**
  * Calendar header made wider for readability; adjusted calendar alignment and separator spacing; tightened list card spacing.

* **Tests**
  * Added rendering tests for single-day, multi-day, cross-month, and open-ended meetings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->