### PR TITLE
Fix loading more comments in other locales

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -112,6 +112,7 @@ camelization
 cami
 Capfile
 carolromero
+Cargar
 Carrer
 carryforward
 catala
@@ -144,6 +145,7 @@ coderabbit
 codespace
 codeql
 coditramuntana
+comentarios
 commentables
 commentaire
 commenters
@@ -751,6 +753,7 @@ reportables
 reportat
 resourcable
 resourceable
+respuestas
 Returs
 Riera
 Rigoberto

--- a/decidim-comments/app/packs/src/decidim/comments/controllers/load_more_comments/controller.js
+++ b/decidim-comments/app/packs/src/decidim/comments/controllers/load_more_comments/controller.js
@@ -92,7 +92,9 @@ export default class extends Controller {
       params.append("alignment", this.alignmentValue);
     }
 
-    const separator = this.urlValue.includes("?") ? "&" : "?";
+    const separator = this.urlValue.includes("?")
+      ? "&"
+      : "?";
     return `${this.urlValue}${separator}${params.toString()}`;
   }
 

--- a/decidim-comments/app/packs/src/decidim/comments/controllers/load_more_comments/controller.js
+++ b/decidim-comments/app/packs/src/decidim/comments/controllers/load_more_comments/controller.js
@@ -79,10 +79,12 @@ export default class extends Controller {
    * @returns {string} The URL with query parameters
    */
   buildUrl() {
+    const locale = document.documentElement.getAttribute("lang") || "en";
     const params = new URLSearchParams({
       "commentable_gid": this.commentableGidValue,
       "order": this.orderValue,
       "offset": this.offsetValue,
+      "locale": locale,
       "load_more": 1
     });
 
@@ -90,7 +92,8 @@ export default class extends Controller {
       params.append("alignment", this.alignmentValue);
     }
 
-    return `${this.urlValue}?${params.toString()}`;
+    const separator = this.urlValue.includes("?") ? "&" : "?";
+    return `${this.urlValue}${separator}${params.toString()}`;
   }
 
   /**

--- a/decidim-comments/app/packs/src/decidim/comments/controllers/show_replies/controller.js
+++ b/decidim-comments/app/packs/src/decidim/comments/controllers/show_replies/controller.js
@@ -101,7 +101,9 @@ export default class extends Controller {
       "load_more": 1
     });
 
-    const separator = this.urlValue.includes("?") ? "&" : "?";
+    const separator = this.urlValue.includes("?")
+      ? "&"
+      : "?";
     return `${this.urlValue}${separator}${params.toString()}`;
   }
 

--- a/decidim-comments/app/packs/src/decidim/comments/controllers/show_replies/controller.js
+++ b/decidim-comments/app/packs/src/decidim/comments/controllers/show_replies/controller.js
@@ -92,14 +92,17 @@ export default class extends Controller {
    * @returns {string} The URL with query parameters
    */
   buildUrl() {
+    const locale = document.documentElement.getAttribute("lang") || "en";
     const params = new URLSearchParams({
       "commentable_gid": this.commentGidValue,
       "order": this.orderValue,
       "offset": 0,
+      "locale": locale,
       "load_more": 1
     });
 
-    return `${this.urlValue}?${params.toString()}`;
+    const separator = this.urlValue.includes("?") ? "&" : "?";
+    return `${this.urlValue}${separator}${params.toString()}`;
   }
 
   /**

--- a/decidim-comments/app/views/decidim/comments/comments/load_more_comments.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/load_more_comments.js.erb
@@ -34,6 +34,7 @@
           component.addReply(inReplyTo, commentHtml);
         } else if (loadMoreWrapper) {
           loadMoreWrapper.insertAdjacentHTML("beforebegin", commentHtml);
+          component._initializeComments($(loadMoreWrapper.previousElementSibling));
         } else {
           component.addThread(commentHtml, <%= alignment.presence || "null" %>);
         }

--- a/decidim-comments/spec/system/load_more_comments_spec.rb
+++ b/decidim-comments/spec/system/load_more_comments_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Load more comments" do
+  let!(:organization) { create(:organization) }
+  let!(:component) { create(:component, manifest_name: :dummy, organization:) }
+  let!(:commentable) { create(:dummy_resource, component:) }
+  let!(:comments) { create_list(:comment, 30, commentable:) }
+
+  let(:resource_path) { resource_locator(commentable).path }
+
+  before do
+    switch_to_host(organization.host)
+    visit resource_path
+  end
+
+  after do
+    expect_no_js_errors
+  end
+
+  context "when there are more comments than the default limit" do
+    it "shows the Load more comments button" do
+      expect(page).to have_content("Load more comments")
+    end
+
+    it "loads more comments when clicking the button", :slow do
+      expect(page).to have_css(".comment", count: 20)
+
+      click_button "Load more comments"
+
+      expect(page).to have_css(".comment", count: 30)
+    end
+  end
+
+  context "when the locale is different than English" do
+    before do
+      visit resource_path
+
+      within_language_menu do
+        click_on "Castellano"
+      end
+    end
+
+    it "shows the Load more comments button in the correct locale" do
+      expect(page).to have_content("Cargar más comentarios")
+    end
+
+    it "loads more comments when clicking the button in the correct locale", :slow do
+      expect(page).to have_css(".comment", count: 20)
+
+      click_button "Cargar más comentarios"
+
+      expect(page).to have_css(".comment", count: 30)
+    end
+  end
+end

--- a/decidim-comments/spec/system/show_replies_spec.rb
+++ b/decidim-comments/spec/system/show_replies_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Show replies" do
+  let!(:organization) { create(:organization) }
+  let!(:component) { create(:component, manifest_name: :dummy, organization:) }
+  let!(:commentable) { create(:dummy_resource, component:) }
+  let!(:comment) { create(:comment, commentable:) }
+  let!(:replies) { create_list(:comment, 3, commentable: comment, root_commentable: commentable) }
+
+  let(:resource_path) { resource_locator(commentable).path }
+
+  before do
+    switch_to_host(organization.host)
+    visit resource_path
+  end
+
+  after do
+    expect_no_js_errors
+  end
+
+  context "when viewing a comment with replies" do
+    it "shows the replies button with the correct count" do
+      expect(page).to have_content("3 replies")
+    end
+
+    it "loads the replies when clicking the button", :slow do
+      click_button "3 replies"
+
+      expect(page).to have_css(".comment-thread .comment", count: 4)
+    end
+  end
+
+  context "when the locale is different than English" do
+    before do
+      visit resource_path
+
+      within_language_menu do
+        click_on "Castellano"
+      end
+    end
+
+    it "shows the replies button in the correct locale" do
+      expect(page).to have_content("3 respuestas")
+    end
+
+    it "loads the replies when clicking the button in the correct locale", :slow do
+      click_button "3 respuestas"
+
+      expect(page).to have_css(".comment-thread .comment", count: 4)
+    end
+  end
+end

--- a/decidim-comments/spec/system/show_replies_spec.rb
+++ b/decidim-comments/spec/system/show_replies_spec.rb
@@ -32,6 +32,58 @@ describe "Show replies" do
     end
   end
 
+  context "when replying to a loaded comment" do
+    let!(:organization) { create(:organization) }
+    let!(:component) { create(:component, manifest_name: :dummy, organization:) }
+    let!(:commentable) { create(:dummy_resource, component:) }
+    let!(:comments) { create_list(:comment, 30, commentable:) }
+    let!(:user) { create(:user, :confirmed, organization:) }
+
+    let(:resource_path) { resource_locator(commentable).path }
+
+    before do
+      switch_to_host(organization.host)
+      login_as user, scope: :user
+      visit resource_path
+    end
+
+    after do
+      expect_no_js_errors
+    end
+
+    it "shows comments after loading more", :slow do
+      expect(page).to have_content("Load more comments")
+
+      click_button "Load more comments"
+
+      expect(page).to have_css(".comment")
+    end
+
+    it "can reply to a loaded comment", :slow do
+      expect(page).to have_css(".comment", count: 20)
+
+      click_button "Load more comments"
+
+      expect(page).to have_css(".comment", minimum: 25)
+
+      # Find reply buttons and click on one of the newly loaded comments
+      all_comments = page.all(".comment")
+      reply_button = all_comments[20].find(".comment__actions button")
+      reply_button.click
+
+      expect(page).to have_css(".add-comment:not(.hidden) textarea")
+
+      textarea = page.all(".add-comment:not(.hidden) textarea").last
+      textarea.native.send_keys("This is my reply")
+
+      expect(page).to have_button("Publish reply", disabled: false)
+
+      click_button "Publish reply"
+
+      expect(page).to have_content("This is my reply")
+    end
+  end
+
   context "when the locale is different than English" do
     before do
       visit resource_path


### PR DESCRIPTION
#### :tophat: What? Why?

After we added the "Load more comments" feature, we actually didn't take into account what happens with other locales, as it only works with English. This PR fixes it.

While working on it, I also found out that if you load more comments and then reply to a loaded comment, you can't publish your reply (the button is disabled). This PR fixes that too. 

(Adding the `no-backport` label as this only applies to v0.32.0.dev)

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/issues/15876
- Fixes #16455

#### Testing

1. Generate comments with 
```bash
bin/rails runner 'proposal = Decidim::Proposals::Proposal.not_hidden.first
user = Decidim::User.first
30.times { |i| Decidim::Comments::Comment.create!(body: {en: "Comment #{i}"}, author: user, commentable: proposal, root_commentable: proposal) }
puts "http://localhost:3000" + Decidim::ResourceLocatorPresenter.new(proposal).path'
``` 
2. Go to the URL provided on the output of the command
3. Change the locale to Castellano using the locale switcher
4. Click in "Cargar más comentarios" 
5. (Before) See that it doesn't load. You have an error in the web developer console
6. (After) See that it loads. Reply to one of the loaded comments

### :camera: Screenshots

#### Before

<img width="899" height="884" alt="image" src="https://github.com/user-attachments/assets/5b78347b-cd4c-41b7-a341-deac1da204d9" />

#### After 

[Kooha-2026-03-24-15-36-58.webm](https://github.com/user-attachments/assets/6e113df7-dd6a-4273-a0a2-bbbba56baf02)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Loading comments and replies now include the active page language and correctly append request parameters so localized content and interactive features work reliably.
  * Dynamically inserted comments are initialized immediately so their UI behaviors function after load.

* **Tests**
  * Added system tests covering "Load more comments" and "Show replies" flows, including multi-language scenarios.

* **Chores**
  * Updated expected spelling list with localized terms used in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->