### PR TITLE
Fix attending organizations overflowing aside box on long names

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -28,7 +28,7 @@
         <h3 class="meeting__aside-block__title"><%= t("organizations", scope: "decidim.meetings.meetings.show") %></h3>
         <ul class="meeting__aside-block__list">
           <% meeting.attending_organizations.split("\n").each do |organizations| %>
-          <li><%= organizations %></li>
+          <li class="break-words"><%= organizations %></li>
           <% end %>
           </ul>
         <% end %>


### PR DESCRIPTION
## What and Why
Long organization names in the meeting aside block overflow the container, breaking the layout. This is reported in #15975.

## Root Cause
`decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb:31` — `<li>` elements rendering attending organization names have no text wrapping applied, causing long strings to overflow the fixed-width aside column.

## Change Summary
- `_meeting_aside.html.erb:31` — added Tailwind `break-words` class to `<li>` elements so long organization names wrap instead of overflow

## Test Plan
- [ ] All existing tests pass
- [ ] Manually verified: long organization names now wrap correctly within the aside box

Closes #15975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping for organization names displayed in the meeting details section, ensuring better readability and proper display across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->