### PR TITLE
Backport 'Do not ask password on invitations when organization has only external accounts' to v0.30

### DIFF
--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -270,7 +270,7 @@ shared_examples "manage impersonations examples" do
         find("*[type=submit]").click
       end
 
-      expect(page).to have_content("successfully")
+      expect(page).to have_callout(I18n.t("updated", scope: "devise.invitations"))
       within_user_menu do
         click_on "My public profile"
       end

--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -270,7 +270,7 @@ shared_examples "manage impersonations examples" do
         find("*[type=submit]").click
       end
 
-      expect(page).to have_callout(I18n.t("updated", scope: "devise.invitations"))
+      expect(page).to have_admin_callout(I18n.t("updated", scope: "devise.invitations"))
       within_user_menu do
         click_on "My public profile"
       end

--- a/decidim-admin/spec/system/admin_invite_spec.rb
+++ b/decidim-admin/spec/system/admin_invite_spec.rb
@@ -37,19 +37,99 @@ describe "Admin invite" do
   end
 
   describe "Accept an invitation" do
-    it "asks for a password and nickname and redirects to the organization dashboard" do
-      visit last_email_link
-
-      within "form.new_user" do
-        fill_in :invitation_user_nickname, with: "caballo_loco"
-        fill_in :invitation_user_password, with: "decidim123456789"
-        check :invitation_user_tos_agreement
-        find("*[type=submit]").click
+    context "when users_registration_mode enabled" do
+      before do
+        Decidim::Organization.last.update!(users_registration_mode: "enabled")
+        visit last_email_link
       end
 
-      expect(page).to have_admin_callout "Your password was set successfully. You are now signed in."
+      it "has password" do
+        expect(page).to have_css "#invitation_user_password"
+      end
 
-      expect(page).to have_current_path "/admin/admin_terms/show"
+      it "asks for a password and nickname and redirects to the organization dashboard" do
+        within "form.new_user" do
+          fill_in :invitation_user_nickname, with: "caballo_loco"
+          fill_in :invitation_user_password, with: "decidim123456789"
+          check :invitation_user_tos_agreement
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout "Invitation accepted successfully. You are now signed in."
+
+        expect(page).to have_current_path "/admin/admin_terms/show"
+      end
+
+      it "shows error when password not valid" do
+        within "form.new_user" do
+          fill_in :invitation_user_nickname, with: "caballo_loco"
+          check :invitation_user_tos_agreement
+          find("*[type=submit]").click
+        end
+
+        within "div.user-password" do
+          expect(page).to have_content "The password is too short."
+        end
+      end
+    end
+
+    context "when users_registration_mode existing" do
+      before do
+        Decidim::Organization.last.update!(users_registration_mode: "existing")
+        visit last_email_link
+      end
+
+      it "has password" do
+        expect(page).to have_css "#invitation_user_password"
+      end
+
+      it "asks for a password and nickname and redirects to the organization dashboard" do
+        within "form.new_user" do
+          fill_in :invitation_user_nickname, with: "caballo_loco"
+          fill_in :invitation_user_password, with: "decidim123456789"
+          check :invitation_user_tos_agreement
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout "Invitation accepted successfully. You are now signed in."
+
+        expect(page).to have_current_path "/admin/admin_terms/show"
+      end
+
+      it "shows error when password not valid" do
+        within "form.new_user" do
+          fill_in :invitation_user_nickname, with: "caballo_loco"
+          check :invitation_user_tos_agreement
+          find("*[type=submit]").click
+        end
+
+        within "div.user-password" do
+          expect(page).to have_content "The password is too short."
+        end
+      end
+    end
+
+    context "when users_registration_mode disabled" do
+      before do
+        Decidim::Organization.last.update!(users_registration_mode: "disabled")
+        visit last_email_link
+      end
+
+      it "has no password" do
+        expect(page).to have_no_css "#invitation_user_password"
+      end
+
+      it "asks for nickname and redirects to the organization dashboard" do
+        within "form.new_user" do
+          fill_in :invitation_user_nickname, with: "caballo_loco"
+          check :invitation_user_tos_agreement
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_admin_callout "Invitation accepted successfully. You are now signed in."
+
+        expect(page).to have_current_path "/admin/admin_terms/show"
+      end
     end
 
     it "displays admin password requirements" do
@@ -133,7 +213,7 @@ describe "Admin invite" do
       check :invitation_user_tos_agreement
       click_on "Save"
 
-      expect(page).to have_content("Your password was set successfully. You are now signed in.")
+      expect(page).to have_content("Invitation accepted successfully. You are now signed in.")
       expect(Decidim::User.find_by(email: "invited_user@example.org")).not_to be_admin
     end
   end

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -4,7 +4,7 @@
     <h1 class="title-decorator inline-block text-left mb-12"><%= t "devise.invitations.edit.header" %></h1>
 
     <p class="text-lg text-gray-2">
-      <%= t("devise.invitations.edit.subtitle").html_safe %>
+      <%= current_organization.users_registration_mode_disabled? ? t("devise.invitations.edit.subtitle_no_password").html_safe : t("devise.invitations.edit.subtitle").html_safe %>
     </p>
   </div>
 
@@ -16,7 +16,7 @@
 
       <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization_name), required: "required", autocomplete: "nickname" %>
 
-      <% if f.object.class.require_password_on_accepting %>
+      <% unless current_organization.users_registration_mode_disabled? %>
         <%= render partial: "decidim/account/password_fields", locals: { form: f, user: resource.admin? ? :admin : :user } %>
       <% end %>
     </div>

--- a/decidim-core/config/initializers/devise.rb
+++ b/decidim-core/config/initializers/devise.rb
@@ -175,6 +175,12 @@ Devise.setup do |config|
   # Default: true
   config.allow_insecure_sign_in_after_accept = true
 
+  # Require password when user accepts the invitation.
+  # Disable if you do not want to ask for or enforce setting a password while accepting,
+  # because it is set when the user is invited or will be set later.
+  # Default: true
+  config.require_password_on_accepting = false
+
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm
   # their account within 3 days after the mail was sent, but on the fourth day

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1996,6 +1996,7 @@ en:
         nickname_help: Your nickname in %{organization}. Can only contain letters, numbers, '-' and '_'.
         submit_button: Save
         subtitle: If you accept the invitation please set your nickname and password.
+        subtitle_no_password: If you accept the invitation please set your nickname.
       invitation_removed: Your invitation was removed.
       invitation_token_invalid: The invitation token provided is not valid!
       new:
@@ -2003,8 +2004,8 @@ en:
         submit_button: Send an invitation
       no_invitations_remaining: No invitations remaining
       send_instructions: An invitation email has been sent to %{email}.
-      updated: Your password was set successfully. You are now signed in.
-      updated_not_active: Your password was set successfully.
+      updated: Invitation accepted successfully. You are now signed in.
+      updated_not_active: Invitation accepted successfully.
     mailer:
       confirmation_instructions:
         action: Confirm my account


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #14336 to v0.30

:hearts: Thank you!