### PR TITLE
Fix flaky spec on `homepage_spec.rb` (part 2)

### DIFF
--- a/decidim-core/app/cells/decidim/data_consent/category.erb
+++ b/decidim-core/app/cells/decidim/data_consent/category.erb
@@ -13,7 +13,7 @@
       <%= icon "close-line", class: "cookies__category-toggle-icon" %>
     </label>
 
-    <div id="accordion-trigger-<%= category[:slug] %>" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
+    <div id="accordion-trigger-<%= category[:slug] %>" role="group" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
       <h3 id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
         <%= category[:title] %>
       </h3>

--- a/decidim-core/spec/system/homepage_spec.rb
+++ b/decidim-core/spec/system/homepage_spec.rb
@@ -35,16 +35,16 @@ describe "Homepage" do
     end
 
     before do
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :hero)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :sub_hero)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :how_to_participate)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :footer_sub_hero)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_content_banner, settings: highlighted_content_banner_settings)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_processes)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :upcoming_meetings)
-      create(:content_block, organization:, scope_name: :homepage, manifest_name: :html, settings: { html_content: { en: "<div class=\"custom-html\">Custom HTML Content</div>" } })
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :hero, weight: 10)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :sub_hero, weight: 20)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :how_to_participate, weight: 30)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :stats, weight: 40)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :footer_sub_hero, weight: 50)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_content_banner, weight: 60, settings: highlighted_content_banner_settings)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_processes, weight: 70)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :highlighted_assemblies, weight: 80)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :upcoming_meetings, weight: 90)
+      create(:content_block, organization:, scope_name: :homepage, manifest_name: :html, weight: 100, settings: { html_content: { en: "<div class=\"custom-html\">Custom HTML Content</div>" } })
 
       switch_to_host(organization.host)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes issue with missing weight on content block spec affecting line 427. 

This was likely caused by #16391

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing
Pipeline should be green

Run the full suite `rspec decidim-core/spec/system/homepage_spec.rb`

### :camera: Screenshots

<img width="2880" height="1374" alt="image" src="https://github.com/user-attachments/assets/9a462e63-5664-48be-a37a-9055d16f8926" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for accordion components with proper ARIA roles, enhancing screen reader support and overall accessibility experience for users relying on assistive technologies.
  * Enhanced homepage content block ordering by implementing explicit weight-based sequencing, ensuring consistent, predictable, and reliable display ordering of homepage content blocks across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->