### PR TITLE
Fix disabled data attribute in submit buttons

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/edit.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/edit.html.erb
@@ -15,7 +15,11 @@
         <%= icon "arrow-left-line" %>
         <%= t("back", scope: "decidim.blogs.posts.edit") %>
       <% end %>
-      <%= f.submit t("button", scope: "decidim.blogs.posts.edit"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
+
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
+        <span><%= t("button", scope: "decidim.blogs.posts.edit") %></span>
+      </button>
+
     </div>
   <% end %>
 <% end %>

--- a/decidim-blogs/app/views/decidim/blogs/posts/new.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/new.html.erb
@@ -16,7 +16,11 @@
         <%= icon "arrow-left-line" %>
         <%= t("back", scope: "decidim.blogs.posts.new") %>
       <% end %>
-      <%= f.submit t("button", scope: "decidim.blogs.posts.new"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
+
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
+        <span><%= t("button", scope: "decidim.blogs.posts.new") %></span>
+      </button>
+
     </div>
   <% end %>
 <% end %>

--- a/decidim-blogs/spec/system/user_manages_posts_spec.rb
+++ b/decidim-blogs/spec/system/user_manages_posts_spec.rb
@@ -39,6 +39,22 @@ describe "User manages posts" do
       login_as user, scope: :user
     end
 
+    context "with an empty form" do
+      it "allows submission and show errors" do
+        visit_component
+        click_on "New post"
+
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        within ".new_post" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
+
     context "when creating a post" do
       it "saves the data" do
         visit_component
@@ -58,6 +74,27 @@ describe "User manages posts" do
 
     context "when editing an authored a post" do
       let!(:post) { create(:post, component:, author: user) }
+
+      context "and empties the form" do
+        it "allows submission and show errors" do
+          visit_component
+
+          click_on translated(post.title)
+          find("#dropdown-trigger-resource-#{post.id}").click
+          click_on "Edit post"
+
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+          fill_in "post_title", with: ""
+
+          within ".edit_post" do
+            find("*[type=submit]").click
+            expect(page).to have_content("There is an error in this field.")
+            expect(page).to have_no_css("*[type=submit][data-disable='true']")
+            expect(find("button[type='submit']")).not_to be_disabled
+          end
+        end
+      end
 
       it "can edit the post" do
         visit_component

--- a/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/edit.html.erb
@@ -12,8 +12,11 @@
           <%= icon "arrow-left-line", class: "fill-current" %>
           <%= t("back", scope: "decidim.debates.debates.edit") %>
         <% end %>
-        <%= form.submit t("save", scope: "decidim.debates.debates.edit"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
-        </div>
+
+        <button type="submit" class="button button__sm md:button__lg button__secondary">
+          <span><%= t("save", scope: "decidim.debates.debates.edit") %></span>
+        </button>
+
       </div>
     <% end %>
   </div>

--- a/decidim-debates/app/views/decidim/debates/debates/new.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/new.html.erb
@@ -13,7 +13,11 @@
           <%= icon "arrow-left-line", class: "fill-current" %>
           <%= t("back", scope: "decidim.debates.debates.new") %>
         <% end %>
-        <%= form.submit t("create", scope: "decidim.debates.debates.new"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
+
+        <button type="submit" class="button button__sm md:button__lg button__secondary">
+          <span><%= t("create", scope: "decidim.debates.debates.new") %></span>
+        </button>
+
         </div>
       </div>
     <% end %>

--- a/decidim-debates/spec/system/user_creates_debate_spec.rb
+++ b/decidim-debates/spec/system/user_creates_debate_spec.rb
@@ -29,6 +29,22 @@ describe "User creates debate" do
                  settings: { taxonomy_filters: [taxonomy_filter.id] })
         end
 
+        context "with an empty form" do
+          it "allows submission and show errors" do
+            visit_component
+            click_on "New debate"
+
+            expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+            within ".new_debate" do
+              find("*[type=submit]").click
+              expect(page).to have_content("There is an error in this field.")
+              expect(page).to have_no_css("*[type=submit][data-disable='true']")
+              expect(find("button[type='submit']")).not_to be_disabled
+            end
+          end
+        end
+
         context "and attachments are not allowed" do
           before do
             component_settings = component["settings"]["global"].merge!(attachments_allowed: false)

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -28,6 +28,27 @@ describe "User edits a debate" do
     let(:user) { create(:user, :confirmed, organization:) }
     let(:author) { user }
 
+    context "and empties the form" do
+      it "allows submission and show errors" do
+        visit_component
+
+        click_on debate.title.values.first
+        find("#dropdown-trigger-resource-#{debate.id}").click
+        click_on "Edit"
+
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        fill_in :debate_title, with: ""
+
+        within ".edit_debate" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
+
     it "allows editing my debate", :slow do
       visit_component
 

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -7,13 +7,15 @@
 <% end %>
 
 <%= cell("decidim/announcement", { body: announcement_body }, callout_class: "secondary") %>
-<%= decidim_form_for(@form, url: fill_data_create_initiative_index_path(locale: current_locale), method: :put, html: { class: "form-defaults new_initiative_form", novalidate: false }) do |f| %>
+<%= decidim_form_for(@form, url: fill_data_create_initiative_index_path(locale: current_locale), method: :put, html: { class: "form-defaults new_initiative_form" }) do |f| %>
   <div class="form__wrapper">
     <%= form_required_explanation %>
 
     <%= f.hidden_field :type_id %>
 
-    <%= f.text_field :title, value: translated_attribute(f.object.title), data: { controller: "character-counter" } %>
+    <%= f.text_field :title,
+                     value: translated_attribute(f.object.title),
+                     data: { controller: "character-counter" } %>
 
     <%= text_editor_for(f, :description, lines: 20, toolbar: :content, value: translated_attribute(f.object.description)) %>
 
@@ -66,7 +68,11 @@
           <%= t(".discard") %>
         <% end %>
       <% end %>
-      <%= f.submit t(".continue"), class: "button button__sm md:button__lg button__secondary", data: { disable_with: t(".continue") } %>
+
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
+        <span><%= t(".continue") %></span>
+      </button>
+
     </div>
   </div>
 <% end %>

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -605,7 +605,7 @@ describe "Initiative" do
           end
         end
 
-        context "and empties the form" do
+        context "with an empty form" do
           let!(:other_initiative_type) { nil }
           let!(:other_initiative_type_scope) { nil }
 

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -605,6 +605,25 @@ describe "Initiative" do
           end
         end
 
+        context "and empties the form" do
+          let!(:other_initiative_type) { nil }
+          let!(:other_initiative_type_scope) { nil }
+
+          it "allows submission and show errors" do
+            expect(page).to have_content "Create a new initiative"
+            expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+            fill_in "initiative_title", with: ""
+
+            within ".new_initiative_form" do
+              find("*[type=submit]").click
+              expect(page).to have_content("There is an error in this field.")
+              expect(page).to have_no_css("*[type=submit][data-disable='true']")
+              expect(find("button[type='submit']")).not_to be_disabled
+            end
+          end
+        end
+
         context "when there is only one initiative type" do
           let!(:other_initiative_type) { nil }
           let!(:other_initiative_type_scope) { nil }

--- a/decidim-initiatives/spec/system/edit_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/edit_initiative_spec.rb
@@ -34,6 +34,28 @@ describe "Edit initiative" do
 
       expect(page).to have_content(new_title)
     end
+
+    context "and empties the form" do
+      it "allows submission and show errors" do
+        visit initiative_path
+
+        within ".initiative__aside" do
+          click_on("Edit")
+        end
+
+        expect(page).to have_content "Edit Initiative"
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        fill_in "initiative_title", with: ""
+
+        within ".edit_initiative" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
   end
 
   before do

--- a/decidim-meetings/app/views/decidim/meetings/meetings/edit.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/edit.html.erb
@@ -15,7 +15,11 @@
         <%= icon "arrow-left-line" %>
         <%= t("back", scope: "decidim.meetings.meetings.edit") %>
       <% end %>
-      <%= f.submit t("update", scope: "decidim.meetings.meetings.edit"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
+
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
+        <span><%= t("update", scope: "decidim.meetings.meetings.edit") %></span>
+      </button>
+
     </div>
   <% end %>
 <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
@@ -19,7 +19,6 @@
 
       <button type="submit" class="button button__sm md:button__lg button__secondary">
         <span><%= t("create", scope: "decidim.meetings.meetings.new") %></span>
-        <%= icon "arrow-right-line" %>
       </button>
     </div>
   <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/new.html.erb
@@ -16,7 +16,11 @@
         <%= icon "arrow-left-line" %>
         <%= t("back", scope: "decidim.meetings.meetings.new") %>
       <% end %>
-      <%= f.submit t("create", scope: "decidim.meetings.meetings.new"), class: "button button__sm md:button__lg button__secondary", data: { disable: true } %>
+
+      <button type="submit" class="button button__sm md:button__lg button__secondary">
+        <span><%= t("create", scope: "decidim.meetings.meetings.new") %></span>
+        <%= icon "arrow-right-line" %>
+      </button>
     </div>
   <% end %>
 <% end %>

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -79,6 +79,25 @@ describe "User creates meeting" do
           component.update!(settings: { creation_enabled_for_participants: true, taxonomy_filters: taxonomy_filter_ids })
         end
 
+        # rubocop:disable Capybara/SpecificMatcher
+        # since we need to test for data attributes, we cannot use have_no_button as the finder matches would be
+        # Invalid option(s) :"data-disable", should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class,
+        # :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :value, :title, :type
+        it "submits empty form" do
+          visit_component
+          click_on "New meeting"
+
+          expect(page).to have_no_css("button[type=submit][data-disable='true']")
+
+          within ".new_meeting" do
+            find("*[type=submit]").click
+          end
+
+          expect(page).to have_no_css("button[type=submit][data-disable='true']")
+          expect(page).to have_no_css("button[type=submit][disabled='']")
+        end
+        # rubocop:enable Capybara/SpecificMatcher
+
         context "and rich_editor_public_view component setting is enabled" do
           before do
             organization.update(rich_text_editor_in_public_views: true)

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -88,12 +88,11 @@ describe "User creates meeting" do
 
             within ".new_meeting" do
               find("*[type=submit]").click
+              expect(page).to have_content("There is an error in this field.", count: 6)
+
+              expect(page).to have_no_css("*[type=submit][data-disable='true']")
+              expect(find("button[type='submit']")).not_to be_disabled
             end
-
-            expect(page).to have_content("There is an error in this field.", count: 6)
-
-            expect(page).to have_no_css("*[type=submit][data-disable='true']")
-            expect(page).to have_no_css("*[type=submit][disabled]")
           end
         end
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -87,14 +87,14 @@ describe "User creates meeting" do
           visit_component
           click_on "New meeting"
 
-          expect(page).to have_no_css("button[type=submit][data-disable='true']")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
 
           within ".new_meeting" do
             find("*[type=submit]").click
           end
 
-          expect(page).to have_no_css("button[type=submit][data-disable='true']")
-          expect(page).to have_no_css("button[type=submit][disabled='']")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(page).to have_no_css("*[type=submit][disabled]")
         end
         # rubocop:enable Capybara/SpecificMatcher
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -79,18 +79,22 @@ describe "User creates meeting" do
           component.update!(settings: { creation_enabled_for_participants: true, taxonomy_filters: taxonomy_filter_ids })
         end
 
-        it "submits empty form" do
-          visit_component
-          click_on "New meeting"
+        context "with an empty form" do
+          it "allows submission and show errors" do
+            visit_component
+            click_on "New meeting"
 
-          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+            expect(page).to have_no_css("*[type=submit][data-disable='true']")
 
-          within ".new_meeting" do
-            find("*[type=submit]").click
+            within ".new_meeting" do
+              find("*[type=submit]").click
+            end
+
+            expect(page).to have_content("There is an error in this field.", count: 6)
+
+            expect(page).to have_no_css("*[type=submit][data-disable='true']")
+            expect(page).to have_no_css("*[type=submit][disabled]")
           end
-
-          expect(page).to have_no_css("*[type=submit][data-disable='true']")
-          expect(page).to have_no_css("*[type=submit][disabled]")
         end
 
         context "and rich_editor_public_view component setting is enabled" do

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -79,10 +79,6 @@ describe "User creates meeting" do
           component.update!(settings: { creation_enabled_for_participants: true, taxonomy_filters: taxonomy_filter_ids })
         end
 
-        # rubocop:disable Capybara/SpecificMatcher
-        # since we need to test for data attributes, we cannot use have_no_button as the finder matches would be
-        # Invalid option(s) :"data-disable", should be one of :above, :below, :left_of, :right_of, :near, :count, :minimum, :maximum, :between, :text, :id, :class,
-        # :style, :visible, :obscured, :exact, :exact_text, :normalize_ws, :match, :wait, :filter_set, :focused, :disabled, :name, :value, :title, :type
         it "submits empty form" do
           visit_component
           click_on "New meeting"
@@ -96,7 +92,6 @@ describe "User creates meeting" do
           expect(page).to have_no_css("*[type=submit][data-disable='true']")
           expect(page).to have_no_css("*[type=submit][disabled]")
         end
-        # rubocop:enable Capybara/SpecificMatcher
 
         context "and rich_editor_public_view component setting is enabled" do
           before do

--- a/decidim-meetings/spec/system/user_edit_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_edit_meeting_spec.rb
@@ -85,6 +85,27 @@ describe "User edit meeting" do
       login_as user, scope: :user
     end
 
+    context "and empties the form" do
+      it "allows submission and show errors" do
+        visit_component
+
+        click_on translated(meeting.title)
+        find("#dropdown-trigger-resource-#{meeting.id}").click
+        click_on "Edit"
+
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        fill_in :meeting_title, with: ""
+
+        within ".meetings_form" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
+
     it "can be updated" do
       visit_component
 

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -23,7 +23,7 @@ describe "Edit proposals" do
       login_as user, scope: :user
     end
 
-    context "and I empty the form" do
+    context "and empties the form" do
       it "allows submission and show errors" do
         visit_component
 

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -23,6 +23,27 @@ describe "Edit proposals" do
       login_as user, scope: :user
     end
 
+    context "and I empty the form" do
+      it "allows submission and show errors" do
+        visit_component
+
+        click_on proposal_title
+        find("#dropdown-trigger-resource-#{proposal.id}").click
+        click_on "Edit"
+
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        fill_in "proposal_title", with: ""
+
+        within ".edit_proposal" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
+
     it "can be updated" do
       visit_component
 

--- a/decidim-proposals/spec/system/new_proposals_spec.rb
+++ b/decidim-proposals/spec/system/new_proposals_spec.rb
@@ -53,6 +53,22 @@ describe "Proposals" do
       visit_component
     end
 
+    context "with an empty form" do
+      it "allows submission and show errors" do
+        visit_component
+        click_on "New proposal"
+
+        expect(page).to have_no_css("*[type=submit][data-disable='true']")
+
+        within ".new_proposal" do
+          find("*[type=submit]").click
+          expect(page).to have_content("There is an error in this field.")
+          expect(page).to have_no_css("*[type=submit][data-disable='true']")
+          expect(find("button[type='submit']")).not_to be_disabled
+        end
+      end
+    end
+
     context "and draft proposal exists for current users" do
       let!(:draft) { create(:proposal, :draft, component:, users: [user]) }
 


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am trying to fix an edge case error, where the submit button does not get enabled if there are some validation errors. 
When submitting the form, the rails-ujs would disable the button when `ajax:beforeSend` is being fired, but the form-validator controller, will stop the propagation therefore, there is no `ajax:complete` event that would trigger the button to be renabled. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16518

#### Testing
1. Login to develop
2. Try to create a meeting from public interface
3. Do not add any form data
4. Click on Create
5. See the submit button stays disabled 
6. Apply patch 
7. Repeat 1,2,3,4 
8. See the button is enabled

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized submit button markup across meetings, debates, and blogs for consistent appearance.

* **Bug Fixes**
  * Submit controls no longer remain in a disabled state after validation errors, allowing retrying submission.

* **Tests**
  * Added system tests covering empty-form submission and edit flows to verify validation messages and that submit buttons remain usable after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->