### PR TITLE
Fix component settings disabled when it is readonly

### DIFF
--- a/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
+++ b/decidim-admin/app/helpers/decidim/admin/settings_helper.rb
@@ -108,7 +108,8 @@ module Decidim
         html = form.select(
           name,
           choices,
-          { include_blank: attribute.include_blank, label: options[:label] }
+          { include_blank: attribute.include_blank, label: options[:label] },
+          { disabled: options[:readonly] || false }
         )
         html << content_tag(:p, options[:help_text], class: "help-text") if options[:help_text]
         html

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -60,7 +60,7 @@ module Decidim
           render_input
         end
 
-        context "when the field should be disbaled" do
+        context "when the field should be disabled" do
           let(:options) { { include_blank: false, readonly: true, label: "A test" } }
 
           it "is supported" do

--- a/decidim-admin/spec/helpers/settings_helper_spec.rb
+++ b/decidim-admin/spec/helpers/settings_helper_spec.rb
@@ -55,9 +55,22 @@ module Decidim
           expect(form).to receive(:select).with(
             :test,
             full_choices,
-            options
+            options, { disabled: false }
           )
           render_input
+        end
+
+        context "when the field should be disbaled" do
+          let(:options) { { include_blank: false, readonly: true, label: "A test" } }
+
+          it "is supported" do
+            expect(form).to receive(:select).with(
+              :test,
+              full_choices,
+              options.except(:readonly), { disabled: true }
+            )
+            render_input
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR I am adding the possibility of disabling the Components settings admin fields

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #14794

#### Testing

Sorry, cannot add 1, 2, 3, 4 :cry: 

On the develop branch
Edit `decidim-accountability/lib/decidim/accountability/component.rb`
Patch "default_taxonomy" as follows (the readonly bit is important)

```
settings.attribute :default_taxonomy, 
                   type: :select, 
                   include_blank: true, 
                   raw_choices: true,
                   choices: lambda { |context| context[:component].available_root_taxonomies.map { |taxonomy| [translated_attribute(taxonomy.name), taxonomy.id] } },
                   readonly: lambda { |context| context[:component].available_root_taxonomies.empty? }
```

Restart your application, visit the accountability component. Remove the default taxonomy filter from component ( the categories ) .... 

See that in the respective component, you have an empty "Default taxonomy" field. 
Apply the patch .... 
Restart the app, revisit the component settings page, see the "Default taxonomy" field is disabled.

### :camera: Screenshots
<img width="1233" height="766" alt="image" src="https://github.com/user-attachments/assets/7d2de5d5-0334-4b33-821b-c024835376e3" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Readonly select fields in admin settings now render as disabled, improving clarity that they cannot be edited.
* **Tests**
  * Added/updated tests to cover readonly behavior for select inputs and verify disabled rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->