### PR TITLE
Fix links to members profiles page

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/pages/user_profile/_member_of.html.erb
@@ -3,7 +3,7 @@
     <div class="font-semibold"><%= t(".member_of") %></div>
     <% assemblies.each_with_index do |assembly, i| %>
       <%= "&nbsp;&#183;&nbsp;".html_safe if i.positive? %>
-      <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly), class: "hover:underline" %>
+      <%= link_to translated_attribute(assembly.title), decidim_assemblies.assembly_path(assembly, locale: I18n.locale), class: "hover:underline" %>
     <% end %>
   </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/member/show.erb
+++ b/decidim-core/app/cells/decidim/member/show.erb
@@ -1,13 +1,13 @@
-<div class="profile__user">
+<%= link_to profile_url, class: "profile__user" do %>
   <div class="profile__user-avatar-container">
-    <div class="<%= has_profile? ? "profile__user-avatar" : "profile__user-avatar !border-0" %>">
-      <%= image_tag(has_profile? ? model.avatar_url(:big) : model.non_user_avatar_path, alt: "member-avatar") %>
+    <div class="profile__user-avatar">
+      <%= image_tag(model.avatar_url(:big), alt: "member-avatar") %>
     </div>
   </div>
   <div>
-    <div class="<%= has_profile? ? "profile__user-name" : "profile__user-name !no-underline" %>">
+    <span class="profile__user-name">
       <%= name %>
-    </div>
+    </span>
     <% if nickname.present? %>
       <span class="profile__user-nick block">
         <%= nickname %>
@@ -20,4 +20,4 @@
       </span>
     </div>
   </div>
-</div>
+<% end %>

--- a/decidim-core/app/cells/decidim/member_cell.rb
+++ b/decidim-core/app/cells/decidim/member_cell.rb
@@ -10,10 +10,6 @@ module Decidim
 
     private
 
-    def has_profile?
-      model.profile_url.present?
-    end
-
     def role_translated
       decidim_html_escape(decidim_sanitize(translated_attribute(role)))
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
@@ -4,7 +4,7 @@ shared_examples "participatory space members" do
   let(:blocks_manifests) { [] }
   let(:organization) { create(:organization) }
   let(:user) { create(:user, organization: participatory_space.organization) }
-  let(:ceased_user) { create(:user, organization: participatory_space.organization) }
+  let(:unpublished_user) { create(:user, organization: participatory_space.organization) }
 
   before do
     switch_to_host(organization.host)
@@ -76,7 +76,7 @@ shared_examples "participatory space members" do
 
   context "when there are some published members" do
     let!(:member) { create(:member, user:, participatory_space:, published: true) }
-    let!(:ceased_member) { create(:member, user: ceased_user, participatory_space:, published: false) }
+    let!(:unpublished_member) { create(:member, user: unpublished_user, participatory_space:, published: false) }
 
     before do
       visit members_path
@@ -106,11 +106,16 @@ shared_examples "participatory space members" do
         end
       end
 
-      it "lists all the non ceased members" do
+      it "lists all the members" do
         within ".layout-main__section" do
           expect(page).to have_css(".profile__user", count: 1)
+          expect(page).to have_no_content(Decidim::ParticipatorySpace::MemberPresenter.new(unpublished_member).name)
 
-          expect(page).to have_no_content(Decidim::ParticipatorySpace::MemberPresenter.new(ceased_member).name)
+          click_on(member.name)
+
+          expect(page).to have_content("Profile")
+          expect(page).to have_content("Member of")
+          expect(page).to have_content(translated_attribute(participatory_space.name))
         end
       end
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
@@ -115,8 +115,6 @@ shared_examples "participatory space members" do
         click_on(member.name)
 
         expect(page).to have_content("Profile")
-        expect(page).to have_content("Member of")
-        expect(page).to have_content(translated_attribute(participatory_space.title))
       end
     end
   end

--- a/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/participatory_space_members_shared_examples.rb
@@ -110,13 +110,13 @@ shared_examples "participatory space members" do
         within ".layout-main__section" do
           expect(page).to have_css(".profile__user", count: 1)
           expect(page).to have_no_content(Decidim::ParticipatorySpace::MemberPresenter.new(unpublished_member).name)
-
-          click_on(member.name)
-
-          expect(page).to have_content("Profile")
-          expect(page).to have_content("Member of")
-          expect(page).to have_content(translated_attribute(participatory_space.name))
         end
+
+        click_on(member.name)
+
+        expect(page).to have_content("Profile")
+        expect(page).to have_content("Member of")
+        expect(page).to have_content(translated_attribute(participatory_space.title))
       end
     end
   end

--- a/decidim-core/lib/decidim/participatory_space_user.rb
+++ b/decidim-core/lib/decidim/participatory_space_user.rb
@@ -11,7 +11,7 @@ module Decidim
     included do
       validate :user_and_space_same_organization
 
-      belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User", optional: true
+      belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
       ransacker :name do
         Arel.sql(%{("decidim_users"."name")::text})


### PR DESCRIPTION
#### :tophat: What? Why?

This PR fixes the Members page by making all the users clickable to its profile. 

Mind that before #13502 you could have Members that were or weren't users, so the cell had to support that. That isn't the case anymore, so I'm cleaning this too.

#### :pushpin: Related Issues
 
- Fixes #16495 

#### Testing

1. Sign in as admin 
2. Go to a process
3. Edit it 
4. Click in the "This space has members" 
5. Add a new Member. Click in "Publish" 
6. Go to the frontend, see the public page
7. (Before) See that you have a hover but you can't click in the profile link 
7. (After) See that you can click in the profile link 

### :camera: Screenshots 

#### Before

<img width="856" height="645" alt="image" src="https://github.com/user-attachments/assets/158c3b05-ee80-4147-a375-9405bb317306" />

#### After

<img width="818" height="602" alt="image" src="https://github.com/user-attachments/assets/bf0d5df9-3b46-4f9c-89aa-f965170ae37f" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Member profile cards are fully clickable as unified links for easier navigation.
  * Avatar display is standardized and consistent across all member profiles.
  * Username styling is simplified for improved visual consistency.
  * "Member of" links now respect the current language/locale.

* **Chores**
  * Participatory space memberships now require an associated user, tightening account association rules.

* **Tests**
  * Member list/profile navigation tests updated to cover unpublished members and profile viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->