### PR TITLE
Remove references to the `banner_image` field in assemblies

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly.rb
@@ -6,7 +6,7 @@ module Decidim
       # A command with all the business logic when creating a new assembly
       # in the system.
       class CreateAssembly < Decidim::Commands::CreateResource
-        fetch_file_attributes :hero_image, :banner_image
+        fetch_file_attributes :hero_image
 
         fetch_form_attributes :title, :subtitle, :weight, :slug, :description, :short_description,
                               :promoted, :taxonomizations, :parent, :organization,

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/duplicate_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/duplicate_assembly.rb
@@ -63,7 +63,7 @@ module Decidim
         end
 
         def duplicate_assembly_attachments
-          [:hero_image, :banner_image].each do |attribute|
+          [:hero_image].each do |attribute|
             next unless @assembly.attached_uploader(attribute).attached?
 
             @duplicated_assembly.send(attribute).attach(@assembly.send(attribute).blob)

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/update_assembly.rb
@@ -6,7 +6,7 @@ module Decidim
       # A command with all the business logic when updating a new assembly
       # in the system.
       class UpdateAssembly < Decidim::Commands::UpdateResource
-        fetch_file_attributes :hero_image, :banner_image
+        fetch_file_attributes :hero_image
 
         fetch_form_attributes :title, :subtitle, :slug, :promoted, :description, :short_description,
                               :taxonomizations, :parent, :private_space, :developer_group, :local_area,

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -54,9 +54,7 @@ module Decidim
         attribute :duration, Decidim::Attributes::LocalizedDate
         attribute :included_at, Decidim::Attributes::LocalizedDate
 
-        attribute :banner_image
         attribute :hero_image
-        attribute :remove_banner_image, Boolean, default: false
         attribute :remove_hero_image, Boolean, default: false
 
         validates :parent, presence: true, if: ->(form) { form.parent.present? }
@@ -69,7 +67,6 @@ module Decidim
         validates :created_by_other, translatable_presence: true, if: ->(form) { form.created_by == "others" }
         validates :title, :subtitle, :description, :short_description, translatable_presence: true
 
-        validates :banner_image, passthru: { to: Decidim::Assembly }
         validates :hero_image, passthru: { to: Decidim::Assembly }
 
         validates :weight, presence: true

--- a/decidim-assemblies/app/models/decidim/assembly.rb
+++ b/decidim-assemblies/app/models/decidim/assembly.rb
@@ -71,9 +71,6 @@ module Decidim
     has_one_attached :hero_image
     validates_upload :hero_image, uploader: Decidim::HeroImageUploader
 
-    has_one_attached :banner_image
-    validates_upload :banner_image, uploader: Decidim::BannerImageUploader
-
     validates :slug, uniqueness: { scope: :organization }
     validates :slug, presence: true, format: { with: Decidim::Assembly.slug_format }
 

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
@@ -494,15 +494,6 @@ describe("AssemblyAdminController", () => {
                   <button id="assembly_hero_image_button" name="hero_image" class="button button__sm button__transparent-secondary" type="button" data-dialog-open="upload_c5515a82-b6d4-4c1c-a957-013c9679b956" data-upload="{&quot;addAttribute&quot;:&quot;hero_image&quot;,&quot;resourceName&quot;:&quot;assembly&quot;,&quot;resourceClass&quot;:&quot;Decidim::Assembly&quot;,&quot;required&quot;:false,&quot;maxFileSize&quot;:10485760.0,&quot;multiple&quot;:false,&quot;titled&quot;:false,&quot;formObjectClass&quot;:&quot;Decidim::Assemblies::Admin::AssemblyForm&quot;}" aria-haspopup="dialog">Add image</button>
                 </div>
               </div>
-              <div class="columns">
-                <div class="upload-modal__files-container upload-container-for-banner_image ">
-                  <div>
-                    <label>Banner image</label>
-                    <div class="upload-modal__files" data-active-uploads="upload_0d6b6c3f-3681-450e-dummy-2"></div>
-                  </div>
-                  <button id="assembly_banner_image_button" name="banner_image" class="button button__sm button__transparent-secondary" type="button" data-dialog-open="upload_0d6b6c3f-3681-450e-dummy-2" data-upload="{&quot;addAttribute&quot;:&quot;banner_image&quot;,&quot;resourceName&quot;:&quot;assembly&quot;,&quot;resourceClass&quot;:&quot;Decidim::Assembly&quot;,&quot;required&quot;:false,&quot;maxFileSize&quot;:10485760.0,&quot;multiple&quot;:false,&quot;titled&quot;:false,&quot;formObjectClass&quot;:&quot;Decidim::Assemblies::Admin::AssemblyForm&quot;}" aria-haspopup="dialog">Add image</button>
-                </div>
-              </div>
             </div>
           </div>
         </div>

--- a/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
+++ b/decidim-assemblies/app/presenters/decidim/assemblies/assembly_presenter.rb
@@ -9,10 +9,6 @@ module Decidim
         assembly.attached_uploader(:hero_image).url
       end
 
-      def banner_image_url
-        assembly.attached_uploader(:banner_image).url
-      end
-
       def area_name
         return if assembly.area.blank?
 

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -59,9 +59,6 @@ module Decidim
             created_by: attributes["created_by"],
             meta_scope: attributes["meta_scope"]
           )
-          import_hero_image(attributes["remote_hero_image_url"])
-          import_banner_image(attributes["remote_banner_image_url"])
-
           @imported_assembly.save!
           @imported_assembly
         end
@@ -175,14 +172,6 @@ module Decidim
         @imported_assembly.attached_uploader(:hero_image).remote_url = url
       rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
         @warnings << I18n.t("decidim.assemblies.admin.imports.hero_image_error", error: format_error(e))
-      end
-
-      def import_banner_image(url)
-        return if url.blank?
-
-        @imported_assembly.attached_uploader(:banner_image).remote_url = url
-      rescue OpenURI::HTTPError, Errno::ENOENT, Errno::ECONNREFUSED, SocketError, Net::OpenTimeout, Net::ReadTimeout => e
-        @warnings << I18n.t("decidim.assemblies.admin.imports.banner_image_error", error: format_error(e))
       end
 
       def format_error(error)

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -59,6 +59,7 @@ module Decidim
             created_by: attributes["created_by"],
             meta_scope: attributes["meta_scope"]
           )
+          import_hero_image(attributes["remote_hero_image_url"])
           @imported_assembly.save!
           @imported_assembly
         end

--- a/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/open_data_assembly_serializer.rb
@@ -12,7 +12,6 @@ module Decidim
             url: EngineRouter.main_proxy(resource).assembly_url(resource),
             subtitle: resource.subtitle,
             remote_hero_image_url: Decidim::ParticipatoryProcesses::ParticipatoryProcessPresenter.new(resource).hero_image_url,
-            remote_banner_image_url: Decidim::Assemblies::AssemblyPresenter.new(resource).banner_image_url,
             developer_group: resource.developer_group,
             local_area: resource.local_area,
             meta_scope: resource.meta_scope,

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -98,10 +98,6 @@
         <div class="columns">
           <%= form.upload :hero_image, button_class: "button button__sm button__transparent-secondary" %>
         </div>
-
-        <div class="columns">
-          <%= form.upload :banner_image, button_class: "button button__sm button__transparent-secondary" %>
-        </div>
       </div>
     </div>
   </div>

--- a/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
@@ -1,4 +1,4 @@
-<% add_decidim_page_title(t("assembly_members.index.title", scope: "decidim")) %>
+<% add_decidim_page_title(t("members", scope: "decidim.participatory_space_members.index")) %>
 <% add_decidim_meta_tags(
      title: translated_attribute(current_participatory_space.title),
      resource: current_participatory_space) %>
@@ -11,13 +11,15 @@ edit_link(
 )
 %>
 
-<%= cell "decidim/content_blocks/participatory_space_hero", nil, resource: current_participatory_space %>
-<div class="container py-8">
-  <h3 class="h3 decorator mb-10">
-    <%= t("members", scope: "decidim.assemblies.assembly_members.index") %>
-    <span class="label text-md ml-2"><%= collection.size %></span>
-  </h3>
-  <div id="assembly_members-grid" class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-12">
+<% content_for :aside do %>
+  <h1 class="title-decorator">
+    <%= t("members", scope: "decidim.participatory_space_members.index") %>
+  </h1>
+<% end %>
+
+<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
+  <section class="layout-main__section">
     <%= render(collection) %>
-  </div>
-</div>
+  </section>
+<% end %>
+

--- a/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
@@ -22,4 +22,3 @@ edit_link(
     <%= render(collection) %>
   </section>
 <% end %>
-

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -282,7 +282,6 @@ en:
             max_results: Maximum amount of elements to show
         imports:
           attachment_error: The attachment "%{title}" could not be imported (%{error}).
-          banner_image_error: The banner image could not be imported (%{error}).
           hero_image_error: The hero image could not be imported (%{error}).
         new_import:
           accepted_types:
@@ -311,9 +310,6 @@ en:
           type: Type
         show:
           title: About this assembly
-      assembly_members:
-        index:
-          members: Members
       content_blocks:
         children_assemblies:
           name: Assemblies
@@ -355,9 +351,6 @@ en:
         duration: Duration
         private_space: This is a private assembly
         social_networks_title: Visit assembly on
-    assembly_members:
-      index:
-        title: Members
     download_your_data:
       show:
         assemblies: Assemblies export

--- a/decidim-assemblies/lib/decidim/api/assembly_type.rb
+++ b/decidim-assemblies/lib/decidim/api/assembly_type.rb
@@ -17,7 +17,6 @@ module Decidim
 
       description "An assembly"
 
-      field :banner_image, String, "The banner image for this assembly", null: true
       field :children, [Decidim::Assemblies::AssemblyType, { null: true }], "Children of this assembly", null: false
       field :children_count, Integer, "Number of children assemblies", null: true
       field :closing_date, Decidim::Core::DateType, "Closing date of the assembly", null: true
@@ -63,10 +62,6 @@ module Decidim
 
       def hero_image
         object.attached_uploader(:hero_image).url
-      end
-
-      def banner_image
-        object.attached_uploader(:banner_image).url
       end
     end
   end

--- a/decidim-assemblies/lib/decidim/assemblies/seeds.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/seeds.rb
@@ -60,7 +60,6 @@ module Decidim
           end,
           organization:,
           hero_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? hero_image : nil, # Keep after organization
-          banner_image: ::Faker::Boolean.boolean(true_ratio: 0.5) ? banner_image : nil, # Keep after organization
           promoted: true,
           published_at: 2.weeks.ago,
           meta_scope: Decidim::Faker::Localized.word,

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -27,7 +27,6 @@ FactoryBot.define do
     description { generate_localized_description(:assembly_description, skip_injection:) }
     organization
     hero_image { Decidim::Dev.test_file("city.jpeg", "image/jpeg") } # Keep after organization
-    banner_image { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") } # Keep after organization
     published_at { Time.current }
     deleted_at { nil }
     meta_scope { generate_localized_word(:assembly_meta_scope, skip_injection:) }

--- a/decidim-assemblies/spec/commands/create_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_spec.rb
@@ -18,7 +18,6 @@ module Decidim::Assemblies
     end
     let(:related_process_ids) { [participatory_processes.map(&:id)] }
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
     let(:taxonomizations) do
       2.times.map { build(:taxonomization, taxonomy: create(:taxonomy, :with_parent, organization:), taxonomizable: nil) }
     end
@@ -34,7 +33,6 @@ module Decidim::Assemblies
         slug: "slug",
         meta_scope: { en: "meta scope" },
         hero_image:,
-        banner_image:,
         promoted: nil,
         developer_group: { en: "developer group" },
         local_area: { en: "local" },
@@ -87,7 +85,6 @@ module Decidim::Assemblies
           content_type: "image/jpeg"
         )
       end
-      let(:banner_image) { hero_image }
 
       before do
         allow(Decidim::ActionLogger).to receive(:log).and_return(true)
@@ -99,7 +96,6 @@ module Decidim::Assemblies
 
       it "adds errors to the form" do
         expect(errors).to receive(:add).with(:hero_image, "File resolution is too large")
-        expect(errors).to receive(:add).with(:banner_image, "File resolution is too large")
         subject.call
       end
     end
@@ -112,14 +108,12 @@ module Decidim::Assemblies
           content_type: "image/png"
         )
       end
-      let(:banner_image) { nil }
       let(:form) do
         Admin::AssemblyForm.from_params(
           title: { en: "title" },
           subtitle: { en: "subtitle" },
           slug: "slug",
           hero_image:,
-          banner_image:,
           description: { en: "description" },
           short_description: { en: "short_description" },
           organization:

--- a/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/decidim/assemblies/admin/import_assembly_spec.rb
@@ -45,10 +45,6 @@ module Decidim::Assemblies::Admin
         "image/jpeg"
       )
       stub_get_request_with_format(
-        "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg",
-        "image/jpeg"
-      )
-      stub_get_request_with_format(
         "http://localhost:3000/uploads/decidim/attachment/file/31/Exampledocument.pdf",
         "application/pdf"
       )

--- a/decidim-assemblies/spec/commands/update_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_spec.rb
@@ -22,7 +22,6 @@ module Decidim::Assemblies
         2.times.map { create(:taxonomization, taxonomy: create(:taxonomy, :with_parent, organization:), taxonomizable: my_assembly) }
       end
       let(:taxonomy) { create(:taxonomy, :with_parent, organization:) }
-      let(:banner_image) { my_assembly.banner_image }
       let(:params) do
         {
           assembly: {
@@ -69,8 +68,7 @@ module Decidim::Assemblies
       end
       let(:attachment_params) do
         {
-          hero_image: hero_image.blob,
-          banner_image: banner_image.blob
+          hero_image: hero_image.blob
         }
       end
       let(:context) do
@@ -105,7 +103,6 @@ module Decidim::Assemblies
       context "when the uploaded hero image has too large dimensions" do
         let(:attachment_params) do
           {
-            banner_image: banner_image.blob,
             hero_image: ActiveStorage::Blob.create_and_upload!(
               io: File.open(Decidim::Dev.asset("5000x5000.png")),
               filename: "5000x5000.png",
@@ -125,7 +122,6 @@ module Decidim::Assemblies
           allow(form).to receive(:invalid?).and_return(false)
           expect(my_assembly).to receive(:valid?).at_least(:once).and_return(false)
           my_assembly.errors.add(:hero_image, "File resolution is too large")
-          my_assembly.errors.add(:banner_image, "File resolution is too large")
         end
 
         it "broadcasts invalid" do
@@ -136,7 +132,6 @@ module Decidim::Assemblies
           command.call
 
           expect(form.errors[:hero_image]).not_to be_empty
-          expect(form.errors[:banner_image]).not_to be_empty
         end
       end
 
@@ -176,37 +171,18 @@ module Decidim::Assemblies
           expect(linked_participatory_processes).to match_array(participatory_processes)
         end
 
-        context "when homepage image is not updated" do
+        context "when hero image is not updated" do
           let(:attachment_params) do
-            {
-              banner_image: banner_image.blob
-            }
+            {}
           end
 
-          it "does not replace the homepage image" do
+          it "does not replace the hero image" do
             expect(my_assembly).not_to receive(:hero_image=)
 
             command.call
             my_assembly.reload
 
             expect(my_assembly.hero_image).to be_present
-          end
-        end
-
-        context "when banner image is not updated" do
-          let(:attachment_params) do
-            {
-              hero_image: hero_image.blob
-            }
-          end
-
-          it "does not replace the banner image" do
-            expect(my_assembly).not_to receive(:banner_image=)
-
-            command.call
-            my_assembly.reload
-
-            expect(my_assembly.banner_image).to be_present
           end
         end
 

--- a/decidim-assemblies/spec/forms/assembly_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_form_spec.rb
@@ -120,7 +120,6 @@ module Decidim
               "short_description_es" => short_description[:es],
               "short_description_ca" => short_description[:ca],
               "hero_image" => attachment,
-              "banner_image" => attachment,
               "slug" => slug,
               "private_space" => private_space,
               "has_members" => has_members,
@@ -185,7 +184,7 @@ module Decidim
           it { is_expected.not_to be_valid }
         end
 
-        context "when attachment (hero_image or banner_image) is too big" do
+        context "when attachment (hero_image) is too big" do
           before do
             organization.settings.tap do |settings|
               settings.upload.maximum_file_size.default = 5
@@ -298,7 +297,6 @@ module Decidim
                 slug: "another-slug",
                 meta_scope: assembly.meta_scope,
                 hero_image: nil,
-                banner_image: nil,
                 promoted: assembly.promoted,
                 description_en: assembly.description,
                 description_ca: assembly.description,
@@ -351,7 +349,6 @@ module Decidim
                 slug: "another-slug",
                 meta_scope: assembly.meta_scope,
                 hero_image: nil,
-                banner_image: nil,
                 promoted: assembly.promoted,
                 description_en: assembly.description,
                 description_ca: assembly.description,

--- a/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
+++ b/decidim-assemblies/spec/presenters/decidim/assemblies/assembly_presenter_spec.rb
@@ -12,25 +12,16 @@ module Decidim
     describe "when no images were uploaded" do
       before do
         assembly.hero_image.purge
-        assembly.banner_image.purge
       end
 
       it "return nil for hero_image_url" do
         expect(subject.hero_image_url).to be_nil
-      end
-
-      it "return nil for banner_image_url" do
-        expect(subject.banner_image_url).to be_nil
       end
     end
 
     describe "when images are attached" do
       it "resolves hero_image_url" do
         expect(subject.hero_image_url).to be_blob_url(assembly.hero_image.blob)
-      end
-
-      it "resolves banner_image_url" do
-        expect(subject.banner_image_url).to be_blob_url(assembly.banner_image.blob)
       end
     end
   end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -51,12 +51,10 @@ module Decidim::Assemblies
           "created_by" => "citizens",
           "meta_scope" => Decidim::Faker::Localized.sentence(word_count: 3),
           "announcement" => Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title },
-          "remote_hero_image_url" => hero_image_url,
-          "remote_banner_image_url" => banner_image_url
+          "remote_hero_image_url" => hero_image_url
         }
       end
       let(:hero_image_url) { nil }
-      let(:banner_image_url) { nil }
 
       it "imports the assembly correctly" do
         expect { subject }.to change(Decidim::Assembly, :count).by(1)
@@ -139,95 +137,22 @@ module Decidim::Assemblies
         end
       end
 
-      context "when banner image URL is present and accessible" do
-        let(:banner_image_url) { "http://example.com/banner.jpg" }
-
-        before do
-          stub_request(:get, banner_image_url)
-            .to_return(status: 200, body: File.read(Decidim::Dev.asset("city2.jpeg")))
-          stub_request(:head, banner_image_url)
-            .to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
-        end
-
-        it "imports the assembly with the banner image" do
-          expect { subject }.to change(Decidim::Assembly, :count).by(1)
-          expect(subject.banner_image).to be_attached
-        end
-
-        it "has no warnings" do
-          subject
-          expect(importer.warnings).to be_empty
-        end
-      end
-
-      context "when banner image URL returns 404 error" do
-        let(:banner_image_url) { "http://example.com/missing-banner.jpg" }
-
-        before do
-          stub_request(:get, banner_image_url)
-            .to_return(status: 404, body: "Not Found")
-          stub_request(:head, banner_image_url)
-            .to_return(status: 404, body: "Not Found")
-        end
-
-        it "imports the assembly successfully" do
-          expect { subject }.to change(Decidim::Assembly, :count).by(1)
-        end
-
-        it "does not attach the banner image" do
-          subject
-          expect(subject.banner_image).not_to be_attached
-        end
-
-        it "collects a warning about the missing banner image" do
-          subject
-          expect(importer.warnings).to include(a_string_matching(/The banner image could not be imported \(404 Not Found\)\./i))
-        end
-      end
-
-      context "when both hero and banner images fail to import" do
-        let(:hero_image_url) { "http://example.com/missing-hero.jpg" }
-        let(:banner_image_url) { "http://example.com/missing-banner.jpg" }
-
-        before do
-          stub_request(:get, hero_image_url).to_return(status: 404)
-          stub_request(:head, hero_image_url).to_return(status: 404)
-          stub_request(:get, banner_image_url).to_return(status: 500)
-          stub_request(:head, banner_image_url).to_return(status: 500)
-        end
-
-        it "imports the assembly successfully" do
-          expect { subject }.to change(Decidim::Assembly, :count).by(1)
-        end
-
-        it "collects warnings for both images" do
-          subject
-          expect(importer.warnings).to include(a_string_matching(/The hero image could not be imported/i))
-          expect(importer.warnings).to include(a_string_matching(/The banner image could not be imported/i))
-          expect(importer.warnings.length).to eq(2)
-        end
-      end
-
       context "when image URL is nil" do
         let(:hero_image_url) { nil }
-        let(:banner_image_url) { nil }
 
         it "imports the assembly without images and no warnings" do
           expect { subject }.to change(Decidim::Assembly, :count).by(1)
           expect(subject.hero_image).not_to be_attached
-          expect(subject.banner_image).not_to be_attached
           expect(importer.warnings).to be_empty
         end
       end
 
       context "when image URL is empty string" do
         let(:hero_image_url) { "" }
-        let(:banner_image_url) { "" }
 
         it "imports the assembly without images and no warnings" do
           expect { subject }.to change(Decidim::Assembly, :count).by(1)
           expect(subject.hero_image).not_to be_attached
-          expect(subject.banner_image).not_to be_attached
           expect(importer.warnings).to be_empty
         end
       end

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_serializer_spec.rb
@@ -22,7 +22,6 @@ module Decidim::Assemblies
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
         expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)
-        expect(serialized[:remote_banner_image_url]).to be_blob_url(resource.banner_image.blob)
         expect(serialized).to include(promoted: resource.promoted)
         expect(serialized).to include(developer_group: resource.developer_group)
         expect(serialized).to include(meta_scope: resource.meta_scope)

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/open_data_assembly_serializer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/open_data_assembly_serializer_spec.rb
@@ -23,7 +23,6 @@ module Decidim::Assemblies
         expect(serialized).to include(short_description: resource.short_description)
         expect(serialized).to include(description: resource.description)
         expect(serialized[:remote_hero_image_url]).to be_blob_url(resource.hero_image.blob)
-        expect(serialized[:remote_banner_image_url]).to be_blob_url(resource.banner_image.blob)
         expect(serialized).to include(promoted: resource.promoted)
         expect(serialized).to include(developer_group: resource.developer_group)
         expect(serialized).to include(meta_scope: resource.meta_scope)

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -18,8 +18,6 @@ shared_examples "manage assemblies" do
     it "updates an assembly" do
       fill_in_i18n(:assembly_title, "#assembly-title-tabs", **attributes[:title].except("machine_translations"))
 
-      dynamically_attach_file(:assembly_banner_image, image3_path, remove_before: true)
-
       within ".edit_assembly" do
         expect(assembly_parent_id_options).not_to include(assembly.id)
         fill_in_i18n(:assembly_subtitle, "#assembly-subtitle-tabs", **attributes[:subtitle].except("machine_translations"))

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -18,6 +18,8 @@ shared_examples "manage assemblies" do
     it "updates an assembly" do
       fill_in_i18n(:assembly_title, "#assembly-title-tabs", **attributes[:title].except("machine_translations"))
 
+      dynamically_attach_file(:assembly_hero_image, image3_path, remove_before: true)
+
       within ".edit_assembly" do
         expect(assembly_parent_id_options).not_to include(assembly.id)
         fill_in_i18n(:assembly_subtitle, "#assembly-subtitle-tabs", **attributes[:subtitle].except("machine_translations"))
@@ -81,12 +83,6 @@ shared_examples "manage assemblies" do
       within %([data-active-uploads] [data-filename="#{hero_blob.filename}"]) do
         src = page.find("img")["src"]
         expect(src).to be_blob_url(hero_blob)
-      end
-
-      banner_blob = assembly.hero_image.blob
-      within %([data-active-uploads] [data-filename="#{banner_blob.filename}"]) do
-        src = page.find("img")["src"]
-        expect(src).to be_blob_url(banner_blob)
       end
     end
   end

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -30,10 +30,6 @@ describe "Admin imports assembly" do
         "image/jpeg"
       )
       stub_get_request_with_format(
-        "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg",
-        "image/jpeg"
-      )
-      stub_get_request_with_format(
         "http://localhost:3000/uploads/decidim/attachment/file/31/Exampledocument.pdf",
         "application/pdf"
       )
@@ -115,10 +111,6 @@ describe "Admin imports assembly" do
         .to_return(status: 404, body: "Not Found")
       stub_request(:head, "http://example.com/missing-hero.jpg")
         .to_return(status: 404, body: "Not Found")
-      stub_request(:get, "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg")
-        .to_return(status: 200, body: File.read(Decidim::Dev.asset("city2.jpeg")))
-      stub_request(:head, "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg")
-        .to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
 
       within_admin_menu do
         click_on "Import"
@@ -149,60 +141,7 @@ describe "Admin imports assembly" do
     end
   end
 
-  context "when banner image URL returns 404" do
-    let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
-    let(:json_file) do
-      Tempfile.new(["assemblies", ".json"]).tap do |file|
-        file.write(json_data.to_json)
-        file.rewind
-      end
-    end
-    let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
-    end
-
-    before do
-      json_data.first["remote_banner_image_url"] = "http://example.com/missing-banner.jpg"
-
-      stub_request(:get, "http://example.com/missing-banner.jpg")
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:head, "http://example.com/missing-banner.jpg")
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:get, "http://localhost:3000/uploads/decidim/assembly/hero_image/1/city.jpeg")
-        .to_return(status: 200, body: File.read(Decidim::Dev.asset("city.jpeg")))
-      stub_request(:head, "http://localhost:3000/uploads/decidim/assembly/hero_image/1/city.jpeg")
-        .to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
-
-      within_admin_menu do
-        click_on "Import"
-      end
-
-      within ".import_assembly" do
-        fill_in_i18n(
-          :assembly_title,
-          "#assembly-title-tabs",
-          en: "Import assembly with 404 banner",
-          es: "Importación de la asamblea",
-          ca: "Importació de l'asamblea"
-        )
-        fill_in :assembly_slug, with: "as-import-404-banner"
-      end
-
-      dynamically_attach_file(:assembly_document, uploaded_file.path)
-      click_on "Import"
-    end
-
-    it "imports successfully and shows a warning about the missing banner image" do
-      expect(page).to have_callout("Assembly successfully imported.")
-      expect(page).to have_callout("Import assembly with 404 banner")
-
-      within ".flash.warning" do
-        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
-      end
-    end
-  end
-
-  context "when both hero and banner image URLs return 404" do
+  context "when hero image URL returns 404" do
     let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
     let(:json_file) do
       Tempfile.new(["assemblies", ".json"]).tap do |file|
@@ -216,15 +155,10 @@ describe "Admin imports assembly" do
 
     before do
       json_data.first["remote_hero_image_url"] = "http://example.com/missing-hero.jpg"
-      json_data.first["remote_banner_image_url"] = "http://example.com/missing-banner.jpg"
 
       stub_request(:get, "http://example.com/missing-hero.jpg")
         .to_return(status: 404, body: "Not Found")
       stub_request(:head, "http://example.com/missing-hero.jpg")
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:get, "http://example.com/missing-banner.jpg")
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:head, "http://example.com/missing-banner.jpg")
         .to_return(status: 404, body: "Not Found")
 
       within_admin_menu do
@@ -237,7 +171,7 @@ describe "Admin imports assembly" do
           "#assembly-title-tabs",
           en: "Import assembly with 404 images",
           es: "Importación de la asamblea",
-          ca: "Importació de l'asamblea"
+          ca: "Importació de l'asamble"
         )
         fill_in :assembly_slug, with: "as-import-404-both"
       end
@@ -246,18 +180,17 @@ describe "Admin imports assembly" do
       click_on "Import"
     end
 
-    it "imports successfully and shows warnings for both missing images" do
+    it "imports successfully and shows warnings for missing images" do
       expect(page).to have_callout("Assembly successfully imported.")
       expect(page).to have_callout("Import assembly with 404 images")
 
       within ".flash.warning" do
         expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
-        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
 
-  context "when both image URLs are too long and return 404" do
+  context "when hero image URL is too long and returns 404" do
     let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
     let(:json_file) do
       Tempfile.new(["assemblies", ".json"]).tap do |file|
@@ -269,19 +202,13 @@ describe "Admin imports assembly" do
       Rack::Test::UploadedFile.new(json_file.path, "application/json")
     end
     let(:hero_image_url) { "http://example.com/#{"a" * 5000}.jpg" }
-    let(:banner_image_url) { "http://example.com/#{"b" * 5000}.jpg" }
 
     before do
       json_data.first["remote_hero_image_url"] = hero_image_url
-      json_data.first["remote_banner_image_url"] = banner_image_url
 
       stub_request(:get, hero_image_url)
         .to_return(status: 404, body: "Not Found")
       stub_request(:head, hero_image_url)
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:get, banner_image_url)
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:head, banner_image_url)
         .to_return(status: 404, body: "Not Found")
 
       within_admin_menu do
@@ -303,13 +230,12 @@ describe "Admin imports assembly" do
       click_on "Import"
     end
 
-    it "imports successfully and shows warnings for both missing images" do
+    it "imports successfully and shows warnings for missing images" do
       expect(page).to have_callout("Assembly successfully imported.")
       expect(page).to have_callout("Import assembly with long 404 images")
 
       within ".flash.warning" do
         expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
-        expect(page).to have_content(/The banner image could not be imported \(404 Not Found\)\./i)
       end
     end
   end
@@ -336,10 +262,6 @@ describe "Admin imports assembly" do
 
       stub_get_request_with_format(
         "http://localhost:3000/uploads/decidim/assembly/hero_image/1/city.jpeg",
-        "image/jpeg"
-      )
-      stub_get_request_with_format(
-        "http://localhost:3000/uploads/decidim/assembly/banner_image/1/city2.jpeg",
         "image/jpeg"
       )
 

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -181,7 +181,7 @@ describe "Admin imports assembly" do
       click_on "Import"
     end
 
-    it "imports successfully and shows warnings for missing images" do
+    it "imports successfully and shows warnings for missing hero image" do
       expect(page).to have_callout("Assembly successfully imported.")
       expect(page).to have_callout("Import assembly with long 404 images")
 

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -141,55 +141,6 @@ describe "Admin imports assembly" do
     end
   end
 
-  context "when hero image URL returns 404" do
-    let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
-    let(:json_file) do
-      Tempfile.new(["assemblies", ".json"]).tap do |file|
-        file.write(json_data.to_json)
-        file.rewind
-      end
-    end
-    let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
-    end
-
-    before do
-      json_data.first["remote_hero_image_url"] = "http://example.com/missing-hero.jpg"
-
-      stub_request(:get, "http://example.com/missing-hero.jpg")
-        .to_return(status: 404, body: "Not Found")
-      stub_request(:head, "http://example.com/missing-hero.jpg")
-        .to_return(status: 404, body: "Not Found")
-
-      within_admin_menu do
-        click_on "Import"
-      end
-
-      within ".import_assembly" do
-        fill_in_i18n(
-          :assembly_title,
-          "#assembly-title-tabs",
-          en: "Import assembly with 404 images",
-          es: "Importación de la asamblea",
-          ca: "Importació de l'asamble"
-        )
-        fill_in :assembly_slug, with: "as-import-404-both"
-      end
-
-      dynamically_attach_file(:assembly_document, uploaded_file.path)
-      click_on "Import"
-    end
-
-    it "imports successfully and shows warnings for missing images" do
-      expect(page).to have_callout("Assembly successfully imported.")
-      expect(page).to have_callout("Import assembly with 404 images")
-
-      within ".flash.warning" do
-        expect(page).to have_content(/The hero image could not be imported \(404 Not Found\)\./i)
-      end
-    end
-  end
-
   context "when hero image URL is too long and returns 404" do
     let(:json_data) { JSON.parse(File.read(Decidim::Dev.asset("assemblies.json"))) }
     let(:json_file) do

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -86,7 +86,6 @@ describe "Admin manages assemblies" do
       end
 
       dynamically_attach_file(:assembly_hero_image, image1_path)
-      dynamically_attach_file(:assembly_banner_image, image2_path)
 
       within ".new_assembly" do
         find("*[type=submit]").click

--- a/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
@@ -43,12 +43,6 @@ describe "Social shares" do
   context "when no hero_image" do
     let(:hero_image) { nil }
 
-    it_behaves_like "a social share meta tag", "city.jpeg"
-  end
-
-  context "when no direct images" do
-    let(:hero_image) { nil }
-
     it_behaves_like "a social share meta tag", "city3.jpeg"
   end
 

--- a/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
@@ -5,12 +5,11 @@ require "decidim/core/test/shared_examples/social_share_examples"
 
 describe "Social shares" do
   let(:organization) { create(:organization) }
-  let(:assembly) { create(:assembly, organization:, description:, short_description:, hero_image:, banner_image:) }
+  let(:assembly) { create(:assembly, organization:, description:, short_description:, hero_image:) }
   let(:content_block) { create(:content_block, organization:, manifest_name: :hero, scope_name: :homepage) }
   let!(:attachment) { create(:attachment, :with_image, attached_to: assembly, file: attachment_file) }
   let(:description) { { en: "Description <p><img src=\"#{description_image_path}\"></p>" } }
   let(:short_description) { { en: "Description <p><img src=\"#{short_description_image_path}\"></p>" } }
-  let(:banner_image) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
   let(:hero_image) { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
   let!(:attachment_file) { Decidim::Dev.test_file("city3.jpeg", "image/jpeg") }
   let(:description_image_path) { Rails.application.routes.url_helpers.rails_blob_path(description_image, only_path: true) }
@@ -49,14 +48,12 @@ describe "Social shares" do
 
   context "when no direct images" do
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
 
     it_behaves_like "a social share meta tag", "city3.jpeg"
   end
 
   context "when no attachments nor direct images" do
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
     let(:attachment) { nil }
 
     it_behaves_like "a social share meta tag", "description_image.jpg"
@@ -70,7 +67,6 @@ describe "Social shares" do
 
   context "when no attachments, description image or direct images" do
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
     let(:attachment) { nil }
     let(:description_image_path) { "" }
     let(:short_description_image_path) { "" }
@@ -80,7 +76,6 @@ describe "Social shares" do
 
   context "when nothing" do
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
     let(:attachment) { nil }
     let(:description_image_path) { "" }
     let(:short_description_image_path) { "" }

--- a/decidim-assemblies/spec/types/assembly_type_spec.rb
+++ b/decidim-assemblies/spec/types/assembly_type_spec.rb
@@ -83,14 +83,6 @@ module Decidim
         end
       end
 
-      describe "bannerImage" do
-        let(:query) { "{ bannerImage }" }
-
-        it "returns the banner image field" do
-          expect(response["bannerImage"]).to be_blob_url(model.banner_image.blob)
-        end
-      end
-
       describe "promoted" do
         let(:query) { "{ promoted }" }
 

--- a/decidim-assemblies/spec/types/integration_schema_spec.rb
+++ b/decidim-assemblies/spec/types/integration_schema_spec.rb
@@ -200,7 +200,6 @@ describe "Decidim::Api::QueryType" do
     it "returns the correct response" do
       data = response["assemblies"].first
       expect(data).to include(assembly_data)
-      expect(data["bannerImage"]).to be_blob_url(assembly.banner_image.blob)
       expect(data["heroImage"]).to be_blob_url(assembly.hero_image.blob)
     end
 
@@ -344,7 +343,6 @@ describe "Decidim::Api::QueryType" do
     it "returns the correct response" do
       data = response["assembly"]
       expect(data).to include(assembly_data)
-      expect(data["bannerImage"]).to be_blob_url(assembly.banner_image.blob)
       expect(data["heroImage"]).to be_blob_url(assembly.hero_image.blob)
     end
 

--- a/decidim-assemblies/spec/types/integration_schema_spec.rb
+++ b/decidim-assemblies/spec/types/integration_schema_spec.rb
@@ -77,7 +77,6 @@ describe "Decidim::Api::QueryType" do
             translation(locale:"#{locale}")
           }
         }
-        bannerImage
         categories {
           id
         }
@@ -230,7 +229,6 @@ describe "Decidim::Api::QueryType" do
             translation(locale:"#{locale}")
           }
         }
-        bannerImage
         categories {
           id
         }

--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_hero_cell.rb
@@ -27,12 +27,8 @@ module Decidim
         decidim_escape_translated(resource.subtitle)
       end
 
-      # If it is called from the landing page content block, use the background image defined there
-      # Else, use the banner image defined in the space (for assemblies)
       def image_path
-        return model.images_container.attached_uploader(:background_image).url if model.respond_to?(:images_container)
-
-        attached_uploader(:banner_image).url
+        model.images_container.attached_uploader(:background_image).url
       end
 
       def has_cta?

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1347,6 +1347,9 @@ en:
       update:
         error: There was a problem updating your notifications settings.
         success: Your notifications settings were successfully updated.
+    participatory_space_members:
+      index:
+        members: Members
     offline:
       name: Offline
       show:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1347,9 +1347,6 @@ en:
       update:
         error: There was a problem updating your notifications settings.
         success: Your notifications settings were successfully updated.
-    participatory_space_members:
-      index:
-        members: Members
     offline:
       name: Offline
       show:
@@ -1537,6 +1534,9 @@ en:
           %{organization_name}
         hello: Dear %{username},
         subject: Inactive account deleted
+    participatory_space_members:
+      index:
+        members: Members
     passwords:
       update:
         error: There was a problem updating the password.

--- a/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
@@ -107,7 +107,7 @@ shared_examples "participatory space members" do
       end
 
       it "lists all the non ceased members" do
-        within "#assembly_members-grid" do
+        within ".layout-main__section" do
           expect(page).to have_css(".profile__user", count: 1)
 
           expect(page).to have_no_content(Decidim::ParticipatorySpace::MemberPresenter.new(ceased_member).name)

--- a/decidim-core/spec/services/decidim/meta_image_url_resolver_spec.rb
+++ b/decidim-core/spec/services/decidim/meta_image_url_resolver_spec.rb
@@ -7,9 +7,8 @@ describe Decidim::MetaImageUrlResolver do
 
   let(:organization) { create(:organization) }
   let(:hero_image) { nil }
-  let(:banner_image) { nil }
   let(:avatar) { nil }
-  let(:participatory_space) { create(:assembly, organization:, hero_image:, banner_image:) }
+  let(:participatory_space) { create(:assembly, organization:, hero_image:) }
   let(:component) { create(:proposal_component, :with_attachments_allowed, participatory_space:) }
   let!(:proposal) { create(:proposal, component:, body:) }
   let(:description_image) do
@@ -38,14 +37,13 @@ describe Decidim::MetaImageUrlResolver do
 
   shared_examples "direct images" do
     let(:hero_image) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
-    let(:banner_image) { Decidim::Dev.test_file("city2.jpeg", "image/jpeg") }
 
     it { is_expected.to end_with("/city.jpeg") }
 
     context "and no hero_image" do
       let(:hero_image) { nil }
 
-      it { is_expected.to end_with("/city2.jpeg") }
+      it { is_expected.to end_with("/icon.png") }
     end
   end
 
@@ -55,7 +53,6 @@ describe Decidim::MetaImageUrlResolver do
 
   context "when there is no image attached" do
     let(:hero_image) { nil }
-    let(:banner_image) { nil }
     let(:resource) { nil }
 
     before do

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
@@ -1,4 +1,4 @@
-<% add_decidim_page_title(t(".title")) %>
+<% add_decidim_page_title(t("members", scope: "decidim.participatory_space_members.index")) %>
 <% add_decidim_meta_tags(
      title: translated_attribute(current_participatory_space.title),
      resource: current_participatory_space) %>
@@ -11,12 +11,14 @@ edit_link(
 )
 %>
 
-<div class="container py-8">
-  <h3 class="h3 decorator mb-8">
-    <%= t("members", scope: "decidim.assemblies.assembly_members.index") %>
-    <span class="label text-md"><%= collection.size %></span>
-  </h3>
-  <div id="assembly_members-grid" class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-12">
+<% content_for :aside do %>
+  <h1 class="title-decorator">
+    <%= t("members", scope: "decidim.participatory_space_members.index") %>
+  </h1>
+<% end %>
+
+<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
+  <section class="layout-main__section">
     <%= render(collection) %>
-  </div>
-</div>
+  </section>
+<% end %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -567,9 +567,6 @@ en:
         title: Participatory processes
       last_activity:
         new_participatory_process: 'New participatory process:'
-      members:
-        index:
-          title: Members
       pages:
         home:
           highlighted_processes:


### PR DESCRIPTION
## :tophat: What? Why?

As we did in #13119 for participatory processes, this PR removes an unused field in our forms: the banner_image in decidim-assemblies.

A side quest that I went while working on this one is the Members page: for Assemblies we still have a pre-redesign adapted layout that doesn't make much sense. Now we use just the two columns layout as the components index pages. 

## :pushpin: Related Issues

- Fixes #13760 (or at least the part that I could understand from it)

## Testing

(Without this PR): upload an image in this field and see if you can find it in the frontend UI (I could not find anything)

For the members page:

1. Log in as admin
2. Edit an assembly and check " This space has members"
3. Add a member and publish it
4. Go to the assembly page
5. Click on "Members"
6. See the page and the layout

## :camera: Screenshots

<img width="2074" height="1316" alt="image" src="https://github.com/user-attachments/assets/b1363394-5ab4-4ff6-b163-4e21b5e808c1" />

### Members page 

####  Before

<img width="907" height="867" alt="image" src="https://github.com/user-attachments/assets/25bd04ae-58cd-43dc-99c4-eabbc679f661" />

#### After 

<img width="841" height="817" alt="image" src="https://github.com/user-attachments/assets/dd311063-3f10-4f49-85d0-dfa900b824e6" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed**
  * Banner image support removed across assemblies: admin UI/forms, create/update/duplicate/import/export flows, API/schema, presenter accessors, seeds/factories, serializers, and tests.

* **Refactor**
  * Member listing pages updated to a two-column layout and hero/background image retrieval simplified.

* **New**
  * Added a localization entry for the members index title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->