### PR TITLE
Fix flaky spec on `admin_moderates_user_spec.rb`

### DIFF
--- a/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
@@ -53,6 +53,7 @@ shared_examples "hideable resource during block" do
       fill_in :block_user_justification, with: "This user is a spammer" * 2 # to have at least 15 chars
 
       click_on I18n.t("decidim.admin.block_user.new.action")
+      expect(page).to have_content(I18n.t("decidim.admin.officializations.block.success"))
 
       expect(content.reload).to be_hidden
 


### PR DESCRIPTION
#### :tophat: What? Why?
This spec seems to be flaky as it failed in CI.

#### :pushpin: Related Issues
- Related to (failed in) #11036

#### Testing
```bash
$ cd decidim-comments
$ for i in {1..20}; do bundle exec rspec ./spec/system/admin_moderates_user_spec.rb[1:1:2:1] || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced hide content workflow test by adding verification for success confirmation message display before checking content visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->