### PR TITLE
Add validations to the host format at system panel

### DIFF
--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -65,6 +65,7 @@ module Decidim
       validate :validate_short_name_uniqueness
       validate :validate_short_name_format
       validate :validate_secret_key_base_for_encryption
+      validate :validate_host_format
 
       def map_model(model)
         self.default_locale = model.default_locale
@@ -133,6 +134,52 @@ module Decidim
 
       def validate_short_name_format
         raise "#{self.class.name} is expected to implement #validate_short_name_format"
+      end
+
+      # Validates the host format for organization domains.
+      #
+      # Valid formats:
+      # - Fully Qualified Domain Names (FQDN): example.org, sub.example.org, my-site.example.org
+      # - Localhost: localhost (common for development)
+      # - IPv4 addresses: 127.0.0.1, 192.168.1.1
+      # - IPv6 addresses: ::1, 2001:db8::1, [::1]
+      #
+      # Invalid formats (will be rejected):
+      # - Hosts containing spaces
+      # - Hosts with invalid characters (!@#$%^&* etc.)
+      # - Hosts with leading/trailing hyphens in labels (e.g., -example.com or example-.com)
+      # - Labels longer than 63 characters
+      # - Total host length exceeding 253 characters
+      #
+      # @see https://en.wikipedia.org/wiki/Fully_qualified_domain_name
+      # @see https://en.wikipedia.org/wiki/IPv4_address
+      # @see https://en.wikipedia.org/wiki/IPv6_address
+      #
+      HOST_FORMAT_REGEX = %r{
+        \A
+        (?:
+          # FQDN: requires at least one dot, labels separated by dots.
+          # Each label: alphanumeric start/end, alphanumerics and hyphens inside, max 63 chars.
+          (?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}
+          |
+          # Localhost: common development hostname.
+          localhost
+          |
+          # IPv4: four octets (0-255 each).
+          (?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)
+          |
+          # IPv6: bracketed form [::1] or unbracketed (standard and compressed forms).
+          (?:\[[\da-fA-F:]+\]|[\da-fA-F:]+\z)
+        )
+        \z
+      }x.freeze
+
+      def validate_host_format
+        return if host.blank?
+
+        return if host.match?(HOST_FORMAT_REGEX)
+
+        errors.add(:host, :invalid)
       end
     end
   end

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -173,7 +173,7 @@ module Decidim
           (?:\[[\da-fA-F:]+\]|[\da-fA-F:]+\z)
         )
         \z
-      }x.freeze
+      }x
 
       def validate_host_format
         return if host.blank?

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -66,6 +66,7 @@ module Decidim
       validate :validate_short_name_format
       validate :validate_secret_key_base_for_encryption
       validate :validate_host_format
+      validate :validate_secondary_hosts_format
 
       def map_model(model)
         self.default_locale = model.default_locale
@@ -180,6 +181,17 @@ module Decidim
         return if host.match?(HOST_FORMAT_REGEX)
 
         errors.add(:host, :invalid)
+      end
+
+      def validate_secondary_hosts_format
+        return if secondary_hosts.blank?
+
+        clean_secondary_hosts.each do |secondary_host|
+          next if secondary_host.match?(HOST_FORMAT_REGEX)
+
+          errors.add(:secondary_hosts, :invalid)
+          break
+        end
       end
     end
   end

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -39,10 +39,10 @@ en:
           attributes:
             host:
               invalid: is invalid
-            secondary_hosts:
-              invalid: is invalid
             password:
               secret_key: You need to define the SECRET_KEY_BASE environment variable to be able to save this field
+            secondary_hosts:
+              invalid: is invalid
   decidim:
     system:
       actions:

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -39,6 +39,8 @@ en:
           attributes:
             host:
               invalid: is invalid
+            secondary_hosts:
+              invalid: is invalid
             password:
               secret_key: You need to define the SECRET_KEY_BASE environment variable to be able to save this field
   decidim:

--- a/decidim-system/config/locales/en.yml
+++ b/decidim-system/config/locales/en.yml
@@ -37,6 +37,8 @@ en:
               must_be_ssl: The redirect URI must be a SSL URI
         organization:
           attributes:
+            host:
+              invalid: is invalid
             password:
               secret_key: You need to define the SECRET_KEY_BASE environment variable to be able to save this field
   decidim:

--- a/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
@@ -467,6 +467,71 @@ module Decidim::System
         end
       end
 
+      describe "secondary_hosts format" do
+        context "when secondary_hosts contains spaces" do
+          before { subject.secondary_hosts = "example .org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when secondary_hosts has special characters" do
+          before { subject.secondary_hosts = "example@org!" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when one of multiple secondary_hosts is invalid" do
+          before { subject.secondary_hosts = "valid.example.org\ninvalid .host" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when secondary_hosts is valid simple domain" do
+          before { subject.secondary_hosts = "example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts is localhost" do
+          before { subject.secondary_hosts = "localhost" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts is valid IPv4" do
+          before { subject.secondary_hosts = "127.0.0.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts has multiple valid hosts" do
+          before { subject.secondary_hosts = "foo.example.org\nbar.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts has empty lines" do
+          before { subject.secondary_hosts = "foo.example.org\r\n\r\nbar.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
       describe "organization uniqueness" do
         let!(:existing_organization) do
           create(

--- a/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
@@ -402,7 +402,7 @@ module Decidim::System
         end
 
         context "when host is valid multi-level subdomain" do
-          before { subject.host = "my-site.example.org" }
+          before { subject.host = "mysite.example.org" }
 
           it { is_expected.to be_valid }
         end

--- a/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
@@ -316,6 +316,157 @@ module Decidim::System
         end
       end
 
+      describe "host format" do
+        context "when host contains spaces" do
+          before { subject.host = "example .org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has leading space" do
+          before { subject.host = " example.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has trailing space" do
+          before { subject.host = "example.org " }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has special characters" do
+          before { subject.host = "example@org!" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has leading hyphen" do
+          before { subject.host = "-example.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has trailing hyphen" do
+          before { subject.host = "example-.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host is localhost" do
+          before { subject.host = "localhost" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid simple domain" do
+          before { subject.host = "example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid subdomain" do
+          before { subject.host = "sub.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid multi-level subdomain" do
+          before { subject.host = "my-site.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid with hyphen" do
+          before { subject.host = "my-site.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4" do
+          before { subject.host = "127.0.0.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4 full" do
+          before { subject.host = "192.168.1.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4 max value" do
+          before { subject.host = "255.255.255.255" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is invalid IPv4 octet > 255" do
+          before { subject.host = "256.0.0.1" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host is valid IPv6 loopback" do
+          before { subject.host = "::1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 bracketed" do
+          before { subject.host = "[::1]" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 full" do
+          before { subject.host = "2001:db8::1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 standard" do
+          before { subject.host = "fe80:0:0:0:1:0:0:1" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
       describe "organization uniqueness" do
         let!(:existing_organization) do
           create(

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -448,6 +448,71 @@ module Decidim::System
         end
       end
 
+      describe "secondary_hosts format" do
+        context "when secondary_hosts contains spaces" do
+          before { subject.secondary_hosts = "example .org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when secondary_hosts has special characters" do
+          before { subject.secondary_hosts = "example@org!" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when one of multiple secondary_hosts is invalid" do
+          before { subject.secondary_hosts = "valid.example.org\ninvalid .host" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:secondary_hosts]).to include("is invalid")
+          end
+        end
+
+        context "when secondary_hosts is valid simple domain" do
+          before { subject.secondary_hosts = "example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts is localhost" do
+          before { subject.secondary_hosts = "localhost" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts is valid IPv4" do
+          before { subject.secondary_hosts = "127.0.0.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts has multiple valid hosts" do
+          before { subject.secondary_hosts = "foo.example.org\nbar.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when secondary_hosts has empty lines" do
+          before { subject.secondary_hosts = "foo.example.org\r\n\r\nbar.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
       describe "organization uniqueness" do
         let!(:existing_organization) do
           create(

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -303,6 +303,151 @@ module Decidim::System
         end
       end
 
+      describe "host format" do
+        context "when host contains spaces" do
+          before { subject.host = "example .org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has leading space" do
+          before { subject.host = " example.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has trailing space" do
+          before { subject.host = "example.org " }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has special characters" do
+          before { subject.host = "example@org!" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has leading hyphen" do
+          before { subject.host = "-example.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host has trailing hyphen" do
+          before { subject.host = "example-.org" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host is localhost" do
+          before { subject.host = "localhost" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid simple domain" do
+          before { subject.host = "example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid subdomain" do
+          before { subject.host = "sub.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid multi-level subdomain" do
+          before { subject.host = "my-site.example.org" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4" do
+          before { subject.host = "127.0.0.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4 full" do
+          before { subject.host = "192.168.1.1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv4 max value" do
+          before { subject.host = "255.255.255.255" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is invalid IPv4 octet > 255" do
+          before { subject.host = "256.0.0.1" }
+
+          it { is_expected.not_to be_valid }
+
+          it "adds an error" do
+            subject.valid?
+            expect(subject.errors[:host]).to include("is invalid")
+          end
+        end
+
+        context "when host is valid IPv6 loopback" do
+          before { subject.host = "::1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 bracketed" do
+          before { subject.host = "[::1]" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 full" do
+          before { subject.host = "2001:db8::1" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when host is valid IPv6 standard" do
+          before { subject.host = "fe80:0:0:0:1:0:0:1" }
+
+          it { is_expected.to be_valid }
+        end
+      end
+
       describe "organization uniqueness" do
         let!(:existing_organization) do
           create(


### PR DESCRIPTION
#### :tophat: What? Why?

On the `Host` field of the System's Organization form we don't do any kind of vaildation, and that makes possible to add broken hosts configuration (such as `localhost      `). This PR adds the validations, both on Host and Secondary hosts.

#### :pushpin: Related Issues

- Fixes #13369 

#### Testing

1, Sign in at http://localhost:3000/system/
2. Create or edit an organization and try to save invalid hosts or secondary hosts

### :camera: Screenshots

<img width="1312" height="866" alt="image" src="https://github.com/user-attachments/assets/ade5313a-116e-4ac4-96a0-6c9c326ab4b2" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host and secondary-host inputs are now validated against allowed formats (domain names, IPv4/IPv6, and localhost).

* **Localization**
  * Added user-facing error messages for invalid host and secondary-host values.

* **Tests**
  * Added comprehensive test coverage for host and secondary-host format validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->