### PR TITLE
Fix icon for disabled delete in proposals states

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposal_states/index.html.erb
@@ -59,9 +59,9 @@
                     <li class="dropdown__item">
                       <div class="dropdown__button-disabled">
                         <%= with_tooltip t("tooltips.deleted_proposal_states_info", scope: "decidim.admin") do %>
-                          <%= icon "pencil-line", class: "text-gray" %>
+                          <%= icon "delete-bin-line", class: "text-gray" %>
                           <span>
-                            <%= t("actions.edit_proposal", scope: "decidim.proposals") %>
+                            <%= t("actions.destroy", scope: "decidim.proposals") %>
                           </span>
                         <% end %>
                       </div>

--- a/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_manages_proposal_states_spec.rb
@@ -227,7 +227,10 @@ describe "Admin manages proposals states" do
       expect(state.reload.proposals).to include(proposal)
       expect(state.proposals_count).to eq(1)
       within "tr", text: translated(state.title) do
+        find("button[data-controller='dropdown']").click
         expect(page).to have_no_link("Delete")
+        expect(page).to have_css(".dropdown__button-disabled span", text: "Delete state")
+        expect(page).to have_css(".dropdown__button-disabled svg")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #16576, I noticed that we introduced a bug with the "Delete state" action in Proposals' states. This PR fixes it. 

#### :pushpin: Related Issues

- Related to #16576 
- Related to #14883

#### Testing

1. Sign in as admin 
2. Go to the admin dashboard
3. Go to a process
4. Go to a proposals component page
5. Click in "Statuses" 
6. Click in the three dots (Action list) of a state
7. (Before) If the state has proposals associated, then you will wrongly see that it says "Edit proposal" (disabled)
8. (After) If the state has proposals associated, then you will see that it says "Delete state" (disabled)

### :camera: Screenshots

#### Before

<img width="871" height="605" alt="image" src="https://github.com/user-attachments/assets/6f57614e-c791-4210-b039-3873bf6a79ad" />

#### After

<img width="891" height="580" alt="2026-04-21-094726_hyprshot" src="https://github.com/user-attachments/assets/9db3e710-2ab0-4f64-8ea7-78a2e1548ee7" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the disabled delete proposal state action to display the proper delete icon and label instead of incorrectly showing the edit icon and label, improving clarity for admin users managing proposal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->