### PR TITLE
Remove the roles menu on footer

### DIFF
--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -57,7 +57,7 @@ module Decidim
         self,
         element_class: "font-semibold underline",
         active_class: "is-active",
-        container_options: { class: "space-y-4 break-inside-avoid", role: :menu },
+        container_options: { class: "space-y-4 break-inside-avoid" },
         label: t("layouts.decidim.footer.decidim_title")
       )
     end

--- a/decidim-core/app/helpers/decidim/menu_helper.rb
+++ b/decidim-core/app/helpers/decidim/menu_helper.rb
@@ -57,6 +57,7 @@ module Decidim
         self,
         element_class: "font-semibold underline",
         active_class: "is-active",
+        role: false,
         container_options: { class: "space-y-4 break-inside-avoid" },
         label: t("layouts.decidim.footer.decidim_title")
       )

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -29,7 +29,7 @@ module Decidim
     delegate :content_tag, :safe_join, :link_to, :active_link_to_class, :is_active_link?, :icon, to: :@view
 
     def render
-      content_tag :li, role: :menuitem, class: link_wrapper_classes do
+      content_tag :li, class: link_wrapper_classes do
         output = if url == "#"
                    [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled")]
                  else

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -29,7 +29,7 @@ module Decidim
     delegate :content_tag, :safe_join, :link_to, :active_link_to_class, :is_active_link?, :icon, to: :@view
 
     def render
-      content_tag :li, class: link_wrapper_classes do
+      content_tag :li, role: menuitem_role, class: link_wrapper_classes do
         output = if url == "#"
                    [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled")]
                  else
@@ -67,6 +67,12 @@ module Decidim
       return @options.element_wrapper_class unless is_active_link?(url, active)
 
       [@options.element_wrapper_class, active_class].compact.join(" ")
+    end
+
+    def menuitem_role
+      return if @options.role == false
+
+      @options.role || :menuitem
     end
 
     def active_class

--- a/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/menu_helper_spec.rb
@@ -13,6 +13,7 @@ module Decidim
     before do
       allow(helper).to receive(:current_organization).and_return(organization)
       allow(helper).to receive(:current_user).and_return(user)
+      allow(helper).to receive(:current_locale).and_return("en")
     end
 
     describe "#menu_highlighted_participatory_process" do
@@ -84,6 +85,13 @@ module Decidim
             end
           end
         end
+      end
+    end
+
+    describe "#footer_menu" do
+      it "renders footer menu items without the menuitem role" do
+        expect(helper.footer_menu.render).to have_css("li")
+        expect(helper.footer_menu.render).to have_no_css("li[role='menuitem']")
       end
     end
   end

--- a/decidim-core/spec/presenters/decidim/footer_menu_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/footer_menu_presenter_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe FooterMenuPresenter, type: :helper do
+    subject { FooterMenuPresenter.new(:custom_menu, view, role: false, label: "Footer") }
+
+    after { MenuRegistry.destroy(:custom_menu) }
+
+    before do
+      MenuRegistry.register :custom_menu do |menu|
+        menu.add_item :foo, "Foo", "/foo"
+      end
+    end
+
+    it "renders menu items without the menuitem role" do
+      expect(subject.render).to have_css("li", count: 1)
+      expect(subject.render).to have_no_css("li[role='menuitem']")
+    end
+  end
+end

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -16,6 +16,10 @@ module Decidim
       expect(subject.render).to have_link("Foo", href: "/boo")
     end
 
+    it "adds the menuitem role by default" do
+      expect(subject.render).to have_css("li[role='menuitem']")
+    end
+
     it "does not add the aria-current attribute for non-active page" do
       expect(subject.render).not_to include('aria-current="page"')
     end


### PR DESCRIPTION
#### :tophat: What? Why?

A different approach to #14886, adding a parameter to remove these roles depending on the menu that is being rendered. 

This way we don't have inline JS and we have a more agnostic solution (that could be applied to other menus). 

#### :pushpin: Related Issues

- Related to #14886 

#### Testing

1. As a user, go to homepage
2. Open you devTools, check that the items in this list doesn't have the role menu item attributes

### :camera: Screenshots

#### Before

<img width="953" height="583" alt="image" src="https://github.com/user-attachments/assets/a482845e-6408-4351-877e-8f974ea264a4" />

#### After 

<img width="1107" height="613" alt="image" src="https://github.com/user-attachments/assets/385eb903-ba35-4256-bd32-adc59fd8dd03" />
 
:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated footer menu to properly handle accessibility role attributes, improving compliance with accessibility standards.

* **Tests**
  * Added test coverage for menu role attribute rendering behavior to ensure proper implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->