### PR TITLE
Change the panels for access mode fields

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/access_mode.test.js
+++ b/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/access_mode.test.js
@@ -1,0 +1,68 @@
+/* global jest */
+
+import { Application } from "@hotwired/stimulus"
+import AccessModeController from "src/decidim/admin/controllers/access_mode/controller"
+
+describe("AccessModeController", () => {
+  let application = null
+  let controller = null
+  let element = null
+  let checkbox = null
+  let accessModeFieldset = null
+
+  beforeEach(async () => {
+    document.body.innerHTML = `
+      <div data-controller="access-mode">
+        <div id="has_members">
+          <input type="hidden" name="has_members" value="0">
+          <input type="checkbox" id="has_members_checkbox" name="has_members" value="1">
+        </div>
+        <fieldset id="access_mode">
+          <legend>Access mode</legend>
+          <label>Open<input type="radio" name="access_mode" value="open"></label>
+        </fieldset>
+      </div>
+    `
+
+    application = Application.start()
+    application.register("access-mode", AccessModeController)
+
+    element = document.querySelector("[data-controller='access-mode']")
+    checkbox = element.querySelector("#has_members input[type='checkbox']")
+    accessModeFieldset = element.querySelector("#access_mode")
+
+    await new Promise((resolve) => {
+      setTimeout(() => {
+        controller = application.getControllerForElementAndIdentifier(element, "access-mode")
+        resolve()
+      }, 0)
+    })
+  })
+
+  afterEach(() => {
+    controller.disconnect()
+    application.stop()
+    document.body.innerHTML = ""
+  })
+
+  it("hides the access_mode fieldset when members checkbox is unchecked", () => {
+    expect(accessModeFieldset.hidden).toBe(true)
+    expect(accessModeFieldset.style.display).toBe("none")
+  })
+
+  it("shows the fieldset when the members checkbox becomes checked", () => {
+    checkbox.checked = true
+    checkbox.dispatchEvent(new Event("change"))
+
+    expect(accessModeFieldset.hidden).toBe(false)
+    expect(accessModeFieldset.style.display).toBe("")
+  })
+
+  it("removes the event listener on disconnect", () => {
+    const removeSpy = jest.spyOn(checkbox, "removeEventListener")
+
+    controller.disconnect()
+
+    expect(removeSpy).toHaveBeenCalledWith("change", controller.toggleAccessMode)
+  })
+})

--- a/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
+++ b/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
@@ -43,6 +43,7 @@ export default class extends Controller {
   toggleAccessMode() {
     const showAccessMode = this.hasMembersCheckbox.checked
 
+    this.accessModeFieldset.disabled = !showAccessMode
     this.accessModeFieldset.hidden = !showAccessMode
     this.accessModeFieldset.style.display = showAccessMode
       ? ""

--- a/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
+++ b/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
@@ -8,8 +8,10 @@ import { Controller } from "@hotwired/stimulus"
  * query the checkbox and the `#access_mode` fieldset that lives inside.
  */
 export default class extends Controller {
+
   /**
    * Find the relevant inputs and attach the change listener.
+   * @returns {void}
    */
   connect() {
     this.hasMembersCheckbox = this.element.querySelector("#has_members input[type='checkbox']")
@@ -26,6 +28,7 @@ export default class extends Controller {
 
   /**
    * Remove the listener bound during `connect`.
+   * @returns {void}
    */
   disconnect() {
     if (this.hasMembersCheckbox && this.toggleAccessMode) {
@@ -35,11 +38,14 @@ export default class extends Controller {
 
   /**
    * Show or hide the access mode fieldset depending on the checkbox state.
+   * @returns {void}
    */
   toggleAccessMode() {
     const showAccessMode = this.hasMembersCheckbox.checked
 
     this.accessModeFieldset.hidden = !showAccessMode
-    this.accessModeFieldset.style.display = showAccessMode ? "" : "none"
+    this.accessModeFieldset.style.display = showAccessMode
+      ? ""
+      : "none"
   }
 }

--- a/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
+++ b/decidim-admin/app/packs/src/decidim/admin/controllers/access_mode/controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Toggles the visibility of the access mode options according to the
+ * "This space has members" checkbox.
+ *
+ * The controller expects to sit on the access accordion so it can
+ * query the checkbox and the `#access_mode` fieldset that lives inside.
+ */
+export default class extends Controller {
+  /**
+   * Find the relevant inputs and attach the change listener.
+   */
+  connect() {
+    this.hasMembersCheckbox = this.element.querySelector("#has_members input[type='checkbox']")
+    this.accessModeFieldset = this.element.querySelector("#access_mode")
+
+    if (!this.hasMembersCheckbox || !this.accessModeFieldset) {
+      return
+    }
+
+    this.toggleAccessMode = this.toggleAccessMode.bind(this)
+    this.hasMembersCheckbox.addEventListener("change", this.toggleAccessMode)
+    this.toggleAccessMode()
+  }
+
+  /**
+   * Remove the listener bound during `connect`.
+   */
+  disconnect() {
+    if (this.hasMembersCheckbox && this.toggleAccessMode) {
+      this.hasMembersCheckbox.removeEventListener("change", this.toggleAccessMode)
+    }
+  }
+
+  /**
+   * Show or hide the access mode fieldset depending on the checkbox state.
+   */
+  toggleAccessMode() {
+    const showAccessMode = this.hasMembersCheckbox.checked
+
+    this.accessModeFieldset.hidden = !showAccessMode
+    this.accessModeFieldset.style.display = showAccessMode ? "" : "none"
+  }
+}

--- a/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
+++ b/decidim-assemblies/app/forms/decidim/assemblies/admin/assembly_form.rb
@@ -69,7 +69,9 @@ module Decidim
         validates :hero_image, passthru: { to: Decidim::Assembly }
 
         validates :weight, presence: true
+
         validates :access_mode, presence: true, inclusion: { in: Decidim::Assembly.access_modes.keys }
+        validate :ensure_access_mode_for_has_members
 
         alias organization current_organization
 
@@ -121,6 +123,10 @@ module Decidim
                         .any?
 
           errors.add(:slug, :taken)
+        end
+
+        def ensure_access_mode_for_has_members
+          self.access_mode = :open if has_members == false
         end
       end
     end

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/assembly_admin.test.js
@@ -857,13 +857,6 @@ describe("AssemblyAdminController", () => {
     it("should initialize the controller and set up event listeners", () => {
       expect(controller).toBeDefined();
       expect(element).toBeDefined();
-
-      // Test that initial state is set correctly
-      const isTransparentCheckbox = element.querySelector("#is_transparent input[type='checkbox']");
-      const specialFeatures = element.querySelector("#special_features");
-
-      expect(isTransparentCheckbox.disabled).toBe(true);
-      expect(specialFeatures.style.display).toBe("none");
     });
 
     it("should call assignBehavior for assembly_type and created_by fields", () => {
@@ -964,67 +957,6 @@ describe("AssemblyAdminController", () => {
     });
   });
 
-  describe("toggleDisabledHiddenFields", () => {
-    it("should initially disable transparent checkbox and hide special features", () => {
-      controller.toggleDisabledHiddenFields();
-
-      const isTransparentCheckbox = element.querySelector("#is_transparent input[type='checkbox']");
-      const specialFeatures = element.querySelector("#special_features");
-
-      expect(isTransparentCheckbox.disabled).toBe(true);
-      expect(specialFeatures.style.display).toBe("none");
-    });
-
-    it("should enable transparent checkbox and show special features when private space is checked", () => {
-      const privateSpaceCheckbox = element.querySelector("#private_space input[type='checkbox']");
-      const isTransparentCheckbox = element.querySelector("#is_transparent input[type='checkbox']");
-      const specialFeatures = element.querySelector("#special_features");
-
-      // Check private space checkbox
-      privateSpaceCheckbox.checked = true;
-
-      controller.toggleDisabledHiddenFields();
-
-      expect(isTransparentCheckbox.disabled).toBe(false);
-      expect(specialFeatures.style.display).toBe("block");
-    });
-
-    it("should disable transparent checkbox and hide special features when private space is unchecked", () => {
-      const privateSpaceCheckbox = element.querySelector("#private_space input[type='checkbox']");
-      const isTransparentCheckbox = element.querySelector("#is_transparent input[type='checkbox']");
-      const specialFeatures = element.querySelector("#special_features");
-
-      // Uncheck private space checkbox
-      privateSpaceCheckbox.checked = false;
-
-      controller.toggleDisabledHiddenFields();
-
-      expect(isTransparentCheckbox.disabled).toBe(true);
-      expect(specialFeatures.style.display).toBe("none");
-    });
-
-    it("should handle missing elements gracefully", () => {
-      // Remove elements to test graceful handling
-      element.querySelector("#private_space").remove();
-      element.querySelector("#is_transparent").remove();
-      element.querySelector("#special_features").remove();
-
-      expect(() => {
-        controller.toggleDisabledHiddenFields();
-      }).not.toThrow();
-    });
-
-    it("should handle missing checkbox inside transparent div", () => {
-      // Remove checkbox from transparent div
-      const isTransparent = element.querySelector("#is_transparent");
-      isTransparent.innerHTML = "";
-
-      expect(() => {
-        controller.toggleDisabledHiddenFields();
-      }).not.toThrow();
-    });
-  });
-
   describe("integration tests", () => {
     it("should maintain correct state when toggling between options", () => {
       const assemblyType = element.querySelector("#assembly_created_by");
@@ -1050,15 +982,4 @@ describe("AssemblyAdminController", () => {
     });
   });
 
-  describe("edge cases", () => {
-    it("should handle elements with no checkbox inside", () => {
-      // Replace private space with div that has no checkbox
-      const privateSpace = element.querySelector("#private_space");
-      privateSpace.innerHTML = "<div>No checkbox here</div>";
-
-      expect(() => {
-        controller.toggleDisabledHiddenFields();
-      }).not.toThrow();
-    });
-  });
 });

--- a/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/controller.js
+++ b/decidim-assemblies/app/packs/src/decidim/assemblies/controllers/assembly_admin/controller.js
@@ -2,13 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    const privateSpace = this.element.querySelector("#private_space");
-
-    if (privateSpace) {
-      privateSpace.addEventListener("change", this.toggleDisabledHiddenFields);
-    }
-    this.toggleDisabledHiddenFields();
-
     this.assignBehavior("assembly_type");
     this.assignBehavior("created_by");
   }
@@ -39,24 +32,4 @@ export default class extends Controller {
       showDiv.style.display = "block";
     }
   }
-
-  toggleDisabledHiddenFields() {
-    const privateSpace = document.getElementById("private_space");
-    const isTransparent = document.getElementById("is_transparent");
-    const specialFeatures = document.getElementById("special_features");
-
-    const enabledPrivateSpace = privateSpace?.querySelector("input[type='checkbox']")?.checked;
-    const isTransparentCheckbox = isTransparent?.querySelector("input[type='checkbox']");
-
-    if (isTransparentCheckbox) {
-      isTransparentCheckbox.disabled = (enabledPrivateSpace === false);
-    }
-
-    if (specialFeatures) {
-      specialFeatures.style.display = enabledPrivateSpace
-        ? "block"
-        : "none";
-    }
-  }
-
 }

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -169,6 +169,39 @@
     </div>
   </div>
 
+  <div class="card" data-controller="accordion" id="accordion-access">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-access" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="access">
+          <%= t("label", scope: "decidim.assemblies.admin.assemblies.form.access") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-access" class="card-section">
+      <div class="row column" id="has_members">
+        <%= form.check_box :has_members, help_text: t(".has_members_help") %>
+      </div>
+
+      <fieldset class="row column" id="access_mode">
+        <legend>
+          <%= t("access.set_this_space_as", scope: "decidim.assemblies.admin.assemblies.form") %>
+        </legend>
+        <div class="radio-group">
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.open") %>
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.restricted") %>
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.transparent") %>
+          <% Decidim::Assembly::ACCESS_MODES.keys.each do |mode| %>
+            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
+              <%= form.radio_button :access_mode, mode %>
+              <span><%= t(mode, scope: "decidim.assemblies.admin.assemblies.form.access.options") %></span>
+             <% end %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+
   <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
@@ -178,7 +211,6 @@
         </h2>
       </button>
     </div>
-
     <div id="panel-visibility" class="card-section">
       <% if params[:parent_id].present? %>
         <%= form.hidden_field :parent_id, value: @form.parent_id %>
@@ -193,27 +225,6 @@
       <div class="row column">
         <%= form.check_box :promoted %>
       </div>
-
-      <div class="row column" id="has_members">
-        <%= form.check_box :has_members, help_text: t(".has_members_help") %>
-      </div>
-
-      <fieldset class="row column" id="access_mode">
-        <legend>
-          <%= t("access.label", scope: "decidim.assemblies.admin.assemblies.form") %>
-        </legend>
-        <div class="radio-group">
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.open") %>
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.restricted") %>
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.transparent") %>
-          <% Decidim::Assembly::ACCESS_MODES.keys.each do |mode| %>
-            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
-              <span><%= t(mode, scope: "decidim.assemblies.admin.assemblies.form.access.options") %></span>
-             <% end %>
-          <% end %>
-        </div>
-      </fieldset>
     </div>
   </div>
 

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -169,7 +169,7 @@
     </div>
   </div>
 
-  <div class="card" data-controller="accordion" id="accordion-access">
+  <div class="card" data-controller="accordion access-mode" id="accordion-access">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-access" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -242,6 +242,7 @@ en:
           form:
             access:
               label: Access
+              set_this_space_as: Set this space as
               options:
                 open: Everyone can see the assembly and participate.
                 restricted: Only members can see and participate.

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -242,11 +242,11 @@ en:
           form:
             access:
               label: Access
-              set_this_space_as: Set this space as
               options:
                 open: Everyone can see the assembly and participate.
                 restricted: Only members can see and participate.
                 transparent: Everyone can see the assembly, but only members can participate.
+              set_this_space_as: Set this space as
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration
             duration_help: If the duration of this assembly is limited, select the end date. Otherwise, it will appear as indefinite.

--- a/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/test/factories.rb
@@ -80,10 +80,12 @@ FactoryBot.define do
     end
 
     trait :transparent do
+      has_members { true }
       access_mode { :transparent }
     end
 
     trait :restricted do
+      has_members { true }
       access_mode { :restricted }
     end
 

--- a/decidim-assemblies/spec/forms/assembly_form_spec.rb
+++ b/decidim-assemblies/spec/forms/assembly_form_spec.rb
@@ -202,6 +202,16 @@ module Decidim
           end
         end
 
+        describe "access_mode reset when has_members is false" do
+          let(:access_mode) { "transparent" }
+          let(:has_members) { false }
+
+          it "resets access_mode to open" do
+            subject.valid?
+            expect(subject.access_mode).to eq("open")
+          end
+        end
+
         context "when everything is OK" do
           it { is_expected.to be_valid }
         end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -80,7 +80,6 @@ describe "Admin manages assemblies" do
         fill_in_i18n(:assembly_target, "#assembly-target-tabs", **attributes[:target].except("machine_translations"))
 
         select(decidim_sanitize_translated(taxonomy.name), from: "taxonomies-#{taxonomy_filter.id}")
-        choose(:assembly_access_mode_open)
 
         fill_in :assembly_slug, with: "slug"
         fill_in :assembly_weight, with: 1

--- a/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
+++ b/decidim-participatory_processes/app/forms/decidim/participatory_processes/admin/participatory_process_form.rb
@@ -49,7 +49,9 @@ module Decidim
         validates :hero_image, passthru: { to: Decidim::ParticipatoryProcess }
 
         validates :weight, presence: true
+
         validates :access_mode, presence: true, inclusion: { in: Decidim::ParticipatoryProcess.access_modes.keys }
+        validate :ensure_access_mode_for_has_members
 
         validates :start_date, date: { before: :end_date, allow_blank: true, if: proc { |obj| obj.end_date.present? } }
         validates :end_date, date: { after: :start_date, allow_blank: true, if: proc { |obj| obj.start_date.present? } }
@@ -89,6 +91,10 @@ module Decidim
                         .any?
 
           errors.add(:slug, :taken)
+        end
+
+        def ensure_access_mode_for_has_members
+          self.access_mode = :open if has_members == false
         end
       end
     end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -146,6 +146,39 @@
     </div>
   </div>
 
+  <div class="card" data-controller="accordion" id="accordion-access">
+    <div class="card-divider">
+      <button class="card-divider-button" data-open="true" data-controls="panel-access" type="button">
+        <%= icon "arrow-right-s-line" %>
+        <h2 class="card-title" id="access">
+          <%= t("label", scope: "decidim.participatory_processes.admin.participatory_processes.form.access") %>
+        </h2>
+      </button>
+    </div>
+    <div id="panel-access" class="card-section">
+      <div class="row column" id="has_members">
+        <%= form.check_box :has_members, help_text: t(".has_members_help") %>
+      </div>
+
+      <fieldset class="row column" id="access_mode">
+        <legend>
+          <%= t("access.set_this_space_as", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
+        </legend>
+        <div class="radio-group">
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.open") %>
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.restricted") %>
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.transparent") %>
+          <% Decidim::ParticipatoryProcess::ACCESS_MODES.keys.each do |mode| %>
+            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
+              <%= form.radio_button :access_mode, mode %>
+              <span><%= t(mode, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options") %></span>
+             <% end %>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
+  </div>
+
   <div class="card" data-controller="accordion" id="accordion-visibility">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-visibility" type="button">
@@ -164,26 +197,6 @@
         <% end %>
       </div>
 
-      <div class="row column" id="has_members">
-        <%= form.check_box :has_members, help_text: t(".has_members_help") %>
-      </div>
-
-      <fieldset class="row column" id="access_mode">
-        <legend>
-          <%= t("access.label", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
-        </legend>
-        <div class="radio-group">
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.open") %>
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.restricted") %>
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.transparent") %>
-          <% Decidim::ParticipatoryProcess::ACCESS_MODES.keys.each do |mode| %>
-            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
-              <span><%= t(mode, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options") %></span>
-             <% end %>
-          <% end %>
-        </div>
-      </fieldset>
       <div class="row column">
         <%= form.check_box :promoted %>
       </div>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -146,7 +146,7 @@
     </div>
   </div>
 
-  <div class="card" data-controller="accordion" id="accordion-access">
+  <div class="card" data-controller="accordion access-mode" id="accordion-access">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-access" type="button">
         <%= icon "arrow-right-s-line" %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -522,6 +522,7 @@ en:
                 open: Everyone can see the process and participate.
                 restricted: Only members can see and participate.
                 transparent: Everyone can see the process, but only members can participate.
+              set_this_space_as: Set this space as
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration
             has_members_help: You will be able to create and publish members

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/test/factories.rb
@@ -57,10 +57,12 @@ FactoryBot.define do
     end
 
     trait :transparent do
+      has_members { true }
       access_mode { :transparent }
     end
 
     trait :restricted do
+      has_members { true }
       access_mode { :restricted }
     end
 

--- a/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
+++ b/decidim-participatory_processes/spec/forms/participatory_process_form_spec.rb
@@ -127,6 +127,16 @@ module Decidim
           end
         end
 
+        describe "access_mode reset when has_members is false" do
+          let(:access_mode) { "transparent" }
+          let(:has_members) { false }
+
+          it "resets access_mode to open" do
+            subject.valid?
+            expect(subject.access_mode).to eq("open")
+          end
+        end
+
         context "when everything is OK" do
           it { is_expected.to be_valid }
         end

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_processes_spec.rb
@@ -87,7 +87,6 @@ describe "Admin manages participatory processes", versioning: true do
         select group_title, from: :participatory_process_participatory_process_group_id
 
         select(decidim_sanitize_translated(taxonomy.name), from: "taxonomies-#{taxonomy_filter.id}")
-        choose(:participatory_process_access_mode_open)
 
         fill_in :participatory_process_slug, with: "slug"
         fill_in :participatory_process_weight, with: 1


### PR DESCRIPTION
#### :tophat: What? Why?

These are the final touches for the Access Mode feature: moves the fields to its own panel, and makes the Members toggle the Access Mode radio buttons. 

#### :pushpin: Related Issues 
- Fixes #15720

#### Testing

0. Sign in as admin
1. Edit a process or an assembly or create a new one
2. See that you have an "Access" panel
3. See that if you click in "This space has members", then the checkboxes are shown or not

### :camera: Screenshots

<img width="1417" height="698" alt="image" src="https://github.com/user-attachments/assets/c7c79b89-fbaa-49e3-b210-ee10dd3d0e6d" />
<img width="1525" height="586" alt="image" src="https://github.com/user-attachments/assets/c26afcb0-29df-46d7-b23b-5997e7500b6c" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access settings now dynamically show or hide based on whether a space has members.

* **Bug Fixes**
  * Access mode is coerced to "open" when a space has no members to prevent invalid states.

* **Chores**
  * Admin form sections reorganized (new "Access" section) and new English i18n labels added.

* **Tests**
  * Added frontend and form specs for access-mode behavior and teardown; adjusted related test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->