### PR TITLE
Fix flaky on proposals' `filter_proposals_spec.rb`

### DIFF
--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -179,6 +179,8 @@ describe "Filter Proposals", :slow do
           check decidim_sanitize_translated(taxonomy.name)
         end
 
+        expect(page).to have_css("[id^='proposals__proposal']", count: 2)
+
         within "#dropdown-menu-order" do
           click_on "Most commented"
         end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a flaky with the proposals filtering spec. 

This PR fixes it. 

#### :pushpin: Related Issues
- Related to  https://github.com/decidim/decidim/actions/runs/22918111692/job/66508967784

#### Testing

This oneliner is pretty consistent in my local machine: 

10/10 failures without the patch
10/10 passes with the patch

```bash
for i in $(seq 1 10) ; do echo $i; bin/rspec decidim-proposals/spec/system/filter_proposals_spec.rb -e "when selecting one taxonomy" ; done
```

### :camera: Stacktrace


```
10
DEPRECATION WARNING: ActiveSupport::Configurable is deprecated without replacement, and will be removed in Rails 8.2.

You can emulate the previous behavior with `class_attribute`.
 (called from <module:Dev> at /workspaces/decidim/decidim-dev/lib/decidim/dev.rb:25)
Run options: include {full_description: /when\ selecting\ one\ taxonomy/}

Randomized with seed 52286

Filter Proposals
  when filtering proposals by TAXONOMY
    when selecting one taxonomy
      lists the filtered proposals
      can be ordered by most commented and most followed after filtering (FAILED - 1)

Failures:

  1) Filter Proposals when filtering proposals by TAXONOMY when selecting one taxonomy can be ordered by most commented and most followed after filtering
     Failure/Error: expect(page).to have_css("[id^='proposals__proposal']", count: 2)
       expected to find visible css "[id^='proposals__proposal']" 2 times, found 4 matches: "<script>alert(\"proposal_title\");</script> Molestias ullam numquam. 208\nAmb. Coy Roob\nOmnis ut perferendis. 191\n0\n0", "<script>alert(\"proposal_title\");</script> Animi voluptatum qui. 195\nJohn McGlynn\nOmnis ut perferendis. 191\n1\n0", "<script>alert(\"proposal_title\");</script> Voluptate quis quibusdam. 223\nBrady Hermann\nTaxonomy name\n0\n0", "<script>alert(\"proposal_title\");</script> Nemo sit reprehenderit. 236\nHilton Okuneva\n0\n0"

     [Screenshot Image]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_filter_proposals_when_filtering_proposals_by_taxonomy_when_selecting_one_taxonomy_can_be_ordered_by_most_commented_and_most_followed_after_filtering_28.png

     [Screenshot HTML]: file:///workspaces/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_filter_proposals_when_filtering_proposals_by_taxonomy_when_selecting_one_taxonomy_can_be_ordered_by_most_commented_and_most_followed_after_filtering_28.html




     # ./spec/system/filter_proposals_spec.rb:193:in 'block (4 levels) in <top (required)>'
     # /workspaces/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <main>'
     # /workspaces/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in 'block (2 levels) in <main>'

Top 2 slowest examples (36.27 seconds, 93.8% of total time):
  Filter Proposals when filtering proposals by TAXONOMY when selecting one taxonomy can be ordered by most commented and most followed after filtering
    32.32 seconds ./spec/system/filter_proposals_spec.rb:172
  Filter Proposals when filtering proposals by TAXONOMY when selecting one taxonomy lists the filtered proposals
    3.96 seconds ./spec/system/filter_proposals_spec.rb:163

Finished in 38.69 seconds (files took 3.65 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/system/filter_proposals_spec.rb:172 # Filter Proposals when filtering proposals by TAXONOMY when selecting one taxonomy can be ordered by most commented and most followed after filtering
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced testing for proposal filtering by taxonomy to ensure accurate result counts when selecting taxonomy filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->