### PR TITLE
Backport 'Improve accessibility on new registration form: email and ToS fields' to v0.30

### DIFF
--- a/decidim-core/app/views/decidim/devise/registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/registrations/new.html.erb
@@ -34,6 +34,7 @@
       <%= f.text_field :name, help_text: t("decidim.devise.registrations.new.username_help"), autocomplete: "name", placeholder: "John Doe" %>
 
       <%= f.email_field :email, autocomplete: "email", placeholder: t("placeholder_email", scope: "decidim.devise.shared") %>
+      <span class="sr-only"><%= t("placeholder_email", scope: "decidim.devise.shared") %></span>
 
       <%= render partial: "decidim/account/password_fields", locals: { form: f, user: :user } %>
     </div>

--- a/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
@@ -1,15 +1,13 @@
 <div id="card__tos" class="form__wrapper-block border-y-2">
   <h2 class="h4"><%= t("decidim.devise.registrations.new.tos_title") %></h2>
+  <span class="sr-only"><%= t("forms.required") %></span>
 
-  <div>
+  <div id="terms_of_service_summary">
     <% terms_of_service_summary_content_blocks.each do |content_block| %>
       <%= cell content_block.manifest.cell, content_block %>
     <% end %>
   </div>
-
-  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" } %>
-</div>
-
+  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" }, "aria-describedby": "terms_of_service_summary" %>
 <div id="card__newsletter" class="form__wrapper-block">
   <h2 class="h4"><%= t("decidim.devise.registrations.new.newsletter_title") %></h2>
   <%= form.check_box :newsletter, label: t("decidim.devise.registrations.new.newsletter"), checked: @form.newsletter, label_options: { class: "form__wrapper-checkbox-label" } %>

--- a/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
@@ -8,6 +8,8 @@
     <% end %>
   </div>
   <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" }, "aria-describedby": "terms_of_service_summary" %>
+</div>
+
 <div id="card__newsletter" class="form__wrapper-block">
   <h2 class="h4"><%= t("decidim.devise.registrations.new.newsletter_title") %></h2>
   <%= form.check_box :newsletter, label: t("decidim.devise.registrations.new.newsletter"), checked: @form.newsletter, label_options: { class: "form__wrapper-checkbox-label" } %>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #15082 to v0.30

:hearts: Thank you!