### PR TITLE
Fix missing return statement in getDefaultErrorMessage

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/notification_action/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/notification_action/controller.js
@@ -205,6 +205,6 @@ export default class extends Controller {
    * @returns {string} The default error message
    */
   getDefaultErrorMessage() {
-    i18n.getMessages("notifications.action_error")
+    return i18n.getMessages("notifications.action_error");
   }
 }


### PR DESCRIPTION
## What and Why
`getDefaultErrorMessage()` in the notification action controller never returns its value — the missing `return` causes the method to always return `undefined`, which means error messages from `i18n.getMessages("notifications.action_error")` are silently dropped.

## Root Cause
`decidim-core/app/packs/src/decidim/controllers/notification_action/controller.js:208` — `i18n.getMessages(...)` is called but the result is not returned.

## Change Summary
- `controller.js:208` — added `return` and semicolon to `getDefaultErrorMessage()`

## Test Plan
- [ ] All existing tests pass
- [ ] Manually verified: method now returns the i18n message string instead of `undefined`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved notification error message display issue. Error messages that appear when notification actions fail were not displaying to users. This fix ensures users receive proper feedback when issues occur with notifications, improving visibility into system problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->