### PR TITLE
Take into account the modules that actually have code during release

### DIFF
--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -199,7 +199,7 @@ module Decidim
 
       def plugins
         Dir.glob("#{root}/decidim-*/").select do |dir|
-          File.exist?(File.join(dir, "lib", "decidim", File.basename(dir).gsub("decidim-", ""), "version.rb"))
+          File.exist?(File.join(dir, "lib", "decidim"))
         end
       end
 

--- a/lib/decidim/gem_manager.rb
+++ b/lib/decidim/gem_manager.rb
@@ -198,7 +198,9 @@ module Decidim
       end
 
       def plugins
-        Dir.glob("#{root}/decidim-*/")
+        Dir.glob("#{root}/decidim-*/").select do |dir|
+          File.exist?(File.join(dir, "lib", "decidim", File.basename(dir).gsub("decidim-", ""), "version.rb"))
+        end
       end
 
       def semver_friendly_version(a_version)


### PR DESCRIPTION
#### :tophat: What? Why?

During the last releases, we have some problems with the differences of modules between versions.

Basically, if you have ran some specs against a newish module (such as `decidim-collaborative_texts` and then change to the release branch of v0.30 (where this module doesn't exists). and then try to do the release, you will have an exception as the GemManager class tries to work with this directory. 

This PR fixes it by only checking out the directories that have actual modules. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16487 and #16486

#### Testing

0. Apply this patch in `develop`:
```patch
diff --git a/decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb b/decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb
index a171d8cf72..3dba22e9a0 100644
--- a/decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb
@@ -74,7 +74,7 @@ describe "Admin edits documents" do
     click_on "Apply"
     expect(page).to have_no_content("Third paragraph")
     expect(page).to have_content("A new content")
-    expect(page).to have_button("Cancel")
+    expect(page).not_to have_button("Cancel")
     expect(page).to have_button("Draft a new version")
     expect(page).to have_button("Consolidate accepted suggestions")
```
1. Run the specs to generate the rspec failures file, restore the file, go to the v0.30 release branch 
```bash
bin/rspec decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb
ls decidim-collaborative_texts/.rspec-failures # see that the file was generated
git restore decidim-collaborative_texts/spec/system/admin_manages_suggestions_spec.rb
git checkout release/0.30-stable
bundle exec rake development_app # To prevent references to the module in the Gemfile
``` 
2. See the bug in the method (is listing `decidim-collaborative_texts`):
```bash
$ bin/rails runner "require 'decidim/gem_manager' ; puts Decidim::GemManager.plugins"
/bundle/vendor/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /home/vscode/.local/share/mise/installs/ruby/3.3.4/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.4 to add mutex_m into its gemspec.
/workspaces/decidim/decidim-accountability/
/workspaces/decidim/decidim-admin/
/workspaces/decidim/decidim-ai/
/workspaces/decidim/decidim-api/
/workspaces/decidim/decidim-assemblies/
/workspaces/decidim/decidim-blogs/
/workspaces/decidim/decidim-budgets/
/workspaces/decidim/decidim-collaborative_texts/
/workspaces/decidim/decidim-comments/
/workspaces/decidim/decidim-conferences/
/workspaces/decidim/decidim-core/
/workspaces/decidim/decidim-debates/
/workspaces/decidim/decidim-design/
/workspaces/decidim/decidim-dev/
/workspaces/decidim/decidim-forms/
/workspaces/decidim/decidim-generators/
/workspaces/decidim/decidim-initiatives/
/workspaces/decidim/decidim-meetings/
/workspaces/decidim/decidim-pages/
/workspaces/decidim/decidim-participatory_processes/
/workspaces/decidim/decidim-proposals/
/workspaces/decidim/decidim-sortitions/
/workspaces/decidim/decidim-surveys/
/workspaces/decidim/decidim-system/
/workspaces/decidim/decidim-templates/
/workspaces/decidim/decidim-verifications/
```
3. Apply the patch from this PR manually
4. Run again the command and see that `decidim-collaborative_texts` isn't listed anymore:
```bash
 bin/rails runner "require 'decidim/gem_manager' ; puts Decidim::GemManager.plugins"
/bundle/vendor/ruby/3.3.0/gems/bootsnap-1.18.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /home/vscode/.local/share/mise/installs/ruby/3.3.4/lib/ruby/3.3.0/mutex_m.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec. Also contact author of activesupport-7.0.8.4 to add mutex_m into its gemspec.
/workspaces/decidim/decidim-accountability/
/workspaces/decidim/decidim-admin/
/workspaces/decidim/decidim-ai/
/workspaces/decidim/decidim-api/
/workspaces/decidim/decidim-assemblies/
/workspaces/decidim/decidim-blogs/
/workspaces/decidim/decidim-budgets/
/workspaces/decidim/decidim-comments/
/workspaces/decidim/decidim-conferences/
/workspaces/decidim/decidim-core/
/workspaces/decidim/decidim-debates/
/workspaces/decidim/decidim-design/
/workspaces/decidim/decidim-dev/
/workspaces/decidim/decidim-forms/
/workspaces/decidim/decidim-generators/
/workspaces/decidim/decidim-initiatives/
/workspaces/decidim/decidim-meetings/
/workspaces/decidim/decidim-pages/
/workspaces/decidim/decidim-participatory_processes/
/workspaces/decidim/decidim-proposals/
/workspaces/decidim/decidim-sortitions/
/workspaces/decidim/decidim-surveys/
/workspaces/decidim/decidim-system/
/workspaces/decidim/decidim-templates/
/workspaces/decidim/decidim-verifications/
``` 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin discovery to validate plugin structure, ensuring only properly configured plugins are recognized and processed; directories missing the expected internal layout are now ignored, preventing errors or unintended processing during plugin scans and version-replacement operations. This reduces noise and avoids failures when iterating over plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->