### PR TITLE
Clear all the enqueued jobs before running tests

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/active_job.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/active_job.rb
@@ -14,6 +14,11 @@ end
 RSpec.configure do |config|
   config.include ActiveJob::TestHelper
   config.include DecidimActiveJobExtensions
+
+  config.before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
 end
 
 ActiveJob::Base.queue_adapter = :test


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #16503 Copilot told us that " In this repo ActiveJob::Base.queue_adapter = :test is configured globally and jobs are not auto-cleared between examples, so this can end up executing leftover jobs from previous specs and make this spec order-dependent/flaky". 

In this PR, Ia am configuring the project to remove any queues before running any specific test. 

<img width="827" height="244" alt="image" src="https://github.com/user-attachments/assets/1fb941ca-edcb-4b1c-ab29-015c82bef2ff" />

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16503

#### Testing
1. Green pipeline

### :camera: Screenshots
 
<img width="827" height="244" alt="image" src="https://github.com/user-attachments/assets/1fb941ca-edcb-4b1c-ab29-015c82bef2ff" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved RSpec test setup to automatically clear ActiveJob state between test examples for more reliable test isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->