### PR TITLE
Prevent double-escaping of `html_safe` text in `decidim_html_escape`

### DIFF
--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -56,7 +56,9 @@ module Decidim
     end
 
     def decidim_html_escape(text)
-      ERB::Util.unwrapped_html_escape(text.to_str)
+      return text if text.html_safe?
+
+      ERB::Util.unwrapped_html_escape(text.to_str).html_safe
     end
 
     def decidim_url_escape(text)

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -109,7 +109,7 @@ module Decidim
     describe "#decidim_html_escape" do
       context "when text is not html_safe" do
         it "escapes the apostrophe" do
-          expect(helper.decidim_html_escape("It's a test")).to eq("It&#39;s a test")
+          expect(helper.decidim_html_escape("User's profile")).to eq("User&#39;s profile")
         end
 
         it "escapes HTML tags" do
@@ -119,11 +119,11 @@ module Decidim
 
       context "when text is already html_safe" do
         it "does not re-escape already escaped entities" do
-          expect(helper.decidim_html_escape("It&#39;s a test".html_safe)).to eq("It&#39;s a test")
+          expect(helper.decidim_html_escape("User&#39;s profile".html_safe)).to eq("User&#39;s profile")
         end
 
         it "returns an html_safe string" do
-          expect(helper.decidim_html_escape("It's a test".html_safe)).to be_html_safe
+          expect(helper.decidim_html_escape("User's profile".html_safe)).to be_html_safe
         end
       end
     end

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -105,5 +105,53 @@ module Decidim
         end
       end
     end
+
+    describe "#decidim_html_escape" do
+      context "when text is not html_safe" do
+        it "escapes the apostrophe" do
+          expect(helper.decidim_html_escape("It's a test")).to eq("It&#39;s a test")
+        end
+
+        it "escapes HTML tags" do
+          expect(helper.decidim_html_escape("<script>alert('xss')</script>")).to eq("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;")
+        end
+      end
+
+      context "when text is already html_safe" do
+        it "does not re-escape already escaped entities" do
+          expect(helper.decidim_html_escape("It&#39;s a test".html_safe)).to eq("It&#39;s a test")
+        end
+
+        it "returns an html_safe string" do
+          expect(helper.decidim_html_escape("It's a test".html_safe)).to be_html_safe
+        end
+      end
+    end
+
+    describe "#decidim_escape_translated" do
+      let(:translated_text) { { "en" => "Component's title" } }
+
+      it "returns an html_safe string so ERB does not escape it again" do
+        expect(helper.decidim_escape_translated(translated_text)).to be_html_safe
+      end
+
+      it "escapes the apostrophe once" do
+        expect(helper.decidim_escape_translated(translated_text)).to eq("Component&#39;s title")
+      end
+
+      context "when translated_attribute returns an html_safe string" do
+        before do
+          allow(helper).to receive(:translated_attribute).with(translated_text).and_return("Component's title".html_safe)
+        end
+
+        it "does not re-escape the apostrophe" do
+          expect(helper.decidim_escape_translated(translated_text)).to eq("Component's title")
+        end
+
+        it "does not turn the apostrophe into &#39;" do
+          expect(helper.decidim_escape_translated(translated_text)).not_to include("&#39;")
+        end
+      end
+    end
   end
 end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -286,13 +286,13 @@ describe "Participatory Processes" do
                 :published,
                 participatory_space: participatory_process,
                 manifest_name: :proposals,
-                name: { en: "It's a component" }
+                name: { en: "User's component" }
               )
             end
 
             it "renders the apostrophe correctly in the sidebar" do
               within ".participatory-space__nav-container" do
-                expect(page).to have_content("It's a component")
+                expect(page).to have_content("User's component")
                 expect(page).to have_no_content("&#39;")
               end
             end

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -279,6 +279,25 @@ describe "Participatory Processes" do
             end
           end
 
+          context "and a component name contains an apostrophe" do
+            let!(:proposals_component) do
+              create(
+                :component,
+                :published,
+                participatory_space: participatory_process,
+                manifest_name: :proposals,
+                name: { en: "It's a component" }
+              )
+            end
+
+            it "renders the apostrophe correctly in the sidebar" do
+              within ".participatory-space__nav-container" do
+                expect(page).to have_content("It's a component")
+                expect(page).to have_no_content("&#39;")
+              end
+            end
+          end
+
           context "and the process statistics are enabled" do
             let(:blocks_manifests) { [:hero, :stats] }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Some views (such as the participatory space sidebar and card metadata) were rendering special characters like apostrophes as their HTML entities (e.g. `&#39;` instead of `'`).

The root cause was in `Decidim::SanitizeHelper#decidim_html_escape`. The method used `text.to_str` (which strips the `html_safe` flag) and returned a non-`html_safe` string. When the result was then interpolated in an ERB template with `<%= %>`, ERB escaped it again. Turning `&#39;` into `&amp;#39;`, which the browser displayed as `&#39;`.

The fix updates `decidim_html_escape` to return the input untouched when it is already `html_safe?` (so previously sanitized content is not escaped a second time), and mark the escaped output as `html_safe` so ERB does not escape it again on render.

#### :pushpin: Related Issues

- Fixes #16565 

#### Testing

1. Create a decidim development app
2. Go to any process and change the name of a component including an apostrophe
3. Go to the public view of the component and see the apostrophe is rendered properly in the sidebar

### :camera: Screenshots

Before:

<img width="1452" height="930" alt="Screenshot 2026-04-13 at 16 17 08" src="https://github.com/user-attachments/assets/ca7d693d-e8ca-4e5a-beec-86e27b4e1257" />

After:

<img width="1471" height="940" alt="Screenshot 2026-04-13 at 17 00 06" src="https://github.com/user-attachments/assets/6f60941b-4250-40a4-9069-075815fb748b" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apostrophes in component names and other UI strings now render as literal characters (no HTML entity like &#39;).
  * Translated content is escaped exactly once and already-safe HTML is not re-escaped, preventing double-escaping in the UI.

* **Tests**
  * Expanded tests to ensure escaping behavior and preservation of already-safe HTML strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->