### PR TITLE
Fix the "SMTP_STARTTLS_AUTO" env var in `production.rb`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,7 @@ bin/rails decidim:upgrade:clean:remove_private_exports_attachments
 echo "/public/sw.js*" >> .gitignore
 bin/rails decidim:upgrade:remove_deleted_users_left_data
 bin/rails decidim:upgrade:fix_deleted_private_follows
+sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,/' config/environments/production.rb
 bin/rails data:migrate
 ```
 
@@ -221,7 +222,39 @@ This works for Ubuntu Linux, other operating systems would need to do other comm
 
 You can read more about this change on PR [#15670](https://github.com/decidim/decidim/pull/15670).
 
-### 3.6. [[TITLE OF THE ACTION]]
+### 3.6. Fix the "SMTP_STARTTLS_AUTO" env var in `production.rb`
+
+It was detected a bug with the enable_starttls_auto configuration for the Action Mailer (SMTP) configuration. For fixing it you need to replace in `config/environmets/production.rb`
+
+If your `config/environments/production.rb` contains an SMTP configuration like this:
+
+```ruby
+config.action_mailer.smtp_settings = {
+  # ... other settings ...
+  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO").to_boolean_string,
+  # ... other settings ...
+}
+```
+
+You should update it to:
+
+```ruby
+config.action_mailer.smtp_settings = {
+  # ... other settings ...
+  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,
+  # ... other settings ...
+}
+```
+
+You can do this with the following oneliner:
+
+```bash
+sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,/' config/environments/production.rb
+```
+
+You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+
+### 3.7. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,7 +46,7 @@ bin/rails decidim:upgrade:clean:remove_private_exports_attachments
 echo "/public/sw.js*" >> .gitignore
 bin/rails decidim:upgrade:remove_deleted_users_left_data
 bin/rails decidim:upgrade:fix_deleted_private_follows
-sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,/' config/environments/production.rb
+sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
 bin/rails data:migrate
 ```
 
@@ -241,7 +241,7 @@ You should update it to:
 ```ruby
 config.action_mailer.smtp_settings = {
   # ... other settings ...
-  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,
+  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).present?,
   # ... other settings ...
 }
 ```
@@ -249,7 +249,7 @@ config.action_mailer.smtp_settings = {
 You can do this with the following command:
 
 ```bash
-sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,/' config/environments/production.rb
+sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
 ```
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -252,7 +252,7 @@ You can do this with the following command:
 sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
 ```
 
-You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+You can read more about this change on PR [#16491](https://github.com/decidim/decidim/pull/16491).
 
 ### 3.7. [[TITLE OF THE ACTION]]
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -224,7 +224,7 @@ You can read more about this change on PR [#15670](https://github.com/decidim/de
 
 ### 3.6. Fix the "SMTP_STARTTLS_AUTO" env var in `production.rb`
 
-It was detected a bug with the enable_starttls_auto configuration for the Action Mailer (SMTP) configuration. For fixing it you need to replace in `config/environmets/production.rb`
+It was detected a bug with the enable_starttls_auto configuration for the Action Mailer (SMTP) configuration. For fixing it you need to replace in `config/environments/production.rb`
 
 If your `config/environments/production.rb` contains an SMTP configuration like this:
 
@@ -246,7 +246,7 @@ config.action_mailer.smtp_settings = {
 }
 ```
 
-You can do this with the following oneliner:
+You can do this with the following command:
 
 ```bash
 sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,/' config/environments/production.rb

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -62,7 +62,7 @@ module Decidim
             |    :user_name      => Decidim::Env.new("SMTP_USERNAME").to_s,
             |    :password       => Decidim::Env.new("SMTP_PASSWORD").to_s,
             |    :domain         => Decidim::Env.new("SMTP_DOMAIN").to_s,
-            |    :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO").to_boolean_string,
+            |    :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,
             |    :openssl_verify_mode => 'none'
             |  }
           HERE

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -62,7 +62,7 @@ module Decidim
             |    :user_name      => Decidim::Env.new("SMTP_USERNAME").to_s,
             |    :password       => Decidim::Env.new("SMTP_PASSWORD").to_s,
             |    :domain         => Decidim::Env.new("SMTP_DOMAIN").to_s,
-            |    :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).to_boolean_string,
+            |    :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).present?,
             |    :openssl_verify_mode => 'none'
             |  }
           HERE


### PR DESCRIPTION
#### :tophat: What? Why?

This PR supersedes #15192 as the description is too long for something that it is really simple.

Basically:

1. There's a `:enable_starttls_auto` configuration for SMTP that "Detects if STARTTLS is enabled in your SMTP server and starts to use it. **Defaults to true**." (from https://guides.rubyonrails.org/v7.1/action_mailer_basics.html)
2. In our default `config/environments/production.rb` we are using `Decidim::Env.new("SMTP_STARTTLS_AUTO").to_boolean_string`. This evaluates to **`false`**
```bash
bin/rails runner 'puts Decidim::Env.new("SMTP_STARTTLS_AUTO").to_boolean_string'
Running via Spring preloader in process 565737
false
``` 
3. We need to change this to default to true. This means that we also ask implementers to make this change manually in their app.

#### :pushpin: Related Issues
 
- Related to #15192 
- Fixes #15022

#### Testing

1. Run this to see that it is true indeed:
```bash
bin/rails runner 'puts Decidim::Env.new("SMTP_STARTTLS_AUTO", true).present?'
Running via Spring preloader in process 566744
true
``` 
2. In an already generated `development_app`, run the command from the release notes and check that it changed indeed.
```bash
cd development_app
sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
``` 
3. Generate a new development_app, to check that the fix works with newly generated apps
```bash
bundle exec rake development_app
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a one-time upgrade step and updated the section title with clear instructions to fix the SMTP_STARTTLS_AUTO environment setting.

* **Chores**
  * Changed interpretation of SMTP_STARTTLS_AUTO when unset so it now defaults to enabled, improving mail configuration consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->