### PR TITLE
Clarify release requirements for NPM and GH

### DIFF
--- a/docs/modules/develop/pages/maintainers/releases.adoc
+++ b/docs/modules/develop/pages/maintainers/releases.adoc
@@ -3,8 +3,8 @@
 In order to release new version you need to:
 
 . be owner of all the gems at RubyGems, ask one of the owners to add you before releasing. Try `gem owner decidim` to find out the owners of the gem. It is worth making sure you are owner of all gems.
-. be owner of all the NPM packages
-. have the `gh` command line installed. You can install by following the https://github.com/cli/cli/blob/trunk/docs/install_linux.md[GH installation instructions].
+. be owner of all the NPM packages. You also need to be authenticated with `npm login`.
+. have the `gh` command line installed. You can install by following the https://github.com/cli/cli/blob/trunk/docs/install_linux.md[GH installation instructions]. You also need to be authenticated with `gh auth login`.
 . have the `yq` command line installed. You can install it with `snap install yq` in Ubuntu.
 . have the `decidim-maintainers_toolbox` gem. You can install it with `gem install decidim-maintainers_toolbox`.
 


### PR DESCRIPTION
#### :tophat: What? Why?

Updated release requirements to include authentication for NPM and GH commands.

A missing detail that I noticed on the last review with a clean devcontainer. 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release prerequisites documentation to explicitly require authentication for JavaScript tooling (NPM and GitHub CLI), clarifying the steps needed to complete the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->