### PR TITLE
Fix bug with the announcements break words rules

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_flash.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_flash.scss
@@ -1,5 +1,5 @@
 .flash {
-  @apply flex justify-start gap-4 border-l-4 border-secondary my-4 p-4 bg-secondary/5 break-all;
+  @apply flex justify-start gap-4 border-l-4 border-secondary my-4 p-4 bg-secondary/5;
 
   &__icon {
     svg {


### PR DESCRIPTION
#### :tophat: What? Why?

While working in the announcements I changed the CSS code because I wanted to show URLs there - but it was a bad idea that I ditched. Sadly, I left the code for this 😞 

This PR fixes it.

#### :pushpin: Related Issues
 
- Related to #16026 
- Fixes #16367

#### Testing

1. Go find an announcement with lots of words and resize the page

### :camera: Screenshots

#### Before

<img width="777" height="504" alt="image" src="https://github.com/user-attachments/assets/272afdc7-0411-4fea-81c7-f83b9718e296" />

#### After

<img width="732" height="456" alt="image" src="https://github.com/user-attachments/assets/6f9fc263-094d-4157-b65f-16584f161bcf" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text-wrapping behavior in notification messages to display text more naturally within flash alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->