### PR TITLE
Document the minimum screen resolution for responsive

### DIFF
--- a/decidim-design/app/views/decidim/design/foundations/layout.html.erb
+++ b/decidim-design/app/views/decidim/design/foundations/layout.html.erb
@@ -47,7 +47,7 @@
 </section>
 
 <section id="mobile" class="design__section">
-  <h2><%= t(".mobile") %> <span class="label">sm</span></h2>
+  <h2><%= t(".mobile") %> <span class="label">xs</span></h2>
 
   <p><%= t(".section_p_mobile") %></p>
 
@@ -111,6 +111,7 @@
     <tbody>
       <%
         rows = []
+        rows << { breakpoint: "xs (375px)", properties: "min-width: 375px;" }
         rows << { breakpoint: "sm (640px)", properties: "max-width: 640px;" }
         rows << { breakpoint: "md (768px)", properties: "max-width: 768px;" }
         rows << { breakpoint: "lg (1024px)", properties: "max-width: 1024px;" }

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -135,11 +135,11 @@ en:
           not_required: Not required
           properties: Properties
           right_aside: Right Aside
-          section_p_breakpoints: 'To manage the responsive max-width of elements we rely on the default `container` Tailwind class, which states the following breakpoints:'
+          section_p_breakpoints: 'To manage the responsive width of elements we rely on the default `container` Tailwind class. The supported resolutions are:'
           section_p_code: When implementing new modules you have some helpers that automatically provides you with the code needed to setup the HTML structure. You should use these helpers instead of directly using div elements with classes, so you maintain consistency.
           section_p_code_html: You can find the basic layouts in %{link_section_code}
           section_p_desktop: Desktop grid system is composed of 12 flexible columns with a gutter between columns of 16px and left and right margins of 48px
-          section_p_mobile: Mobile grid system is composed of 4 flexible columns with a gutter between columns of 16px and left and right margins of 16px. For sizes below 320px this margins are set to 8px
+          section_p_mobile: Mobile grid system is composed of 4 flexible columns with a gutter between columns of 16px and left and right margins of 16px.
           section_p_tablet: Tablet grid system is composed of 8 flexible columns with a gutter between columns of 16px and left and right margins of 24px
           tablet: Tablet
           title: Layout


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago we have a discussion about what is the minimum supported resolution for mobile devices.

After some research, at @decidim/product we decided that currently with the resources that we have, we can support screen sizes with a minimum of 375px. This was actually formalized through the introduction of the screen "xs" size at https://github.com/decidim/decidim/pull/15134 

This PR documents this decision at the design guide  

#### :pushpin: Related Issues
 
- Fixes #9782

#### Testing

Go to http://localhost:3000/design/foundations/layout

### :camera: Screenshots

<img width="1042" height="913" alt="image" src="https://github.com/user-attachments/assets/661cfd12-8d59-4449-a128-138a4ae4ded9" />
<img width="857" height="454" alt="image" src="https://github.com/user-attachments/assets/e3fcd9a5-7efe-4f5c-baae-452e81fed10d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extra-small (xs) viewport breakpoint support at 375px for improved mobile responsiveness.

* **Documentation**
  * Updated responsive design breakpoint documentation with clearer terminology and mobile behavior descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->