### PR TITLE
Bump publiccode version from v0.4 to v0.5

### DIFF
--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: italia/publiccode-parser-action@v1
-        with:
-          publiccode: 'publiccode.yml'
+      - name: Install publiccode-parser
+        run: curl -sSL https://github.com/italia/publiccode-parser-go/releases/latest/download/publiccode-parser-linux-amd64 -o publiccode-parser && chmod +x publiccode-parser
+      - name: Validate publiccode.yml
+        run: ./publiccode-parser --no-network publiccode.yml

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install publiccode-parser
-        run: curl -sSL https://github.com/italia/publiccode-parser-go/releases/latest/download/publiccode-parser-linux-amd64 -o publiccode-parser && chmod +x publiccode-parser
+        run: |
+          curl -sSL https://github.com/italia/publiccode-parser-go/releases/latest/download/publiccode-parser-go_Linux_x86_64.tar.gz -o publiccode-parser.tar.gz
+          tar -xzf publiccode-parser.tar.gz publiccode-parser-go
+          chmod +x publiccode-parser-go
       - name: Validate publiccode.yml
-        run: ./publiccode-parser --no-network publiccode.yml
+        run: ./publiccode-parser-go --no-network publiccode.yml

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -7,7 +7,7 @@ jobs:
   publiccode_yml_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Install publiccode-parser
         run: curl -sSL https://github.com/italia/publiccode-parser-go/releases/latest/download/publiccode-parser-linux-amd64 -o publiccode-parser && chmod +x publiccode-parser
       - name: Validate publiccode.yml

--- a/.github/workflows/publiccode-yml-validation.yml
+++ b/.github/workflows/publiccode-yml-validation.yml
@@ -7,11 +7,8 @@ jobs:
   publiccode_yml_validation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install publiccode-parser
-        run: |
-          curl -sSL https://github.com/italia/publiccode-parser-go/releases/latest/download/publiccode-parser-go_Linux_x86_64.tar.gz -o publiccode-parser.tar.gz
-          tar -xzf publiccode-parser.tar.gz publiccode-parser-go
-          chmod +x publiccode-parser-go
-      - name: Validate publiccode.yml
-        run: ./publiccode-parser-go --no-network publiccode.yml
+      - uses: actions/checkout@v6
+      - uses: italia/publiccode-parser-action@v1
+        with:
+          publiccode: 'publiccode.yml'
+          no-network: true

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -55,11 +55,11 @@ legal:
   license: AGPL-3.0-or-later
   mainCopyrightOwner: Associació de Software Lliure Decidim
 
-organisation:
-  name: Associació de Software Lliure Decidim
 
 maintenance:
   type: "internal"
+  contacts:
+    - name: Associació de Software Lliure Decidim
 
   contacts:
     - name: Andrés Pereira de Lucena

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -1,12 +1,12 @@
-publiccodeYmlVersion: "0.4"
+publiccodeYmlVersion: "0.5"
 
 name: Decidim
 url: "https://github.com/decidim/decidim.git"
 platforms:
   - web
 developmentStatus: stable
-softwareVersion: "0.29.2"
-releaseDate: "2025-02-12"
+softwareVersion: "0.31.2"
+releaseDate: "2025-02-26"
 logo: "https://raw.githubusercontent.com/decidim/decidim/refs/heads/develop/logo.svg"
 softwareType: "library"
 
@@ -54,7 +54,9 @@ description:
 legal:
   license: AGPL-3.0-or-later
   mainCopyrightOwner: Associació de Software Lliure Decidim
-  repoOwner: Associació de Software Lliure Decidim
+
+organization:
+  name: Associació de Software Lliure Decidim
 
 maintenance:
   type: "internal"

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -55,7 +55,7 @@ legal:
   license: AGPL-3.0-or-later
   mainCopyrightOwner: Associació de Software Lliure Decidim
 
-organization:
+organisation:
   name: Associació de Software Lliure Decidim
 
 maintenance:

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -55,11 +55,8 @@ legal:
   license: AGPL-3.0-or-later
   mainCopyrightOwner: Associació de Software Lliure Decidim
 
-
 maintenance:
   type: "internal"
-  contacts:
-    - name: Associació de Software Lliure Decidim
 
   contacts:
     - name: Andrés Pereira de Lucena

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -44,7 +44,7 @@ description:
       - "Result: Ensure accountability in your participatory processes by converting proposals into results and tracking their implementation with the level of detail you prefer."
       - "Post: Don’t forget to blog about your activities and share your learnings."
     documentation: "https://docs.decidim.org"
-    apiDocumentation: "https://meta.decidim.org/api"
+    apiDocumentation: "https://meta.decidim.org/api/docs"
     awards:
       - Sharing & Reuse Awards by European Commission (2019)
       - Innovation in Politics Awards (2021)


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes upgrade notification from publiccode:

<img width="2827" height="666" alt="image" src="https://github.com/user-attachments/assets/08f30b2e-2530-48d1-a181-fd33125a8343" />

See the output error on https://github.com/decidim/decidim/pull/15895 CI 

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### Testing
CI should be green

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped software version to 0.31.2.
  * Updated release date to February 26, 2025.
  * Updated public metadata format version to 0.5.
  * Updated API documentation URL.
  * Removed repository owner field from public metadata.
  * Adjusted CI validation to run a local validator invocation instead of the previous action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->