### PR TITLE
Document why the "Most followed" sorting option is shown

### DIFF
--- a/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
+++ b/decidim-proposals/app/controllers/concerns/decidim/proposals/orderable.rb
@@ -24,7 +24,7 @@ module Decidim
             possible_orders << "most_voted" if most_voted_order_available?
             possible_orders << "most_liked" if most_liked_order_available?
             possible_orders << "most_commented" if most_commented_order_available?
-            possible_orders << "most_followed"
+            possible_orders << "most_followed" # always shown, as the author automatically follows their proposals
             possible_orders << "with_more_authors" if with_more_authors_order_available?
             possible_orders
           end


### PR DESCRIPTION
#### :tophat: What? Why?

We introduced some logic to conditionally show some of the Sorting options depending if it makes sense or not: 

- most commented (only is shown if there are comments enabled and there are comments in the proposals)
- most likes (idem but with likes)
- most voted (if the votes enabled options is shown)

I was doing the "most followed" option, but then I realized that this will be shown always, as the author automatically follow their proposals. 

The alternative would be to have something non-intuitive: to only show the follows when there are more than 1 instead of 0, but as I said, it is not intuitivie and difficult to explain/understand. 

This PR documents why this option isn't consistnet with the others. 

We can finally close #9397 🥳 

#### :pushpin: Related Issues
 
- Fixes #9397 

#### Testing

Everything should be green

### :camera: Screenshots

(This is how it works after all the sorting options of #9397 are handled) 

<img width="1407" height="581" alt="image" src="https://github.com/user-attachments/assets/1253fb30-74c5-4a9c-95dc-7930a143064d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification regarding proposal ordering behavior.

---

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->