### PR TITLE
Add action log for conferences' duplicate action

### DIFF
--- a/decidim-conferences/app/commands/decidim/conferences/admin/duplicate_conference.rb
+++ b/decidim-conferences/app/commands/decidim/conferences/admin/duplicate_conference.rb
@@ -24,10 +24,12 @@ module Decidim
         def call
           return broadcast(:invalid) if form.invalid?
 
-          Conference.transaction do
-            duplicate_conference
-            duplicate_conference_attachments
-            duplicate_conference_components if @form.duplicate_components?
+          Decidim.traceability.perform_action!("duplicate", @conference, form.current_user) do
+            Conference.transaction do
+              duplicate_conference
+              duplicate_conference_attachments
+              duplicate_conference_components if @form.duplicate_components?
+            end
           end
 
           broadcast(:ok, @duplicated_conference)

--- a/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_presenter.rb
+++ b/decidim-conferences/app/presenters/decidim/conferences/admin_log/conference_presenter.rb
@@ -40,7 +40,7 @@ module Decidim
 
         def action_string
           case action
-          when "create", "publish", "unpublish", "update", "update_diploma", "soft_delete", "restore"
+          when "create", "duplicate", "publish", "unpublish", "update", "update_diploma", "soft_delete", "restore"
             "decidim.admin_log.conference.#{action}"
           else
             super

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -321,8 +321,8 @@ en:
         deleted_conferences_info: Conferences can only be deleted if status is "Unpublished".
     admin_log:
       conference:
-        duplicate: "%{user_name} duplicated the %{resource_name} conference"
         create: "%{user_name} created the %{resource_name} conference"
+        duplicate: "%{user_name} duplicated the %{resource_name} conference"
         publish: "%{user_name} published the %{resource_name} conference"
         restore: "%{user_name} restored the %{resource_name} conference"
         send_conference_diplomas: "%{user_name} sent certificates of attendance to the %{resource_name} conference atendees"

--- a/decidim-conferences/config/locales/en.yml
+++ b/decidim-conferences/config/locales/en.yml
@@ -321,6 +321,7 @@ en:
         deleted_conferences_info: Conferences can only be deleted if status is "Unpublished".
     admin_log:
       conference:
+        duplicate: "%{user_name} duplicated the %{resource_name} conference"
         create: "%{user_name} created the %{resource_name} conference"
         publish: "%{user_name} published the %{resource_name} conference"
         restore: "%{user_name} restored the %{resource_name} conference"

--- a/decidim-conferences/spec/commands/duplicate_conference_spec.rb
+++ b/decidim-conferences/spec/commands/duplicate_conference_spec.rb
@@ -7,6 +7,7 @@ module Decidim::Conferences
     subject { described_class.new(form, conference) }
 
     let(:organization) { create(:organization) }
+    let(:current_user) { create(:user, organization:) }
     let(:errors) { double.as_null_object }
     let!(:conference) { create(:conference, organization:, taxonomies: [taxonomy]) }
     let(:taxonomy) { create(:taxonomy, :with_parent, organization:) }
@@ -17,7 +18,8 @@ module Decidim::Conferences
         invalid?: invalid,
         title: { en: "title" },
         slug: "duplicated-slug",
-        duplicate_components?: duplicate_components
+        duplicate_components?: duplicate_components,
+        current_user:
       )
     end
 
@@ -55,6 +57,20 @@ module Decidim::Conferences
 
       it "broadcasts ok" do
         expect { subject.call }.to broadcast(:ok)
+      end
+
+      it "traces the action", versioning: true do
+        expect(Decidim.traceability)
+          .to receive(:perform_action!)
+          .with("duplicate", conference, current_user)
+          .and_call_original
+
+        expect { subject.call }.to change(Decidim::ActionLog, :count)
+        action_log = Decidim::ActionLog.last
+
+        expect(action_log.action).to eq("duplicate")
+        expect(action_log.resource).to eq(conference)
+        expect(action_log.version).to be_present
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

When an admin duplicates a Conference, it doesn't generate an action log entry. 

This PR fixes it by generating this action.

#### :pushpin: Related Issues
 
- Fixes #15811 

#### Testing

1. Sign in as admin
2. Duplicate a conference
3. Go to http://localhost:3000/admin/ 
4. See the "Admin log" 

### :camera: Screenshots

<img width="1306" height="677" alt="image" src="https://github.com/user-attachments/assets/b6ced582-7a7f-4d9a-9117-3891483cfb3c" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conference duplication now creates a tracked audit action so duplication events are recorded with the acting user.

* **Documentation**
  * Added localization for the duplication action so audit logs display a readable, translated message.

* **Tests**
  * Added tests to ensure duplication actions are traced, logged, and create the expected audit entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->