### PR TITLE
Do not allow browsing resources in deleted components

### DIFF
--- a/decidim-accountability/spec/system/admin/admin_manages_component_publication_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_manages_component_publication_spec.rb
@@ -24,6 +24,12 @@ describe "Admin manages component publication" do
 
         include_examples "removes component resources from search index"
       end
+
+      context "when component is deleted" do
+        let!(:component) { create(:accountability_component, :trashed, participatory_space:) }
+
+        include_examples "cannot browse component data"
+      end
     end
 
     context "when there are children" do

--- a/decidim-admin/app/views/decidim/admin/components/_component_row.html.erb
+++ b/decidim-admin/app/views/decidim/admin/components/_component_row.html.erb
@@ -4,7 +4,7 @@
       <%= icon("draggable", class: "dragger") %>
     </td>
     <td class="!text-left" data-label="<%= t("index.headers.name", scope: "decidim.admin.components") %>">
-      <% if component.manifest.admin_engine %>
+      <% if component.manifest.admin_engine && !component.deleted? %>
         <%= link_to translated_attribute(component.name), manage_component_path(component) %><br>
       <% else %>
         <%= translated_attribute component.name %>

--- a/decidim-admin/lib/decidim/admin/test/manage_resource_soft_deletion_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_resource_soft_deletion_examples.rb
@@ -53,7 +53,7 @@ shared_examples "manage soft deletable component or space" do |resource_name|
       resource.destroy!
       resource.reload
       visit trash_path
-      click_on title[:en]
+      click_on title[:en] unless resource.is_a?(Decidim::Component)
     end
 
     it "shows warning message" do

--- a/decidim-blogs/spec/system/admin_manages_component_publication_spec.rb
+++ b/decidim-blogs/spec/system/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:post_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end

--- a/decidim-budgets/spec/system/admin_manages_component_publication_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_component_publication_spec.rb
@@ -24,6 +24,12 @@ describe "Admin manages component publication" do
 
         include_examples "removes component resources from search index"
       end
+
+      context "when component is deleted" do
+        let!(:component) { create(:budgets_component, :trashed, participatory_space:) }
+
+        include_examples "cannot browse component data"
+      end
     end
 
     context "with a project" do

--- a/decidim-collaborative_texts/spec/system/admin/admin_manages_component_publication_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:collaborative_text_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end

--- a/decidim-debates/spec/system/admin_manages_component_publication_spec.rb
+++ b/decidim-debates/spec/system/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:debates_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
@@ -143,6 +143,21 @@ shared_examples "add component resources to search index" do
   end
 end
 
+shared_examples "cannot browse component data" do
+  before do
+    visit decidim_admin_participatory_processes.components_path(component.participatory_space)
+    click_on "View deleted components"
+  end
+
+  it "has no access to the component data" do
+    expect(page).to have_current_path(decidim_admin_participatory_processes.manage_trash_components_path(component.participatory_space))
+    within "tr", text: translated(component.name) do
+      expect(page).to have_content(translated(component.name))
+      expect(page).not_to have_link(translated(component.name))
+    end
+  end
+end
+
 shared_examples "removes component resources from search index" do
   before do
     resource.reload.component.manifest.run_hooks(:publish, resource.reload.component)

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
@@ -153,7 +153,7 @@ shared_examples "cannot browse component data" do
     expect(page).to have_current_path(decidim_admin_participatory_processes.manage_trash_components_path(component.participatory_space))
     within "tr", text: translated(component.name) do
       expect(page).to have_content(translated(component.name))
-      expect(page).not_to have_link(translated(component.name))
+      expect(page).to have_no_link(translated(component.name))
     end
   end
 end

--- a/decidim-elections/spec/system/admin/admin_manages_component_publication_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:elections_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end

--- a/decidim-meetings/spec/system/admin/admin_manages_component_publication_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:meeting_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end

--- a/decidim-proposals/spec/system/admin/admin_manages_component_publication_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_component_publication_spec.rb
@@ -23,5 +23,11 @@ describe "Admin manages component publication" do
 
       include_examples "removes component resources from search index"
     end
+
+    context "when component is deleted" do
+      let!(:component) { create(:proposal_component, :trashed, participatory_space:) }
+
+      include_examples "cannot browse component data"
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am disabling the link to component resources in the component trash view.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16364

#### Testing
1. Login as admin 
2. Visit a space, browse the components 
3. Choose to delete a component 
4. Browse the deleted resources 
5. Click on component data 
6. See error 
7. Apply patch 
8. Repeat 4
9. See there is no link to navigate to.


### :camera: Screenshots
Before: 
<img width="1445" height="752" alt="image" src="https://github.com/user-attachments/assets/706f435c-b71a-4916-a28d-fd979daf53bd" />

After:
<img width="1786" height="391" alt="image" src="https://github.com/user-attachments/assets/77b8caad-fafc-4c8c-a347-682a22044de4" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted components no longer appear as clickable links in admin lists; they are rendered as plain text.
  * Access to deleted component data is blocked from the admin interface.

* **Tests**
  * Expanded test coverage across modules to verify deleted/trashed components are shown without links and are inaccessible, including a shared test scenario for this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->