### PR TITLE
Refactor progress_calculator and count_calculator methods definitions 

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
+++ b/decidim-accountability/app/cells/decidim/accountability/status_cell.rb
@@ -7,7 +7,7 @@ module Decidim
     # This cell renders the status of a taxonomy or a result.
     class StatusCell < Decidim::ViewModel
       include Decidim::Accountability::ApplicationHelper
-      include Decidim::Accountability::BreadcrumbHelper
+      include Decidim::Accountability::CalculatorHelper
       include ActionView::Helpers::NumberHelper
 
       def show
@@ -78,10 +78,6 @@ module Decidim
         return true unless options.has_key?(:render_count)
 
         options[:render_count]
-      end
-
-      def count_calculator(taxonomy_id)
-        Decidim::Accountability::ResultsCalculator.new(current_component, taxonomy_id).count
       end
 
       def decidim

--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -8,9 +8,9 @@ module Decidim
 
       helper Decidim::TraceabilityHelper
       helper Decidim::Accountability::BreadcrumbHelper
-      include Decidim::Accountability::CalculatorHelper
+      helper Decidim::Accountability::CalculatorHelper
 
-      helper_method :results, :result, :count_calculator, :progress_calculator, :selected_root_taxonomy, :selected_taxonomy_children, :selected_taxonomy_grandchildren?
+      helper_method :results, :result, :selected_root_taxonomy, :selected_taxonomy_children, :selected_taxonomy_grandchildren?
 
       def show
         raise ActionController::RoutingError, "Not Found" unless result

--- a/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
+++ b/decidim-accountability/app/controllers/decidim/accountability/results_controller.rb
@@ -8,8 +8,9 @@ module Decidim
 
       helper Decidim::TraceabilityHelper
       helper Decidim::Accountability::BreadcrumbHelper
+      include Decidim::Accountability::CalculatorHelper
 
-      helper_method :results, :result, :count_calculator, :selected_root_taxonomy, :selected_taxonomy_children, :selected_taxonomy_grandchildren?
+      helper_method :results, :result, :count_calculator, :progress_calculator, :selected_root_taxonomy, :selected_taxonomy_children, :selected_taxonomy_grandchildren?
 
       def show
         raise ActionController::RoutingError, "Not Found" unless result
@@ -63,10 +64,6 @@ module Decidim
                                     else
                                       current_component.available_root_taxonomies.find_by(id: params[:root_taxonomy_id])
                                     end
-      end
-
-      def count_calculator(taxonomy_id)
-        Decidim::Accountability::ResultsCalculator.new(current_component, taxonomy_id).count
       end
 
       def add_parent_breadcrumb_item

--- a/decidim-accountability/app/helpers/decidim/accountability/breadcrumb_helper.rb
+++ b/decidim-accountability/app/helpers/decidim/accountability/breadcrumb_helper.rb
@@ -5,10 +5,6 @@ module Decidim
     # Helpers needed to render the navigation breadcrumbs in results.
     #
     module BreadcrumbHelper
-      def progress_calculator(taxonomy_id)
-        Decidim::Accountability::ResultsCalculator.new(current_component, taxonomy_id).progress
-      end
-
       def taxonomy
         return if (taxonomy_id = params.dig(:filter, :taxonomies_part_of_contains)).blank?
 

--- a/decidim-accountability/app/helpers/decidim/accountability/calculator_helper.rb
+++ b/decidim-accountability/app/helpers/decidim/accountability/calculator_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Accountability
+    # Helpers for calculating results progress and count
+    module CalculatorHelper
+      def progress_calculator(taxonomy_id)
+        ResultsCalculator.new(current_component, taxonomy_id).progress
+      end
+
+      def count_calculator(taxonomy_id)
+        ResultsCalculator.new(current_component, taxonomy_id).count
+      end
+    end
+  end
+end

--- a/decidim-accountability/spec/cells/decidim/accountability/status_cell_spec.rb
+++ b/decidim-accountability/spec/cells/decidim/accountability/status_cell_spec.rb
@@ -62,7 +62,7 @@ module Decidim::Accountability
       it "does not use custom progress when model has progress" do
         html = status_cell(result, progress: 80).call
         expect(html).to have_content("50%")
-        expect(html).not_to have_content("80%")
+        expect(html).to have_no_content("80%")
       end
     end
 

--- a/decidim-accountability/spec/cells/decidim/accountability/status_cell_spec.rb
+++ b/decidim-accountability/spec/cells/decidim/accountability/status_cell_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Accountability
+  describe StatusCell, type: :cell do
+    controller Decidim::Accountability::ResultsController
+
+    let!(:component) { create(:accountability_component) }
+    let!(:taxonomy) { create(:taxonomy, :with_parent, organization: component.organization) }
+    let!(:result) { create(:result, component:, progress: 50) }
+    let(:component_settings) { double(display_progress_enabled?: true) }
+
+    def status_cell(model, options = {})
+      cell("decidim/accountability/status", model, options).tap do |cell|
+        allow(cell).to receive(:component_settings).and_return(component_settings)
+        allow(cell).to receive(:current_component).and_return(component)
+      end
+    end
+
+    context "when rendering a taxonomy" do
+      let(:model) { taxonomy }
+
+      context "with results" do
+        let!(:result) { create(:result, component:, taxonomies: [taxonomy], progress: 75) }
+
+        it "renders the status" do
+          html = status_cell(taxonomy).call
+          expect(html).to have_css(".accountability__status")
+        end
+
+        it "shows the progress" do
+          html = status_cell(taxonomy).call
+          expect(html).to have_content("75%")
+        end
+      end
+
+      context "with no results" do
+        it "does not render" do
+          expect(status_cell(taxonomy).render?).to be false
+        end
+      end
+    end
+
+    context "when rendering a result" do
+      let(:model) { result }
+
+      it "renders the status" do
+        html = status_cell(result).call
+        expect(html).to have_css(".accountability__status")
+      end
+
+      it "shows the progress from the model" do
+        html = status_cell(result).call
+        expect(html).to have_content("50%")
+      end
+    end
+
+    context "with custom progress passed via options" do
+      let(:model) { result }
+
+      it "does not use custom progress when model has progress" do
+        html = status_cell(result, progress: 80).call
+        expect(html).to have_content("50%")
+        expect(html).not_to have_content("80%")
+      end
+    end
+
+    context "with custom count passed via options" do
+      let(:model) { result }
+
+      it "displays the count" do
+        html = status_cell(result, count: 42).call
+        expect(html).to have_content("42")
+      end
+    end
+
+    context "when render_blank option is true" do
+      let(:model) { taxonomy }
+
+      it "renders even without results" do
+        expect(status_cell(taxonomy, render_blank: true).render?).to be true
+      end
+    end
+
+    context "when render_count is false" do
+      let(:model) { result }
+
+      it "does not display the count" do
+        html = status_cell(result, count: 99, render_count: false).call.to_s
+        expect(html).not_to include(">99<")
+      end
+    end
+  end
+end

--- a/decidim-accountability/spec/helpers/decidim/accountability/calculator_helper_spec.rb
+++ b/decidim-accountability/spec/helpers/decidim/accountability/calculator_helper_spec.rb
@@ -73,10 +73,6 @@ module Decidim::Accountability
         expect(helper.count_calculator(taxonomy.id)).to eq(3)
       end
 
-      it "counts results including child taxonomies" do
-        expect(helper.count_calculator(taxonomy.id)).to eq(3)
-      end
-
       it "handles taxonomy with no results" do
         other_taxonomy = create(:taxonomy, organization: current_component.organization)
         expect(helper.count_calculator(other_taxonomy.id)).to eq(0)

--- a/decidim-accountability/spec/helpers/decidim/accountability/calculator_helper_spec.rb
+++ b/decidim-accountability/spec/helpers/decidim/accountability/calculator_helper_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Accountability
+  describe CalculatorHelper do
+    let(:participatory_process) { create(:participatory_process, :with_steps) }
+    let(:current_component) { create(:accountability_component, participatory_space: participatory_process) }
+    let(:taxonomy) { create(:taxonomy, :with_parent, organization: current_component.organization) }
+    let(:sub_taxonomy) { create(:taxonomy, parent: taxonomy, organization: current_component.organization) }
+
+    let!(:result1) do
+      create(
+        :result,
+        component: current_component,
+        taxonomies: [taxonomy],
+        parent: nil,
+        progress: 40
+      )
+    end
+    let!(:result2) do
+      create(
+        :result,
+        component: current_component,
+        taxonomies: [taxonomy, sub_taxonomy],
+        parent: nil,
+        progress: 20
+      )
+    end
+    let!(:result3) do
+      create(
+        :result,
+        component: current_component,
+        taxonomies: [sub_taxonomy],
+        parent: nil,
+        progress: nil
+      )
+    end
+    let!(:result4) do
+      create(
+        :result,
+        component: current_component,
+        parent: nil,
+        progress: 50
+      )
+    end
+
+    before do
+      allow(helper).to receive(:current_component).and_return(current_component)
+    end
+
+    describe "#progress_calculator" do
+      it "calculates the average progress for all results when no taxonomy_id is given" do
+        expect(helper.progress_calculator(nil)).to eq(27.5)
+      end
+
+      it "calculates the average progress for a specific taxonomy (including children)" do
+        expect(helper.progress_calculator(taxonomy.id)).to eq(20)
+      end
+
+      it "handles taxonomy with no results gracefully" do
+        other_taxonomy = create(:taxonomy, organization: current_component.organization)
+        expect(helper.progress_calculator(other_taxonomy.id)).to be_nil
+      end
+    end
+
+    describe "#count_calculator" do
+      it "counts all results when no taxonomy_id is given" do
+        expect(helper.count_calculator(nil)).to eq(4)
+      end
+
+      it "counts results for a specific taxonomy (including children)" do
+        expect(helper.count_calculator(taxonomy.id)).to eq(3)
+      end
+
+      it "counts results including child taxonomies" do
+        expect(helper.count_calculator(taxonomy.id)).to eq(3)
+      end
+
+      it "handles taxonomy with no results" do
+        other_taxonomy = create(:taxonomy, organization: current_component.organization)
+        expect(helper.count_calculator(other_taxonomy.id)).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing some cells in Accountability, it was detected some duplication in some method definitions. This PR moves them to a new `CalculatorHelper` to make them DRY. 

#### :pushpin: Related Issues
 
- Fixes #13593 

#### Testing

Everything should be green and work the same  

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized progress and count calculations into a shared calculator helper; status rendering updated to use this shared logic and redundant methods removed.

* **Refactor**
  * Controller now exposes the shared calculator helper for consistent use in views.

* **Tests**
  * Added comprehensive specs validating progress aggregation (including child categories), counts, and status-rendering scenarios (overrides, blank rendering, and count suppression).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->