### PR TITLE
Fix images in milestones

### DIFF
--- a/decidim-accountability/app/cells/decidim/accountability/result_show/milestones.erb
+++ b/decidim-accountability/app/cells/decidim/accountability/result_show/milestones.erb
@@ -13,7 +13,7 @@
         </div>
         <% if translated_attribute(milestone.description).present? %>
           <div class="editor-content">
-            <%= decidim_sanitize_translated(milestone.description) %>
+            <%= decidim_sanitize_admin(translated_attribute(milestone.description)) %>
           </div>
         <% end %>
       </div>

--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -247,6 +247,28 @@ describe "Explore results", :versioning do
           expect(page).to have_content(I18n.l(milestone.entry_date, format: :decidim_short))
           expect(page).to have_content(decidim_sanitize_translated(milestone.description))
         end
+
+        context "and milestone's description contains an image" do
+          let!(:image_blob) do
+            ActiveStorage::Blob.create_and_upload!(
+              io: File.open(Decidim::Dev.asset("city.jpeg")),
+              filename: "city.jpeg",
+              content_type: "image/jpeg"
+            )
+          end
+
+          before do
+            image_url = Rails.application.routes.url_helpers.rails_blob_path(image_blob, only_path: true)
+            milestone.update!(description: { "en" => "<p>Milestone description</p><img src=\"#{image_url}\" alt=\"city_image\">" })
+          end
+
+          it "displays the image" do
+            visit current_path
+            expect(page).to have_content(decidim_sanitize_translated(milestone.title))
+            expect(page).to have_content(I18n.l(milestone.entry_date, format: :decidim_short))
+            expect(page).to have_css(".editor-content img[alt=city_image]")
+          end
+        end
       end
 
       context "with subresults" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR updates the milestone cell to allow the display of images in front if added in the description in back.

#### Testing
As an admin in the BO, go to a process > accountability > add a milestone to a result, and add an image in description (screenshot one)
As a user in the FO, go to the process > accountabilty > result.
See that the image is displayed (screenshot two)

### :camera: Screenshots
**ONE**
<img width="1096" height="818" alt="568946986-46ebcd97-b83f-4bbb-be74-48e8405a3cc6" src="https://github.com/user-attachments/assets/5e44dcf4-ab85-424e-b513-b8e1c9a6e78c" />

**TWO**
<img width="1074" height="821" alt="568947402-68e0305a-2d76-46c1-aa3b-e2611ecdbcf3" src="https://github.com/user-attachments/assets/36e82971-b232-484a-8783-10088faeb1b8" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the rendering of images and rich formatted content within milestone descriptions to ensure they display properly on the milestone detail pages.

* **Tests**
  * Added system test coverage to verify that images embedded within milestone descriptions render correctly and display as expected on milestone detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->