### PR TITLE
Fix rubocop message antipattern configuration for decidim.org

### DIFF
--- a/decidim-dev/config/rubocop/decidim-linters/configuration.yml
+++ b/decidim-dev/config/rubocop/decidim-linters/configuration.yml
@@ -1,0 +1,5 @@
+require:
+  - decidim/dev/rubocop/cop/decidim/message_antipattern
+
+Decidim/MessageAntipattern:
+  Enabled: true

--- a/decidim-dev/config/rubocop/decidim-linters/configuration.yml
+++ b/decidim-dev/config/rubocop/decidim-linters/configuration.yml
@@ -3,3 +3,6 @@ require:
 
 Decidim/MessageAntipattern:
   Enabled: true
+  Include:
+    - "**/spec/**/*"
+    - "**/test/**/*"

--- a/decidim-dev/config/rubocop/ruby/configuration.yml
+++ b/decidim-dev/config/rubocop/ruby/configuration.yml
@@ -1,7 +1,3 @@
-require:
-  - rubocop
-  - decidim/dev/rubocop/cop/decidim/message_antipattern
-
 # Common configuration.
 AllCops:
   Include:

--- a/decidim-dev/rubocop-decidim.yml
+++ b/decidim-dev/rubocop-decidim.yml
@@ -28,9 +28,3 @@ inherit_from:
   - config/rubocop/yard/configuration.yml
   - config/rubocop/disabled.yml
   - config/rubocop/decidim-linters/configuration.yml
-
-Decidim/MessageAntipattern:
-  Enabled: true
-  Include:
-    - "**/spec/**/*"
-    - "**/test/**/*"

--- a/decidim-dev/rubocop-decidim.yml
+++ b/decidim-dev/rubocop-decidim.yml
@@ -27,6 +27,7 @@ inherit_from:
   - config/rubocop/factory_bot/disabled.yml
   - config/rubocop/yard/configuration.yml
   - config/rubocop/disabled.yml
+  - config/rubocop/decidim-linters/configuration.yml
 
 Decidim/MessageAntipattern:
   Enabled: true


### PR DESCRIPTION
#### :tophat: What? Why?
This PR attempts to fix issues to do with linters particular with `message_antipattern` within the decidim.org repo: https://github.com/decidim/decidim.org

Moving the require into a separate file linters file in decidim-dev so it can be disabled on .org

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing

### :camera: Screenshots


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized RuboCop lint configuration to improve clarity and rule management.
  * Added and enabled a project-specific lint that enforces messaging patterns in spec and test files.
  * Removed redundant global lint declarations and extended configuration inheritance to ensure consistent rule loading across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->