### PR TITLE
Fix inconsistency issues with the locales URLs - part 2

### DIFF
--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -78,7 +78,7 @@ shared_examples "manage results" do
       expect(page).to have_content("created result")
       expect(page).to have_content(attributes[:title]["en"])
 
-      visit decidim.last_activities_path
+      visit decidim.last_activities_path(locale: I18n.locale)
       expect(page).to have_content("New result: #{translated(attributes[:title])}")
 
       within "#filters" do

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
@@ -29,7 +29,7 @@ describe "Admin manages assembly publication" do
     end
 
     visit decidim.root_path
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
 
     expect(page).to have_content("New assembly: #{title}")
 

--- a/decidim-blogs/spec/shared/manage_posts_examples.rb
+++ b/decidim-blogs/spec/shared/manage_posts_examples.rb
@@ -68,7 +68,7 @@ shared_examples "manage posts" do |audit_check: true|
 
     perform_enqueued_jobs
 
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
     expect(page).to have_content("New post: #{translated(attributes[:title])}")
 
     within "#filters" do

--- a/decidim-budgets/spec/system/explore_projects_spec.rb
+++ b/decidim-budgets/spec/system/explore_projects_spec.rb
@@ -265,7 +265,7 @@ describe "Explore projects", :slow do
   describe "search" do
     before do
       switch_to_host(organization.host)
-      visit decidim.search_path
+      visit decidim.search_path(locale: I18n.locale)
     end
 
     it "shows the project" do

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
@@ -29,7 +29,7 @@ describe "Admin manages conference publication" do
     end
 
     visit decidim.root_path
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
 
     expect(page).to have_content("New conference: #{title}")
 

--- a/decidim-core/app/cells/decidim/badges/show.erb
+++ b/decidim-core/app/cells/decidim/badges/show.erb
@@ -4,7 +4,7 @@
     <h2 class="h4"><%= t "decidim.gamification.title" %></h2>
     <p>
       <%= t "decidim.gamification.description" %>
-      <%= link_to t("decidim.gamification.all_badges_link"), gamification_badges_path, class: "text-secondary underline" %>
+      <%= link_to t("decidim.gamification.all_badges_link"), gamification_badges_path(locale: current_locale), class: "text-secondary underline" %>
     </p>
   </div>
 </div>

--- a/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
@@ -44,7 +44,7 @@ module Decidim
         elsif Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?
           decidim_participatory_processes.participatory_processes_path(locale: current_locale)
         elsif current_user
-          decidim.account_path
+          decidim.account_path(locale: current_locale)
         elsif current_organization.sign_up_enabled?
           decidim.new_user_registration_path
         else

--- a/decidim-core/app/cells/decidim/content_blocks/last_activity/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/last_activity/show.erb
@@ -3,7 +3,7 @@
     <h2 class="home__section-title">
       <%= t("decidim.content_blocks.last_activity.title") %>
     </h2>
-    <%= link_to last_activities_path, class: "button button__sm button__text-secondary" do %>
+    <%= link_to last_activities_path(locale: current_locale), class: "button button__sm button__text-secondary" do %>
         <%= t("view_all", scope: "decidim.content_blocks.last_activity") %>
         <%= icon "arrow-right-line", class: "fill-current" %>
       <% end %>

--- a/decidim-core/app/cells/decidim/profile_actions_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_actions_cell.rb
@@ -22,12 +22,12 @@ module Decidim
       values[:options] = values.delete(:options) || {}
       return values if values.has_key?(:cell)
 
-      values[:path] = send(values[:path]) if values[:path].present?
+      values[:path] = send(values[:path], locale: current_locale) if values[:path].present?
       values[:text] = t(key, scope: translations_scope)
       values
     end
 
-    def new_conversation_path
+    def new_conversation_path(*)
       current_or_new_conversation_path_with(profile_holder)
     end
 

--- a/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
+++ b/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
@@ -29,7 +29,7 @@ module Decidim
 
     def filter_url(resource_type)
       if options[:source] == :last_activities
-        last_activities_path(filter: { with_resource_type: resource_type })
+        last_activities_path(locale: current_locale, filter: { with_resource_type: resource_type })
       else
         profile_activity_path(nickname: params[:nickname], filter: { resource_type: })
       end

--- a/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
+++ b/decidim-core/app/cells/decidim/tos_page/refuse_btn_modal.erb
@@ -9,7 +9,7 @@
       <%= t("refuse.modal_title", scope: "decidim.pages.terms_of_service") %>
     </h3>
     <p id="dialog-desc-tos-refuse-modal">
-      <%= t("refuse.modal_body", scope: "decidim.pages.terms_of_service", download_your_data_path: decidim.download_your_data_path, delete_path: decidim.delete_account_path) %>
+      <%= t("refuse.modal_body", scope: "decidim.pages.terms_of_service", download_your_data_path: decidim.download_your_data_path, delete_path: decidim.delete_account_path(locale: current_locale)) %>
     </p>
   </div>
   <div data-dialog-actions>

--- a/decidim-core/app/controllers/concerns/decidim/needs_password_change.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_password_change.rb
@@ -24,7 +24,7 @@ module Decidim
 
     def password_update_permitted_path?(target_path)
       permitted_paths = [(tos_path if respond_to?(:tos_path, true)),
-                         decidim.delete_account_path,
+                         decidim.delete_account_path(locale: current_locale),
                          decidim.accept_tos_path,
                          decidim.download_your_data_path,
                          decidim.export_download_your_data_path,

--- a/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
+++ b/decidim-core/app/controllers/concerns/decidim/needs_tos_accepted.rb
@@ -36,7 +36,7 @@ module Decidim
       return true if request.path.starts_with?(decidim.download_your_data_path)
 
       permitted_paths = [tos_path,
-                         decidim.delete_account_path,
+                         decidim.delete_account_path(locale: current_locale),
                          decidim.accept_tos_path]
       # ensure that path with or without query string pass
       permitted_paths.find { |el| el.split("?").first == request.path }

--- a/decidim-core/app/controllers/decidim/last_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/last_activities_controller.rb
@@ -37,7 +37,7 @@ module Decidim
       {
         label: t("decidim.last_activities.name"),
         active: true,
-        url: last_activities_path
+        url: last_activities_path(locale: current_locale)
       }
     end
   end

--- a/decidim-core/app/controllers/decidim/open_data_controller.rb
+++ b/decidim-core/app/controllers/decidim/open_data_controller.rb
@@ -15,7 +15,7 @@ module Decidim
       else
         schedule_open_data_generation(resource)
         flash[:alert] = t("decidim.open_data.not_available_yet")
-        redirect_back_or_to(open_data_path)
+        redirect_back_or_to(open_data_path(locale: current_locale))
       end
     end
 

--- a/decidim-core/app/controllers/decidim/searches_controller.rb
+++ b/decidim-core/app/controllers/decidim/searches_controller.rb
@@ -54,7 +54,7 @@ module Decidim
       {
         label: t("decidim.search.name"),
         active: true,
-        url: search_path
+        url: search_path(locale: I18n.locale)
       }
     end
   end

--- a/decidim-core/app/events/decidim/change_nickname_event.rb
+++ b/decidim-core/app/events/decidim/change_nickname_event.rb
@@ -13,7 +13,7 @@ module Decidim
 
     def i18n_options
       {
-        link_to_account_settings: url_helpers.account_path
+        link_to_account_settings: url_helpers.account_path(locale: I18n.locale)
       }
     end
   end

--- a/decidim-core/app/events/decidim/welcome_notification_event.rb
+++ b/decidim-core/app/events/decidim/welcome_notification_event.rb
@@ -46,7 +46,7 @@ module Decidim
         .gsub("{{name}}", user.presenter.name)
         .gsub("{{organization}}", organization_name(organization))
         .gsub("{{help_url}}", url_helpers.pages_url(host: organization.host, locale: I18n.locale))
-        .gsub("{{badges_url}}", url_helpers.gamification_badges_url(host: organization.host))
+        .gsub("{{badges_url}}", url_helpers.gamification_badges_url(locale: I18n.locale, host: organization.host))
         .html_safe
     end
   end

--- a/decidim-core/app/helpers/decidim/searches_helper.rb
+++ b/decidim-core/app/helpers/decidim/searches_helper.rb
@@ -25,6 +25,7 @@ module Decidim
     # space_state - An optional String with the name of the state of the space
     def search_path_by(resource_type: nil, space_state: nil)
       new_params = {
+        locale: current_locale,
         utf8: params[:utf8],
         filter: {
           with_scope: params.dig(:filter, :with_scope),

--- a/decidim-core/app/views/decidim/open_data/index.html.erb
+++ b/decidim-core/app/views/decidim/open_data/index.html.erb
@@ -81,27 +81,27 @@
       <h3 class="h5"><%= t("components", scope: "decidim.open_data.index.download") %></h3>
       <ul>
         <% open_data_component_manifests.each do |manifest| %>
-          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name)) %></li>
+          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name, locale: current_locale)) %></li>
         <% end %>
       </ul>
 
       <h3 class="h5"><%= t("spaces", scope: "decidim.open_data.index.download") %></h3>
       <ul>
         <% open_data_participatory_space_manifests.each do |manifest| %>
-          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name)) %></li>
+          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name, locale: current_locale)) %></li>
         <% end %>
       </ul>
 
       <h3 class="h5"><%= t("core", scope: "decidim.open_data.index.download") %></h3>
       <ul>
         <% open_data_core_manifests.each do |manifest| %>
-          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name)) %></li>
+          <li><%= link_to(t("download_resource", scope: "decidim.open_data.index", resource_name: manifest.name), open_data_download_resource_path(manifest.name, locale: current_locale)) %></li>
         <% end %>
       </ul>
     </div>
 
     <div class="mt-4 flex flex-col items-center">
-      <%= link_to t("download_open_data", scope: "decidim.open_data.index"), decidim.open_data_download_path, class: "button button__primary button__xl" %>
+      <%= link_to t("download_open_data", scope: "decidim.open_data.index"), decidim.open_data_download_path(locale: current_locale), class: "button button__primary button__xl" %>
     </div>
   </div>
 

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -24,7 +24,7 @@
     <% if Decidim.module_installed?(:meetings) %>
       <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
     <% end %>
-    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.open_data"), decidim.open_data_path %></li>
+    <li class="font-semibold underline"><%= link_to t("layouts.decidim.footer.open_data"), decidim.open_data_path(locale: current_locale) %></li>
   </ul>
 </nav>
 

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -20,7 +20,7 @@
 <nav role="navigation" aria-label="<%= t("layouts.decidim.footer.resources") %>">
   <h2 class="h4 mb-4"><%= t("layouts.decidim.footer.resources") %></h2>
   <ul class="space-y-4 break-inside-avoid">
-    <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path %></li>
+    <li class="font-semibold underline"><%= link_to t("decidim.profiles.show.activity"), decidim.last_activities_path(locale: current_locale) %></li>
     <% if Decidim.module_installed?(:meetings) %>
       <li class="font-semibold underline"><%= link_to t("decidim.pages.home.extended.meetings"), Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path %></li>
     <% end %>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -4,7 +4,7 @@
   <h2 class="h4 mb-4"><%= t("layouts.decidim.user_menu.profile") %></h2>
   <ul class="space-y-4 break-inside-avoid">
     <% if current_user %>
-      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path(locale: current_locale) %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
@@ -1,6 +1,6 @@
 <% unread_data ||= current_user_unread_data %>
 <li class="dropdown__item">
-  <%= link_to decidim.account_path, class: "dropdown__button" do %>
+  <%= link_to decidim.account_path(locale: current_locale), class: "dropdown__button" do %>
     <%= icon "user-smile-line" %>
     <span><%= t("layouts.decidim.user_menu.profile") %></span>
   <% end %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_search.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_search.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(decidim.search_path, method: :get, id: "form-search_topbar") do %>
+<%= form_tag(decidim.search_path(locale: current_locale), method: :get, id: "form-search_topbar") do %>
   <button type="submit" aria-label="<%= t("decidim.search.term_input_placeholder") %>">
     <%= icon "search-line" %>
   </button>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_form_search_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_form_search_mobile.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag(decidim.search_path, method: :get, id: "form-search-mobile", class: "filter-search") do %>
+<%= form_tag(decidim.search_path(locale: current_locale), method: :get, id: "form-search-mobile", class: "filter-search") do %>
         <%= text_field_tag(
             :term,
             nil,

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -59,13 +59,16 @@ Decidim::Core::Engine.routes.draw do
       put "apply_password" => "devise/passwords"
     end
 
-    resource :account, only: [:show, :update, :destroy], controller: "account" do
-      member do
-        get :delete
-        post :resend_confirmation_instructions
-        post :cancel_email_change
+    scope "/:locale" do
+      resource :account, only: [:show, :update, :destroy], controller: "account" do
+        member do
+          get :delete
+          post :resend_confirmation_instructions
+          post :cancel_email_change
+        end
       end
     end
+
     resources :conversations, only: [:new, :create, :index, :show, :update], controller: "messaging/conversations"
     post "/conversations/check_multiple", to: "messaging/conversations#check_multiple"
     resources :notifications, only: [:index, :destroy] do
@@ -92,6 +95,15 @@ Decidim::Core::Engine.routes.draw do
       to: "free_resource_authorization_modals#show",
       as: :free_resource_authorization_modal
     )
+
+    get "/account/*rest", to: redirect { |params, request|
+      locale = Decidim::LocaleRouterDetector.new(request, params).locale
+      "/#{locale}/account/#{params[:rest]}"
+    }
+    get "/account", to: redirect { |params, request|
+      locale = Decidim::LocaleRouterDetector.new(request, params).locale
+      "/#{locale}/account"
+    }
   end
 
   resources :profiles, only: [:show], param: :nickname, constraints: { nickname: %r{[^/]+} }, format: false

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -122,6 +122,9 @@ Decidim::Core::Engine.routes.draw do
   scope "/:locale" do
     resources :pages, only: [:index, :show], format: false
     resources :last_activities, only: [:index]
+    get "/open-data", to: "open_data#index", as: :open_data
+    get "/open-data/download", to: "open_data#download", as: :open_data_download
+    get "/open-data/download/:resource", to: "open_data#download", as: :open_data_download_resource
     get "/search", to: "searches#index", as: :search
     namespace :gamification do
       resources :badges, only: [:index]
@@ -167,6 +170,15 @@ Decidim::Core::Engine.routes.draw do
     "/#{locale}/gamification/#{params[:rest]}"
   }
 
+  get "/open-data/*rest", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+    "/#{locale}/open-data/#{params[:rest]}"
+  }
+  get "/open-data", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+    "/#{locale}/open-data"
+  }
+
   get "/resource_autocomplete", to: "resource_autocomplete#index", as: :resource_autocomplete
 
   get "/link", to: "links#new", as: :link
@@ -177,10 +189,6 @@ Decidim::Core::Engine.routes.draw do
 
   match "/404", to: "errors#not_found", via: :all
   match "/500", to: "errors#internal_server_error", via: :all
-
-  get "/open-data", to: "open_data#index", as: :open_data
-  get "/open-data/download", to: "open_data#download", as: :open_data_download
-  get "/open-data/download/:resource", to: "open_data#download", as: :open_data_download_resource
 
   resource :follow, only: [:create, :destroy]
   resource :report, only: [:create]

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -110,6 +110,9 @@ Decidim::Core::Engine.routes.draw do
   scope "/:locale" do
     resources :pages, only: [:index, :show], format: false
     get "/search", to: "searches#index", as: :search
+    namespace :gamification do
+      resources :badges, only: [:index]
+    end
   end
 
   get "/search", to: redirect { |params, request|
@@ -132,6 +135,11 @@ Decidim::Core::Engine.routes.draw do
   get "/pages/*rest", to: redirect { |params, request|
     locale = Decidim::LocaleRouterDetector.new(request, params).locale
     "/#{locale}/pages/#{params[:rest]}"
+  }
+
+  get "/gamification/*rest", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+    "/#{locale}/gamification/#{params[:rest]}"
   }
 
   get "/resource_autocomplete", to: "resource_autocomplete#index", as: :resource_autocomplete
@@ -172,10 +180,6 @@ Decidim::Core::Engine.routes.draw do
   end
 
   resources :editor_images, only: [:create]
-
-  namespace :gamification do
-    resources :badges, only: [:index]
-  end
 
   resources :newsletters, only: [:show] do
     get :unsubscribe, on: :collection

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -109,11 +109,24 @@ Decidim::Core::Engine.routes.draw do
 
   scope "/:locale" do
     resources :pages, only: [:index, :show], format: false
+    resources :last_activities, only: [:index]
     get "/search", to: "searches#index", as: :search
     namespace :gamification do
       resources :badges, only: [:index]
     end
   end
+
+  get "/last_activities", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+
+    query_string = Rack::Utils.parse_nested_query(request.query_string.to_s)
+    query_string.delete("locale")
+    query_string = CGI.unescape(query_string.to_query)
+
+    path = "/#{locale}/last_activities"
+    path += "?#{query_string}" unless query_string.empty?
+    path
+  }
 
   get "/search", to: redirect { |params, request|
     locale = Decidim::LocaleRouterDetector.new(request, params).locale
@@ -186,8 +199,6 @@ Decidim::Core::Engine.routes.draw do
   end
 
   resources :upload_validations, only: [:create]
-
-  resources :last_activities, only: [:index]
 
   resources :short_links, only: [:index, :show], path: "s"
 

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -109,7 +109,20 @@ Decidim::Core::Engine.routes.draw do
 
   scope "/:locale" do
     resources :pages, only: [:index, :show], format: false
+    get "/search", to: "searches#index", as: :search
   end
+
+  get "/search", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+
+    query_string = Rack::Utils.parse_nested_query(request.query_string.to_s)
+    query_string.delete("locale")
+    query_string = CGI.unescape(query_string.to_query)
+
+    path = "/#{locale}/search"
+    path += "?#{query_string}" unless query_string.empty?
+    path
+  }
 
   get "/pages", to: redirect { |params, request|
     locale = Decidim::LocaleRouterDetector.new(request, params).locale
@@ -121,7 +134,6 @@ Decidim::Core::Engine.routes.draw do
     "/#{locale}/pages/#{params[:rest]}"
   }
 
-  get "/search", to: "searches#index", as: :search
   get "/resource_autocomplete", to: "resource_autocomplete#index", as: :resource_autocomplete
 
   get "/link", to: "links#new", as: :link

--- a/decidim-core/lib/decidim/core/menu.rb
+++ b/decidim-core/lib/decidim/core/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :user_menu do |menu|
           menu.add_item :account,
                         t("account", scope: "layouts.decidim.user_profile"),
-                        decidim.account_path,
+                        decidim.account_path(locale: I18n.locale),
                         position: 1.0,
                         active: :exact
 
@@ -30,7 +30,7 @@ module Decidim
 
           menu.add_item :delete_account,
                         t("delete_my_account", scope: "layouts.decidim.user_profile"),
-                        decidim.delete_account_path,
+                        decidim.delete_account_path(locale: I18n.locale),
                         position: 999,
                         active: :exact
         end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -641,7 +641,7 @@ shared_examples "comments" do
       end
 
       it "shows the entry in last activities" do
-        visit decidim.last_activities_path
+        visit decidim.last_activities_path(locale: I18n.locale)
         expect(page).to have_content("New comment: #{content}")
 
         within "#filters" do

--- a/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/reports_examples.rb
@@ -66,7 +66,7 @@ shared_examples "higher user role hides resource with comments" do
     end
 
     it "hides the resource" do
-      visit decidim.search_path
+      visit decidim.search_path(locale: I18n.locale)
       expect(page).to have_content(translated(comments.first.body))
       expect(page).to have_content(translated(comments.second.body))
 
@@ -95,7 +95,7 @@ shared_examples "higher user role hides resource with comments" do
       expect(comments.first.reload).to be_hidden
       expect(comments.second.reload).to be_hidden
 
-      visit decidim.search_path
+      visit decidim.search_path(locale: I18n.locale)
       expect(page).to have_no_content(translated(comments.first.body))
       expect(page).to have_no_content(translated(comments.second.body))
     end

--- a/decidim-core/lib/decidim/core/test/shared_examples/searchable_results_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/searchable_results_examples.rb
@@ -19,7 +19,7 @@ shared_examples "searchable results" do
       fill_in "term", with: term
       find(search_input_selector).native.send_keys :enter
 
-      expect(page).to have_current_path decidim.search_path, ignore_query: true
+      expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
       expect(page).to have_content(%(results for the search: "#{term}"))
       expect(page).to have_css(".filter-search.filter-container")
       expect(page.find("#search-count h2").text.to_i).to be_positive
@@ -33,7 +33,7 @@ shared_examples "searchable results" do
         fill_in "term", with: term
         find(search_input_selector).native.send_keys :enter
 
-        expect(page).to have_current_path decidim.search_path, ignore_query: true
+        expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
         expect(page).to have_content(%(results for the search: "#{term}"))
         expect(page).to have_css(".filter-search.filter-container")
         expect(page.find("#search-count h2").text.to_i).to be_positive
@@ -52,7 +52,7 @@ shared_examples "searchable results" do
         fill_in "term", with: term
         find(search_input_selector).native.send_keys :enter
 
-        expect(page).to have_current_path decidim.search_path, ignore_query: true
+        expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
         expect(page).to have_content(%(results for the search: "#{term}"))
         expect(page).to have_css(".filter-search.filter-container")
         expect(page.find("#search-count h2").text.to_i).not_to be_positive
@@ -68,7 +68,7 @@ shared_examples "searchable results" do
           fill_in "term", with: term
           find(search_input_selector).native.send_keys :enter
 
-          expect(page).to have_current_path decidim.search_path, ignore_query: true
+          expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
           expect(page).to have_content(%(results for the search: "#{term}"))
           expect(page).to have_css(".filter-search.filter-container")
           expect(page.find("#search-count h2").text.to_i).not_to be_positive

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -43,10 +43,10 @@ module Decidim
             let(:user) { build(:user, :admin, sign_in_count: 1) }
 
             before do
-              controller.store_location_for(user, account_path)
+              controller.store_location_for(user, account_path(locale: I18n.locale))
             end
 
-            it { is_expected.to eq account_path }
+            it { is_expected.to eq account_path(locale: I18n.locale) }
           end
 
           context "and is not an admin" do
@@ -63,10 +63,10 @@ module Decidim
 
                 context "when there is a pending redirection" do
                   before do
-                    controller.store_location_for(user, account_path)
+                    controller.store_location_for(user, account_path(locale: I18n.locale))
                   end
 
-                  it { is_expected.to eq account_path }
+                  it { is_expected.to eq account_path(locale: I18n.locale) }
                 end
 
                 context "when there is a pending onboarding action with the authorization pending" do

--- a/decidim-core/spec/controllers/open_data_controller_spec.rb
+++ b/decidim-core/spec/controllers/open_data_controller_spec.rb
@@ -19,7 +19,7 @@ module Decidim
     describe "GET download" do
       before do
         OpenDataJob.perform_now(organization) if generate_file
-        get :download
+        get :download, params: { locale: I18n.locale }
       end
 
       context "when the open data file exists" do
@@ -35,7 +35,7 @@ module Decidim
         let(:generate_file) { false }
 
         it "redirects to the open data page" do
-          expect(controller).to redirect_to(open_data_path)
+          expect(controller).to redirect_to(open_data_path(locale: I18n.locale))
         end
 
         it "warns the user" do

--- a/decidim-core/spec/controllers/sessions_controller_spec.rb
+++ b/decidim-core/spec/controllers/sessions_controller_spec.rb
@@ -19,10 +19,10 @@ module Decidim
             let(:user) { build(:user, :admin, sign_in_count: 1) }
 
             before do
-              controller.store_location_for(user, account_path)
+              controller.store_location_for(user, account_path(locale: I18n.locale))
             end
 
-            it { is_expected.to eq account_path }
+            it { is_expected.to eq account_path(locale: I18n.locale) }
           end
 
           context "and is not an admin" do
@@ -39,10 +39,10 @@ module Decidim
 
                 context "when there is a pending redirection" do
                   before do
-                    controller.store_location_for(user, account_path)
+                    controller.store_location_for(user, account_path(locale: I18n.locale))
                   end
 
-                  it { is_expected.to eq account_path }
+                  it { is_expected.to eq account_path(locale: I18n.locale) }
                 end
 
                 context "when there is a pending onboarding action with the authorization pending" do

--- a/decidim-core/spec/events/decidim/change_nickname_event_spec.rb
+++ b/decidim-core/spec/events/decidim/change_nickname_event_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::ChangeNicknameEvent do
 
   describe "notification_title" do
     it "is generated correctly" do
-      expect(subject.notification_title).to include("We have corrected the way nicknames are used so that there are no duplicates, and that is why we have removed the case-sensitive rule. <br/> Your nickname was created after another one with the same name, so we have automatically renamed it. You can change it from <a href=\"/account\">your account settings</a>.")
+      expect(subject.notification_title).to include("We have corrected the way nicknames are used so that there are no duplicates, and that is why we have removed the case-sensitive rule. <br/> Your nickname was created after another one with the same name, so we have automatically renamed it. You can change it from <a href=\"/en/account\">your account settings</a>.")
     end
   end
 end

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -96,4 +96,44 @@ describe "Redirect routes" do
       expect(response).to redirect_to("/es/search")
     end
   end
+
+  context "when checking the badges page" do
+    it "redirects old url with missing locale" do
+      get("/gamification/badges", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/gamification/badges")
+    end
+
+    it "redirects old url with locale" do
+      get("/gamification/badges?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/gamification/badges")
+    end
+
+    it "redirects to default locale when the locale is invalid" do
+      get("/gamification/badges?locale=esp", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/gamification/badges")
+    end
+
+    it "redirects user to the new url" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/gamification/badges", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/ca/gamification/badges")
+    end
+
+    it "redirects user to the new url when using custom locale" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/gamification/badges?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/gamification/badges")
+    end
+  end
 end

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -95,4 +95,12 @@ describe "Redirect routes" do
       end
     end
   end
+
+  context "when browsing open-data" do
+    it_behaves_like "redirects to the new url", "open-data"
+
+    context "and the download" do
+      it_behaves_like "redirects to the new url", "open-data/download"
+    end
+  end
 end

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -70,4 +70,15 @@ describe "Redirect routes" do
   context "when browsing gamification" do
     it_behaves_like "redirects to the new url", "gamification/badges"
   end
+
+  context "when browsing last_activities" do
+    it_behaves_like "redirects to the new url", "last_activities" do
+      it "redirects old url with query string with missing locale" do
+        page_with_query_string = "/last_activities?filter[with_resource_type]=Decidim::Comments::Comment&per_page=50"
+        get(page_with_query_string, headers:)
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("/en#{page_with_query_string}")
+      end
+    end
+  end
 end

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -71,6 +71,20 @@ describe "Redirect routes" do
     it_behaves_like "redirects to the new url", "gamification/badges"
   end
 
+  context "when browsing account" do
+    let!(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      login_as user, scope: :user
+    end
+
+    it_behaves_like "redirects to the new url", "account"
+
+    context "and account delete section" do
+      it_behaves_like "redirects to the new url", "account/delete"
+    end
+  end
+
   context "when browsing last_activities" do
     it_behaves_like "redirects to the new url", "last_activities" do
       it "redirects old url with query string with missing locale" do

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -6,134 +6,68 @@ describe "Redirect routes" do
   let(:organization) { create(:organization, available_locales: %w(en es ca), default_locale: "en") }
   let(:headers) { { "HOST" => organization.host } }
 
-  it "redirects old url with missing locale" do
-    get("/pages", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/en/pages")
-  end
-
-  it "redirects old url with locale" do
-    get("/pages?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages")
-  end
-
-  it "redirects to default locale when the locale is invalid" do
-    get("/pages?locale=esp", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/en/pages")
-  end
-
-  it "redirects old url with locale and additional params" do
-    get("/pages/foo-bar?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages/foo-bar")
-  end
-
-  it "redirects user to the new url" do
-    user = create(:user, :confirmed, organization:, locale: "ca")
-    login_as user, scope: :user
-
-    get("/", headers:)
-    get("/pages", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/ca/pages")
-  end
-
-  it "redirects user to the new url when using custom locale" do
-    user = create(:user, :confirmed, organization:, locale: "ca")
-    login_as user, scope: :user
-
-    get("/", headers:)
-    get("/pages?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages")
-  end
-
-  context "when checking the search page" do
-    it "redirects old url with missing locale" do
-      get("/search", headers:)
+  shared_examples "redirects to the new url" do |url|
+    it "redirects old url (/#{url}) with missing locale to new version (/en/#{url})" do
+      get("/#{url}", headers:)
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/en/search")
+      expect(response).to redirect_to("/en/#{url}")
     end
 
-    it "redirects old url with query string with missing locale" do
-      page_with_query_string = "/search?filter[term]=&filter[with_resource_type]=Decidim::Comments::Comment&filter[with_scope]&per_page=50"
-      get(page_with_query_string, headers:)
+    it "redirects old url (/#{url}?locale=es) with locale to new version (/es/#{url})" do
+      get("/#{url}?locale=es", headers:)
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/en#{page_with_query_string}")
+      expect(response).to redirect_to("/es/#{url}")
     end
 
-    it "redirects old url with locale" do
-      get("/search?locale=es", headers:)
+    it "redirects to default locale (/en/#{url}) when the locale is invalid (/#{url}?locale=esp)" do
+      get("/#{url}?locale=esp", headers:)
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/es/search")
+      expect(response).to redirect_to("/en/#{url}")
     end
 
-    it "redirects to default locale when the locale is invalid" do
-      get("/search?locale=esp", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/en/search")
-    end
-
-    it "redirects user to the new url" do
+    it "redirects user to the new url (/ca/#{url})" do
       user = create(:user, :confirmed, organization:, locale: "ca")
       login_as user, scope: :user
 
       get("/", headers:)
-      get("/search", headers:)
+      get("/#{url}", headers:)
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/ca/search")
+      expect(response).to redirect_to("/ca/#{url}")
     end
 
-    it "redirects user to the new url when using custom locale" do
+    it "redirects user to the new url (/es/#{url}) when using custom locale (/#{url}?locale=es)" do
       user = create(:user, :confirmed, organization:, locale: "ca")
       login_as user, scope: :user
 
       get("/", headers:)
-      get("/search?locale=es", headers:)
+      get("/#{url}?locale=es", headers:)
       expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/es/search")
+      expect(response).to redirect_to("/es/#{url}")
     end
   end
 
-  context "when checking the badges page" do
-    it "redirects old url with missing locale" do
-      get("/gamification/badges", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/en/gamification/badges")
+  context "when browsing pages" do
+    it_behaves_like "redirects to the new url", "pages" do
+      it "redirects old url with locale and additional params" do
+        get("/pages/foo-bar?locale=es", headers:)
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("/es/pages/foo-bar")
+      end
     end
+  end
 
-    it "redirects old url with locale" do
-      get("/gamification/badges?locale=es", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/es/gamification/badges")
+  context "when browsing search" do
+    it_behaves_like "redirects to the new url", "search" do
+      it "redirects old url with query string with missing locale" do
+        page_with_query_string = "/search?filter[term]=&filter[with_resource_type]=Decidim::Comments::Comment&filter[with_scope]&per_page=50"
+        get(page_with_query_string, headers:)
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("/en#{page_with_query_string}")
+      end
     end
+  end
 
-    it "redirects to default locale when the locale is invalid" do
-      get("/gamification/badges?locale=esp", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/en/gamification/badges")
-    end
-
-    it "redirects user to the new url" do
-      user = create(:user, :confirmed, organization:, locale: "ca")
-      login_as user, scope: :user
-
-      get("/", headers:)
-      get("/gamification/badges", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/ca/gamification/badges")
-    end
-
-    it "redirects user to the new url when using custom locale" do
-      user = create(:user, :confirmed, organization:, locale: "ca")
-      login_as user, scope: :user
-
-      get("/", headers:)
-      get("/gamification/badges?locale=es", headers:)
-      expect(response).to have_http_status(:moved_permanently)
-      expect(response).to redirect_to("/es/gamification/badges")
-    end
+  context "when browsing gamification" do
+    it_behaves_like "redirects to the new url", "gamification/badges"
   end
 end

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -49,4 +49,51 @@ describe "Redirect routes" do
     expect(response).to have_http_status(:moved_permanently)
     expect(response).to redirect_to("/es/pages")
   end
+
+  context "when checking the search page" do
+    it "redirects old url with missing locale" do
+      get("/search", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/search")
+    end
+
+    it "redirects old url with query string with missing locale" do
+      page_with_query_string = "/search?filter[term]=&filter[with_resource_type]=Decidim::Comments::Comment&filter[with_scope]&per_page=50"
+      get(page_with_query_string, headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en#{page_with_query_string}")
+    end
+
+    it "redirects old url with locale" do
+      get("/search?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/search")
+    end
+
+    it "redirects to default locale when the locale is invalid" do
+      get("/search?locale=esp", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/search")
+    end
+
+    it "redirects user to the new url" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/search", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/ca/search")
+    end
+
+    it "redirects user to the new url when using custom locale" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/search?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/search")
+    end
+  end
 end

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -26,7 +26,7 @@ describe "Account" do
 
   context "when on the account page" do
     before do
-      visit decidim.account_path
+      visit decidim.account_path(locale: I18n.locale)
     end
 
     it_behaves_like "accessible page"
@@ -314,7 +314,7 @@ describe "Account" do
 
     context "when on the delete my account page" do
       before do
-        visit decidim.delete_account_path
+        visit decidim.delete_account_path(locale: I18n.locale)
       end
 
       it "does not display the authorizations message by default" do
@@ -347,7 +347,7 @@ describe "Account" do
         let!(:authorization) { create(:authorization, :granted, user:) }
 
         it "displays the authorizations message" do
-          visit decidim.delete_account_path
+          visit decidim.delete_account_path(locale: I18n.locale)
 
           expect(page).to have_content("Some data bound to your authorization will be saved for security.")
         end

--- a/decidim-core/spec/system/gamification_spec.rb
+++ b/decidim-core/spec/system/gamification_spec.rb
@@ -18,7 +18,7 @@ describe "Gamification" do
       end
 
       it "shows a list of badges" do
-        visit decidim.profile_path(user.nickname)
+        visit decidim.profile_path(user.nickname, locale: I18n.locale)
         click_on "Badges"
         within "div[data-badge='test']" do
           expect(page).to have_content "Level 2"
@@ -31,17 +31,17 @@ describe "Gamification" do
     let!(:user) { create(:user, organization:) }
 
     it "can be reached from the profile's badges page" do
-      visit decidim.profile_path(user.nickname)
+      visit decidim.profile_path(user.nickname, locale: I18n.locale)
       click_on "Badges"
       within ".profile__badge-banner" do
         click_on "See all available badges"
       end
 
-      expect(page).to have_current_path(decidim.gamification_badges_path)
+      expect(page).to have_current_path(decidim.gamification_badges_path(locale: I18n.locale))
     end
 
     it "shows a list of available badges" do
-      visit decidim.gamification_badges_path
+      visit decidim.gamification_badges_path(locale: I18n.locale)
       expect(page).to have_content "Tests badge"
       expect(page).to have_content "Participants get this badge by creating tests"
       expect(page).to have_content "Use a test environment for decidim"

--- a/decidim-core/spec/system/paginate_spec.rb
+++ b/decidim-core/spec/system/paginate_spec.rb
@@ -20,7 +20,7 @@ describe "Paginate specs" do
     end
 
     it "shows the paginator" do
-      page_params = { filter: { with_resource_type: "Decidim::Proposals::Proposal" }, host: organization.host, port: Capybara.server_port }
+      page_params = { locale: I18n.locale, filter: { with_resource_type: "Decidim::Proposals::Proposal" }, host: organization.host, port: Capybara.server_port }
       visit decidim.search_path(per_page:, **page_params)
 
       expect(page).to have_content("Results per page:")
@@ -52,7 +52,7 @@ describe "Paginate specs" do
     end
 
     it "shows the paginator" do
-      page_params = { filter: { with_resource_type: "Decidim::Proposals::Proposal" }, host: organization.host, port: Capybara.server_port }
+      page_params = { locale: I18n.locale, filter: { with_resource_type: "Decidim::Proposals::Proposal" }, host: organization.host, port: Capybara.server_port }
       visit decidim.search_path(**page_params)
 
       expect(page).to have_content("Results per page:")

--- a/decidim-core/spec/system/search_spec.rb
+++ b/decidim-core/spec/system/search_spec.rb
@@ -28,7 +28,7 @@ describe "Search" do
     end
 
     it "displays the results page" do
-      expect(page).to have_current_path decidim.search_path, ignore_query: true
+      expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
       expect(page).to have_content(/results for the search: "#{term}"/i)
       expect(page).to have_css(".filter-search.filter-container")
     end
@@ -76,7 +76,7 @@ describe "Search" do
     end
 
     it "displays the results page" do
-      visit %{/search?filter[with_resource_type]=Decidim::Proposals::Proposal&page=2&per_page=25'"()%26%25<zzz><ScRiPt >alert("XSS")</ScRiPt>}
+      visit %{/en/search?filter[with_resource_type]=Decidim::Proposals::Proposal&page=2&per_page=25'"()%26%25<zzz><ScRiPt >alert("XSS")</ScRiPt>}
 
       expect(page).to have_content("100 results for the search")
       expect(page).to have_content("Results per page")

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -46,7 +46,7 @@ describe "Profile" do
         click_on "Edit profile"
       end
 
-      expect(page).to have_current_path(decidim.account_path)
+      expect(page).to have_current_path(decidim.account_path(locale: I18n.locale))
     end
   end
 

--- a/decidim-core/spec/system/user_tos_acceptance_spec.rb
+++ b/decidim-core/spec/system/user_tos_acceptance_spec.rb
@@ -88,7 +88,7 @@ describe "UserTosAcceptance" do
 
         it "shows an option delete the account" do
           within "#tos-refuse-modal" do
-            expect(page).to have_link("delete your account", href: decidim.delete_account_path)
+            expect(page).to have_link("delete your account", href: decidim.delete_account_path(locale: I18n.locale))
           end
         end
       end

--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -172,7 +172,7 @@ RSpec.shared_examples "manage debates" do
     visit decidim_admin.root_path
     expect(page).to have_content("created the #{translated(attributes[:title])} debate on the")
 
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
     expect(page).to have_content("New debate: #{decidim_sanitize_translated(attributes[:title])}")
 
     within "#filters" do

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_publication_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_publication_spec.rb
@@ -97,7 +97,7 @@ describe "Admin manages initiative publication" do
       click_on "OK"
     end
 
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
     expect(page).to have_content("New initiative: #{title}")
 
     within "#filters" do

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -86,7 +86,7 @@ describe "Admin manages meetings" do
         expect(page).to have_content("Unpublish")
       end
 
-      visit decidim.last_activities_path
+      visit decidim.last_activities_path(locale: I18n.locale)
       expect(page).to have_content("New meeting: #{decidim_sanitize_translated(meeting.title)}")
 
       within "#filters" do

--- a/decidim-meetings/spec/system/search_meetings_spec.rb
+++ b/decidim-meetings/spec/system/search_meetings_spec.rb
@@ -48,7 +48,7 @@ describe "Search meetings" do
           click_on
         end
 
-        expect(page).to have_current_path decidim.search_path, ignore_query: true
+        expect(page).to have_current_path decidim.search_path(locale: I18n.locale), ignore_query: true
         expect(page).to have_content(%(results for the search: "#{term}"))
         expect(page).to have_css(".filter-search.filter-container")
         expect(page.find("#search-count h2").text.to_i).to eq(0)

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -125,7 +125,7 @@ describe "User creates meeting" do
           expect(page).to have_content(meeting_end_time)
           expect(page).to have_css("[data-author]", text: user.name)
 
-          visit decidim.last_activities_path
+          visit decidim.last_activities_path(locale: I18n.locale)
           expect(page).to have_content("New meeting: #{meeting_title}")
 
           within "#filters" do

--- a/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_publication_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_manages_participatory_process_publication_spec.rb
@@ -29,7 +29,7 @@ describe "Admin manages participatory process publication" do |_options|
     end
 
     visit decidim.root_path
-    visit decidim.last_activities_path
+    visit decidim.last_activities_path(locale: I18n.locale)
 
     expect(page).to have_content("New participatory process: #{title}")
 

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -90,7 +90,7 @@ shared_examples "manage proposals" do
             visit decidim_admin.root_path
             expect(page).to have_content("created the proposal #{translated(attributes[:title])} from the merging of")
 
-            visit decidim.last_activities_path
+            visit decidim.last_activities_path(locale: I18n.locale)
             expect(page).to have_content("New proposal: #{translated(attributes[:title])}")
 
             within "#filters" do

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -218,7 +218,7 @@ shared_examples "proposals wizards" do |options|
       it "shows the activity logs" do
         click_on "Publish"
 
-        visit decidim.last_activities_path
+        visit decidim.last_activities_path(locale: I18n.locale)
         expect(page).to have_content("New proposal: #{translated(proposal_draft.title)}")
 
         within "#filters" do


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am changing URLs for multiple pages to include the locale. 

- [x] Search page
- [x] Badges page
- [x] Last Activities
- [x] Account Area
- [x] Open Data
- [ ] TBD

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/16307

#### Testing
1. Switch to this branch
2. Visit the end user application 
3.1. Visit the search page. See you are redirected to /locale/search

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-localized search and gamification URLs now redirect to locale-prefixed paths and preserve query strings.
* **UI**
  * Topbar and mobile search forms plus badge links use locale-aware routes to load pages in the correct language.
* **Notifications**
  * Welcome notification badge link now points to the locale-aware badges page.
* **Tests**
  * System and request specs updated to cover locale-aware routes, redirects, and localized navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->