### PR TITLE
Remove the roles menu on filters

### DIFF
--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -4,7 +4,7 @@
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
   <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", controller: "accordion form-filter" } do |form| %>
 
-    <button id="dropdown-trigger-filters" data-controller="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
+    <button id="dropdown-trigger-filters" data-controller="dropdown" data-target="dropdown-menu-filters" data-open-md="true" data-add-aria-roles="false">
       <%= icon "arrow-down-s-line" %>
       <%= icon "arrow-up-s-line" %>
       <span>
@@ -14,13 +14,13 @@
 
     <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
-        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem", "data-skip-to-content": true %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", "data-skip-to-content": true %>
       <% end %>
 
-      <p id="filter-help-text" class="filter-help" role="menuitem" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
+      <p id="filter-help-text" class="filter-help" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
 
       <% if local_assigns.has_key?(:search_variable) %>
-        <div class="filter-search filter-container" role="menuitem">
+        <div class="filter-search filter-container">
           <%= form.search_field search_variable,
                                 label: false,
                                 placeholder: search_label,

--- a/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>


### PR DESCRIPTION
#### :tophat: What? Why?

A different approach to #14944, implementing the data attribute from #16489 to remove these roles in this page.

#### :pushpin: Related Issues
 
- Related to #14944 and #16489 
 
#### Testing

1. As a user, go to the /processes page in a narrow view (i.e. mobile) 
2. Open you devTools, check that the ul id="dropdown-menu-filters" and its li children have no attribute role

### :camera: Screenshots

#### Before

<img width="869" height="466" alt="image" src="https://github.com/user-attachments/assets/a00e8347-677b-4166-9a9f-d880392435f8" />

#### After

<img width="856" height="418" alt="image" src="https://github.com/user-attachments/assets/b970cbe5-5ce4-4290-91a6-f58fc7dc19fc" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Refined accessibility attributes in filter components across multiple views to ensure proper interpretation by assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->