### PR TITLE
Fix grandchildren navigation in assemblies

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.js.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/index.js.erb
@@ -6,7 +6,7 @@ $('[data-assembly-id="<%= parent_assembly_id %>"]').after(
 );
 
 // Dispatch the `ajax:loaded` event with the newly inserted element
-const insertedElement = $('[data-assembly-id="<%= parent_assembly_id %>"]').next()[0];
+var insertedElement = $('[data-assembly-id="<%= parent_assembly_id %>"]').next()[0];
 document.dispatchEvent(new CustomEvent("ajax:loaded", { detail: insertedElement }));
 
 var component = new window.Decidim.AdminAssembliesListComponent();

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -203,4 +203,61 @@ describe "Admin manages assemblies" do
       end
     end
   end
+
+  context "when navigating grandchild assemblies (3rd level)" do
+    let!(:grandmother_assembly) { create(:assembly, organization:) }
+    let!(:mother_assembly) { create(:assembly, organization:, parent: grandmother_assembly) }
+    let!(:child_assembly) { create(:assembly, :with_content_blocks, organization:, parent: mother_assembly) }
+    let(:assembly) { child_assembly }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit decidim_admin_assemblies.assemblies_path
+    end
+
+    describe "listing grandchild assemblies" do
+      it "expands both parent and grandparent assemblies to show child" do
+        expect(page).to have_no_content(translated(mother_assembly.title))
+        expect(page).to have_no_content(translated(child_assembly.title))
+
+        # Opens grandmother (1st level)
+        within "tr", text: translated(grandmother_assembly.title) do
+          find("a[data-arrow-down]").click
+        end
+
+        expect(page).to have_content(translated(mother_assembly.title))
+        expect(page).to have_no_content(translated(child_assembly.title))
+
+        # Opens mother (2nd level)
+        within "tr", text: translated(mother_assembly.title) do
+          find("a[data-arrow-down]").click
+        end
+
+        expect(page).to have_content(translated(child_assembly.title))
+
+        # Opens actions dropdown in child
+        find("button[data-target='actions-assembly-#{child_assembly.id}']").click
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Share link")
+        expect(page).to have_content("Export")
+
+        # Collapse mother (2nd level)
+        within "tr", text: translated(mother_assembly.title) do
+          find("a[data-arrow-up]").click
+        end
+
+        expect(page).to have_no_content(translated(child_assembly.title))
+        expect(page).to have_content(translated(mother_assembly.title))
+
+        # Collapse grandmother (1st level)
+        within "tr", text: translated(grandmother_assembly.title) do
+          find("a[data-arrow-up]").click
+        end
+
+        expect(page).to have_no_content(translated(mother_assembly.title))
+        expect(page).to have_no_content(translated(child_assembly.title))
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

We have a problem with Assemblies navigation in admin panel, where if an assembly has grandchildren, they can't be seen in the main page.

This PR fixes this bug.

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/14805 (as that's where I introduced this bug)
- Fixes #16294 

#### Testing

1. Define a three assemblies: One grandmother, one mother and one child
```
* Grandmother assembly
  * Mother assembly
    * Child assembly
```
2. Go to https://localhost:3000/admin/assemblies
3. Click in the arrow next to the Grandmother
4. Click in the arrow next to the Mother
5. See that the Child appears

### :camera: Screenshots

#### Before

<img width="892" height="1003" alt="image" src="https://github.com/user-attachments/assets/6e87e628-65ec-438f-8f60-bfdd31870d66" />

#### After

<img width="873" height="537" alt="image" src="https://github.com/user-attachments/assets/6706994c-cc69-407d-934f-5c9ef6e27e9b" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for navigating three-level assembly hierarchies in the admin interface.

* **Tests**
  * Expanded system test coverage for nested assembly navigation, expansion/collapse functionality, and action item visibility.

* **Refactor**
  * Updated variable scoping in assemblies list component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->