### PR TITLE
Fix inconsistency issues with the locales URLs - part 1

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -40,10 +40,10 @@
 
         <% if moderation.user.nickname.present? %>
           <td data-label="<%= t(".name") %>">
-            <%= link_to moderation.user.name, decidim.profile_path(moderation.user.nickname) %>
+            <%= link_to moderation.user.name, decidim.profile_path(moderation.user.nickname, locale: current_locale) %>
           </td>
           <td data-label="<%= t(".nickname") %>">
-            <%= link_to moderation.user.nickname, decidim.profile_path(moderation.user.nickname) %>
+            <%= link_to moderation.user.nickname, decidim.profile_path(moderation.user.nickname, locale: current_locale) %>
           </td>
         <% else %>
           <td data-label="<%= t(".name") %>">

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -25,10 +25,10 @@
         <tr data-user-id="<%= user.id %>">
           <% if user.nickname.present? %>
             <td data-label="<%= t(".name") %>">
-              <%= link_to user.name, decidim.profile_path(user.nickname) %>
+              <%= link_to user.name, decidim.profile_path(user.nickname, locale: current_locale) %>
             </td>
             <td data-label="<%= t(".nickname") %>">
-              <%= link_to user.nickname, decidim.profile_path(user.nickname) %>
+              <%= link_to user.nickname, decidim.profile_path(user.nickname, locale: current_locale) %>
             </td>
           <% else %>
             <td data-label="<%= t(".name") %>">

--- a/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
@@ -7,7 +7,7 @@ shared_examples "hideable resource during block" do
 
   let!(:admin) { create(:user, :confirmed, :admin, organization:) }
   let(:reportable) { create(:user, :confirmed, organization:) }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
 
   let(:participatory_process) { create(:participatory_process, organization:) }
   let(:component) { create(:dummy_component, participatory_space: participatory_process) }

--- a/decidim-admin/spec/system/admin_moderates_user_spec.rb
+++ b/decidim-admin/spec/system/admin_moderates_user_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin reports user" do
   let(:admin) { create(:user, :confirmed, :admin) }
   let(:reportable) { create(:user, :confirmed, organization: admin.organization) }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
 
   before do
     switch_to_host(admin.organization.host)

--- a/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
@@ -88,7 +88,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
       end
 
       def root_url

--- a/decidim-blogs/spec/lib/decidim/blogs/schema_org_blog_posting_post_serializer_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/schema_org_blog_posting_post_serializer_spec.rb
@@ -70,7 +70,7 @@ module Decidim::Blogs
           it "serializes the author" do
             expect(serialized[:author][:@type]).to eq("Person")
             expect(serialized[:author][:name]).to eq(post.author.name)
-            expect(serialized[:author][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/profiles/#{post.author.nickname}")
+            expect(serialized[:author][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/en/profiles/#{post.author.nickname}")
           end
 
           context "when author is deleted" do

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -87,7 +87,7 @@ describe "Decidim::Api::QueryType" do
           "name" => endo.author.name,
           "nickname" => "@#{endo.author.nickname}",
           "organizationName" => { "translation" => translated(endo.author.organization.name) },
-          "profilePath" => "/profiles/#{endo.author.nickname}"
+          "profilePath" => "/en/profiles/#{endo.author.nickname}"
         }
       end,
       "likesCount" => 5,

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -504,16 +504,16 @@ describe "Orders" do
             end
 
             it "shows private-only activity log entry" do
-              page.visit decidim.profile_activity_path(nickname: user.nickname)
+              page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
               expect(page).to have_content("New budgeting vote at #{translated(budget.title)}")
               expect(page).to have_link(translated(budget.title), href: router.budget_path(budget))
             end
 
             it "does not show activity log entry to another user" do
               relogin_as another_user, scope: :user
-              page.visit decidim.profile_activity_path(nickname: user.nickname)
+              page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
               expect(page).to have_content(user.name)
-              expect(page).to have_current_path "/profiles/#{user.nickname}/activity"
+              expect(page).to have_current_path "/#{I18n.locale}/profiles/#{user.nickname}/activity"
               expect(page).to have_no_content("New budgeting vote at")
               expect(page).to have_no_link(translated(budget.title))
             end

--- a/decidim-comments/lib/decidim/comments/test/shared_examples/translatable_comment.rb
+++ b/decidim-comments/lib/decidim/comments/test/shared_examples/translatable_comment.rb
@@ -12,6 +12,7 @@ shared_examples_for "a translated comment event" do
     let(:comment) { create(:comment, body:, commentable:) }
     let(:en_version) { "<div><p>#{comment.body["en"]}</p></div>" }
     let(:machine_translated) { "<div><p>#{comment.body["machine_translations"]["ca"]}</p></div>" }
+    let(:untranslated_content) { en_version }
 
     it_behaves_like "a translated event"
   end

--- a/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/comment_created_event_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Comments::CommentCreatedEvent do
   let(:email_subject) { "There is a new comment from #{comment_author.name} in #{resource_title}" }
   let(:email_intro) { "#{resource_title} has been commented. You can read the comment in this page:" }
   let(:email_outro) { "You have received this notification because you are following \"#{resource_title}\" or its author. You can unfollow it from the previous link." }
-  let(:notification_title) { "There is a new comment from <a href=\"/profiles/#{comment_author.nickname}\">#{comment_author.name} @#{comment_author.nickname}</a> in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>" }
+  let(:notification_title) { "There is a new comment from <a href=\"/en/profiles/#{comment_author.nickname}\">#{comment_author.name} @#{comment_author.nickname}</a> in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>" }
 
   it_behaves_like "a simple event email"
   it_behaves_like "a simple event notification"

--- a/decidim-comments/spec/events/decidim/comments/reply_created_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/reply_created_event_spec.rb
@@ -11,7 +11,7 @@ describe Decidim::Comments::ReplyCreatedEvent do
   let(:email_subject) { "#{comment_author_name} has replied your comment in #{resource_title}" }
   let(:email_intro) { "#{comment_author_name} has replied your comment in #{resource_title}. You can read it in this page:" }
   let(:email_outro) { "You have received this notification because your comment was replied." }
-  let(:notification_title) { "<a href=\"/profiles/#{comment_author.nickname}\">#{comment_author_name} @#{comment_author.nickname}</a> has replied your comment in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>" }
+  let(:notification_title) { "<a href=\"/en/profiles/#{comment_author.nickname}\">#{comment_author_name} @#{comment_author.nickname}</a> has replied your comment in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a>" }
 
   it_behaves_like "a simple event email"
   it_behaves_like "a simple event notification"

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -10,7 +10,7 @@ describe Decidim::Comments::UserMentionedEvent do
   let(:event_name) { "decidim.events.comments.user_mentioned" }
   let(:ca_comment_content) { "<div><p>Un commentaire pour #{author_link}</p></div>" }
   let(:en_comment_content) { "<div><p>Comment mentioning some user, #{author_link}</p></div>" }
-  let(:author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
+  let(:author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/#{I18n.locale}/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
   let(:parsed_body) { Decidim::ContentProcessor.parse("Comment mentioning some user, @#{author.nickname}", current_organization: organization) }
   let(:parsed_ca_body) { Decidim::ContentProcessor.parse("Un commentaire pour @#{author.nickname}", current_organization: organization) }
   let(:body) { { en: parsed_body.rewrite, machine_translations: { ca: parsed_ca_body.rewrite } } }
@@ -22,7 +22,7 @@ describe Decidim::Comments::UserMentionedEvent do
   let(:author) { create(:user, organization:) }
   let!(:comment) { create(:comment, body:, author:, commentable:) }
   let(:user) { create(:user, organization:, locale: "ca") }
-  let(:notification_title) { "You have been mentioned in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a> by <a href=\"/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a>" }
+  let(:notification_title) { "You have been mentioned in <a href=\"#{resource_path}?commentId=#{comment.id}#comment_#{comment.id}\">#{resource_title}</a> by <a href=\"/#{I18n.locale}/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a>" }
   let(:email_subject) { "You have been mentioned in #{resource_title}" }
   let(:email_intro) { "You have been mentioned" }
   let(:email_outro) { "You have received this notification because you have been mentioned in #{resource_title}." }
@@ -47,9 +47,12 @@ describe Decidim::Comments::UserMentionedEvent do
     let(:component) { create(:component, participatory_space: participatory_process) }
     let(:commentable) { create(:dummy_resource, component:) }
     let!(:comment) { create(:comment, body:, author:, commentable:) }
-    let(:en_version) { en_comment_content }
+    let(:en_version) { I18n.with_locale("en") { en_comment_content } }
     let(:machine_translated) { ca_comment_content }
     let(:translatable) { true }
+
+    let(:untranslated_content) { "<div><p>Comment mentioning some user, #{ca_author_link}</p></div>" }
+    let(:ca_author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/ca/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
 
     it_behaves_like "a translated event"
   end

--- a/decidim-core/app/cells/decidim/profile_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_cell.rb
@@ -77,7 +77,7 @@ module Decidim
     # i18n-tasks-use t("decidim.profiles.show.followers")
     def tab_item(key)
       values = TABS_ITEMS[key].dup
-      values[:path] = send(values[:path], nickname: profile_holder.nickname)
+      values[:path] = send(values[:path], nickname: profile_holder.nickname, locale: current_locale)
       values[:text] = t(key, scope: "decidim.profiles.show")
       values
     end

--- a/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
+++ b/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
@@ -31,7 +31,7 @@ module Decidim
       if options[:source] == :last_activities
         last_activities_path(filter: { with_resource_type: resource_type })
       else
-        profile_activity_path(nickname: params[:nickname], filter: { resource_type: })
+        profile_activity_path(nickname: params[:nickname], locale: current_locale, filter: { resource_type: })
       end
     end
 

--- a/decidim-core/app/cells/decidim/user_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/user_profile_cell.rb
@@ -20,7 +20,7 @@ module Decidim
     end
 
     def resource_path
-      user.try(:profile_url) || decidim.profile_path(user.nickname)
+      user.try(:profile_url) || decidim.profile_path(user.nickname, locale: I18n.locale)
     end
 
     def presented_resource

--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -30,7 +30,7 @@ module Decidim
           conversation = conversation_between(current_user, @form.recipient)
         end
 
-        return redirect_back_or_to(profile_path(current_user.nickname)) if @form.recipient.empty?
+        return redirect_back_or_to(profile_path(current_user.nickname, locale: current_locale)) if @form.recipient.empty?
 
         return redirect_to conversation_path(conversation) if conversation
 

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -72,7 +72,10 @@ module Decidim
     end
 
     def author_profile_url
-      @author_profile_url ||= @author.is_a?(Decidim::UserBaseEntity) && !@author.deleted? ? decidim.profile_url(@author.nickname, host: @organization.host) : nil
+      @author_profile_url ||= if @author.is_a?(Decidim::UserBaseEntity) && !@author.deleted?
+                                decidim.profile_url(@author.nickname, locale: I18n.locale,
+                                                                      host: @organization.host)
+                              end
     end
 
     def original_language(reportable)

--- a/decidim-core/app/presenters/decidim/log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/user_presenter.rb
@@ -77,7 +77,7 @@ module Decidim
       #
       # Returns an HTML-safe String.
       def user_path
-        h.decidim.profile_path(present_user_nickname)
+        h.decidim.profile_path(present_user_nickname, locale: I18n.locale)
       end
     end
   end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -31,7 +31,7 @@ module Decidim
     def profile_url
       return "" if respond_to?(:deleted?) && deleted?
 
-      decidim.profile_url(__getobj__.nickname)
+      decidim.profile_url(__getobj__.nickname, locale: I18n.locale)
     end
 
     def avatar
@@ -52,7 +52,7 @@ module Decidim
     def profile_path
       return "" if respond_to?(:deleted?) && deleted?
 
-      decidim.profile_path(__getobj__.nickname)
+      decidim.profile_path(__getobj__.nickname, locale: I18n.locale)
     end
 
     def direct_messages_enabled?(context)

--- a/decidim-core/app/serializers/decidim/exporters/serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/serializer.rb
@@ -62,7 +62,7 @@ module Decidim
       def profile_url(user)
         return "" if user.respond_to?(:deleted?) && user.deleted?
 
-        EngineRouter.new("decidim", { host: }).profile_url(user.nickname)
+        EngineRouter.new("decidim", { host: }).profile_url(user.nickname, locale: I18n.locale)
       end
 
       def root_url

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,6 +1,6 @@
 <li role="presentation"><%= link_to t(".profile"), decidim.account_path, role: "menuitem" %></li>
 <% if current_user.nickname.present? && !current_user.managed? %>
-  <li role="presentation"><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname), role: "menuitem" %></li>
+  <li role="presentation"><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname, locale: current_locale), role: "menuitem" %></li>
 <% end %>
 <li role="presentation"><%= link_to t(".notifications"), decidim.notifications_path, role: "menuitem" %></li>
 <li role="presentation"><%= link_to t(".conversations"), decidim.conversations_path, role: "menuitem" %></li>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -5,7 +5,7 @@
   <ul class="space-y-4 break-inside-avoid">
     <% if current_user %>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
-      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname, locale: current_locale) %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 </li>
 <li class="dropdown__item">
-  <%= link_to decidim.profile_path(current_user.nickname), class: "dropdown__button" do %>
+  <%= link_to decidim.profile_path(current_user.nickname, locale: current_locale), class: "dropdown__button" do %>
     <%= icon "account-circle-line" %>
     <span><%= t("layouts.decidim.user_menu.public_profile") %></span>
   <% end %>

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -94,14 +94,6 @@ Decidim::Core::Engine.routes.draw do
     )
   end
 
-  resources :profiles, only: [:show], param: :nickname, constraints: { nickname: %r{[^/]+} }, format: false
-  scope "/profiles/:nickname", format: false, constraints: { nickname: %r{[^/]+} } do
-    get "following", to: "profiles#following", as: "profile_following"
-    get "followers", to: "profiles#followers", as: "profile_followers"
-    get "badges", to: "profiles#badges", as: "profile_badges"
-    get "activity", to: "user_activities#index", as: "profile_activity"
-  end
-
   scope :timeouts do
     post "heartbeat", to: "timeouts#heartbeat"
     get "seconds_until_timeout", to: "timeouts#seconds_until_timeout"
@@ -109,6 +101,13 @@ Decidim::Core::Engine.routes.draw do
 
   scope "/:locale" do
     resources :pages, only: [:index, :show], format: false
+    resources :profiles, only: [:show], param: :nickname, constraints: { nickname: %r{[^/]+} }, format: false
+    scope "/profiles/:nickname", format: false, constraints: { nickname: %r{[^/]+} } do
+      get "following", to: "profiles#following", as: "profile_following"
+      get "followers", to: "profiles#followers", as: "profile_followers"
+      get "badges", to: "profiles#badges", as: "profile_badges"
+      get "activity", to: "user_activities#index", as: "profile_activity"
+    end
   end
 
   get "/pages", to: redirect { |params, request|
@@ -119,6 +118,18 @@ Decidim::Core::Engine.routes.draw do
   get "/pages/*rest", to: redirect { |params, request|
     locale = Decidim::LocaleRouterDetector.new(request, params).locale
     "/#{locale}/pages/#{params[:rest]}"
+  }
+
+  get "/profiles/*rest", to: redirect { |params, request|
+    locale = Decidim::LocaleRouterDetector.new(request, params).locale
+
+    query_string = Rack::Utils.parse_nested_query(request.query_string.to_s)
+    query_string.delete("locale")
+    query_string = CGI.unescape(query_string.to_query)
+
+    path = "/#{locale}/profiles/#{params[:rest]}"
+    path += "?#{query_string}" unless query_string.empty?
+    path
   }
 
   get "/search", to: "searches#index", as: :search

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -123,6 +123,9 @@ Decidim::Core::Engine.routes.draw do
   get "/profiles/*rest", to: redirect { |params, request|
     locale = Decidim::LocaleRouterDetector.new(request, params).locale
 
+    # Handle explicitly the query strings, as we have some filters and pagination on the activity tab.
+    # We need to handle URLs like
+    # https://nightly.decidim.org/profiles/visitant_bqqppvus/activity?filter[resource_type]=Decidim::Initiative
     query_string = Rack::Utils.parse_nested_query(request.query_string.to_s)
     query_string.delete("locale")
     query_string = CGI.unescape(query_string.to_query)

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -1033,7 +1033,7 @@ shared_examples "comments" do
 
         it "replaces the mention with a link to the user's profile" do
           expect(page).to have_comment_from(user, "A valid user mention: @#{mentioned_user.nickname}", wait: 20)
-          expect(page).to have_link "@#{mentioned_user.nickname}", href: "http://#{mentioned_user.organization.host}:#{Capybara.server_port}/profiles/#{mentioned_user.nickname}"
+          expect(page).to have_link "@#{mentioned_user.nickname}", href: "http://#{mentioned_user.organization.host}:#{Capybara.server_port}/en/profiles/#{mentioned_user.nickname}"
         end
       end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/resource_liked_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/resource_liked_event_examples.rb
@@ -51,7 +51,7 @@ shared_examples_for "resource liked event" do
         .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> #{resource_type} has been liked by ")
 
       expect(subject.notification_title)
-        .to include("<a href=\"/profiles/#{author.nickname}\">#{author.name} #{author_presenter.nickname}</a>.")
+        .to include("<a href=\"/en/profiles/#{author.nickname}\">#{author.name} #{author_presenter.nickname}</a>.")
     end
   end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/translated_event_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/translated_event_examples.rb
@@ -75,7 +75,7 @@ shared_examples_for "a translated event" do
         end
 
         it "does not offer an alternate translation" do
-          expect(subject.safe_resource_translated_text).to eq(en_version)
+          expect(subject.safe_resource_translated_text).to eq(untranslated_content)
         end
       end
     end
@@ -123,7 +123,7 @@ shared_examples_for "a translated event" do
         end
 
         it "does not offer an alternate translation" do
-          expect(subject.safe_resource_translated_text).to eq(en_version)
+          expect(subject.safe_resource_translated_text).to eq(untranslated_content)
         end
       end
     end

--- a/decidim-core/lib/decidim/gamification/base_event.rb
+++ b/decidim-core/lib/decidim/gamification/base_event.rb
@@ -8,12 +8,13 @@ module Decidim
       delegate :url_helpers, to: "Decidim::Core::Engine.routes"
 
       def resource_path
-        url_helpers.profile_badges_path(nickname: user.nickname)
+        url_helpers.profile_badges_path(nickname: user.nickname, locale: I18n.locale)
       end
 
       def resource_url
         url_helpers.profile_badges_url(
           nickname: user.nickname,
+          locale: I18n.locale,
           host: user.organization.host
         )
       end

--- a/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
+++ b/decidim-core/spec/content_renderers/decidim/user_renderer_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     let(:user) { create(:user, :confirmed) }
     let(:renderer) { described_class.new(content) }
     let(:presenter) { Decidim::UserPresenter.new(user) }
-    let(:profile_url) { "http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}" }
+    let(:profile_url) { "http://#{user.organization.host}:#{Capybara.server_port}/en/profiles/#{user.nickname}" }
 
     context "when content has a valid Decidim::User Global ID" do
       let(:content) { "This text contains a valid Decidim::User Global ID: #{user.to_global_id}" }

--- a/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
@@ -16,7 +16,7 @@ module Decidim
     describe "#badges" do
       context "with an user with uppercase" do
         it "returns the lowercased user" do
-          get :badges, params: { nickname: "NICK" }
+          get :badges, params: { locale: I18n.locale, nickname: "NICK" }
           expect(response).to render_template(:show)
         end
       end
@@ -25,8 +25,8 @@ module Decidim
     describe "#show" do
       context "with a normal user" do
         it "redirects to the correct page" do
-          get :show, params: { nickname: "Nick" }
-          expect(response).to redirect_to("/profiles/nick/activity")
+          get :show, params: { locale: I18n.locale, nickname: "Nick" }
+          expect(response).to redirect_to("/#{I18n.locale}/profiles/nick/activity")
         end
       end
 
@@ -34,7 +34,7 @@ module Decidim
         let!(:user) { create(:user, :confirmed, :blocked, nickname: "nick", organization:) }
 
         it "does not return the page" do
-          expect { get :show, params: { nickname: "Nick" } }.to raise_error(ActionController::RoutingError)
+          expect { get :show, params: { locale: I18n.locale, nickname: "Nick" } }.to raise_error(ActionController::RoutingError)
         end
       end
     end

--- a/decidim-core/spec/controllers/decidim/user_activities_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/user_activities_controller_spec.rb
@@ -17,14 +17,14 @@ module Decidim
       context "with an unknown user" do
         it "raises an ActionController::RoutingError" do
           expect do
-            get :index, params: { nickname: "foobar" }
+            get :index, params: { locale: I18n.locale, nickname: "foobar" }
           end.to raise_error(ActionController::RoutingError, "Missing user: foobar")
         end
       end
 
       context "with an user with uppercase" do
         it "returns the lowercased user" do
-          get :index, params: { nickname: "NICK" }
+          get :index, params: { locale: I18n.locale, nickname: "NICK" }
           expect(response).to render_template(:index)
         end
       end

--- a/decidim-core/spec/controllers/messaging/conversations_controller_spec.rb
+++ b/decidim-core/spec/controllers/messaging/conversations_controller_spec.rb
@@ -61,7 +61,7 @@ module Decidim
         subject { get :new, params: { recipient_id: user.id } }
 
         it "redirects to the profile path" do
-          expect(subject).to redirect_to profile_path(user.nickname)
+          expect(subject).to redirect_to profile_path(user.nickname, locale: I18n.locale)
         end
       end
 

--- a/decidim-core/spec/events/decidim/author_event_spec.rb
+++ b/decidim-core/spec/events/decidim/author_event_spec.rb
@@ -48,7 +48,7 @@ module Decidim
 
       it "has an author path" do
         expect(subject.author_path).to be_present
-        expect(subject.author_path).to start_with("/profile")
+        expect(subject.author_path).to start_with("/en/profile")
       end
 
       it "has an author url" do

--- a/decidim-core/spec/lib/gamification/badge_earned_event_spec.rb
+++ b/decidim-core/spec/lib/gamification/badge_earned_event_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let(:event_name) { "decidim.events.gamification.badge_earned" }
       let(:resource) { create(:user) }
       let(:resource_path) do
-        Decidim::Core::Engine.routes.url_helpers.profile_badges_path(nickname: resource.nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_badges_path(nickname: resource.nickname, locale: I18n.locale)
       end
 
       it_behaves_like "a simple event", skip_space_checks: true

--- a/decidim-core/spec/lib/gamification/level_up_event_spec.rb
+++ b/decidim-core/spec/lib/gamification/level_up_event_spec.rb
@@ -11,7 +11,7 @@ module Decidim
       let(:event_name) { "decidim.events.gamification.level_up" }
       let(:resource) { create(:user) }
       let(:resource_path) do
-        Decidim::Core::Engine.routes.url_helpers.profile_badges_path(nickname: resource.nickname)
+        Decidim::Core::Engine.routes.url_helpers.profile_badges_path(nickname: resource.nickname, locale: I18n.locale)
       end
 
       it_behaves_like "a simple event", skip_space_checks: true

--- a/decidim-core/spec/mailers/reported_mailer_spec.rb
+++ b/decidim-core/spec/mailers/reported_mailer_spec.rb
@@ -87,7 +87,7 @@ module Decidim
 
         context "when the author is a user" do
           it "includes the name of the author and a link to their profile" do
-            expect(mail).to have_link(author.name, href: decidim.profile_url(author.nickname, host: organization.host))
+            expect(mail).to have_link(author.name, href: decidim.profile_url(author.nickname, locale: I18n.locale, host: organization.host))
           end
         end
 

--- a/decidim-core/spec/presenters/decidim/log/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/user_presenter_spec.rb
@@ -17,7 +17,7 @@ describe Decidim::Log::UserPresenter, type: :helper do
   describe "#present" do
     context "when the user exists" do
       it "links to their profile" do
-        expect(subject).to include("href=\"/profiles/#{user_nickname}\">")
+        expect(subject).to include("href=\"/en/profiles/#{user_nickname}\">")
       end
     end
 
@@ -31,7 +31,7 @@ describe Decidim::Log::UserPresenter, type: :helper do
       end
 
       it "does not link to their profile" do
-        expect(subject).not_to include("href=\"/profiles/")
+        expect(subject).not_to include("href=\"/en/profiles/")
         expect(subject).to include("John O'Hara")
       end
     end

--- a/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/user_presenter_spec.rb
@@ -58,7 +58,7 @@ module Decidim
     describe "#profile_url" do
       subject { described_class.new(user).profile_url }
 
-      it { is_expected.to eq("http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}") }
+      it { is_expected.to eq("http://#{user.organization.host}:#{Capybara.server_port}/en/profiles/#{user.nickname}") }
     end
 
     describe "#avatar_url" do
@@ -95,7 +95,7 @@ module Decidim
     describe "#profile_path" do
       subject { presenter.profile_path }
 
-      it { is_expected.to eq("/profiles/#{user.nickname}") }
+      it { is_expected.to eq("/en/profiles/#{user.nickname}") }
     end
 
     context "when user is deleted" do
@@ -112,7 +112,7 @@ module Decidim
       subject { presenter.display_mention }
 
       it do
-        expect(subject).to have_link(user.nickname, href: "http://#{user.organization.host}:#{Capybara.server_port}/profiles/#{user.nickname}")
+        expect(subject).to have_link(user.nickname, href: "http://#{user.organization.host}:#{Capybara.server_port}/en/profiles/#{user.nickname}")
       end
     end
 

--- a/decidim-core/spec/requests/redirect_routes_spec.rb
+++ b/decidim-core/spec/requests/redirect_routes_spec.rb
@@ -6,47 +6,68 @@ describe "Redirect routes" do
   let(:organization) { create(:organization, available_locales: %w(en es ca), default_locale: "en") }
   let(:headers) { { "HOST" => organization.host } }
 
-  it "redirects old url with missing locale" do
-    get("/pages", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/en/pages")
+  shared_examples "redirects to the new url" do |url|
+    it "redirects old url (/#{url}) with missing locale to new version (/en/#{url})" do
+      get("/#{url}", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/#{url}")
+    end
+
+    it "redirects old url (/#{url}?locale=es) with locale to new version (/es/#{url})" do
+      get("/#{url}?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/#{url}")
+    end
+
+    it "redirects to default locale (/en/#{url}) when the locale is invalid (/#{url}?locale=esp)" do
+      get("/#{url}?locale=esp", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/en/#{url}")
+    end
+
+    it "redirects user to the new url (/ca/#{url})" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/#{url}", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/ca/#{url}")
+    end
+
+    it "redirects user to the new url (/es/#{url}) when using custom locale (/#{url}?locale=es)" do
+      user = create(:user, :confirmed, organization:, locale: "ca")
+      login_as user, scope: :user
+
+      get("/", headers:)
+      get("/#{url}?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/#{url}")
+    end
   end
 
-  it "redirects old url with locale" do
-    get("/pages?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages")
+  it_behaves_like "redirects to the new url", "pages" do
+    it "redirects old url with locale and additional params" do
+      get("/pages/foo-bar?locale=es", headers:)
+      expect(response).to have_http_status(:moved_permanently)
+      expect(response).to redirect_to("/es/pages/foo-bar")
+    end
   end
 
-  it "redirects to default locale when the locale is invalid" do
-    get("/pages?locale=esp", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/en/pages")
-  end
+  context "when visiting profile pages" do
+    let!(:user) { create(:user, :confirmed, nickname: "my_user", organization:) }
 
-  it "redirects old url with locale and additional params" do
-    get("/pages/foo-bar?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages/foo-bar")
-  end
+    it_behaves_like "redirects to the new url", "profiles/my_user/activity" do
+      it "redirects old url with query string with missing locale" do
+        page_with_query_string = "/profiles/my_user/activity?filter[resource_type]=Decidim::Comments::Comment&page=2&per_page=50"
+        get(page_with_query_string, headers:)
+        expect(response).to have_http_status(:moved_permanently)
+        expect(response).to redirect_to("/en#{page_with_query_string}")
+      end
+    end
 
-  it "redirects user to the new url" do
-    user = create(:user, :confirmed, organization:, locale: "ca")
-    login_as user, scope: :user
-
-    get("/", headers:)
-    get("/pages", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/ca/pages")
-  end
-
-  it "redirects user to the new url when using custom locale" do
-    user = create(:user, :confirmed, organization:, locale: "ca")
-    login_as user, scope: :user
-
-    get("/", headers:)
-    get("/pages?locale=es", headers:)
-    expect(response).to have_http_status(:moved_permanently)
-    expect(response).to redirect_to("/es/pages")
+    it_behaves_like "redirects to the new url", "profiles/my_user/badges"
+    it_behaves_like "redirects to the new url", "profiles/my_user/following"
+    it_behaves_like "redirects to the new url", "profiles/my_user/followers"
   end
 end

--- a/decidim-core/spec/system/follow_users_spec.rb
+++ b/decidim-core/spec/system/follow_users_spec.rb
@@ -15,7 +15,7 @@ describe "Follow users" do
   context "when not following the user" do
     context "when user clicks the Follow button" do
       it "makes the user follow the user" do
-        visit decidim.profile_path(followable.nickname)
+        visit decidim.profile_path(followable.nickname, locale: I18n.locale)
         expect do
           click_on "Follow"
           expect(page).to have_content(/stop following/i)
@@ -31,7 +31,7 @@ describe "Follow users" do
 
     context "when user clicks the Follow button" do
       it "makes the user follow the user" do
-        visit decidim.profile_path(followable.nickname)
+        visit decidim.profile_path(followable.nickname, locale: I18n.locale)
         expect do
           click_on "Stop following"
           expect(page).to have_content "Follow"

--- a/decidim-core/spec/system/gamification_spec.rb
+++ b/decidim-core/spec/system/gamification_spec.rb
@@ -18,7 +18,7 @@ describe "Gamification" do
       end
 
       it "shows a list of badges" do
-        visit decidim.profile_path(user.nickname)
+        visit decidim.profile_path(user.nickname, locale: I18n.locale)
         click_on "Badges"
         within "div[data-badge='test']" do
           expect(page).to have_content "Level 2"
@@ -31,7 +31,7 @@ describe "Gamification" do
     let!(:user) { create(:user, organization:) }
 
     it "can be reached from the profile's badges page" do
-      visit decidim.profile_path(user.nickname)
+      visit decidim.profile_path(user.nickname, locale: I18n.locale)
       click_on "Badges"
       within ".profile__badge-banner" do
         click_on "See all available badges"

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -263,7 +263,7 @@ describe "Conversations" do
       let(:recipient) { create(:user, :confirmed, organization:) }
 
       before do
-        visit decidim.profile_path(recipient.nickname)
+        visit decidim.profile_path(recipient.nickname, locale: I18n.locale)
       end
 
       it "has a contact link" do

--- a/decidim-core/spec/system/user_activity_spec.rb
+++ b/decidim-core/spec/system/user_activity_spec.rb
@@ -73,7 +73,7 @@ describe "User activity" do
         allow_any_instance_of(Decidim::ActivityCell).to receive(:resource_link_path).and_return("/example/path")
         # rubocop:enable RSpec/AnyInstance
 
-        page.visit decidim.profile_activity_path(nickname: user.nickname)
+        page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
         within "#activities-container" do
           expect(page).to have_css("[data-activity]", count: 3)
 
@@ -88,7 +88,7 @@ describe "User activity" do
 
   describe "accessing the user activity page" do
     before do
-      page.visit decidim.profile_activity_path(nickname: user.nickname)
+      page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
     end
 
     it "displays the activities at the home page" do
@@ -119,7 +119,7 @@ describe "User activity" do
     context "when accessing a nonexistent profile" do
       before do
         allow(page.config).to receive(:raise_server_errors).and_return(false)
-        visit decidim.profile_activity_path(nickname: "invalid_nickname")
+        visit decidim.profile_activity_path(nickname: "invalid_nickname", locale: I18n.locale)
       end
 
       it "displays an error message" do

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -12,11 +12,11 @@ describe "Profile" do
   context "when has casing in the nickname" do
     before do
       switch_to_host(user.organization.host)
-      visit decidim.profile_path(user.nickname.upcase)
+      visit decidim.profile_path(user.nickname.upcase, locale: I18n.locale)
     end
 
     it "downcases the path" do
-      expect(page).to have_current_path(decidim.profile_activity_path(user.nickname.downcase))
+      expect(page).to have_current_path(decidim.profile_activity_path(user.nickname.downcase, locale: I18n.locale))
     end
   end
 
@@ -52,7 +52,7 @@ describe "Profile" do
 
   context "when navigating publicly" do
     before do
-      visit decidim.profile_path(user.nickname)
+      visit decidim.profile_path(user.nickname, locale: I18n.locale)
     end
 
     it "is not indexable by crawlers" do
@@ -72,13 +72,13 @@ describe "Profile" do
       it "displays the correct links for profile activity" do
         visit current_path
         within "#filters" do
-          expect(page).to have_link("All activity types", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "all" }))
-          expect(page).to have_link("Proposal", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Proposals::Proposal" }))
-          expect(page).to have_link("Comment", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Comments::Comment" }))
-          expect(page).to have_link("Debate", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Debates::Debate" }))
-          expect(page).to have_link("Initiative", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Initiative" }))
-          expect(page).to have_link("Meeting", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Meetings::Meeting" }))
-          expect(page).to have_link("Post", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Blogs::Post" }))
+          expect(page).to have_link("All activity types", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "all" }))
+          expect(page).to have_link("Proposal", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Proposals::Proposal" }))
+          expect(page).to have_link("Comment", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Comments::Comment" }))
+          expect(page).to have_link("Debate", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Debates::Debate" }))
+          expect(page).to have_link("Initiative", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Initiative" }))
+          expect(page).to have_link("Meeting", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Meetings::Meeting" }))
+          expect(page).to have_link("Post", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Blogs::Post" }))
         end
 
         expect(page).to have_content("New comment")
@@ -147,7 +147,7 @@ describe "Profile" do
       end
 
       it "shows the number of followers and following" do
-        visit decidim.profile_path(user.nickname)
+        visit decidim.profile_path(user.nickname, locale: I18n.locale)
         within(".profile__details") do
           expect(page).to have_content("1 follower")
           expect(page).to have_content("2 follows")
@@ -155,7 +155,7 @@ describe "Profile" do
       end
 
       it "lists the followers" do
-        visit decidim.profile_path(user.nickname)
+        visit decidim.profile_path(user.nickname, locale: I18n.locale)
         click_on "Followers"
 
         expect(page).to have_content(other_user.name)
@@ -163,7 +163,7 @@ describe "Profile" do
       end
 
       it "lists the followings" do
-        visit decidim.profile_path(user.nickname)
+        visit decidim.profile_path(user.nickname, locale: I18n.locale)
         click_on "Follows"
 
         expect(page).to have_no_content("Some of the resources followed are not public.")
@@ -181,7 +181,7 @@ describe "Profile" do
         end
 
         it "lists only the public followings" do
-          visit decidim.profile_path(user.nickname)
+          visit decidim.profile_path(user.nickname, locale: I18n.locale)
           within(".profile__details") do
             expect(page).to have_content("3 follows")
           end
@@ -203,7 +203,7 @@ describe "Profile" do
         end
 
         it "lists only the unblocked followings" do
-          visit decidim.profile_path(user.nickname)
+          visit decidim.profile_path(user.nickname, locale: I18n.locale)
 
           click_on "Follows"
           expect(page).to have_content("Some of the resources followed are not public.")
@@ -221,7 +221,7 @@ describe "Profile" do
         end
 
         it "lists only the unblocked followers" do
-          visit decidim.profile_path(user.nickname)
+          visit decidim.profile_path(user.nickname, locale: I18n.locale)
 
           click_on "Followers"
           expect(page).to have_content(translated(other_user.name))
@@ -235,7 +235,7 @@ describe "Profile" do
         before do
           user.organization.update(badges_enabled: true)
           Decidim::Gamification.set_score(user, :test, 10)
-          visit decidim.profile_path(user.nickname)
+          visit decidim.profile_path(user.nickname, locale: I18n.locale)
         end
 
         it "shows a badges tab" do
@@ -246,7 +246,7 @@ describe "Profile" do
       context "when badges are disabled" do
         before do
           user.organization.update(badges_enabled: false)
-          visit decidim.profile_path(user.nickname)
+          visit decidim.profile_path(user.nickname, locale: I18n.locale)
         end
 
         it "shows a badges tab" do
@@ -263,7 +263,7 @@ describe "Profile" do
         .with(a_kind_of(Symbol), a_kind_of(Decidim::ProfileCell))
         .and_return("Rendered from #{view_hook} view hook")
 
-      visit decidim.profile_path(user.nickname)
+      visit decidim.profile_path(user.nickname, locale: I18n.locale)
     end
 
     context "with user_profile_bottom view hook" do

--- a/decidim-core/spec/system/user_report_spec.rb
+++ b/decidim-core/spec/system/user_report_spec.rb
@@ -6,7 +6,7 @@ describe "Report User" do
   let(:user) { create(:user, :confirmed) }
   let!(:users) { create_list(:user, 3, :confirmed, organization: user.organization) }
   let(:reportable) { users.first }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
 
   before do
     switch_to_host(user.organization.host)
@@ -15,7 +15,7 @@ describe "Report User" do
   context "when the user is blocked" do
     let(:user) { create(:user, :confirmed, :blocked) }
     let(:admin) { create(:user, :admin, :confirmed, organization: user.organization) }
-    let(:reportable_path) { decidim.profile_path(user.nickname) }
+    let(:reportable_path) { decidim.profile_path(user.nickname, locale: I18n.locale) }
 
     before do
       switch_to_host(user.organization.host)

--- a/decidim-core/spec/types/user_type_spec.rb
+++ b/decidim-core/spec/types/user_type_spec.rb
@@ -118,7 +118,7 @@ module Decidim
         let(:query) { "{ profilePath }" }
 
         it "returns the user profile path" do
-          expect(response).to include("profilePath" => "/profiles/#{model.nickname}")
+          expect(response).to include("profilePath" => "/en/profiles/#{model.nickname}")
         end
 
         context "when user is deleted" do

--- a/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
+++ b/decidim-debates/spec/events/decidim/debates/create_debate_event_spec.rb
@@ -24,7 +24,7 @@ describe Decidim::Debates::CreateDebateEvent do
     let(:email_subject) { "New debate \"#{resource_title}\" by @#{author.nickname}" }
     let(:email_intro) { "Hi,\n#{author.name} @#{author.nickname}, who you are following, has created a new debate \"#{resource_title}\". Check it out and contribute:" }
     let(:email_outro) { "You have received this notification because you are following @#{author.nickname}. You can stop receiving notifications following the previous link." }
-    let(:notification_title) { "<a href=\"/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a> created the <a href=\"#{resource_path}\">#{resource_title}</a> debate." }
+    let(:notification_title) { "<a href=\"/en/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a> created the <a href=\"#{resource_path}\">#{resource_title}</a> debate." }
 
     it_behaves_like "a simple event"
     it_behaves_like "a simple event email"

--- a/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
@@ -206,7 +206,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
       end
 
       def root_url

--- a/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
+++ b/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
@@ -179,7 +179,7 @@ module Decidim
     end
 
     def profile_url(nickname)
-      Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+      Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
     end
 
     def host

--- a/decidim-initiatives/spec/events/decidim/initiatives/create_initiative_event_spec.rb
+++ b/decidim-initiatives/spec/events/decidim/initiatives/create_initiative_event_spec.rb
@@ -18,7 +18,7 @@ describe Decidim::Initiatives::CreateInitiativeEvent do
   let(:email_subject) { "New initiative by @#{initiative_author.nickname}" }
   let(:email_intro) { "#{initiative_author.name} @#{initiative_author.nickname}, who you are following, has created a new initiative, check it out and contribute:" }
   let(:email_outro) { "You have received this notification because you are following @#{initiative_author.nickname}. You can stop receiving notifications following the previous link." }
-  let(:notification_title) { "The <a href=\"#{resource_path}\">#{resource_title}</a> initiative was created by <a href=\"/profiles/#{initiative_author.nickname}\">#{initiative_author.name} @#{initiative_author.nickname}</a>." }
+  let(:notification_title) { "The <a href=\"#{resource_path}\">#{resource_title}</a> initiative was created by <a href=\"/en/profiles/#{initiative_author.nickname}\">#{initiative_author.name} @#{initiative_author.nickname}</a>." }
 
   it_behaves_like "a simple event email"
   it_behaves_like "a simple event notification"

--- a/decidim-meetings/lib/decidim/meetings/test/translated_event.rb
+++ b/decidim-meetings/lib/decidim/meetings/test/translated_event.rb
@@ -8,6 +8,7 @@ shared_examples_for "a translated meeting event" do
     let(:meeting_component) { create(:meeting_component, participatory_space: participatory_process) }
     let(:translatable) { true }
     let(:en_version) { resource.description["en"] }
+    let(:untranslated_content) { en_version }
     let(:machine_translated) { resource.description["machine_translations"]["ca"] }
 
     let(:resource) do

--- a/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/schema_org_event_meeting_serializer_spec.rb
@@ -71,7 +71,7 @@ module Decidim::Meetings
           it "serializes the organizer" do
             expect(serialized[:organizer][:@type]).to eq("Person")
             expect(serialized[:organizer][:name]).to eq(meeting.author.name)
-            expect(serialized[:organizer][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/profiles/#{meeting.author.nickname}")
+            expect(serialized[:organizer][:url]).to eq("http://#{organization.host}:#{Capybara.server_port}/en/profiles/#{meeting.author.nickname}")
           end
 
           context "with deleted author" do

--- a/decidim-meetings/spec/presenters/decidim/meetings/admin_log/invite_presenter_spec.rb
+++ b/decidim-meetings/spec/presenters/decidim/meetings/admin_log/invite_presenter_spec.rb
@@ -19,7 +19,7 @@ module Decidim::Meetings::AdminLog
       context "when invite still exists" do
         it "renders the invite information" do
           user = action_log.user
-          inviter = "<a class=\"logs__log__author\" title=\"@#{user.nickname}\" href=\"/profiles/#{user.nickname}\">#{user.name}</a>"
+          inviter = "<a class=\"logs__log__author\" title=\"@#{user.nickname}\" href=\"/en/profiles/#{user.nickname}\">#{user.name}</a>"
           space = "<a class=\"logs__log__space\" href=\"/en/processes/#{participatory_space.slug}\">#{decidim_escape_translated(participatory_space.title)}</a>"
           action_string = "#{inviter} invited #{invite.user.name} to join <span class=\"logs__log__resource\"></span> meeting on the #{space} space"
           expect(subject).to include action_string

--- a/decidim-proposals/app/events/decidim/proposals/coauthor_accepted_invite_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/coauthor_accepted_invite_event.rb
@@ -14,11 +14,11 @@ module Decidim
       delegate :name, to: :coauthor, prefix: true, allow_nil: true
 
       def author_path
-        profile_path(author.nickname)
+        profile_path(author.nickname, locale: I18n.locale)
       end
 
       def coauthor_path
-        profile_path(coauthor.nickname) if coauthor
+        profile_path(coauthor.nickname, locale: I18n.locale) if coauthor
       end
 
       def author

--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -15,7 +15,7 @@ module Decidim
       def i18n_options
         return super if author.blank?
 
-        author_path = link_to("@#{author.nickname}", profile_path(author.nickname))
+        author_path = link_to("@#{author.nickname}", profile_path(author.nickname, locale: I18n.locale))
         author_string = "#{author.name} #{author_path}"
         super.merge({ author: author_string })
       end

--- a/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/admin/proposal_note_created_event_spec.rb
@@ -16,7 +16,7 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
   let(:email_subject) { "#{author.name} has replied your private note in #{resource_title}." }
   let(:email_intro) { %(#{author.name} has replied your private note in #{resource_title}. Check it out at <a href="#{admin_proposal_info_url}">the admin panel</a>.) }
   let(:email_outro) { "You have received this notification because you are the author of the note." }
-  let(:notification_title) { %(<a href="/profiles/#{author.nickname}">#{author.name} @#{author.nickname}</a> has replied your private note in <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>.) }
+  let(:notification_title) { %(<a href="/en/profiles/#{author.nickname}">#{author.name} @#{author.nickname}</a> has replied your private note in <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>.) }
 
   it_behaves_like "a simple event"
   it_behaves_like "a simple event email"
@@ -29,7 +29,7 @@ describe Decidim::Proposals::Admin::ProposalNoteCreatedEvent do
     let(:admin_proposal_info_path) { "/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}" }
     let(:admin_proposal_info_url) { "http://#{organization.host}/admin/assemblies/#{participatory_space.slug}/components/#{component.id}/manage/proposals/#{resource.id}?locale=#{I18n.locale}" }
     let(:email_intro) { %(#{author.name} has replied your private note in #{resource_title}. Check it out at <a href="#{admin_proposal_info_url}">the admin panel</a>.) }
-    let(:notification_title) { %(<a href="/profiles/#{author.nickname}">#{author.name} @#{author.nickname}</a> has replied your private note in <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>.) }
+    let(:notification_title) { %(<a href="/en/profiles/#{author.nickname}">#{author.name} @#{author.nickname}</a> has replied your private note in <a href="#{resource_path}">#{resource_title}</a>. Check it out at <a href="#{admin_proposal_info_path}">the admin panel</a>.) }
 
     it_behaves_like "a simple event email"
     it_behaves_like "a simple event notification"

--- a/decidim-proposals/spec/events/decidim/proposals/coauthor_accepted_invite_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/coauthor_accepted_invite_event_spec.rb
@@ -14,7 +14,7 @@ module Decidim
         }
       end
       let(:notification_title) do
-        "<a href=\"/profiles/#{coauthor.nickname}\">#{coauthor.name}</a> has accepted your invitation to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
+        "<a href=\"/en/profiles/#{coauthor.nickname}\">#{coauthor.name}</a> has accepted your invitation to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
       end
       let(:participatory_process) { create(:participatory_process, organization:) }
       let(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }

--- a/decidim-proposals/spec/events/decidim/proposals/coauthor_invited_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/coauthor_invited_event_spec.rb
@@ -46,7 +46,7 @@ module Decidim
       describe "notification_title" do
         it "is generated correctly" do
           expect(subject.notification_title)
-            .to eq("<a href=\"/profiles/#{author.nickname}\">#{author.name}</a> would like to invite you as a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>.")
+            .to eq("<a href=\"/en/profiles/#{author.nickname}\">#{author.name}</a> would like to invite you as a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>.")
         end
       end
     end

--- a/decidim-proposals/spec/events/decidim/proposals/coauthor_rejected_invite_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/coauthor_rejected_invite_event_spec.rb
@@ -14,7 +14,7 @@ module Decidim
         }
       end
       let(:notification_title) do
-        "<a href=\"/profiles/#{coauthor.nickname}\">#{coauthor.name}</a> has declined your invitation to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
+        "<a href=\"/en/profiles/#{coauthor.nickname}\">#{coauthor.name}</a> has declined your invitation to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
       end
       let(:participatory_process) { create(:participatory_process, organization:) }
       let(:proposal_component) { create(:proposal_component, participatory_space: participatory_process) }

--- a/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/publish_proposal_event_spec.rb
@@ -55,7 +55,7 @@ module Decidim
             .to include("The <a href=\"#{resource_path}\">#{resource_title}</a> proposal was published by ")
 
           expect(subject.notification_title)
-            .to include("<a href=\"/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a>.")
+            .to include("<a href=\"/en/profiles/#{author.nickname}\">#{author.name} @#{author.nickname}</a>.")
         end
       end
 
@@ -75,7 +75,7 @@ module Decidim
         include_context "when a simple event"
 
         let(:event_name) { "decidim.events.proposals.proposal_published_for_space" }
-        let(:notification_title) { "The proposal <a href=\"#{resource_path}\">#{resource_title}</a> has been added to #{participatory_space_title} by #{author.name} <a href=\"/profiles/#{author.nickname}\">@#{author.nickname}</a>." }
+        let(:notification_title) { "The proposal <a href=\"#{resource_path}\">#{resource_title}</a> has been added to #{participatory_space_title} by #{author.name} <a href=\"/en/profiles/#{author.nickname}\">@#{author.nickname}</a>." }
         let(:email_outro) { "You have received this notification because you are following \"#{participatory_space_title}\". You can stop receiving notifications following the previous link." }
         let(:email_intro) { "The proposal \"#{resource_title}\" has been added to \"#{participatory_space_title}\" that you are following." }
         let(:email_subject) { "New proposal \"#{resource_title}\" added to #{participatory_space_title}" }
@@ -99,6 +99,7 @@ module Decidim
         let(:en_version) { subject.resource_text["en"] }
         let(:machine_translated) { subject.resource_text["machine_translations"]["ca"] }
         let(:translatable) { true }
+        let(:untranslated_content) { subject.resource_text["en"] }
 
         it_behaves_like "a translated event"
       end

--- a/decidim-proposals/spec/events/decidim/proposals/rejected_coauthorship_event_spec.rb
+++ b/decidim-proposals/spec/events/decidim/proposals/rejected_coauthorship_event_spec.rb
@@ -12,7 +12,7 @@ module Decidim
       let(:event_name) { "decidim.events.proposals.rejected_coauthorship" }
 
       let(:notification_title) do
-        "You have declined the invitation from <a href=\"/profiles/#{author.nickname}\">#{author.name}</a> to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
+        "You have declined the invitation from <a href=\"/en/profiles/#{author.nickname}\">#{author.name}</a> to become a co-author of the proposal <a href=\"#{resource_path}\">#{resource_title}</a>."
       end
 
       include_context "when a simple event"

--- a/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
@@ -418,7 +418,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
       end
 
       def meeting_url(meeting)

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -183,7 +183,7 @@ describe "Decidim::Api::QueryType" do
           "name" => e.author.name,
           "nickname" => "@#{e.author.nickname}",
           "organizationName" => { "translation" => translated(e.author.organization.name) },
-          "profilePath" => "/profiles/#{e.author.nickname}" }
+          "profilePath" => "/en/profiles/#{e.author.nickname}" }
       end,
       "likesCount" => proposal.likes.size,
       "executionPeriod" => execution_period,

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -222,7 +222,7 @@ describe "Respond a survey" do
     let(:router) { Decidim::EngineRouter.main_proxy(component) }
 
     it "shows action log entry" do
-      page.visit decidim.profile_activity_path(nickname: user.nickname)
+      page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
       expect(page).to have_content("New survey: #{translated(survey.questionnaire.title)}")
       expect(page).to have_content(translated(survey.component.participatory_space.title))
       expect(page).to have_link(translated(survey.questionnaire.title), href: router.survey_path(survey))

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -10,11 +10,11 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
   let(:organization_host) { "#{resource.current_user.organization.host}:#{Capybara.server_port}" }
 
   let(:resource_title) { resource.current_user.name }
-  let(:resource_path) { "/profiles/#{resource.current_user.nickname}" }
-  let(:resource_url) { "http://#{organization_host}/profiles/#{resource.current_user.nickname}" }
-  let(:notification_title) { "The participant <a href=\"/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>)." }
+  let(:resource_path) { "/en/profiles/#{resource.current_user.nickname}" }
+  let(:resource_url) { "http://#{organization_host}/en/profiles/#{resource.current_user.nickname}" }
+  let(:notification_title) { "The participant <a href=\"/en/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"/en/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>)." }
   let(:email_subject) { "Failed verification attempt against another participant" }
-  let(:email_intro) { "The participant <a href=\"http://#{organization_host}/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"http://#{organization_host}/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>)." }
+  let(:email_intro) { "The participant <a href=\"http://#{organization_host}/en/profiles/#{resource.current_user.nickname}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"http://#{organization_host}/en/profiles/#{resource.managed_user.nickname}\">#{resource.managed_user.name}</a>)." }
   let(:email_outro) { "Check the <a href=\"http://#{organization_host}/admin/conflicts\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue." }
 
   it_behaves_like "a simple event email"
@@ -26,7 +26,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
     end
 
     it "includes managed_user_profile" do
-      expect(subject.default_i18n_options[:managed_user_path]).to eq("/profiles/#{resource.managed_user.nickname}")
+      expect(subject.default_i18n_options[:managed_user_path]).to eq("/en/profiles/#{resource.managed_user.nickname}")
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am adding the locale in the user profiles pages

- Activity page is migrated 
  - from: `/profiles/visitant_bqqppvus/activity`  (and query_string params)
  - to `/en/profiles/visitant_bqqppvus/activity` (and query_string params)
- Badges page is migrated 
  - from `/profiles/visitant_bqqppvus/badges`
  - to `/en/profiles/visitant_bqqppvus/badges`
- Follows page is migrated 
  - from `/profiles/visitant_bqqppvus/following` 
  - to `/en/profiles/visitant_bqqppvus/following`
- Followers page is migrated 
  - from `/profiles/visitant_bqqppvus/followers` 
  - to `/en/profiles/visitant_bqqppvus/followers`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/issues/16307

#### Testing
1. Visit the local development site using this branch 
2. Visit the user profile page
3. See it always have the locale in the url as `/en/rest of url` while navigating the profile area

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile links and generated profile URLs are now locale-aware (e.g., /en/profiles/username) for consistent language context.

* **Refactor**
  * Profile routes have been moved under a locale scope and legacy profile requests are redirected to locale-prefixed paths.

* **Tests**
  * Many specs and system tests updated to expect locale-prefixed profile paths/URLs and reflect the routing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->