### PR TITLE
Remove the roles menu on spaces nav links

### DIFF
--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,10 +1,10 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-add-aria-roles="false">
+  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-add-aria-roles="false" data-open-md="true">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
-  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav" aria-hidden="true">
+  <ul id="dropdown-menu-participatory-space" class="participatory-space__nav">
     <% model.each do |item| %>
       <li>
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>

--- a/decidim-core/app/cells/decidim/nav_links/show.erb
+++ b/decidim-core/app/cells/decidim/nav_links/show.erb
@@ -1,12 +1,12 @@
 <div class="participatory-space__nav-container">
-  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true">
+  <button id="dropdown-trigger-participatory-space" data-controller="dropdown" data-target="dropdown-menu-participatory-space" data-auto-close="true" data-scroll-to-menu="true" data-add-aria-roles="false">
     <span><%= t("decidim.searches.filters.jump_to") %></span>
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>
   </button>
   <ul id="dropdown-menu-participatory-space" class="participatory-space__nav" aria-hidden="true">
     <% model.each do |item| %>
-      <li role="menuitem">
+      <li>
         <%= link_to item[:url], class: "participatory-space__nav-item" do %>
           <%= decidim_escape_translated(item[:name]) %>
           <%= icon "arrow-right-line" %>

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -270,7 +270,7 @@ describe "Participatory Processes" do
         end
 
         context "and the process has some components" do
-          let(:blocks_manifests) { [:main_data] }
+          let(:blocks_manifests) { [:hero, :main_data] }
 
           it "shows the components" do
             within ".participatory-space__nav-container" do
@@ -278,6 +278,8 @@ describe "Participatory Processes" do
               expect(page).to have_no_content(decidim_escape_translated(meetings_component.name))
             end
           end
+
+          it_behaves_like "accessible page"
 
           context "and the process statistics are enabled" do
             let(:blocks_manifests) { [:hero, :stats] }


### PR DESCRIPTION
#### :tophat: What? Why?

A different approach to #14944 (related to the nav links in a participatory space). We solve this by using the same data attributes added at #16489. 

This way we don't have inline JS and we have a more agnostic solution (that could be applied to other menus). 

While fixing this, I also noticed a wrong `aria-hidden="true"` attribute, that makes that this page doesn't pass the a11y validations. I fixed it by using the `data-open-md` and also added a spec for this. 

#### :pushpin: Related Issues

- Related to #14886 

#### Testing

1. As a user, go to process page
2. Open you devTools, check that the items in the nav links list doesn't have the role menu item attributes

### :camera: Screenshots

#### Before

<img width="1746" height="991" alt="image" src="https://github.com/user-attachments/assets/22481643-296f-4580-9b7f-daf3fc416e39" />

#### After 

<img width="1833" height="932" alt="image" src="https://github.com/user-attachments/assets/a780cec6-fa22-4aa3-b72e-78a6a54dc8fc" />
 
:hearts: Thank you!

<!-- This is 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dropdown menu accessibility with improved ARIA role handling and refined responsive menu opening behavior.

* **Tests**
  * Expanded accessibility testing coverage for participatory process pages to verify compliance across different layout configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->