### PR TITLE
Remove automatic numbering of questions in the frontend

### DIFF
--- a/decidim-forms/app/packs/stylesheets/decidim/forms/forms.scss
+++ b/decidim-forms/app/packs/stylesheets/decidim/forms/forms.scss
@@ -22,7 +22,7 @@
   }
 
   &__question-label {
-    @apply text-black text-xl font-semibold relative before:content-[attr(data-response-idx)] before:w-6 before:h-6 md:before:absolute md:before:-left-4 md:before:-translate-x-full before:inline-flex before:justify-center before:rounded-full before:bg-background before:text-lg before:text-gray-2 before:font-semibold;
+    @apply text-black text-xl font-semibold;
   }
 
   &__question-description {

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_questionnaire.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_questionnaire.html.erb
@@ -17,7 +17,6 @@
 
   <%= invisible_captcha %>
   <% response_idx = 0 %>
-  <% cleaned_response_idx = 1 %>
   <% @form.responses_by_step.each_with_index do |step_responses, step_index| %>
     <div id="step-<%= step_index %>" class="response-questionnaire__step" <%= "hidden" if !step_index.zero? %>>
 
@@ -39,15 +38,10 @@
               response_form:,
               response:,
               response_idx:,
-              cleaned_response_idx:,
               disabled: !current_participatory_space.can_participate?(current_user)
             ) %>
           <% end %>
         </div>
-
-        <% if !(response.question.separator? || response.question.title_and_description?) %>
-          <% cleaned_response_idx += 1 %>
-        <% end %>
 
         <% response_idx += 1 %>
 

--- a/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
+++ b/decidim-forms/app/views/decidim/forms/questionnaires/_response.html.erb
@@ -24,8 +24,7 @@
   <div class="response-questionnaire__question">
     <%
     label_options = {
-      class: "response-questionnaire__question-label questionnaire-question",
-      data: { "response-idx": cleaned_response_idx }
+      class: "response-questionnaire__question-label questionnaire-question"
     }
     label_options[:for] = nil if %w(matrix_single matrix_multiple single_option multiple_option).include?(response.question.question_type)
     %>

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/has_questionnaire.rb
@@ -192,9 +192,7 @@ shared_examples_for "has questionnaire" do
 
         expect(form_fields[0]).to have_i18n_content(question.body)
         expect(form_fields[1]).to have_i18n_content(other_question.body)
-        2.times do |index|
-          expect(form_fields[index]).to have_css("[data-response-idx='#{index + 1}']")
-        end
+        expect(page.text.index(translated_attribute(other_question.body))).to be > page.text.index(translated_attribute(question.body))
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The automatic numbering of the surveys' questions is difficult to make compatible with the display conditions, as the number and order of the questions can change. 

This PR removes this number in the surveys' questions.

I left it out in `decidim-demographics` as we have a similar questions ordering for the responses of the questionnaire by the admin, but we don't have this problem (as we don't have displays conditions there).

#### :pushpin: Related Issues

- Fixes #13207 

#### Testing

1. Go to a surveys' frontend and check out the questions numbers 

### :camera: Screenshots

#### Before

<img width="1393" height="844" alt="image" src="https://github.com/user-attachments/assets/4b6a104b-e05d-41c1-9369-a57fa05d7374" />

#### After

<img width="1319" height="914" alt="image" src="https://github.com/user-attachments/assets/650ab009-d584-4e15-a6c6-786743e2cc8f" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed numeric response index indicators from question labels, simplifying label display and layout in questionnaires.
* **Refactor**
  * Simplified questionnaire rendering by removing extra per-response index tracking and related markup.
* **Tests**
  * Updated tests to assert question order by text position instead of relying on numeric index attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->