### PR TITLE
Fix the "Attending organizations" container in meetings

### DIFF
--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_aside.html.erb
@@ -28,7 +28,7 @@
         <h3 class="meeting__aside-block__title"><%= t("organizations", scope: "decidim.meetings.meetings.show") %></h3>
         <ul class="meeting__aside-block__list">
           <% meeting.attending_organizations.split("\n").each do |organizations| %>
-          <li><%= organizations %></li>
+          <li class="break-all"><%= organizations %></li>
           <% end %>
           </ul>
         <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
The `<li>` container which lists the organisations attended within the closure of a meeting overflowed the container when organisation names were very long. 

While #16567 suggested using `break-words`, this actually didn't solve the issue. This PR adds the tailwind class `break-all` to fit the strings into the container when too long.

#### :pushpin: Related Issues
- Fixes #15975

#### Testing
1. Login
2. Head to a space with a meeting open/published.
3. Close it
4. Within the closing form add some mins 
5. In the "Attending organizations" add some very long characters
6. Save by closing
7. Head to frontend
8. See the organisations container working as intended

Remove the class to see a before and after if you wish :)

### :camera: Screenshots
DESKTOP:
<img width="515" height="694" alt="image" src="https://github.com/user-attachments/assets/c7305cc8-ec41-40e4-9ba2-c22b0c3a6a87" />

MOBILE:
<img width="1179" height="1460" alt="image" src="https://github.com/user-attachments/assets/dc88cc96-283e-4b8d-a0a6-88b3155f6e11" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the attending organizations list display with improved text wrapping for better handling of longer organization names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->