### PR TITLE
Add GitHub Security Advisory to policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,11 @@ responsibly by any of these ways:
 
 1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
 
-2. sending an email to security [at] decidim [dot] org and not by
-creating a github/metadecidim issue.
+1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
+
+2. sending an email to security [at] decidim [dot] org
+
+Please do not create a public github/metadecidim issue for security vulnerabilities.
 
 We appreciate your effort to make Decidim more secure.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,11 @@ include the latest design and features.
 Security is very important to us.
 
 If you have any issue regarding security, please disclose the information
-responsibly by sending an email to security [at] decidim [dot] org and not by
+responsibly by any of these ways:
+
+1. create a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
+
+2. sending an email to security [at] decidim [dot] org and not by
 creating a github/metadecidim issue.
 
 We appreciate your effort to make Decidim more secure.
@@ -53,3 +57,5 @@ be extended to 4 months.
 
 By adhering to this security policy, we aim to address security concerns
 effectively and responsibly in our open source software project.
+
+[GitHub Security Advisory]: https://github.com/decidim/decidim/security/advisories/new

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,8 +25,6 @@ responsibly by any of these ways:
 
 1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
 
-1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
-
 2. sending an email to security [at] decidim [dot] org
 
 Please do not create a public github/metadecidim issue for security vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,11 +21,11 @@ include the latest design and features.
 Security is very important to us.
 
 If you have any issue regarding security, please disclose the information
-responsibly by any of these ways:
+responsibly through any of the following ways:
 
-1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
+1. Creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
 
-2. sending an email to security [at] decidim [dot] org
+2. Sending an email to security [at] decidim [dot] org
 
 Please do not create a public github/metadecidim issue for security vulnerabilities.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,7 @@ Security is very important to us.
 If you have any issue regarding security, please disclose the information
 responsibly by any of these ways:
 
-1. create a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
+1. creating a new advisory through the [GitHub Security Advisory][GitHub Security Advisory]
 
 2. sending an email to security [at] decidim [dot] org and not by
 creating a github/metadecidim issue.


### PR DESCRIPTION
#### :tophat: What? Why?

I noticed that in the Security Policy we don't have any information regarding the GH Advisories feature and this is one of the ways of responsible disclosure with us. 

This PR adds it. 

#### Testing

Read the change (as it is docs) 
Click in the link in the preview tab (as it is a Markdown link and can be wrong) 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated vulnerability reporting guidance: reporters may now submit security disclosures either via a GitHub Security Advisory or by email; the prior prohibition on creating public repository issues for vulnerabilities remains. The guidance clarifies options and adds a direct reference link to the GitHub Security Advisory creation page for submitters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->