### PR TITLE
Be smart with the 'most liked' sorting option

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -22,7 +22,7 @@ module Decidim
           @possible_orders ||= begin
             possible_orders = %w(random recent)
             possible_orders << "most_voted" if most_voted_order_available?
-            possible_orders << "most_liked" if current_settings.likes_enabled?
+            possible_orders << "most_liked" if most_liked_order_available?
             possible_orders << "most_commented" if most_commented_order_available?
             possible_orders << "most_followed"
             possible_orders << "with_more_authors" if with_more_authors_order_available?
@@ -63,6 +63,12 @@ module Decidim
           return @most_commented_order_available if defined?(@most_commented_order_available)
 
           @most_commented_order_available = Decidim::Proposals::Proposal.most_commented_available?(current_component)
+        end
+
+        def most_liked_order_available?
+          return @most_liked_order_available if defined?(@most_liked_order_available)
+
+          @most_liked_order_available = current_settings.likes_enabled? && Decidim::Proposals::Proposal.most_liked_available?(current_component)
         end
 
         def order_by_votes?

--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -68,7 +68,7 @@ module Decidim
         def most_liked_order_available?
           return @most_liked_order_available if defined?(@most_liked_order_available)
 
-          @most_liked_order_available = current_settings.likes_enabled? && Decidim::Proposals::Proposal.most_liked_available?(current_component)
+          @most_liked_order_available = Decidim::Proposals::Proposal.most_liked_available?(current_component)
         end
 
         def order_by_votes?

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -185,6 +185,15 @@ module Decidim
           .exists?
       end
 
+      def self.most_liked_available?(component)
+        where(component:)
+          .published
+          .not_hidden
+          .not_withdrawn
+          .where("likes_count > 0")
+          .exists?
+      end
+
       acts_as_list scope: :decidim_component_id
 
       searchable_fields({

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -186,6 +186,8 @@ module Decidim
       end
 
       def self.most_liked_available?(component)
+        return false unless component.current_settings.likes_enabled?
+
         where(component:)
           .published
           .not_hidden

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -186,7 +186,7 @@ module Decidim
       end
 
       def self.most_liked_available?(component)
-        return false unless component.current_settings.likes_enabled?
+        return false unless component.current_settings&.likes_enabled?
 
         where(component:)
           .published

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -186,8 +186,6 @@ module Decidim
       end
 
       def self.most_liked_available?(component)
-        return false unless component.current_settings&.likes_enabled?
-
         where(component:)
           .published
           .not_hidden

--- a/decidim-proposals/lib/decidim/proposals/component.rb
+++ b/decidim-proposals/lib/decidim/proposals/component.rb
@@ -37,6 +37,7 @@ Decidim.register_component(:proposals) do |component|
   POSSIBLE_SORT_ORDERS = %w(automatic random recent most_liked most_voted most_commented most_followed with_more_authors).freeze
   WITH_MORE_AUTHORS_ORDER = "with_more_authors"
   MOST_COMMENTED_ORDER = "most_commented"
+  MOST_LIKED_ORDER = "most_liked"
 
   sort_order_choices = lambda do |context|
     component = context[:component]
@@ -44,6 +45,7 @@ Decidim.register_component(:proposals) do |component|
 
     orders = orders.excluding(WITH_MORE_AUTHORS_ORDER) unless component && Decidim::Proposals::Proposal.with_more_authors_available?(component)
     orders = orders.excluding(MOST_COMMENTED_ORDER) unless component && Decidim::Proposals::Proposal.most_commented_available?(component)
+    orders = orders.excluding(MOST_LIKED_ORDER) unless component && Decidim::Proposals::Proposal.most_liked_available?(component)
 
     orders
   end

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -111,8 +111,18 @@ module Decidim
             let(:default_sort_order) { "most_liked" }
             let(:likes_enabled) { true }
 
-            it "default_order is most_liked" do
-              expect(controller.send(:default_order)).to eq(default_sort_order)
+            context "when there are no proposals with likes" do
+              it "defaults to random" do
+                expect(controller.send(:default_order)).to eq("random")
+              end
+            end
+
+            context "when there are proposals with likes" do
+              let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+
+              it "default_order is most_liked" do
+                expect(controller.send(:default_order)).to eq(default_sort_order)
+              end
             end
           end
 
@@ -195,6 +205,7 @@ module Decidim
 
         context "with likes enabled" do
           let(:likes_enabled) { true }
+          let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
 
           it "shows most_liked option to sort" do
             expect(view.available_orders).to include("most_liked")
@@ -206,6 +217,28 @@ module Decidim
 
           it "does not show most_liked option to sort" do
             expect(view.available_orders).not_to include("most_liked")
+          end
+        end
+
+        context "with or without likes and most_liked availability" do
+          let!(:proposal_without_likes) { create(:proposal, component:) }
+          let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+          let(:likes_enabled) { true }
+
+          context "when there are no proposals with likes" do
+            before do
+              proposal_with_likes.update!(likes_count: 0)
+            end
+
+            it "does not show most_liked option to sort" do
+              expect(view.available_orders).not_to include("most_liked")
+            end
+          end
+
+          context "when there are proposals with likes" do
+            it "shows most_liked option to sort" do
+              expect(view.available_orders).to include("most_liked")
+            end
           end
         end
 
@@ -359,6 +392,59 @@ module Decidim
 
             it "returns false" do
               expect(controller.send(:most_commented_order_available?)).to be false
+            end
+          end
+        end
+      end
+
+      describe "#most_liked_order_available?" do
+        let!(:proposal_without_likes) { create(:proposal, component:) }
+        let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+
+        context "when likes are disabled" do
+          let(:likes_enabled) { false }
+
+          it "returns false" do
+            expect(controller.send(:most_liked_order_available?)).to be false
+          end
+        end
+
+        context "when likes are enabled" do
+          let(:likes_enabled) { true }
+
+          context "when there are proposals with only zero likes" do
+            before do
+              proposal_with_likes.update!(likes_count: 0)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_liked_order_available?)).to be false
+            end
+          end
+
+          context "when there are proposals with likes" do
+            it "returns true" do
+              expect(controller.send(:most_liked_order_available?)).to be true
+            end
+          end
+
+          context "when proposals are not published" do
+            before do
+              proposal_with_likes.update!(published_at: nil)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_liked_order_available?)).to be false
+            end
+          end
+
+          context "when proposals are hidden" do
+            before do
+              create(:moderation, reportable: proposal_with_likes, hidden_at: Time.current)
+            end
+
+            it "returns false" do
+              expect(controller.send(:most_liked_order_available?)).to be false
             end
           end
         end

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -37,6 +37,7 @@ module Decidim
       let(:view) { controller.view_context }
 
       before do
+        allow(component).to receive(:current_settings).and_return(current_settings)
         allow(controller).to receive(:component_settings).and_return(component_settings)
         allow(controller).to receive(:current_settings).and_return(current_settings)
         allow(controller).to receive(:current_participatory_space).and_return(participatory_process)

--- a/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
+++ b/decidim-proposals/spec/controllers/concerns/orderable_spec.rb
@@ -24,7 +24,6 @@ module Decidim
                votes_enabled?: votes_enabled,
                votes_blocked?: votes_blocked,
                votes_hidden?: votes_hidden,
-               likes_enabled?: likes_enabled,
                comments_enabled?: comments_enabled)
       end
       let(:component_default_sort_order) { "automatic" }
@@ -37,7 +36,6 @@ module Decidim
       let(:view) { controller.view_context }
 
       before do
-        allow(component).to receive(:current_settings).and_return(current_settings)
         allow(controller).to receive(:component_settings).and_return(component_settings)
         allow(controller).to receive(:current_settings).and_return(current_settings)
         allow(controller).to receive(:current_participatory_space).and_return(participatory_process)
@@ -402,51 +400,39 @@ module Decidim
         let!(:proposal_without_likes) { create(:proposal, component:) }
         let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
 
-        context "when likes are disabled" do
-          let(:likes_enabled) { false }
+        context "when there are proposals with only zero likes" do
+          before do
+            proposal_with_likes.update!(likes_count: 0)
+          end
 
           it "returns false" do
             expect(controller.send(:most_liked_order_available?)).to be false
           end
         end
 
-        context "when likes are enabled" do
-          let(:likes_enabled) { true }
+        context "when there are proposals with likes" do
+          it "returns true" do
+            expect(controller.send(:most_liked_order_available?)).to be true
+          end
+        end
 
-          context "when there are proposals with only zero likes" do
-            before do
-              proposal_with_likes.update!(likes_count: 0)
-            end
-
-            it "returns false" do
-              expect(controller.send(:most_liked_order_available?)).to be false
-            end
+        context "when proposals are not published" do
+          before do
+            proposal_with_likes.update!(published_at: nil)
           end
 
-          context "when there are proposals with likes" do
-            it "returns true" do
-              expect(controller.send(:most_liked_order_available?)).to be true
-            end
+          it "returns false" do
+            expect(controller.send(:most_liked_order_available?)).to be false
+          end
+        end
+
+        context "when proposals are hidden" do
+          before do
+            create(:moderation, reportable: proposal_with_likes, hidden_at: Time.current)
           end
 
-          context "when proposals are not published" do
-            before do
-              proposal_with_likes.update!(published_at: nil)
-            end
-
-            it "returns false" do
-              expect(controller.send(:most_liked_order_available?)).to be false
-            end
-          end
-
-          context "when proposals are hidden" do
-            before do
-              create(:moderation, reportable: proposal_with_likes, hidden_at: Time.current)
-            end
-
-            it "returns false" do
-              expect(controller.send(:most_liked_order_available?)).to be false
-            end
+          it "returns false" do
+            expect(controller.send(:most_liked_order_available?)).to be false
           end
         end
       end

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -137,6 +137,58 @@ module Decidim
         end
       end
 
+      describe ".most_liked_available?" do
+        let(:component) { create(:proposal_component) }
+
+        context "when there are no proposals with likes" do
+          let!(:proposal_without_likes) { create(:proposal, component:) }
+
+          it "returns false" do
+            expect(described_class.most_liked_available?(component)).to be false
+          end
+        end
+
+        context "when there are proposals with likes" do
+          let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+
+          it "returns true" do
+            expect(described_class.most_liked_available?(component)).to be true
+          end
+
+          context "when proposals are not published" do
+            let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+
+            before do
+              proposal_with_likes.update!(published_at: nil)
+            end
+
+            it "returns false" do
+              expect(described_class.most_liked_available?(component)).to be false
+            end
+          end
+
+          context "when proposals are hidden" do
+            let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5) }
+
+            before do
+              create(:moderation, reportable: proposal_with_likes, hidden_at: Time.current)
+            end
+
+            it "returns false" do
+              expect(described_class.most_liked_available?(component)).to be false
+            end
+          end
+
+          context "when proposals are withdrawn" do
+            let!(:proposal_with_likes) { create(:proposal, component:, likes_count: 5, withdrawn_at: Time.current) }
+
+            it "returns false" do
+              expect(described_class.most_liked_available?(component)).to be false
+            end
+          end
+        end
+      end
+
       it "has a votes association returning proposal votes" do
         expect(subject.votes.count).to eq(0)
       end

--- a/decidim-proposals/spec/system/proposals_spec.rb
+++ b/decidim-proposals/spec/system/proposals_spec.rb
@@ -681,6 +681,22 @@ describe "Proposals" do
       end
     end
 
+    context "when there are no proposals with likes" do
+      let!(:proposals) { create_list(:proposal, 3, component:) }
+
+      before do
+        visit_component
+      end
+
+      it "does not show 'most_liked' ordering option" do
+        within ".order-by" do
+          expect(page).to have_css("div.order-by a", text: "Random")
+          page.find("a", text: "Random").click
+          expect(page).to have_no_content("Most liked")
+        end
+      end
+    end
+
     context "when searching proposals" do
       let!(:proposals) do
         [


### PR DESCRIPTION
#### :tophat: What? Why?

This is a follow-up to #16104 and #16136, this time implementing this change for the "Most liked" sorting option

#### :pushpin: Related Issues

- Related to #16104
- Related to #16136 
- Related to https://github.com/decidim/decidim/issues/9397 (not closing it, as I'll handle the other options after this is merged) 

#### Testing

2. Apply this patch
3. Go to the backend an create a new Proposals comment
4. See that you don't have the "Most liked" sorting option in the Default sorting selection
5. Create the component
6. Go to the fronted, see that you don't have the "Most liked" sorting option in the index page
7. Create a new proposal
8. Do a like to this proposal
9. Go to the configuration form of the proposal, see that you have the "Most liked" sorting option in the Default sorting selection
6. Go to the fronted, see that you have the "Most liked" sorting option in the index page 

### :camera: Screenshots

#### Without likes

<img width="1533" height="531" alt="image" src="https://github.com/user-attachments/assets/8cd94ed5-1c0b-43c8-89bb-2f9ccddbb9be" />
<img width="1541" height="508" alt="image" src="https://github.com/user-attachments/assets/6676e04f-e6b4-4c81-8645-d326b573d61f" />

#### With likes 

<img width="1204" height="631" alt="image" src="https://github.com/user-attachments/assets/adc14b12-c13d-43e2-ba5e-d1a0dd796aa0" />
<img width="1361" height="393" alt="image" src="https://github.com/user-attachments/assets/a1e28478-04d7-4ff8-8d50-83619c9912d2" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Most liked" ordering now appears only when likes are enabled and there are proposals with likes; it will be excluded otherwise and can become the default when applicable.

* **Tests**
  * Expanded unit and system tests covering availability and defaulting of "Most liked" across likes enabled/disabled, presence of liked proposals, and visibility states (published/hidden/withdrawn).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->