### PR TITLE
Show agenda before the tab panels in meetings

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting.html.erb
@@ -55,13 +55,13 @@
     <% end %>
   </section>
 
-  <%= cell "decidim/tab_panels", tab_panel_items %>
-
   <% if meeting.agenda.present? && meeting.agenda.visible? %>
     <section class="layout-main__section">
       <%= render "meeting_agenda" %>
     </section>
   <% end %>
+
+  <%= cell "decidim/tab_panels", tab_panel_items %>
 
   <% if meeting.closed? && meeting.closing_visible? %>
     <section class="layout-main__section">


### PR DESCRIPTION
#### :tophat: What? Why?

On meetings we show the Agenda section after the "Participants" list and the other tabs.

This makes it more difficult to find, as you could have lots of participants registered on this meeting. 

This PR changes the order of these elements, so the agenda gets shown before these tabs. 

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/16215 

#### Testing

1. Log in as admin
2. Go to a meeting with registrations enabled
3. Register for this meeting and click "show my attendance publicly" 
4. Edit this meeting
5. Add an agenda, and agenda item, and check the "Visible" checkbox
6. Go to the frontend
7. See that the Agenda is before the participants list (and the whole tab panel). 

### :camera: Screenshots 

<img width="1610" height="760" alt="image" src="https://github.com/user-attachments/assets/30ce16b4-55eb-4e6d-91bb-e9a287e4730b" />

#### Before

<img width="1271" height="892" alt="image" src="https://github.com/user-attachments/assets/ac6e92bd-ef9f-4b7c-aec8-5f46db6caea3" />

#### After

<img width="1385" height="887" alt="image" src="https://github.com/user-attachments/assets/e7687113-1071-4d2b-870f-8915d3125f60" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/Layout**
  * Reorganized the meetings page layout by repositioning content sections for improved information hierarchy and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->