### PR TITLE
Do not send notifications in unpublished posts' attachments

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -59,7 +59,7 @@ module Decidim
       def notify_followers
         return unless @attachment.attached_to.is_a?(Decidim::Followable)
 
-        return unless @attachment.attached_to.respond_to?(:published?) && @attachment.attached_to.published?
+        return if @attachment.attached_to.respond_to?(:published?) && !@attachment.attached_to.published?
 
         Decidim::EventsManager.publish(
           event: "decidim.events.attachments.attachment_created",

--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -59,6 +59,8 @@ module Decidim
       def notify_followers
         return unless @attachment.attached_to.is_a?(Decidim::Followable)
 
+        return unless @attachment.attached_to.respond_to?(:published?) && @attachment.attached_to.published?
+
         Decidim::EventsManager.publish(
           event: "decidim.events.attachments.attachment_created",
           event_class: Decidim::AttachmentCreatedEvent,

--- a/decidim-admin/app/commands/decidim/admin/create_attachment.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_attachment.rb
@@ -58,7 +58,6 @@ module Decidim
 
       def notify_followers
         return unless @attachment.attached_to.is_a?(Decidim::Followable)
-
         return if @attachment.attached_to.respond_to?(:published?) && !@attachment.attached_to.published?
 
         Decidim::EventsManager.publish(

--- a/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
@@ -68,7 +68,6 @@ module Decidim::Admin
         subject
       end
 
-
       it "traces the action", versioning: true do
         expect(Decidim.traceability)
           .to receive(:perform_action!)

--- a/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
@@ -57,7 +57,7 @@ module Decidim::Admin
         subject
       end
 
-      it "does not notify the followers on a unpublished resource" do
+      it "does not notify the followers on an unpublished resource" do
         follower = create(:user, organization: attached_to.organization)
         create(:follow, followable: attached_to, user: follower)
         attached_to.unpublish!

--- a/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_attachment_spec.rb
@@ -41,7 +41,7 @@ module Decidim::Admin
         expect(Decidim::Attachment.count).to eq(1)
       end
 
-      it "notifies the followers" do
+      it "notifies the followers on a published resource" do
         follower = create(:user, organization: attached_to.organization)
         create(:follow, followable: attached_to, user: follower)
 
@@ -56,6 +56,18 @@ module Decidim::Admin
 
         subject
       end
+
+      it "does not notify the followers on a unpublished resource" do
+        follower = create(:user, organization: attached_to.organization)
+        create(:follow, followable: attached_to, user: follower)
+        attached_to.unpublish!
+
+        expect(Decidim::EventsManager)
+          .not_to receive(:publish)
+
+        subject
+      end
+
 
       it "traces the action", versioning: true do
         expect(Decidim.traceability)


### PR DESCRIPTION
#### :tophat: What? Why?
When a user is following a participatory space, and it has a blog, for example, and the admin creates a new attachment for a post, the user gets a notification even if the post is not published yet.


#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #16142

#### Testing
As specified by the issue:
- Create a participatory process with a Blog component
- Have users follow the process
- As admin, create a new blog post and set a future publish date (e.g. next week)
- Save the post — it is now unpublished for regular users
- Add an attachment to this unpublished blog post
- Observe: Followers receive notifications about the uploaded document

After applying this PR you won't receive the notification.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Follower notifications for attachments are now sent only when the attached resource is published, preventing notifications for unpublished items and reducing stray notifications.

* **Tests**
  * Specs updated and a new test added to explicitly cover the unpublished case, ensuring the attachment-created event is not published for unpublished resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->