### PR TITLE
Add a GH workflow for checking locale completeness on "New Crowdin updates"

### DIFF
--- a/.github/workflows/check_locale_completeness.yml
+++ b/.github/workflows/check_locale_completeness.yml
@@ -1,0 +1,29 @@
+name: Check locale completeness
+
+on:
+  push:
+    branches:
+      - "chore/l10n/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-locale:
+    name: Check locale completeness
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Run locale completeness check
+        run: bin/rake check_locale_completeness


### PR DESCRIPTION
#### :tophat: What? Why?

The last releases were delayed because we had some issues with the i18n completeness specs.

This PR adds a GH workflow so this is actually check in the "New Crowdin updates" PRs, preventing merging these branches if there's an error. This way we don't need to do the whole release flow just to find out that there are missing translations/interpolation errors. 

#### :pushpin: Related Issues
 
- Related to #16487 and #16486

#### Testing

This will be difficult to check if we don't do it in a "New Crowdin updates" kind of PR, so I guess we should merge this and wait a couple of days if these branches have an error.  

:hearts: Thank you!
