### PR TITLE
Fix for sorting newly added questions

### DIFF
--- a/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
+++ b/decidim-forms/app/packs/src/decidim/forms/admin/forms.js
@@ -9,6 +9,7 @@ import AutoButtonsByPositionComponent from "src/decidim/admin/auto_buttons_by_po
 import AutoLabelByPositionComponent from "src/decidim/admin/auto_label_by_position.component"
 import createDynamicFields from "src/decidim/admin/dynamic_fields.component"
 import createFieldDependentInputs from "src/decidim/admin/field_dependent_inputs.component"
+import sortable from "html5sortable/dist/html5sortable.es"
 
 export default function createEditableForm() {
   const wrapperSelector = ".questionnaire-questions";
@@ -403,6 +404,15 @@ export default function createEditableForm() {
       if (fieldElement) {
         fieldElement.querySelectorAll("select.language-change").forEach((container) => {
           window.deprecate(container, "language-change", "select.language-change")
+        });
+      }
+
+      const sortableContainer = document.querySelector(".questionnaire-questions-list[data-draggable-table]");
+      if (sortableContainer) {
+        sortable(sortableContainer, {
+          forcePlaceholderSize: true,
+          items: ".questionnaire-question",
+          handle: sortableContainer.dataset.draggableHandle || ".card-divider"
         });
       }
 

--- a/decidim-surveys/spec/system/question_ordering_spec.rb
+++ b/decidim-surveys/spec/system/question_ordering_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Question ordering", "#reorder_questions" do
+  let(:manifest_name) { "surveys" }
+  let!(:component) do
+    create(:component,
+           manifest:,
+           participatory_space:,
+           published_at: nil)
+  end
+  let!(:questionnaire) { create(:questionnaire) }
+  let!(:survey) { create(:survey, :published, :clean_after_publish, component:, questionnaire:) }
+  let!(:first_question) { create(:questionnaire_question, questionnaire:, body: { en: "First question" }, position: 0) }
+  let!(:second_question) { create(:questionnaire_question, questionnaire:, body: { en: "Second question" }, position: 1) }
+
+  include_context "when managing a component as an admin"
+
+  before do
+    within "tr", text: decidim_sanitize_translated(survey.title) do
+      find("button[data-controller='dropdown']").click
+      click_on "Questions"
+    end
+  end
+
+  it "shows questions in the correct order" do
+    expect(page).to have_content("First question #1")
+    expect(page).to have_content("Second question #2")
+  end
+
+  it "updates positions after adding a new question", :js do
+    click_on "Add question"
+
+    expect(page).to have_content("First question #1")
+    expect(page).to have_content("Second question #2")
+    expect(page).to have_content("Question #3")
+  end
+
+  it "can add and save new questions with correct positions", :js do
+    click_on "Add question"
+
+    expand_all_questions
+
+    within ".questionnaire-question:last-of-type" do
+      fill_in find_nested_form_field_locator("body_en"), with: "Third question"
+    end
+
+    click_on "Save"
+    expect(page).to have_callout("Survey questions successfully saved.")
+
+    expect(page).to have_content("First question #1")
+    expect(page).to have_content("Second question #2")
+    expect(page).to have_content("Third question #3")
+  end
+
+  it "allows reordering a newly added question", :js do
+    create_and_fill_third_question
+
+    drag_latest_question_to_first
+
+    ordered_headers = question_headers
+    expect(ordered_headers[0]).to include("Third question #1")
+    expect(ordered_headers[1]).to include("First question #2")
+    expect(ordered_headers[2]).to include("Second question #3")
+  end
+
+  it "persists the reordered questions after saving", :js do
+    create_and_fill_third_question
+
+    drag_latest_question_to_first
+
+    click_on "Save"
+    expect(page).to have_callout("Survey questions successfully saved.")
+
+    ordered_headers = question_headers
+    expect(ordered_headers[0]).to include("Third question #1")
+    expect(ordered_headers[1]).to include("First question #2")
+    expect(ordered_headers[2]).to include("Second question #3")
+  end
+
+  def expand_all_questions
+    find(".button.expand-all").click
+  end
+
+  def find_nested_form_field_locator(attribute, visible: :visible)
+    find_nested_form_field(attribute, visible:)["id"]
+  end
+
+  def find_nested_form_field(attribute, visible: :visible)
+    current_scope.find(nested_form_field_selector(attribute), visible:)
+  end
+
+  def nested_form_field_selector(attribute)
+    "[id$=#{attribute}]"
+  end
+
+  def create_and_fill_third_question
+    click_on "Add question"
+
+    expand_all_questions
+
+    within ".questionnaire-question:last-of-type" do
+      fill_in find_nested_form_field_locator("body_en"), with: "Third question"
+    end
+  end
+
+  def drag_latest_question_to_first
+    draggable_questions = all(".questionnaire-question .card-divider")
+    draggable_questions.last.drag_to(draggable_questions.first)
+  end
+
+  def question_headers
+    all(".questionnaire-question .card-divider").map(&:text)
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

While checking some bug reports on surveys, I noticed that we have a bug: when you add a new question in a survey's questionnaire and try to sort it, that doesn't work. The workaoround is to save the questionnaire, and then you're able to change its order.

This PR fixes it and makes it sortable when the question is created. 

#### :pushpin: Related Issues
 
- Related to #13207 (as that was the one that I was checking out when I found this one)

#### Testing

1. Sign in as admin
2. Edit a Survey
3. Go to Questions
4. Add a new question
5. Drag and drop it with the icon
6. (Before) Nothing happens
7. (After) See that it can change the order - and when it is saved the order is respected

### :camera: Screenshots

#### Before
[Kooha-2026-03-06-18-06-24.webm](https://github.com/user-attachments/assets/6db849c5-0c80-4069-b8be-f5708a2ef3fc)

#### After
[Kooha-2026-03-06-18-07-29.webm](https://github.com/user-attachments/assets/2118c488-d6f2-44fc-b58b-77e391015e04)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop functionality to reorder questions in surveys and forms.

* **Tests**
  * Added system tests validating question ordering, including adding new questions, reordering, and persistence of changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->