### PR TITLE
Show or not initiatives components menu depending on state

### DIFF
--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -45,9 +45,11 @@ edit_link(
       </section>
     <% end %>
 
-    <section class="layout-aside__section">
-      <%= cell("decidim/nav_links", initiative_nav_items(current_initiative)) %>
-    </section>
+    <% if current_initiative.open? || current_initiative.accepted? %>
+      <section class="layout-aside__section">
+        <%= cell("decidim/nav_links", initiative_nav_items(current_initiative)) %>
+      </section>
+    <% end %>
 
     <% if current_initiative.type.promoting_committee_enabled? && current_user&.admin? %>
       <div class="layout-aside__section">

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -307,6 +307,79 @@ describe "Initiative" do
       end
     end
 
+    context "when initiative state is created" do
+      let(:state) { :created }
+
+      before do
+        initiative.update!(published_at: nil)
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "does not show the components menu" do
+        expect(page).to have_no_css(".participatory-space__nav-container")
+      end
+    end
+
+    context "when initiative state is validating" do
+      let(:state) { :validating }
+
+      before do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "does not show the components menu" do
+        expect(page).to have_no_css(".participatory-space__nav-container")
+      end
+    end
+
+    context "when initiative state is discarded" do
+      let(:state) { :discarded }
+
+      before do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "does not show the components menu" do
+        expect(page).to have_no_css(".participatory-space__nav-container")
+      end
+    end
+
+    context "when initiative state is rejected" do
+      let(:state) { :rejected }
+
+      before do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "does not show the components menu" do
+        expect(page).to have_no_css(".participatory-space__nav-container")
+      end
+    end
+
+    context "when initiative state is open" do
+      let(:state) { :open }
+
+      before do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "shows the components menu" do
+        expect(page).to have_css(".participatory-space__nav-container")
+      end
+    end
+
+    context "when initiative state is accepted" do
+      let(:state) { :accepted }
+
+      before do
+        visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
+      end
+
+      it "shows the components menu" do
+        expect(page).to have_css(".participatory-space__nav-container")
+      end
+    end
+
     context "when signed in as the author of the initiative" do
       before do
         sign_in initiative.author


### PR DESCRIPTION
#### :tophat: What? Why?

When an initiative is just created (and isn't approved by the technical validation) it can has access to the Meetings and Pages through the components menu.

This PR hides this access depending on the state of the initiative.

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/11624 

#### Testing

0. Log in as a regular user
1. Create an initiative 
2. Do not send it to technical validation
3. Go to the public page of this initiative (I had to get the ID and change it from another initiative, I don't know if there's another link to this page)
4. (Before) see that you have the components menu
5. (After) see that you don't have the components menu
6. Send it to technical validation
7. Go back to this same page
8. See that you still don't have the components menu 
9. Log out as regular user
10. Log in as admin 
11. Publish this initiative
12. Go to the public page
13. See that you have the components menu

### :camera: Screenshots

#### Before

<img width="1535" height="909" alt="image" src="https://github.com/user-attachments/assets/7952688d-fe7d-4cfa-ab9d-562b60f03667" />


#### After

<img width="1469" height="801" alt="image" src="https://github.com/user-attachments/assets/75e7b281-3143-4ff5-bfe6-b9a1dbe0ddff" />

<img width="1372" height="699" alt="image" src="https://github.com/user-attachments/assets/6ed3f781-9c3d-4f8d-80c1-8dad083a059e" />
<img width="1434" height="902" alt="image" src="https://github.com/user-attachments/assets/ad841bbd-c3d0-4862-aa7a-b06a3c40e7e4" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Initiative components navigation menu is now hidden when an initiative is in created, validating, discarded, or rejected states, and visible only when open or accepted.

* **Tests**
  * Added test coverage for navigation menu visibility across different initiative states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->