### PR TITLE
Fix flaky spec on accountability's `component_spec.rb`

### DIFF
--- a/decidim-accountability/spec/lib/decidim/accountability/component_spec.rb
+++ b/decidim-accountability/spec/lib/decidim/accountability/component_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 describe "Accountability component" do # rubocop:disable RSpec/DescribeClass
   let!(:component) { create(:accountability_component) }
-  let(:organization) { component.organization }
+  let!(:organization) { component.organization }
   let!(:current_user) { create(:user, :confirmed, :admin, organization:) }
 
   describe "on edit", type: :system do
@@ -26,7 +26,7 @@ describe "Accountability component" do # rubocop:disable RSpec/DescribeClass
     let!(:results) { create_list(:result, 5, component:) }
 
     before do
-      clear_enqueued_jobs
+      perform_enqueued_jobs(only: [Decidim::FindAndUpdateDescendantsJob, Decidim::UpdateSearchIndexesJob])
     end
 
     describe "publish" do
@@ -36,7 +36,7 @@ describe "Accountability component" do # rubocop:disable RSpec/DescribeClass
         expect(Decidim::SearchableResource.where(resource: results)).to be_empty
         component.publish!
 
-        perform_enqueued_jobs(only: Decidim::UpdateSearchIndexesJob) do
+        perform_enqueued_jobs(only: [Decidim::FindAndUpdateDescendantsJob, Decidim::UpdateSearchIndexesJob]) do
           component.manifest.run_hooks(:publish, component)
         end
 


### PR DESCRIPTION
The accountability `component_spec.rb` publish/unpublish hooks specs were intermittently failing because `Decidim::FindAndUpdateDescendantsJob` was not being performed before `Decidim::UpdateSearchIndexesJob`, causing search index counts to be 0 instead of the expected value.

## Changes

- **`decidim-accountability/spec/lib/decidim/accountability/component_spec.rb`**
  - Promote `organization` to `let!` to ensure eager evaluation alongside `component`
  - Include `Decidim::FindAndUpdateDescendantsJob` alongside `Decidim::UpdateSearchIndexesJob` in both the `before` block and the `perform_enqueued_jobs` block — descendant indexing must run before search index updates for the assertions to see the correct record count

```ruby
before do
  perform_enqueued_jobs(only: [Decidim::FindAndUpdateDescendantsJob, Decidim::UpdateSearchIndexesJob])
end

perform_enqueued_jobs(only: [Decidim::FindAndUpdateDescendantsJob, Decidim::UpdateSearchIndexesJob]) do
  component.manifest.run_hooks(:publish, component)
end
```