### PR TITLE
Bump check-spelling to 0.0.26

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -143,7 +143,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: apply spelling updates
-      uses: check-spelling/check-spelling@v0.0.25
+      uses: check-spelling/check-spelling@v0.0.26
       with:
         experimental_apply_changes_via_bot: 1
         checkout: true

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.25
+      uses: check-spelling/check-spelling@v0.0.26
       with:
         suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
         checkout: true


### PR DESCRIPTION
#### :tophat: What? Why?
While working on several PRs (like [16516](https://github.com/decidim/decidim/pull/16516) )  i have noticed that check spelling is failing 
<img width="1195" height="198" alt="image" src="https://github.com/user-attachments/assets/05df4088-17f0-446d-acad-19efed25c065" />

Following the link https://docs.check-spelling.dev/Feature:-Restricted-Permissions
I have noticed the referenced PR https://github.com/check-spelling/check-spelling/issues/103 is already closed. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
The pipeline should be green

### :camera: Screenshots

<img width="1195" height="198" alt="image" src="https://github.com/user-attachments/assets/05df4088-17f0-446d-acad-19efed25c065" />

:hearts: Thank you!
