### PR TITLE
Allow overriding the role attribute on accordions

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
@@ -1,0 +1,117 @@
+/* global jest */
+
+import AccordionController from "src/decidim/controllers/accordion/controller";
+
+jest.mock("a11y-accordion-component", () => ({
+  render: jest.fn(),
+  destroy: jest.fn()
+}));
+
+describe("AccordionController", () => {
+  let controller = null;
+  let accordionElement = null;
+  let panel1 = null;
+  let panel2 = null;
+
+  const createController = (controllerElement) => {
+    const ControllerClass = AccordionController;
+    const instance = Object.create(ControllerClass.prototype);
+    Reflect.defineProperty(instance, "element", {
+      get: () => controllerElement,
+      configurable: true
+    });
+    return instance;
+  };
+
+  beforeEach(() => {
+    window.matchMedia = jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      addListener: jest.fn(),
+      removeListener: jest.fn()
+    }));
+
+    document.body.innerHTML = `
+      <div id="test-accordion" data-controller="accordion">
+        <button id="trigger-1" data-controls="panel-1">Trigger 1</button>
+        <div id="panel-1">Panel 1 Content</div>
+        <button id="trigger-2" data-controls="panel-2">Trigger 2</button>
+        <div id="panel-2">Panel 2 Content</div>
+      </div>
+    `;
+
+    accordionElement = document.getElementById("test-accordion");
+    panel1 = document.getElementById("panel-1");
+    panel2 = document.getElementById("panel-2");
+
+    controller = createController(accordionElement);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    Reflect.deleteProperty(window, "matchMedia");
+  });
+
+  describe("fixPanelRole", () => {
+    it("changes role from region to group when data-panel-role is group", () => {
+      panel1.setAttribute("role", "region");
+      panel2.setAttribute("role", "region");
+
+      accordionElement.dataset.panelRole = "group";
+      controller.fixPanelRole();
+
+      expect(panel1.getAttribute("role")).toBe("group");
+      expect(panel2.getAttribute("role")).toBe("group");
+    });
+
+    it("removes role attribute when data-panel-role is none", () => {
+      panel1.setAttribute("role", "region");
+      panel2.setAttribute("role", "region");
+
+      accordionElement.dataset.panelRole = "none";
+      controller.fixPanelRole();
+
+      expect(panel1.getAttribute("role")).toBeNull();
+      expect(panel2.getAttribute("role")).toBeNull();
+    });
+
+    it("does nothing when data-panel-role is not set", () => {
+      panel1.setAttribute("role", "region");
+      panel2.setAttribute("role", "region");
+
+      delete accordionElement.dataset.panelRole;
+      controller.fixPanelRole();
+
+      expect(panel1.getAttribute("role")).toBe("region");
+      expect(panel2.getAttribute("role")).toBe("region");
+    });
+
+    it("does nothing when data-panel-role is empty", () => {
+      panel1.setAttribute("role", "region");
+
+      accordionElement.dataset.panelRole = "";
+      controller.fixPanelRole();
+
+      expect(panel1.getAttribute("role")).toBe("region");
+    });
+
+    it("sets custom role value when data-panel-role is set", () => {
+      panel1.setAttribute("role", "region");
+
+      accordionElement.dataset.panelRole = "navigation";
+      controller.fixPanelRole();
+
+      expect(panel1.getAttribute("role")).toBe("navigation");
+    });
+
+    it("handles non-existent panels gracefully", () => {
+      accordionElement.dataset.panelRole = "group";
+
+      const nonExistentTrigger = document.createElement("button");
+      nonExistentTrigger.dataset.controls = "non-existent-panel";
+      accordionElement.appendChild(nonExistentTrigger);
+
+      expect(() => controller.fixPanelRole()).not.toThrow();
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
@@ -79,7 +79,7 @@ describe("AccordionController", () => {
       panel1.setAttribute("role", "region");
       panel2.setAttribute("role", "region");
 
-      delete accordionElement.dataset.panelRole;
+      Reflect.deleteProperty(accordionElement.dataset, "panelRole");
       controller.fixPanelRole();
 
       expect(panel1.getAttribute("role")).toBe("region");
@@ -115,3 +115,4 @@ describe("AccordionController", () => {
     });
   });
 });
+

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
@@ -108,7 +108,7 @@ describe("AccordionController", () => {
       accordionElement.dataset.panelRole = "group";
 
       const nonExistentTrigger = document.createElement("button");
-      nonExistentTrigger.dataset.controls = "non-existent-panel";
+      nonExistentTrigger.dataset.controls = "nonexistent-panel";
       accordionElement.appendChild(nonExistentTrigger);
 
       expect(() => controller.fixPanelRole()).not.toThrow();

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
@@ -104,7 +104,7 @@ describe("AccordionController", () => {
       expect(panel1.getAttribute("role")).toBe("navigation");
     });
 
-    it("handles non-existent panels gracefully", () => {
+    it("handles nonexistent panels gracefully", () => {
       accordionElement.dataset.panelRole = "group";
 
       const nonExistentTrigger = document.createElement("button");

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
@@ -39,6 +39,8 @@ export default class extends Controller {
 
     Accordions.render(this.element.id, accordionOptions);
 
+    this.fixPanelRole();
+
     this.expandIfNeeded();
 
     this.boundReconnect = this.reconnect.bind(this);
@@ -86,6 +88,28 @@ export default class extends Controller {
   }
   expandToggle() {
     this.previouslyExpanded = this.toggleButton.getAttribute("aria-expanded");
+  }
+
+  fixPanelRole() {
+    const panelRole = this.element.dataset.panelRole;
+    if (!panelRole) {
+      return;
+    }
+
+    const panels = this.element.querySelectorAll("[data-controls]");
+    panels.forEach((trigger) => {
+      const panelId = trigger.dataset.controls;
+      const panel = document.getElementById(panelId);
+      if (!panel) {
+        return;
+      }
+
+      if (panelRole === "none") {
+        panel.removeAttribute("role");
+      } else {
+        panel.setAttribute("role", panelRole);
+      }
+    });
   }
 
   /**

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -2,7 +2,7 @@
 <% search_label = t("decidim.searches.filters.search") unless local_assigns.has_key?(:search_label) %>
 
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
-  <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", controller: "accordion form-filter" } do |form| %>
+  <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", controller: "accordion form-filter", panel_role: "group" } do |form| %>
 
     <button id="dropdown-trigger-filters" data-controller="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
       <%= icon "arrow-down-s-line" %>


### PR DESCRIPTION
#### :tophat: What? Why?

This PR is related to the issues detected at #14944, more particularly: 

> changing inappropriate role="region" for role="group" on filters

Although in accordions most of the times it makes sense that it is a `role="region"`semantically, other times it makes sense that this is actually a `role="group"`, as it doesn't need to be used for assistive technology. 

As this depends in the cases, I'm proposing something like #16489, to have a data attribute that can change this depending on the implementation.

#### :pushpin: Related Issues

- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/region_role
- https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/group_role 

#### Testing

1. As a user, go to the index of processes
2. Open the devTools and check that divs with `id="panel-dropdown-menu-(...)"` have a `role="group"`

### :camera: Screenshots

#### Before

<img width="834" height="696" alt="image" src="https://github.com/user-attachments/assets/95412396-4006-4877-a7fc-a5dea8936554" />

#### After

<img width="852" height="601" alt="image" src="https://github.com/user-attachments/assets/66e68d26-33e5-47d3-a5ff-c172583a76e7" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accordion components support configurable panel roles via a data attribute, allowing setting, customizing, or explicitly removing semantic roles for improved accessibility.

* **Tests**
  * New tests verify panel role behavior across various role values and edge cases, including missing panel references and proper test-environment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->