### PR TITLE
Fix decidim-design section by removing MeetingsSCell call

### DIFF
--- a/decidim-design/app/helpers/decidim/design/cards_helper.rb
+++ b/decidim-design/app/helpers/decidim/design/cards_helper.rb
@@ -335,18 +335,6 @@ module Decidim
                 'cell("decidim/meetings/meeting_l", _RESOURCE_)'
               ]
             }
-          ),
-          cell_table_item(
-            t("decidim.design.helpers.meeting_s"),
-            {
-              cell: "decidim/meetings/meeting_s",
-              args: [resource],
-              call_string: [
-                "card_for(_RESOURCE_, size: :s)",
-                'cell("decidim/meetings/meeting", _RESOURCE_, size: :s)',
-                'cell("decidim/meetings/meeting_s", _RESOURCE_)'
-              ]
-            }
           )
         ]
       end

--- a/decidim-design/config/locales/en.yml
+++ b/decidim-design/config/locales/en.yml
@@ -225,7 +225,6 @@ en:
         list: List
         main_colors: Main Colors
         meeting_l: Meeting L
-        meeting_s: Meeting S
         meetings: Meetings
         meetings_html: Used by <i>Meetings</i> cards
         metadata_items: Metadata items

--- a/decidim-design/decidim-design.gemspec
+++ b/decidim-design/decidim-design.gemspec
@@ -30,6 +30,15 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency "decidim-core", version
-
+  s.add_development_dependency "decidim-accountability", version
+  s.add_development_dependency "decidim-assemblies", version
+  s.add_development_dependency "decidim-blogs", version
+  s.add_development_dependency "decidim-budgets", version
+  s.add_development_dependency "decidim-conferences", version
+  s.add_development_dependency "decidim-debates", version
   s.add_development_dependency "decidim-dev", version
+  s.add_development_dependency "decidim-initiatives", version
+  s.add_development_dependency "decidim-meetings", version
+  s.add_development_dependency "decidim-participatory_processes", version
+  s.add_development_dependency "decidim-proposals", version
 end

--- a/decidim-design/spec/factories.rb
+++ b/decidim-design/spec/factories.rb
@@ -1,3 +1,13 @@
 # frozen_string_literal: true
 
 require "decidim/core/test/factories"
+require "decidim/accountability/test/factories"
+require "decidim/blogs/test/factories"
+require "decidim/budgets/test/factories"
+require "decidim/debates/test/factories"
+require "decidim/meetings/test/factories"
+require "decidim/proposals/test/factories"
+require "decidim/assemblies/test/factories"
+require "decidim/conferences/test/factories"
+require "decidim/initiatives/test/factories"
+require "decidim/participatory_processes/test/factories"

--- a/decidim-design/spec/system/components_spec.rb
+++ b/decidim-design/spec/system/components_spec.rb
@@ -38,6 +38,18 @@ describe "Components" do
   end
 
   context "when on cards page" do
+    let!(:result) { create(:result) }
+    let!(:meeting) { create(:meeting, :published) }
+    let!(:post) { create(:post, :published) }
+    let!(:project) { create(:project) }
+    let!(:debate) { create(:debate) }
+    let!(:proposal) { create(:proposal, :published) }
+    let!(:assembly) { create(:assembly, :published) }
+    let!(:conference) { create(:conference, :published) }
+    let!(:initiative) { create(:initiative) }
+    let!(:process) { create(:participatory_process, :published) }
+    let!(:process_group) { create(:participatory_process_group) }
+
     it_behaves_like "showing the design page", "Cards", "Variations"
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Back in #15535 we have removed the meetings_s cell, and apparently during review, i have forgot a place to check 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #15535

#### Testing
1. Boot up the application 
2. Visit Design application 
3. Check from left menu the Cards section
4. See an error 
5. Apply patch 
6. Refresh the page, see the 500 error is gone
7. PS: I have not touched any CSS, as it is not in the scope of the fix

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1787" height="701" alt="image" src="https://github.com/user-attachments/assets/4d53ac20-1b83-43ce-9bba-d6e5d7cfbc84" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the smaller/compact meeting card variant; only the standard meeting card size is now shown.

* **Localization**
  * Deleted the corresponding compact meeting translation key from English locales.

* **Chores**
  * Added several development-time design integrations to support additional Decidim modules.

* **Tests**
  * Expanded test factories and added fixtures to cover a broader set of content types for card-related specs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->