### PR TITLE
Reduce user scope in digest mails, inline tasks

### DIFF
--- a/decidim-core/lib/tasks/decidim_mailers_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_mailers_tasks.rake
@@ -4,20 +4,42 @@ namespace :decidim do
   namespace :mailers do
     desc "Sends the notification digest email with the daily report"
     task notifications_digest_daily: :environment do
-      notifications_digest(:daily)
+      time = Time.now.utc
+      notification_users =
+        Decidim::Notification
+        .daily(time)
+        .select(:decidim_user_id)
+        .distinct
+
+      target_users =
+        Decidim::User.where(
+          id: notification_users,
+          notifications_sending_frequency: :daily
+        )
+
+      target_users.find_each do |user|
+        Decidim::EmailNotificationsDigestGeneratorJob.perform_later(user.id, :daily, time:)
+      end
     end
 
     desc "Sends the notification digest email with the weekly report"
     task notifications_digest_weekly: :environment do
-      notifications_digest(:weekly)
-    end
-  end
+      time = Time.now.utc
+      notification_users =
+        Decidim::Notification
+        .weekly(time)
+        .select(:decidim_user_id)
+        .distinct
 
-  def notifications_digest(frequency)
-    target_users = Decidim::User.where(notifications_sending_frequency: frequency)
-    time = Time.now.utc
-    target_users.find_each do |user|
-      Decidim::EmailNotificationsDigestGeneratorJob.perform_later(user.id, frequency, time:)
+      target_users =
+        Decidim::User.where(
+          id: notification_users,
+          notifications_sending_frequency: :weekly
+        )
+
+      target_users.find_each do |user|
+        Decidim::EmailNotificationsDigestGeneratorJob.perform_later(user.id, :weekly, time:)
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
We preselect all Notifications and the affected users in the configured time period. Then we only enqueue the job for these users.

Tasks were inlined to prevent rake task method bleed: https://albertoalmagro.com/ruby-methods-defined-in-rake-tasks/

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #16129

#### Testing
*Describe the best way to test or validate your PR.*
Run the digest task and count the amount of jobs generated.

### :camera: Screenshots
Not applicable

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded the notification digest email system to improve accuracy and consistency in daily and weekly email delivery. The system now uses more efficient recipient targeting that respects user notification frequency preferences, ensuring better alignment between user settings and email delivery. Background task scheduling has been further optimized for improved overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->