### PR TITLE
Clean-up the releases notes for v0.30 branch

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,7 +37,7 @@ bin/rails db:migrate
 
 ### 2.1. [[TITLE OF THE ACTION]]
 
-You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 
 ## 3. One time actions
 
@@ -45,7 +45,7 @@ These are one time actions that need to be done after the code is updated in the
 
 ### 3.1. [[TITLE OF THE ACTION]]
 
-You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
+You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 
 ## 4. Scheduled tasks
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,12 @@ the instructions for all the patch releases in GitHub:
 
 - <https://github.com/decidim/decidim/releases/tag/v0.30.0>
 - <https://github.com/decidim/decidim/releases/tag/v0.30.1>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.2>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.3>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.4>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.5>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.6>
+- <https://github.com/decidim/decidim/releases/tag/v0.30.7>
 
 ## 1. Upgrade notes
 
@@ -23,42 +29,13 @@ gem "decidim-dev", github: "decidim/decidim", branch: "release/0.30-stable"
 bundle update decidim
 bin/rails decidim:upgrade
 bin/rails db:migrate
-echo "/public/sw.js*" >> .gitignore
-bin/rails decidim:upgrade:fix_action_log
-bin/rails decidim:upgrade:clean:remove_private_exports_attachments
-bin/rails decidim:upgrade:remove_deleted_users_left_data
-bin/rails decidim:upgrade:fix_deleted_private_follows
 ```
 
 ### 1.3. Follow the steps and commands detailed in these notes
 
 ## 2. General notes
 
-### 2.1. Old private exports are now expired
-
-Due to some data consistency issues with the private exports, we have decided to expire all the previously generated files. Users are able to request and receive a new private export file.
-
-if you are upgrading from a lover version like 0.30, and you have already ran this command, you can skip this step.
-
-Run the following command to expire all the private exports:
-
-```console
-bin/rails decidim:upgrade:clean:remove_private_exports_attachments
-```
-
-You can read more about this change on PR [#15020](https://github.com/decidim/decidim/pull/15020).
-
-#### 2.2. Fix gitignore for ServiceWorker related files
-
-We detected a bug where some dynamic files are not added to the gitignore, so they could be committed to the repository. For fixing it, you need to add them to your gitignore file:
-
-```bash
-echo "/public/sw.js*" >> .gitignore
-```
-
-You can read more about this change on PR [#15601](https://github.com/decidim/decidim/pull/15601).
-
-### 2.3. [[TITLE OF THE ACTION]]
+### 2.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 
@@ -66,43 +43,7 @@ You can read more about this change on PR [\#XXXX](https://github.com/decidim/de
 
 These are one time actions that need to be done after the code is updated in the production database.
 
-### 3.1. Fix incorrect ActionLog entries
-
-The action of hiding a component from a menu was being stored as a public action. These can lead to crashing the application if some related participatory space is removed.
-
-In order to correct the existing entries you should run the following rake task:
-
-```bash
-bin/rails decidim:upgrade:fix_action_log
-```
-
-You can read more about this change on PR [#15390](https://github.com/decidim/decidim/pull/15390).
-
-### 3.3. Remove the follows of former private users
-
-To delete the follows of ex private users of non transparent assemblies or processes, run
-
-```console
-bin/rails decidim:upgrade:fix_deleted_private_follows
-```
-
-You can read more about this change on PR [#12878](https://github.com/decidim/decidim/pull/12878).
-
-### 3.4. Remove user data left behind by `Decidim::DestroyAccount`
-
-When a user deletes their account and the `Decidim::DestroyAccount` command is executed, certain related data such as authorizations, versions, private exports, access grants, access tokens, notifications, and reminders were left behind. To fix this issue, we've added a new rake task to clean up the leftover data for previously deleted users.
-
-```ruby
-bin/rails decidim:upgrade:remove_deleted_users_left_data
-```
-
-You can read more about this change on PR [#14731](https://github.com/decidim/decidim/pull/14731).
-
-### 3.5. [[TITLE OF THE ACTION]]
-
-You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
-
-### 3.5. [[TITLE OF THE ACTION]]
+### 3.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [\#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 


### PR DESCRIPTION
#### :tophat: What? Why?

I've looking all the releases notes for the patches and see that there were some pending changes to communicate correctly in the releases notes, so I did it in the last one: 

https://github.com/decidim/decidim/releases/tag/v0.30.7

This PR cleans them up so we have a clean state, and we only have things non communicated in a release note here.  

I did the same for v0.31 at #16564

#### Testing

Read the markdown, we should have only things that we didn't have in any release notes (so, nothing at the moment) 

:hearts: Thank you!
