### PR TITLE
(Deprecated) Fix double-escaping of component names in participatory space nav links

### DIFF
--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -30,7 +30,7 @@ module Decidim
            )
         ] + components.map do |component|
           {
-            name: decidim_escape_translated(component.name),
+            name: component.name,
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -30,7 +30,7 @@ module Decidim
            )
         ] + components.map do |component|
           {
-            name: component.name,
+            name: translated_attribute(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -201,7 +201,8 @@ shared_examples "manage assembly components" do
 
       it "hides the component from the menu" do
         visit decidim_assemblies.assembly_path(assembly)
-        expect(page).to have_content decidim_escape_translated(component.name)
+        expect(page).to have_content translated(component.name)
+        expect(page.html).to include decidim_escape_translated(component.name).gsub("&quot;", "\"")
 
         visit decidim_admin_assemblies.components_path(assembly)
 
@@ -216,7 +217,7 @@ shared_examples "manage assembly components" do
         end
 
         visit decidim_assemblies.assembly_path(assembly)
-        expect(page).to have_no_content decidim_escape_translated(component.name)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -214,8 +214,9 @@ describe "Assemblies" do
 
         it "shows the components" do
           within ".participatory-space__nav-container" do
-            expect(page).to have_content(decidim_escape_translated(proposals_component.name))
-            expect(page).to have_no_content(decidim_escape_translated(meetings_component.name))
+            expect(page).to have_content(translated(proposals_component.name))
+            expect(page.html).to include(decidim_escape_translated(proposals_component.name).gsub("&quot;", "\""))
+            expect(page).to have_no_content(translated(meetings_component.name))
           end
         end
       end

--- a/decidim-core/app/cells/decidim/card_metadata_cell.rb
+++ b/decidim-core/app/cells/decidim/card_metadata_cell.rb
@@ -29,7 +29,7 @@ module Decidim
       return unless show_space?
 
       {
-        text: decidim_escape_translated(participatory_space.title),
+        text: translated_attribute(participatory_space.title),
         icon: resource_type_icon_key(participatory_space.class),
         url: Decidim::ResourceLocatorPresenter.new(participatory_space).path
       }

--- a/decidim-core/app/cells/decidim/card_metadata_cell.rb
+++ b/decidim-core/app/cells/decidim/card_metadata_cell.rb
@@ -29,7 +29,7 @@ module Decidim
       return unless show_space?
 
       {
-        text: translated_attribute(participatory_space.title),
+        text: decidim_escape_translated(participatory_space.title).html_safe,
         icon: resource_type_icon_key(participatory_space.class),
         url: Decidim::ResourceLocatorPresenter.new(participatory_space).path
       }

--- a/decidim-core/lib/decidim/core/test/shared_examples/has_space_in_mcell_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/has_space_in_mcell_examples.rb
@@ -8,7 +8,8 @@ shared_examples_for "has space in m-cell" do
     let(:show_space) { true }
 
     it "renders the space where the model belongs to" do
-      expect(cell_html).to have_content(decidim_escape_translated(model.component.participatory_space.title))
+      expect(cell_html).to have_content(translated_attribute(model.component.participatory_space.title))
+      expect(cell_html.to_s).to include(decidim_escape_translated(model.component.participatory_space.title).gsub("&quot;", "\""))
     end
   end
 end

--- a/decidim-core/spec/cells/decidim/card_metadata_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/card_metadata_cell_spec.rb
@@ -26,7 +26,8 @@ describe Decidim::CardMetadataCell, type: :cell do
     let(:options) { { show_space: true } }
 
     it "renders the space the model belongs to" do
-      expect(cell_html).to have_content(decidim_escape_translated(model.component.participatory_space.title))
+      expect(cell_html).to have_content(translated_attribute(model.component.participatory_space.title))
+      expect(cell_html.to_s).to include(decidim_escape_translated(model.component.participatory_space.title).gsub("&quot;", "\""))
     end
   end
 

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -13,7 +13,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: decidim_escape_translated(component.name),
+            name: component.name,
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
+++ b/decidim-initiatives/app/helpers/decidim/initiatives/initiatives_helper.rb
@@ -13,7 +13,7 @@ module Decidim
 
         components.map do |component|
           {
-            name: component.name,
+            name: translated_attribute(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -212,7 +212,8 @@ describe "Admin manages initiative components" do
 
       it "hides the component from the menu" do
         visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
-        expect(page).to have_content decidim_escape_translated(component.name)
+        expect(page).to have_content translated(component.name)
+        expect(page.html).to include decidim_escape_translated(component.name).gsub("&quot;", "\"")
 
         visit decidim_admin_initiatives.components_path(initiative)
 
@@ -227,7 +228,7 @@ describe "Admin manages initiative components" do
         end
 
         visit decidim_initiatives.initiative_path(initiative, locale: I18n.locale)
-        expect(page).to have_no_content decidim_escape_translated(component.name)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-initiatives/spec/system/initiative_spec.rb
+++ b/decidim-initiatives/spec/system/initiative_spec.rb
@@ -247,15 +247,17 @@ describe "Initiative" do
 
       it "shows the components" do
         within ".participatory-space__nav-container" do
-          expect(page).to have_content(decidim_escape_translated(meetings_component.name))
-          expect(page).to have_no_content(decidim_escape_translated(unpublished_proposals_component.name))
-          expect(page).to have_content(decidim_escape_translated(blogs_component.name))
+          expect(page).to have_content(translated(meetings_component.name))
+          expect(page.html).to include(decidim_escape_translated(meetings_component.name).gsub("&quot;", "\""))
+          expect(page).to have_no_content(translated(unpublished_proposals_component.name))
+          expect(page).to have_content(translated(blogs_component.name))
+          expect(page.html).to include(decidim_escape_translated(blogs_component.name).gsub("&quot;", "\""))
         end
       end
 
       it "allows visiting the components" do
         within ".participatory-space__nav-container" do
-          click_on decidim_escape_translated(meetings_component.name)
+          click_on translated(meetings_component.name)
         end
 
         expect(page).to have_css('[id^="meetings__meeting"]', count: 3)
@@ -388,7 +390,7 @@ describe "Initiative" do
 
       it "has special permissions to create posts" do
         within ".participatory-space__nav-container" do
-          click_on decidim_escape_translated(blogs_component.name)
+          click_on translated(blogs_component.name)
         end
 
         expect(page).to have_content("New post")
@@ -396,7 +398,7 @@ describe "Initiative" do
 
       it "has special permissions to create meetings" do
         within ".participatory-space__nav-container" do
-          click_on decidim_escape_translated(meetings_component.name)
+          click_on translated(meetings_component.name)
         end
 
         expect(page).to have_content("New meeting")

--- a/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/content_blocks/highlighted_meetings_cell_spec.rb
@@ -49,7 +49,8 @@ module Decidim
             it { expect(meetings_ids).not_to include(item_id(unpublished_meeting)) }
 
             it "shows the participatory space on homepage" do
-              expect(html).to have_content(decidim_escape_translated(meeting.component.participatory_space.title))
+              expect(html).to have_content(translated_attribute(meeting.component.participatory_space.title))
+              expect(html.to_s).to include(decidim_escape_translated(meeting.component.participatory_space.title).gsub("&quot;", "\""))
             end
 
             it "orders them correctly" do

--- a/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
+++ b/decidim-meetings/spec/cells/decidim/meetings/meeting_l_cell_spec.rb
@@ -136,7 +136,8 @@ module Decidim::Meetings
       let(:my_cell) { cell("decidim/meetings/meeting_l", meeting, context: { show_space: true }) }
 
       it "shows the participatory space" do
-        expect(subject).to have_content(decidim_escape_translated(meeting.component.participatory_space.title))
+        expect(subject).to have_content(translated_attribute(meeting.component.participatory_space.title))
+        expect(subject.to_s).to include(decidim_escape_translated(meeting.component.participatory_space.title).gsub("&quot;", "\""))
       end
     end
 

--- a/decidim-meetings/spec/controllers/decidim/meetings/directory/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/directory/meetings_controller_spec.rb
@@ -65,8 +65,8 @@ describe Decidim::Meetings::Directory::MeetingsController do
     it { expect(response).to have_http_status(:success) }
 
     it "shows the participatory space for each meeting" do
-      expect(response.body).to include(ERB::Util.html_escape(decidim_escape_translated(participatory_process1.title)))
-      expect(response.body).to include(ERB::Util.html_escape(decidim_escape_translated(participatory_process2.title)))
+      expect(response.body).to include(decidim_escape_translated(participatory_process1.title))
+      expect(response.body).to include(decidim_escape_translated(participatory_process2.title))
     end
   end
 end

--- a/decidim-meetings/spec/system/directory_meetings_spec.rb
+++ b/decidim-meetings/spec/system/directory_meetings_spec.rb
@@ -34,8 +34,10 @@ describe "Global meetings directory", :slow do
 
   it "shows the participatory space name for each meeting in the main list" do
     within ".layout-2col__main" do
-      expect(page).to have_content(decidim_escape_translated(participatory_process1.title))
-      expect(page).to have_content(decidim_escape_translated(participatory_process2.title))
+      expect(page).to have_content translated(participatory_process1.title)
+      expect(page.html).to include decidim_escape_translated(participatory_process1.title).gsub("&quot;", "\"")
+      expect(page).to have_content translated(participatory_process2.title)
+      expect(page.html).to include decidim_escape_translated(participatory_process2.title).gsub("&quot;", "\"")
     end
   end
 end

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -65,7 +65,7 @@ module Decidim
         ] + components.map do |component|
           {
             id: component.id,
-            name: component.name,
+            name: translated_attribute(component.name),
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -65,7 +65,7 @@ module Decidim
         ] + components.map do |component|
           {
             id: component.id,
-            name: decidim_escape_translated(component.name),
+            name: component.name,
             url: main_component_path(component),
             active: is_active_link?(main_component_path(component), :inclusive)
           }

--- a/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_process_components_examples.rb
@@ -321,7 +321,8 @@ shared_examples "manage process components" do
 
       it "hides the component from the menu" do
         visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
-        expect(page).to have_content decidim_escape_translated(component.name)
+        expect(page).to have_content translated(component.name)
+        expect(page.html).to include decidim_escape_translated(component.name).gsub("&quot;", "\"")
 
         visit decidim_admin_participatory_processes.components_path(participatory_process)
 
@@ -336,7 +337,7 @@ shared_examples "manage process components" do
         end
 
         visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
-        expect(page).to have_no_content decidim_escape_translated(component.name)
+        expect(page).to have_no_content translated(component.name)
       end
     end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -288,12 +288,12 @@ describe "Participatory Processes" do
               :published,
               participatory_space: participatory_process,
               manifest_name: :proposals,
-              name: { en: "Seguiment \"pop\" & 'test'" }
+              name: { en: "Tracking \"pop\" & 'test'" }
             )
             visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
 
             within ".participatory-space__nav-container" do
-              expect(page).to have_content('Seguiment "pop" & \'test\'')
+              expect(page).to have_content('Tracking "pop" & \'test\'')
               expect(page).to have_no_content("&quot;")
               expect(page).to have_no_content("&amp;")
             end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -281,6 +281,23 @@ describe "Participatory Processes" do
 
           it_behaves_like "accessible page"
 
+          it "displays component names with special characters (\", ', &) correctly in the nav links" do
+            create(
+              :component,
+              :published,
+              participatory_space: participatory_process,
+              manifest_name: :proposals,
+              name: { en: "Seguiment \"pop\" & 'test'" }
+            )
+            visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
+
+            within ".participatory-space__nav-container" do
+              expect(page).to have_content('Seguiment "pop" & \'test\'')
+              expect(page).to have_no_content("&quot;")
+              expect(page).to have_no_content("&amp;")
+            end
+          end
+
           context "and the process statistics are enabled" do
             let(:blocks_manifests) { [:hero, :stats] }
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -274,8 +274,9 @@ describe "Participatory Processes" do
 
           it "shows the components" do
             within ".participatory-space__nav-container" do
-              expect(page).to have_content(decidim_escape_translated(proposals_component.name))
-              expect(page).to have_no_content(decidim_escape_translated(meetings_component.name))
+              expect(page).to have_content(translated(proposals_component.name))
+              expect(page).to have_no_content(translated(meetings_component.name))
+              expect(page.html).to include decidim_escape_translated(proposals_component.name).gsub("&quot;", "\"")
             end
           end
 


### PR DESCRIPTION
#### :tophat: What? Why?
The nav links in the `participatory_space_main_data` content block (and in initiative show pages) were calling `decidim_escape_translated` twice for component names:

1. In the helpers that build nav items (`process_nav_items`, `assembly_nav_items`, `initiative_nav_items`): the `:name` key was set to `decidim_escape_translated(component.name)`.
2. In the NavLinksCell view (`decidim/nav_links/show.erb`): each item is rendered with `<%= decidim_escape_translated(item[:name]) %>`.

When a component name contained special characters (e.g. `Accountability "test"`), this had unwanted consequences:

- **First escape:** `"` → `&quot;`, `&` → `&amp;`, etc. So the name became e.g. `Accountability &quot;test&quot;`.
- **Second escape:** The already-escaped string was escaped again, so `&` in `&quot;` became `&amp;`, producing e.g. `Accountability &amp;quot;test&amp;quot;` in the HTML.
- **Result:** The page rendered literal `&quot;` or `&amp;quot;` instead of the intended quote character, so names appeared broken (e.g. `Accountability &amp;quot;test&amp;quot;` instead of `Accountability "test"`).

This PR changes helpers that feed `NavLinksCell passing the raw translatable attribute in the `:name` key and fix some tests to check that the content appears as expected and the html is properly escaped

**Note:** Conferences use a different partial (`_conference_nav_item`) that outputs `item[:name]` directly and does not call `decidim_escape_translated`. There the helper must still pass already-escaped content, so **conference_helper** was left unchanged.

*Link your PR to an issue*
- Related to #16144
- Fixes #?

#### Testing

Create and publish a component named "Component \"test\"" in a participatory space and enable the main content block with the nav links menu.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="667" height="341" alt="image" src="https://github.com/user-attachments/assets/d79ab008-e287-4c17-910c-494f084779bc" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation labels now show component names using the updated translated rendering so menu entries display readable names (including quotes and ampersands) as intended.
* **Tests**
  * Updated and expanded tests to verify visible name rendering and to assert the page HTML contains the appropriate escaped/unescaped variants for special-character cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->