### PR TITLE
Improve date picker usability by selecting the date on click

### DIFF
--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_datepicker.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_datepicker.scss
@@ -22,10 +22,6 @@
     @apply top-2;
   }
 
-  &__pick-calendar {
-    @apply z-[3];
-  }
-
   &__close-calendar {
     @apply z-[3];
   }

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
@@ -363,7 +363,6 @@ describe("AssemblyAdminController", () => {
                       <div aria-disabled="false" aria-label="Choose date" class="wc-datepicker sc-wc-datepicker" role="group">
                       </div>
                     </wc-datepicker>
-                    <button class="datepicker__pick-calendar button button__secondary button__xs" disabled="true" type="button">Select</button>
                     <button class="datepicker__close-calendar button button__transparent-secondary button__xs" type="button">Close</button>
                   </div>
                 </div>
@@ -388,7 +387,6 @@ describe("AssemblyAdminController", () => {
                   <div class="datepicker__container" style="display: none;">
                     <wc-datepicker id="assembly_included_at_date_datepicker" locale="en" class="sc-wc-datepicker-h sc-wc-datepicker-s hydrated">
                     </wc-datepicker>
-                    <button class="datepicker__pick-calendar button button__secondary button__xs" disabled="true" type="button">Select</button>
                     <button class="datepicker__close-calendar button button__transparent-secondary button__xs" type="button">Close</button>
                   </div>
                 </div>
@@ -411,7 +409,6 @@ describe("AssemblyAdminController", () => {
                     </svg>
                   </button>
                   <div class="datepicker__container" style="display: none;">
-                    <button class="datepicker__pick-calendar button button__secondary button__xs" disabled="true" type="button">Select</button>
                     <button class="datepicker__close-calendar button button__transparent-secondary button__xs" type="button">Close</button>
                   </div>
                 </div>
@@ -433,7 +430,6 @@ describe("AssemblyAdminController", () => {
                     </svg>
                   </button>
                   <div class="datepicker__container" style="display: none;">
-                    <button class="datepicker__pick-calendar button button__secondary button__xs" disabled="true" type="button">Select</button>
                     <button class="datepicker__close-calendar button button__transparent-secondary button__xs" type="button">Close</button>
                   </div>
                 </div>

--- a/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
@@ -46,13 +46,6 @@ export default function generateDatePicker(input, row, formats) {
   closeCalendar.setAttribute("class", "datepicker__close-calendar button button__transparent-secondary button__xs");
   closeCalendar.setAttribute("type", "button");
 
-  const pickCalendar = document.createElement("button");
-  pickCalendar.innerText = i18n.select;
-  pickCalendar.setAttribute("class", "datepicker__pick-calendar button button__secondary button__xs");
-  pickCalendar.setAttribute("disabled", true);
-  pickCalendar.setAttribute("type", "button");
-
-  datePickerContainer.appendChild(pickCalendar);
   datePickerContainer.appendChild(closeCalendar);
 
   dateColumn.appendChild(datePickerContainer);
@@ -103,15 +96,11 @@ export default function generateDatePicker(input, row, formats) {
   let pickedDate = null;
 
   datePicker.addEventListener("selectDate", (event) => {
-    pickCalendar.removeAttribute("disabled");
     pickedDate = event.detail;
-  });
+    prevDate = pickedDate;
 
-  pickCalendar.addEventListener("click", (event) => {
-    event.preventDefault();
 
     date.value = displayDate(datePicker.value, formats);
-    prevDate = pickedDate;
     if (input.type === "date") {
       input.value = `${pickedDate}`;
     } else if (input.type === "datetime-local") {

--- a/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/datepicker/generate_datepicker.js
@@ -99,7 +99,6 @@ export default function generateDatePicker(input, row, formats) {
     pickedDate = event.detail;
     prevDate = pickedDate;
 
-
     date.value = displayDate(datePicker.value, formats);
     if (input.type === "date") {
       input.value = `${pickedDate}`;

--- a/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_datepicker.scss
@@ -102,14 +102,6 @@
     @apply absolute z-30 bottom-2 right-1;
   }
 
-  &__pick-calendar {
-    @apply absolute z-30 bottom-2 right-16 mr-1;
-
-    &:disabled {
-      @apply bg-gray;
-    }
-  }
-
   &__close-clock {
     @apply absolute z-30 bottom-2 right-1;
   }

--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -100,7 +100,6 @@ describe "Datepicker" do
         formatted_month = format("%02d", month)
 
         find("td > span", text: "20", match: :first).click
-        find(".datepicker__pick-calendar").click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click
@@ -145,17 +144,12 @@ describe "Datepicker" do
             expect(page).to have_css("#example_input_date_datepicker")
           end
 
-          it "has disabled select button" do
-            find(".datepicker__calendar-button").click
-            expect(page).to have_button("Select", disabled: true)
-          end
-
           context "when choosing a date" do
-            it "enables the select button" do
+            it "hides the datepicker calendar" do
               find(".datepicker__calendar-button").click
               yesterday = Date.yesterday.strftime("%-d")
               find("td > span", text: yesterday, match: :first).click
-              expect(page).to have_button("Select", disabled: false)
+              expect(page).to have_css("#example_input_date_datepicker", visible: :hidden)
             end
           end
         end
@@ -175,11 +169,9 @@ describe "Datepicker" do
             find('span > input[name="year"]').set("1994")
             find(".wc-datepicker__next-month-button").click
             find("td > span", text: "20", match: :first).click
-            find(".datepicker__pick-calendar").click
             find(".datepicker__calendar-button").click
             element = find("td.wc-datepicker__date--selected")
             expect(element).to have_content("20")
-            expect(page).to have_button("Select", disabled: false)
           end
         end
       end
@@ -508,7 +500,6 @@ describe "Datepicker" do
         formatted_month = format("%02d", month)
 
         find("td > span", text: "20", match: :first).click
-        find(".datepicker__pick-calendar").click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click
@@ -764,7 +755,6 @@ describe "Datepicker" do
         formatted_month = format("%02d", month)
 
         find("td > span", text: "20", match: :first).click
-        find(".datepicker__pick-calendar").click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click

--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -149,6 +149,7 @@ describe "Datepicker" do
               find(".datepicker__calendar-button").click
               yesterday = Date.yesterday.strftime("%-d")
               find("td > span", text: yesterday, match: :first).click
+              expect(find_by_id("example_input_date").value).not_to eq("")
               expect(page).to have_css("#example_input_date_datepicker", visible: :hidden)
             end
           end


### PR DESCRIPTION
#### :tophat: What? Why?

* Move "Select" button click event logic into `datePicker` `selectDate` event.
* Update tests that expect the "Select" button presence
* Remove unused `Select` button styles

The new behavior will match common user expectations for date pickers and removes an unnecessary extra click.

#### :pushpin: Related Issues
- Closes #16385 

#### Testing

* Open any form that has a date field with the Datepicker component
* Select the calendar icon in the date input
* Then click on a date. The calendar will close, and the field will be updated.
* Repeat the process with the keyboard actions

### :camera: Screenshots

<img width="608" height="476" alt="Screenshot from 2026-03-18 20-41-15" src="https://github.com/user-attachments/assets/a69099df-8615-40f3-bd43-af485f1ad5a3" />

![ezgif-71be05a41de8d369](https://github.com/user-attachments/assets/bc1abd3c-b944-4e6f-935f-c3d834c2d04f)



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the extra "Select"/confirm button from date pickers; choosing a date now closes the calendar and updates the input immediately.

* **Tests**
  * Updated date picker tests to check calendar visibility and input value after date selection instead of button enable/disable states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->