### PR TITLE
Remove the roles menu on tabbed partial

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
@@ -76,6 +76,32 @@ export default class extends Controller {
     }
 
     Dropdowns.render(this.element.id, dropdownOptions);
+
+    const addAriaRoles = this.element.dataset.addAriaRoles !== "false";
+    if (!addAriaRoles) {
+      this.removeAriaRoles();
+    }
+  }
+
+  removeAriaRoles() {
+    const target = this.element.dataset.target;
+    const dropdownMenu = document.getElementById(target);
+    if (!dropdownMenu) {
+      return;
+    }
+
+    dropdownMenu.removeAttribute("role");
+    dropdownMenu.removeAttribute("aria-labelledby");
+    dropdownMenu.removeAttribute("tabindex");
+
+    dropdownMenu.querySelectorAll("li").forEach((li) => {
+      li.removeAttribute("role");
+    });
+
+    dropdownMenu.querySelectorAll("a").forEach((anchor) => {
+      anchor.removeAttribute("role");
+      anchor.removeAttribute("tabindex");
+    });
   }
 
   /**

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -1,6 +1,12 @@
+/* global jest */
 /* eslint max-lines: ["error", 400] */
 
 import DropdownController from "src/decidim/controllers/dropdown/controller";
+
+jest.mock("a11y-dropdown-component", () => ({
+  render: jest.fn(),
+  destroy: jest.fn()
+}));
 
 describe("DropdownController", () => {
   let element = null;
@@ -18,6 +24,13 @@ describe("DropdownController", () => {
   };
 
   beforeEach(() => {
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }));
+
     document.body.innerHTML = `
       <button
         id="dropdown-trigger"
@@ -42,6 +55,7 @@ describe("DropdownController", () => {
 
   afterEach(() => {
     document.body.innerHTML = "";
+    Reflect.deleteProperty(window, "matchMedia");
   });
 
   describe("removeAriaRoles", () => {
@@ -129,31 +143,45 @@ describe("DropdownController", () => {
   });
 
   describe("data-add-aria-roles option", () => {
-    it("detects when data-add-aria-roles is false", () => {
-      element.setAttribute("data-add-aria-roles", "false");
-      expect(element.dataset.addAriaRoles).toBe("false");
-    });
-
-    it("detects when data-add-aria-roles is true", () => {
+    it("keeps role menu when data-add-aria-roles is true", () => {
       element.setAttribute("data-add-aria-roles", "true");
-      expect(element.dataset.addAriaRoles).toBe("true");
+      dropdownMenuEl.setAttribute("role", "menu");
+      dropdownMenuEl.querySelector("li").setAttribute("role", "none");
+      dropdownMenuEl.querySelector("a").setAttribute("role", "menuitem");
+      const testController = createController(element);
+
+      testController.connect();
+
+      expect(dropdownMenuEl.getAttribute("role")).toBe("menu");
+      expect(dropdownMenuEl.querySelector("li").getAttribute("role")).toBe("none");
+      expect(dropdownMenuEl.querySelector("a").getAttribute("role")).toBe("menuitem");
     });
 
-    it("evaluates addAriaRoles correctly when false", () => {
+    it("keeps role menu when data-add-aria-roles is not set (default)", () => {
+      dropdownMenuEl.setAttribute("role", "menu");
+      dropdownMenuEl.querySelector("li").setAttribute("role", "none");
+      dropdownMenuEl.querySelector("a").setAttribute("role", "menuitem");
+      const testController = createController(element);
+
+      testController.connect();
+
+      expect(dropdownMenuEl.getAttribute("role")).toBe("menu");
+      expect(dropdownMenuEl.querySelector("li").getAttribute("role")).toBe("none");
+      expect(dropdownMenuEl.querySelector("a").getAttribute("role")).toBe("menuitem");
+    });
+
+    it("removes role menu when data-add-aria-roles is false", () => {
       element.setAttribute("data-add-aria-roles", "false");
-      const addAriaRoles = element.dataset.addAriaRoles !== "false";
-      expect(addAriaRoles).toBe(false);
-    });
+      dropdownMenuEl.setAttribute("role", "menu");
+      dropdownMenuEl.querySelector("li").setAttribute("role", "none");
+      dropdownMenuEl.querySelector("a").setAttribute("role", "menuitem");
+      const testController = createController(element);
 
-    it("evaluates addAriaRoles correctly when true", () => {
-      element.setAttribute("data-add-aria-roles", "true");
-      const addAriaRoles = element.dataset.addAriaRoles !== "false";
-      expect(addAriaRoles).toBe(true);
-    });
+      testController.connect();
 
-    it("evaluates addAriaRoles correctly when undefined", () => {
-      const addAriaRoles = element.dataset.addAriaRoles !== "false";
-      expect(addAriaRoles).toBe(true);
+      expect(dropdownMenuEl.getAttribute("role")).toBeNull();
+      expect(dropdownMenuEl.querySelector("li").getAttribute("role")).toBeNull();
+      expect(dropdownMenuEl.querySelector("a").getAttribute("role")).toBeNull();
     });
   });
 });

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -1,0 +1,177 @@
+/* eslint max-lines: ["error", 400] */
+
+describe("DropdownController - removeAriaRoles", () => {
+  let element = null;
+  let dropdownMenuEl = null;
+
+  const createRemoveAriaRoles = (dropdownElement) => {
+    return function() {
+      const target = dropdownElement.dataset.target;
+      const dropdownMenu = document.getElementById(target);
+      if (!dropdownMenu) {
+        return;
+      }
+
+      dropdownMenu.removeAttribute("role");
+      dropdownMenu.removeAttribute("aria-labelledby");
+      dropdownMenu.removeAttribute("tabindex");
+
+      dropdownMenu.querySelectorAll("li").forEach((li) => {
+        li.removeAttribute("role");
+      });
+
+      dropdownMenu.querySelectorAll("a").forEach((anchor) => {
+        anchor.removeAttribute("role");
+        anchor.removeAttribute("tabindex");
+      });
+    };
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button
+        id="dropdown-trigger"
+        data-controller="dropdown"
+        data-target="dropdown-menu"
+        data-open-md="true"
+        data-auto-close="true"
+      >
+        Dropdown Trigger
+      </button>
+      <ul id="dropdown-menu" class="dropdown-menu">
+        <li><a href="/link1">Link 1</a></li>
+        <li><a href="/link2">Link 2</a></li>
+        <li><a href="/link3">Link 3</a></li>
+      </ul>
+    `;
+
+    element = document.getElementById("dropdown-trigger");
+    dropdownMenuEl = document.getElementById("dropdown-menu");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("removeAriaRoles", () => {
+    it("removes role attribute from dropdown menu", () => {
+      dropdownMenuEl.setAttribute("role", "menu");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(dropdownMenuEl.getAttribute("role")).toBeNull();
+    });
+
+    it("removes aria-labelledby attribute from dropdown menu", () => {
+      dropdownMenuEl.setAttribute("aria-labelledby", "trigger");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(dropdownMenuEl.getAttribute("aria-labelledby")).toBeNull();
+    });
+
+    it("removes tabindex attribute from dropdown menu", () => {
+      dropdownMenuEl.setAttribute("tabindex", "-1");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(dropdownMenuEl.getAttribute("tabindex")).toBeNull();
+    });
+
+    it("removes role from li elements", () => {
+      const li = dropdownMenuEl.querySelector("li");
+      li.setAttribute("role", "none");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(li.getAttribute("role")).toBeNull();
+    });
+
+    it("removes role from all li elements", () => {
+      const listItems = dropdownMenuEl.querySelectorAll("li");
+      listItems.forEach((li) => {
+        li.setAttribute("role", "none");
+      });
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      listItems.forEach((li) => {
+        expect(li.getAttribute("role")).toBeNull();
+      });
+    });
+
+    it("removes role from anchor elements", () => {
+      const anchor = dropdownMenuEl.querySelector("a");
+      anchor.setAttribute("role", "menuitem");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(anchor.getAttribute("role")).toBeNull();
+    });
+
+    it("removes tabindex from anchor elements", () => {
+      const anchor = dropdownMenuEl.querySelector("a");
+      anchor.setAttribute("tabindex", "-1");
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      removeAriaRoles();
+
+      expect(anchor.getAttribute("tabindex")).toBeNull();
+    });
+
+    it("handles missing dropdown menu gracefully", () => {
+      const mockElement = document.createElement("button");
+      mockElement.dataset.target = "nonexistent-menu";
+      const removeAriaRoles = createRemoveAriaRoles(mockElement);
+
+      expect(() => {
+        removeAriaRoles();
+      }).not.toThrow();
+    });
+
+    it("handles elements without the attributes gracefully", () => {
+      const removeAriaRoles = createRemoveAriaRoles(element);
+
+      expect(() => {
+        removeAriaRoles();
+      }).not.toThrow();
+
+      expect(dropdownMenuEl.getAttribute("role")).toBeNull();
+    });
+  });
+
+  describe("data-add-aria-roles option", () => {
+    it("detects when data-add-aria-roles is false", () => {
+      element.setAttribute("data-add-aria-roles", "false");
+      expect(element.dataset.addAriaRoles).toBe("false");
+    });
+
+    it("detects when data-add-aria-roles is true", () => {
+      element.setAttribute("data-add-aria-roles", "true");
+      expect(element.dataset.addAriaRoles).toBe("true");
+    });
+
+    it("evaluates addAriaRoles correctly when false", () => {
+      element.setAttribute("data-add-aria-roles", "false");
+      const addAriaRoles = element.dataset.addAriaRoles !== "false";
+      expect(addAriaRoles).toBe(false);
+    });
+
+    it("evaluates addAriaRoles correctly when true", () => {
+      element.setAttribute("data-add-aria-roles", "true");
+      const addAriaRoles = element.dataset.addAriaRoles !== "false";
+      expect(addAriaRoles).toBe(true);
+    });
+
+    it("evaluates addAriaRoles correctly when undefined", () => {
+      const addAriaRoles = element.dataset.addAriaRoles !== "false";
+      expect(addAriaRoles).toBe(true);
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -1,30 +1,20 @@
 /* eslint max-lines: ["error", 400] */
 
-describe("DropdownController - removeAriaRoles", () => {
+import DropdownController from "src/decidim/controllers/dropdown/controller";
+
+describe("DropdownController", () => {
   let element = null;
   let dropdownMenuEl = null;
+  let controller = null;
 
-  const createRemoveAriaRoles = (dropdownElement) => {
-    return function() {
-      const target = dropdownElement.dataset.target;
-      const dropdownMenu = document.getElementById(target);
-      if (!dropdownMenu) {
-        return;
-      }
-
-      dropdownMenu.removeAttribute("role");
-      dropdownMenu.removeAttribute("aria-labelledby");
-      dropdownMenu.removeAttribute("tabindex");
-
-      dropdownMenu.querySelectorAll("li").forEach((li) => {
-        li.removeAttribute("role");
-      });
-
-      dropdownMenu.querySelectorAll("a").forEach((anchor) => {
-        anchor.removeAttribute("role");
-        anchor.removeAttribute("tabindex");
-      });
-    };
+  const createController = (controllerElement) => {
+    const ControllerClass = DropdownController;
+    const instance = Object.create(ControllerClass.prototype);
+    Reflect.defineProperty(instance, "element", {
+      get: () => controllerElement,
+      configurable: true
+    });
+    return instance;
   };
 
   beforeEach(() => {
@@ -47,6 +37,7 @@ describe("DropdownController - removeAriaRoles", () => {
 
     element = document.getElementById("dropdown-trigger");
     dropdownMenuEl = document.getElementById("dropdown-menu");
+    controller = createController(element);
   });
 
   afterEach(() => {
@@ -56,27 +47,24 @@ describe("DropdownController - removeAriaRoles", () => {
   describe("removeAriaRoles", () => {
     it("removes role attribute from dropdown menu", () => {
       dropdownMenuEl.setAttribute("role", "menu");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(dropdownMenuEl.getAttribute("role")).toBeNull();
     });
 
     it("removes aria-labelledby attribute from dropdown menu", () => {
       dropdownMenuEl.setAttribute("aria-labelledby", "trigger");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(dropdownMenuEl.getAttribute("aria-labelledby")).toBeNull();
     });
 
     it("removes tabindex attribute from dropdown menu", () => {
       dropdownMenuEl.setAttribute("tabindex", "-1");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(dropdownMenuEl.getAttribute("tabindex")).toBeNull();
     });
@@ -84,9 +72,8 @@ describe("DropdownController - removeAriaRoles", () => {
     it("removes role from li elements", () => {
       const li = dropdownMenuEl.querySelector("li");
       li.setAttribute("role", "none");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(li.getAttribute("role")).toBeNull();
     });
@@ -96,9 +83,8 @@ describe("DropdownController - removeAriaRoles", () => {
       listItems.forEach((li) => {
         li.setAttribute("role", "none");
       });
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       listItems.forEach((li) => {
         expect(li.getAttribute("role")).toBeNull();
@@ -108,9 +94,8 @@ describe("DropdownController - removeAriaRoles", () => {
     it("removes role from anchor elements", () => {
       const anchor = dropdownMenuEl.querySelector("a");
       anchor.setAttribute("role", "menuitem");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(anchor.getAttribute("role")).toBeNull();
     });
@@ -118,9 +103,8 @@ describe("DropdownController - removeAriaRoles", () => {
     it("removes tabindex from anchor elements", () => {
       const anchor = dropdownMenuEl.querySelector("a");
       anchor.setAttribute("tabindex", "-1");
-      const removeAriaRoles = createRemoveAriaRoles(element);
 
-      removeAriaRoles();
+      controller.removeAriaRoles();
 
       expect(anchor.getAttribute("tabindex")).toBeNull();
     });
@@ -128,18 +112,16 @@ describe("DropdownController - removeAriaRoles", () => {
     it("handles missing dropdown menu gracefully", () => {
       const mockElement = document.createElement("button");
       mockElement.dataset.target = "nonexistent-menu";
-      const removeAriaRoles = createRemoveAriaRoles(mockElement);
+      const mockController = createController(mockElement);
 
       expect(() => {
-        removeAriaRoles();
+        mockController.removeAriaRoles();
       }).not.toThrow();
     });
 
     it("handles elements without the attributes gracefully", () => {
-      const removeAriaRoles = createRemoveAriaRoles(element);
-
       expect(() => {
-        removeAriaRoles();
+        controller.removeAriaRoles();
       }).not.toThrow();
 
       expect(dropdownMenuEl.getAttribute("role")).toBeNull();

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -11,16 +11,16 @@
 
   <div class="vertical-tabs">
     <nav role="navigation" aria-label="<%= I18n.t("layouts.decidim.navigation.aria_label", title: translated_attribute(page.title)) %>">
-      <button id="dropdown-trigger-pages" data-controller="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true">
+      <button id="dropdown-trigger-pages" data-controller="dropdown" data-target="dropdown-menu-pages" data-open-md="true" data-auto-close="true" data-add-aria-roles="false">
         <span>
           <%= translated_attribute(page.title) %>
         </span>
         <%= icon "arrow-down-s-line" %>
         <%= icon "arrow-up-s-line" %>
       </button>
-      <ul id="dropdown-menu-pages" class="vertical-tabs__list" role="menu">
+      <ul id="dropdown-menu-pages" class="vertical-tabs__list">
         <% pages.each do |sibling| %>
-          <li class="<%= "is-active" if page == sibling %>" role="menuitem">
+          <li class="<%= "is-active" if page == sibling %>">
             <%= link_to translated_attribute(sibling.title), page_path(sibling.slug, locale: current_locale), "aria-current": ("page" if page == sibling) %>
           </li>
         <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

A different approach to #14951, adding a data attribute to remove these roles in this page. 

This way we don't have inline JS and we have a more agnostic solution (that could be applied in other possible Drodpwon controller implementations). 

#### :pushpin: Related Issues

- Related to #14951 

#### Testing

1. As a user, go to the footer of decidim page and in "Help" column, click on "General"
2. Open you devTools, check that the `ul id="dropdown-menu-pages"` and its `li `children have no attribute role
3. Check inside active `li` that the `a` link has a `aria-current="page"`, and check that inside non active `li` the `aria-current` on `a` has a false value
~~4. Click anywhere on window and check that `ul aria-hidden` attribute value is still false~~  I don't agree with this change proposed by the auditor: it is breaking one of the features of this dropdown library, where a menu can be closed if clicked outside (or if the Escape key is pressed). Also it'd mean that this particular page is not consistent with the other dropdown menus. I prefer to leave it as is. 


### :camera: Screenshots

#### Before

<img width="906" height="521" alt="image" src="https://github.com/user-attachments/assets/8c0f6674-3505-44fa-accb-81f165fb9ad1" />

#### After 

<img width="911" height="724" alt="image" src="https://github.com/user-attachments/assets/887bd48c-5544-4810-a0c8-cc708ca1396d" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dropdowns now support opting out of automatic accessibility role assignment; when disabled, ARIA roles and tabindex are removed from the menu and its items to match markup preferences.

* **Tests**
  * Added tests covering ARIA attribute removal, no-op behavior when elements are missing, and configuration-driven preservation vs. removal of roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->