### PR TITLE
Remove unecessary locale argument in URL helpers

### DIFF
--- a/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/moderated_users/index.html.erb
@@ -40,10 +40,10 @@
 
         <% if moderation.user.nickname.present? %>
           <td data-label="<%= t(".name") %>">
-            <%= link_to moderation.user.name, decidim.profile_path(moderation.user.nickname, locale: current_locale) %>
+            <%= link_to moderation.user.name, decidim.profile_path(moderation.user.nickname) %>
           </td>
           <td data-label="<%= t(".nickname") %>">
-            <%= link_to moderation.user.nickname, decidim.profile_path(moderation.user.nickname, locale: current_locale) %>
+            <%= link_to moderation.user.nickname, decidim.profile_path(moderation.user.nickname) %>
           </td>
         <% else %>
           <td data-label="<%= t(".name") %>">

--- a/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
+++ b/decidim-admin/app/views/decidim/admin/officializations/index.html.erb
@@ -25,10 +25,10 @@
         <tr data-user-id="<%= user.id %>">
           <% if user.nickname.present? %>
             <td data-label="<%= t(".name") %>">
-              <%= link_to user.name, decidim.profile_path(user.nickname, locale: current_locale) %>
+              <%= link_to user.name, decidim.profile_path(user.nickname) %>
             </td>
             <td data-label="<%= t(".nickname") %>">
-              <%= link_to user.nickname, decidim.profile_path(user.nickname, locale: current_locale) %>
+              <%= link_to user.nickname, decidim.profile_path(user.nickname) %>
             </td>
           <% else %>
             <td data-label="<%= t(".name") %>">

--- a/decidim-admin/app/views/decidim/admin/static_pages/_topic.html.erb
+++ b/decidim-admin/app/views/decidim/admin/static_pages/_topic.html.erb
@@ -57,7 +57,7 @@
                     <% end %>
 
                     <li class="dropdown__item">
-                      <%= link_to decidim.page_path(page, locale: current_locale), target: "_blank", data: { "external-link": false }, class: "dropdown__button" do %>
+                      <%= link_to decidim.page_path(page), target: "_blank", data: { "external-link": false }, class: "dropdown__button" do %>
                         <%= icon "eye-line" %>
                         <%= t("actions.view", scope: "decidim.admin.static_pages") %>
                       <% end %>

--- a/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/manage_hide_content_examples.rb
@@ -7,7 +7,7 @@ shared_examples "hideable resource during block" do
 
   let!(:admin) { create(:user, :confirmed, :admin, organization:) }
   let(:reportable) { create(:user, :confirmed, organization:) }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
 
   let(:participatory_process) { create(:participatory_process, organization:) }
   let(:component) { create(:dummy_component, participatory_space: participatory_process) }

--- a/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
@@ -14,7 +14,7 @@ describe "Admin manages static page content blocks" do
 
   context "when editing a non-persisted content block" do
     it "creates the content block to the db before editing it" do
-      visit decidim_admin.edit_static_page_path(tos_page, locale: I18n.locale)
+      visit decidim_admin.edit_static_page_path(tos_page)
 
       expect(Decidim::ContentBlock.count).to eq 0
 
@@ -54,7 +54,7 @@ describe "Admin manages static page content blocks" do
     let!(:content_block2) { create(:content_block, organization:, manifest_name: :section, scope_name: :static_page, scoped_resource_id: tos_page.id, settings: { content_en: content2 }) }
 
     it "shows all of them" do
-      visit decidim.page_path(tos_page, locale: I18n.locale)
+      visit decidim.page_path(tos_page)
       expect(page).to have_content(content1)
       expect(page).to have_content(content2)
     end
@@ -75,7 +75,7 @@ describe "Admin manages static page content blocks" do
 
       expect(page).to have_content("Content block successfully deleted")
 
-      visit decidim.page_path(tos_page, locale: I18n.locale)
+      visit decidim.page_path(tos_page)
       expect(page).to have_no_content(content)
     end
   end
@@ -91,7 +91,7 @@ describe "Admin manages static page content blocks" do
                           en: "<p>Custom privacy policy summary text!</p>"
 
       click_on "Update"
-      visit decidim.page_path(tos_page, locale: I18n.locale)
+      visit decidim.page_path(tos_page)
       expect(page).to have_content("Custom privacy policy summary text!")
 
       logout

--- a/decidim-admin/spec/system/admin_moderates_user_spec.rb
+++ b/decidim-admin/spec/system/admin_moderates_user_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Admin reports user" do
   let(:admin) { create(:user, :confirmed, :admin) }
   let(:reportable) { create(:user, :confirmed, organization: admin.organization) }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
 
   before do
     switch_to_host(admin.organization.host)

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -17,12 +17,12 @@ describe "Content pages" do
     let(:decidim_page) { decidim_pages.first }
 
     it_behaves_like "editable content for admins" do
-      let(:target_path) { decidim.pages_path(locale: I18n.locale) }
+      let(:target_path) { decidim.pages_path() }
     end
 
     context "when requesting the pages path" do
       before do
-        visit decidim.pages_path(locale: I18n.locale)
+        visit decidim.pages_path()
       end
 
       it "shows the list of topics" do
@@ -41,7 +41,7 @@ describe "Content pages" do
           find("button[role=button]").click
 
           expect(page).to have_css(
-            "a[href=\"#{decidim.page_path(decidim_page, locale: I18n.locale)}\"]",
+            "a[href=\"#{decidim.page_path(decidim_page)}\"]",
             text: page_title
           )
         end

--- a/decidim-admin/spec/system/static_pages_spec.rb
+++ b/decidim-admin/spec/system/static_pages_spec.rb
@@ -17,12 +17,12 @@ describe "Content pages" do
     let(:decidim_page) { decidim_pages.first }
 
     it_behaves_like "editable content for admins" do
-      let(:target_path) { decidim.pages_path() }
+      let(:target_path) { decidim.pages_path }
     end
 
     context "when requesting the pages path" do
       before do
-        visit decidim.pages_path()
+        visit decidim.pages_path
       end
 
       it "shows the list of topics" do

--- a/decidim-assemblies/app/cells/decidim/assemblies/assembly_g_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/assembly_g_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def resource_path
-        Decidim::Assemblies::Engine.routes.url_helpers.assembly_path(model, locale: current_locale)
+        Decidim::Assemblies::Engine.routes.url_helpers.assembly_path(model)
       end
 
       def resource_image_url

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Assemblies::Engine.routes.url_helpers.assemblies_path(locale: current_locale)
+          Decidim::Assemblies::Engine.routes.url_helpers.assemblies_path()
         end
 
         def max_results

--- a/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
+++ b/decidim-assemblies/app/cells/decidim/assemblies/content_blocks/highlighted_assemblies_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Assemblies::Engine.routes.url_helpers.assemblies_path()
+          Decidim::Assemblies::Engine.routes.url_helpers.assemblies_path
         end
 
         def max_results

--- a/decidim-assemblies/app/controllers/decidim/assemblies/members_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/members_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         raise ActionController::RoutingError, "No members for this assembly" if members.none?
 
         enforce_permission_to :list, :members
-        redirect_to decidim_assemblies.assembly_path(current_participatory_space, locale: I18n.locale) unless can_visit_index?
+        redirect_to decidim_assemblies.assembly_path(current_participatory_space) unless can_visit_index?
       end
 
       private

--- a/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
+++ b/decidim-assemblies/app/helpers/decidim/assemblies/assemblies_helper.rb
@@ -23,8 +23,8 @@ module Decidim
           *(if participatory_space.members_public_page?
               [{
                 name: t("assembly_member_menu_item", scope: "layouts.decidim.assembly_navigation"),
-                url: decidim_assemblies.assembly_members_path(participatory_space, locale: current_locale),
-                active: is_active_link?(decidim_assemblies.assembly_members_path(participatory_space, locale: current_locale), :inclusive)
+                url: decidim_assemblies.assembly_members_path(participatory_space),
+                active: is_active_link?(decidim_assemblies.assembly_members_path(participatory_space), :inclusive)
               }]
             end
            )

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_assembly_row.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_assembly_row.html.erb
@@ -96,7 +96,7 @@
 
           <% if allowed_to? :preview, :assembly, assembly: assembly %>
             <li class="dropdown__item">
-              <%= link_to decidim_assemblies.assembly_path(assembly, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+              <%= link_to decidim_assemblies.assembly_path(assembly), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
                 <%= icon "eye-line" %>
                 <%= t("actions.preview", scope: "decidim.admin") %>
               <% end %>

--- a/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/assemblies/show.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
   title: translated_attribute(current_participatory_space.title),
   description: translated_attribute(current_participatory_space.short_description),
-  url: assembly_url(current_participatory_space, locale: I18n.locale),
+  url: assembly_url(current_participatory_space),
   resource: current_participatory_space) %>
 
 <%

--- a/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
+++ b/decidim-assemblies/app/views/layouts/decidim/admin/assembly.html.erb
@@ -3,7 +3,7 @@
 <% add_decidim_page_title(translated_attribute(current_participatory_space.title)) %>
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <%= link_to decidim_assemblies.assembly_path(current_participatory_space, locale: current_locale), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
+    <%= link_to decidim_assemblies.assembly_path(current_participatory_space), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
       <%= icon "eye-line" %>
       <span>
         <%= t("see_assembly", scope: "decidim.admin.menu.assemblies_submenu") %>

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(),
+                        decidim_assemblies.assemblies_path,
                         position: 2.2,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(),
+                        decidim_assemblies.assemblies_path,
                         position: 2.2,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(),
+                        decidim_assemblies.assemblies_path,
                         position: 20,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive

--- a/decidim-assemblies/lib/decidim/assemblies/menu.rb
+++ b/decidim-assemblies/lib/decidim/assemblies/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(locale: current_locale),
+                        decidim_assemblies.assemblies_path(),
                         position: 2.2,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(locale: current_locale),
+                        decidim_assemblies.assemblies_path(),
                         position: 2.2,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :assemblies,
                         I18n.t("menu.assemblies", scope: "decidim"),
-                        decidim_assemblies.assemblies_path(locale: current_locale),
+                        decidim_assemblies.assemblies_path(),
                         position: 20,
                         if: OrganizationPublishedAssemblies.new(current_organization, current_user).any?,
                         active: :inclusive

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -50,7 +50,7 @@ module Decidim
           end
 
           it "redirects to 404" do
-            expect { get :index, params: {  } }.to raise_error(ActionController::RoutingError)
+            expect { get :index, params: { locale: I18n.locale } }.to raise_error(ActionController::RoutingError)
           end
         end
 
@@ -78,7 +78,7 @@ module Decidim
         let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
 
         it "includes only published assemblies with their children (two levels)" do
-          get :index, params: {  }, format: :json
+          get :index, params: { locale: I18n.locale }, format: :json
           expect(parsed_response).to contain_exactly({
                                                        name: translated(promoted.title),
                                                        children: []
@@ -112,7 +112,7 @@ module Decidim
       describe "GET show" do
         context "when the assembly is unpublished" do
           it "redirects to sign in path" do
-            get :show, params: { slug: unpublished_assembly.slug }
+            get :show, params: { slug: unpublished_assembly.slug, locale: I18n.locale }
 
             expect(response).to redirect_to(new_user_session_path)
           end
@@ -125,7 +125,7 @@ module Decidim
             end
 
             it "redirects to root path" do
-              get :show, params: { slug: unpublished_assembly.slug }
+              get :show, params: { slug: unpublished_assembly.slug, locale: I18n.locale }
 
               expect(response).to redirect_to(root_path)
             end

--- a/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/assemblies_controller_spec.rb
@@ -50,7 +50,7 @@ module Decidim
           end
 
           it "redirects to 404" do
-            expect { get :index, params: { locale: I18n.locale } }.to raise_error(ActionController::RoutingError)
+            expect { get :index, params: {  } }.to raise_error(ActionController::RoutingError)
           end
         end
 
@@ -78,7 +78,7 @@ module Decidim
         let(:parsed_response) { JSON.parse(response.body, symbolize_names: true) }
 
         it "includes only published assemblies with their children (two levels)" do
-          get :index, params: { locale: I18n.locale }, format: :json
+          get :index, params: {  }, format: :json
           expect(parsed_response).to contain_exactly({
                                                        name: translated(promoted.title),
                                                        children: []
@@ -112,7 +112,7 @@ module Decidim
       describe "GET show" do
         context "when the assembly is unpublished" do
           it "redirects to sign in path" do
-            get :show, params: { slug: unpublished_assembly.slug, locale: I18n.locale }
+            get :show, params: { slug: unpublished_assembly.slug }
 
             expect(response).to redirect_to(new_user_session_path)
           end
@@ -125,7 +125,7 @@ module Decidim
             end
 
             it "redirects to root path" do
-              get :show, params: { slug: unpublished_assembly.slug, locale: I18n.locale }
+              get :show, params: { slug: unpublished_assembly.slug }
 
               expect(response).to redirect_to(root_path)
             end

--- a/decidim-assemblies/spec/controllers/members_controller_spec.rb
+++ b/decidim-assemblies/spec/controllers/members_controller_spec.rb
@@ -23,7 +23,7 @@ module Decidim
         )
       end
 
-      let(:destination_path) { decidim_assemblies.assembly_path(participatory_space, locale: I18n.locale) }
+      let(:destination_path) { decidim_assemblies.assembly_path(participatory_space) }
 
       let(:slug_param) { "assembly_slug" }
       let(:slug) { participatory_space.slug }

--- a/decidim-assemblies/spec/requests/assembly_search_spec.rb
+++ b/decidim-assemblies/spec/requests/assembly_search_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Assembly search" do
   end
 
   let(:filter_params) { {} }
-  let(:request_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+  let(:request_path) { decidim_assemblies.assemblies_path() }
 
   before do
     get(

--- a/decidim-assemblies/spec/requests/assembly_search_spec.rb
+++ b/decidim-assemblies/spec/requests/assembly_search_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Assembly search" do
   end
 
   let(:filter_params) { {} }
-  let(:request_path) { decidim_assemblies.assemblies_path() }
+  let(:request_path) { decidim_assemblies.assemblies_path }
 
   before do
     get(

--- a/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assemblies_examples.rb
@@ -119,7 +119,7 @@ shared_examples "manage assemblies" do
         end
 
         page.within_window(new_window) do
-          expect(page).to have_current_path decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          expect(page).to have_current_path decidim_assemblies.assembly_path(assembly)
           expect(page).to have_content(translated(assembly.title))
         end
       end

--- a/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
+++ b/decidim-assemblies/spec/shared/manage_assembly_components_examples.rb
@@ -200,7 +200,7 @@ shared_examples "manage assembly components" do
       end
 
       it "hides the component from the menu" do
-        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        visit decidim_assemblies.assembly_path(assembly)
         expect(page).to have_content decidim_escape_translated(component.name)
 
         visit decidim_admin_assemblies.components_path(assembly)
@@ -215,7 +215,7 @@ shared_examples "manage assembly components" do
           expect(page).to have_css("a", text: "Unpublish")
         end
 
-        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        visit decidim_assemblies.assembly_path(assembly)
         expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end

--- a/decidim-assemblies/spec/system/access_mode_restricted_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/access_mode_restricted_assemblies_spec.rb
@@ -11,7 +11,7 @@ describe "Access Mode Restricted Assemblies" do
   let!(:other_user) { create(:user, :confirmed, organization:) }
   let!(:other_user2) { create(:user, :confirmed, organization:) }
 
-  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path() }
+  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path }
   let(:restricted_participatory_space_path) { decidim_assemblies.assembly_path(restricted_participatory_space) }
   let(:restricted_participatory_space_attachment_path) { decidim_admin_assemblies.assembly_attachments_path(restricted_participatory_space) }
   let(:css_class_selector) { "#assemblies-grid" }

--- a/decidim-assemblies/spec/system/access_mode_restricted_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/access_mode_restricted_assemblies_spec.rb
@@ -11,8 +11,8 @@ describe "Access Mode Restricted Assemblies" do
   let!(:other_user) { create(:user, :confirmed, organization:) }
   let!(:other_user2) { create(:user, :confirmed, organization:) }
 
-  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
-  let(:restricted_participatory_space_path) { decidim_assemblies.assembly_path(restricted_participatory_space, locale: I18n.locale) }
+  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path() }
+  let(:restricted_participatory_space_path) { decidim_assemblies.assembly_path(restricted_participatory_space) }
   let(:restricted_participatory_space_attachment_path) { decidim_admin_assemblies.assembly_attachments_path(restricted_participatory_space) }
   let(:css_class_selector) { "#assemblies-grid" }
 

--- a/decidim-assemblies/spec/system/access_mode_transparent_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/access_mode_transparent_assemblies_spec.rb
@@ -8,8 +8,8 @@ describe "Access Mode Transparent Assemblies" do
   let!(:participatory_space) { create(:assembly, :published, organization:) }
   let!(:transparent_participatory_space) { create(:assembly, :published, :transparent, organization:) }
 
-  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
-  let(:transparent_participatory_space_path) { decidim_assemblies.assembly_path(transparent_participatory_space, locale: I18n.locale) }
+  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path() }
+  let(:transparent_participatory_space_path) { decidim_assemblies.assembly_path(transparent_participatory_space) }
   let(:transparent_participatory_space_attachment_path) { decidim_admin_assemblies.assembly_attachments_path(transparent_participatory_space) }
   let(:css_class_selector) { "#assemblies-grid" }
 

--- a/decidim-assemblies/spec/system/access_mode_transparent_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/access_mode_transparent_assemblies_spec.rb
@@ -8,7 +8,7 @@ describe "Access Mode Transparent Assemblies" do
   let!(:participatory_space) { create(:assembly, :published, organization:) }
   let!(:transparent_participatory_space) { create(:assembly, :published, :transparent, organization:) }
 
-  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path() }
+  let(:participatory_space_index_path) { decidim_assemblies.assemblies_path }
   let(:transparent_participatory_space_path) { decidim_assemblies.assembly_path(transparent_participatory_space) }
   let(:transparent_participatory_space_attachment_path) { decidim_admin_assemblies.assembly_attachments_path(transparent_participatory_space) }
   let(:css_class_selector) { "#assemblies-grid" }

--- a/decidim-assemblies/spec/system/admin/admin_access_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_access_spec.rb
@@ -13,7 +13,7 @@ describe "AdminAccess" do
     let(:role) { create(:assembly_admin, :confirmed, organization:, assembly: participatory_space) }
     let(:target_path) { decidim_admin_assemblies.edit_assembly_path(participatory_space) }
     let(:unauthorized_target_path) { decidim_admin_assemblies.edit_assembly_path(other_participatory_space) }
-    let(:participatory_space_path) { decidim_assemblies.assembly_path(participatory_space, locale: I18n.locale) }
+    let(:participatory_space_path) { decidim_assemblies.assembly_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin menu shows only assigned space",

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages assembly publication" do
   include_context "when admin administrating an assembly"
 
   let(:admin_page_path) { decidim_admin_assemblies.assemblies_path }
-  let(:public_collection_path) { decidim_assemblies.assemblies_path() }
+  let(:public_collection_path) { decidim_assemblies.assemblies_path }
   let(:title) { "My space" }
   let!(:participatory_space) { assembly }
   let(:publish_callout_message) { "Assembly successfully published." }

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_publication_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages assembly publication" do
   include_context "when admin administrating an assembly"
 
   let(:admin_page_path) { decidim_admin_assemblies.assemblies_path }
-  let(:public_collection_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+  let(:public_collection_path) { decidim_assemblies.assemblies_path() }
   let(:title) { "My space" }
   let!(:participatory_space) { assembly }
   let(:publish_callout_message) { "Assembly successfully published." }

--- a/decidim-assemblies/spec/system/assemblies_breadcrumbs_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_breadcrumbs_spec.rb
@@ -17,7 +17,7 @@ describe "Assemblies Breadcrumb" do
 
   context "when viewing a child assembly page" do
     scenario "shows breadcrumb with parent assembly and child assembly" do
-      visit decidim_assemblies.assembly_path(child_assembly, locale: I18n.locale)
+      visit decidim_assemblies.assembly_path(child_assembly)
 
       within ".menu-bar" do
         expect(page).to have_content("Assemblies")
@@ -53,7 +53,7 @@ describe "Assemblies Breadcrumb" do
 
   context "when viewing a parent assembly page" do
     scenario "shows breadcrumb with only parent assembly" do
-      visit decidim_assemblies.assembly_path(parent_assembly, locale: I18n.locale)
+      visit decidim_assemblies.assembly_path(parent_assembly)
 
       within ".menu-bar" do
         expect(page).to have_content("Assemblies")
@@ -84,7 +84,7 @@ describe "Assemblies Breadcrumb" do
     let(:component) { create(:component, manifest_name: "proposals", participatory_space: standalone_assembly) }
 
     scenario "shows breadcrumb with only assembly" do
-      visit decidim_assemblies.assembly_path(standalone_assembly, locale: I18n.locale)
+      visit decidim_assemblies.assembly_path(standalone_assembly)
 
       within ".menu-bar" do
         expect(page).to have_content("Assemblies")

--- a/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
@@ -79,7 +79,7 @@ describe "Social shares" do
   end
 
   context "when listing all assemblies" do
-    let(:resource) { decidim_assemblies.assemblies_path() }
+    let(:resource) { decidim_assemblies.assemblies_path }
 
     it_behaves_like "a social share meta tag", "icon.png"
   end

--- a/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_social_share_spec.rb
@@ -79,7 +79,7 @@ describe "Social shares" do
   end
 
   context "when listing all assemblies" do
-    let(:resource) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+    let(:resource) { decidim_assemblies.assemblies_path() }
 
     it_behaves_like "a social share meta tag", "icon.png"
   end

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -35,13 +35,13 @@ describe "Assemblies" do
 
   context "when there are no assemblies and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+      let(:target_path) { decidim_assemblies.assemblies_path() }
     end
   end
 
   context "when the assembly does not exist" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_assemblies.assembly_path(99_999_999, locale: I18n.locale) }
+      let(:target_path) { decidim_assemblies.assembly_path(99_999_999) }
     end
   end
 
@@ -53,7 +53,7 @@ describe "Assemblies" do
 
     context "and directly accessing from URL" do
       it_behaves_like "a 404 page" do
-        let(:target_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+        let(:target_path) { decidim_assemblies.assemblies_path() }
       end
     end
   end
@@ -65,17 +65,17 @@ describe "Assemblies" do
     let!(:unpublished_assembly) { create(:assembly, :unpublished, organization:) }
 
     it_behaves_like "editable content for admins" do
-      let(:target_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+      let(:target_path) { decidim_assemblies.assemblies_path() }
     end
 
     it_behaves_like "shows contextual help" do
-      let(:index_path) { decidim_assemblies.assemblies_path(locale: I18n.locale) }
+      let(:index_path) { decidim_assemblies.assemblies_path() }
       let(:manifest_name) { :assemblies }
     end
 
     context "and requesting the assemblies path" do
       before do
-        visit decidim_assemblies.assemblies_path(locale: I18n.locale)
+        visit decidim_assemblies.assemblies_path()
       end
 
       it "lists all the highlighted assemblies" do
@@ -101,7 +101,7 @@ describe "Assemblies" do
       it "links to the individual assembly page" do
         first("a.card__grid", text: translated(assembly.title, locale: :en)).click
 
-        expect(page).to have_current_path decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        expect(page).to have_current_path decidim_assemblies.assembly_path(assembly)
       end
     end
   end
@@ -110,7 +110,7 @@ describe "Assemblies" do
     let(:assembly) { base_assembly }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { assembly }
-    let(:followable_path) { decidim_assemblies.assembly_path(assembly, locale: I18n.locale) }
+    let(:followable_path) { decidim_assemblies.assembly_path(assembly) }
   end
 
   describe "when going to the assembly page" do
@@ -124,19 +124,19 @@ describe "Assemblies" do
     end
 
     it_behaves_like "editable content for admins" do
-      let(:target_path) { decidim_assemblies.assembly_path(assembly, locale: I18n.locale) }
+      let(:target_path) { decidim_assemblies.assembly_path(assembly) }
     end
 
     context "and requesting the assembly path with main data and type and duration blocks active" do
       before do
-        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+        visit decidim_assemblies.assembly_path(assembly)
       end
 
       context "when hero, main_data extra_data, metadata and dates_metadata blocks are enabled" do
         let(:blocks_manifests) { [:hero, :main_data, :extra_data, :metadata, :dates_metadata] }
 
         before do
-          visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          visit decidim_assemblies.assembly_path(assembly)
         end
 
         it "shows the details of the given assembly" do
@@ -165,7 +165,7 @@ describe "Assemblies" do
 
           before do
             assembly.update(duration:, closing_date:)
-            visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+            visit decidim_assemblies.assembly_path(assembly)
           end
 
           it "shows indefinite duration without closing date" do
@@ -240,7 +240,7 @@ describe "Assemblies" do
         let(:blocks_manifests) { [:related_assemblies] }
 
         before do
-          visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          visit decidim_assemblies.assembly_path(assembly)
         end
 
         it "shows only the published children assemblies" do
@@ -262,7 +262,7 @@ describe "Assemblies" do
         let(:blocks_manifests) { [:related_assemblies] }
 
         before do
-          visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          visit decidim_assemblies.assembly_path(assembly)
         end
 
         it "shows only the published and transparent children assemblies" do
@@ -278,7 +278,7 @@ describe "Assemblies" do
         let!(:unpublished_child_assembly) { create(:assembly, :unpublished, organization:, parent: assembly, access_mode: :restricted) }
 
         before do
-          visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          visit decidim_assemblies.assembly_path(assembly)
         end
 
         it "not shows any children assemblies" do
@@ -293,7 +293,7 @@ describe "Assemblies" do
     let!(:child_assembly) { create(:assembly, organization:, parent: parent_assembly) }
 
     before do
-      visit decidim_assemblies.assembly_path(child_assembly, locale: I18n.locale)
+      visit decidim_assemblies.assembly_path(child_assembly)
     end
 
     it "have a link to the parent assembly" do

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -35,7 +35,7 @@ describe "Assemblies" do
 
   context "when there are no assemblies and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_assemblies.assemblies_path() }
+      let(:target_path) { decidim_assemblies.assemblies_path }
     end
   end
 
@@ -53,7 +53,7 @@ describe "Assemblies" do
 
     context "and directly accessing from URL" do
       it_behaves_like "a 404 page" do
-        let(:target_path) { decidim_assemblies.assemblies_path() }
+        let(:target_path) { decidim_assemblies.assemblies_path }
       end
     end
   end
@@ -65,17 +65,17 @@ describe "Assemblies" do
     let!(:unpublished_assembly) { create(:assembly, :unpublished, organization:) }
 
     it_behaves_like "editable content for admins" do
-      let(:target_path) { decidim_assemblies.assemblies_path() }
+      let(:target_path) { decidim_assemblies.assemblies_path }
     end
 
     it_behaves_like "shows contextual help" do
-      let(:index_path) { decidim_assemblies.assemblies_path() }
+      let(:index_path) { decidim_assemblies.assemblies_path }
       let(:manifest_name) { :assemblies }
     end
 
     context "and requesting the assemblies path" do
       before do
-        visit decidim_assemblies.assemblies_path()
+        visit decidim_assemblies.assemblies_path
       end
 
       it "lists all the highlighted assemblies" do

--- a/decidim-assemblies/spec/system/filter_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/filter_assemblies_spec.rb
@@ -26,7 +26,7 @@ describe "Filter Assemblies" do
 
     context "and choosing a taxonomy" do
       before do
-        visit decidim_assemblies.assemblies_path(filter: { with_any_taxonomies: { taxonomy.parent_id => [taxonomy.id] } }, locale: I18n.locale)
+        visit decidim_assemblies.assemblies_path(filter: { with_any_taxonomies: { taxonomy.parent_id => [taxonomy.id] } })
       end
 
       it "lists all assemblies belonging to that taxonomy" do

--- a/decidim-assemblies/spec/system/members_spec.rb
+++ b/decidim-assemblies/spec/system/members_spec.rb
@@ -6,9 +6,9 @@ require "decidim/core/test/shared_examples/participatory_space_members_shared_ex
 describe "Assembly members" do
   let(:assembly) { create(:assembly, :with_content_blocks, organization:, blocks_manifests:, has_members: true) }
   let(:participatory_space) { assembly }
-  let(:participatory_space_homepage_path) { decidim_assemblies.assembly_path(participatory_space, locale: I18n.locale) }
-  let(:members_path) { decidim_assemblies.assembly_members_path(participatory_space, locale: I18n.locale) }
-  let(:unexisting_participatory_space_members_path) { decidim_assemblies.assembly_members_path(assembly_slug: 999_999_999, locale: I18n.locale) }
+  let(:participatory_space_homepage_path) { decidim_assemblies.assembly_path(participatory_space) }
+  let(:members_path) { decidim_assemblies.assembly_members_path(participatory_space) }
+  let(:unexisting_participatory_space_members_path) { decidim_assemblies.assembly_members_path(assembly_slug: 999_999_999) }
 
   it_behaves_like "participatory space members"
 end

--- a/decidim-assemblies/spec/system/preview_assembly_with_share_token_spec.rb
+++ b/decidim-assemblies/spec/system/preview_assembly_with_share_token_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Preview assembly with share token" do
   let(:organization) { create(:organization) }
   let!(:participatory_space) { create(:assembly, organization:, published_at: nil) }
-  let(:resource_path) { decidim_assemblies.assembly_path(participatory_space, locale: I18n.locale) }
+  let(:resource_path) { decidim_assemblies.assembly_path(participatory_space) }
 
   it_behaves_like "preview participatory space with a share_token"
 end

--- a/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/post_serializer_spec.rb
@@ -88,7 +88,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
       end
 
       def root_url

--- a/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
+++ b/decidim-budgets/app/controllers/decidim/budgets/projects_controller.rb
@@ -84,7 +84,7 @@ module Decidim
 
         {
           label: translated_attribute(project.title),
-          url: Decidim::EngineRouter.main_proxy(current_component).budget_project_url(budget, project, locale: current_locale),
+          url: Decidim::EngineRouter.main_proxy(current_component).budget_project_url(budget, project),
           active: false,
           resource: project
         }
@@ -95,7 +95,7 @@ module Decidim
 
         {
           label: translated_attribute(budget.title),
-          url: Decidim::EngineRouter.main_proxy(current_component).budget_projects_url(budget, locale: current_locale),
+          url: Decidim::EngineRouter.main_proxy(current_component).budget_projects_url(budget),
           active: false,
           resource: budget
         }

--- a/decidim-budgets/spec/system/orders_spec.rb
+++ b/decidim-budgets/spec/system/orders_spec.rb
@@ -504,14 +504,14 @@ describe "Orders" do
             end
 
             it "shows private-only activity log entry" do
-              page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
+              page.visit decidim.profile_activity_path(nickname: user.nickname)
               expect(page).to have_content("New budgeting vote at #{translated(budget.title)}")
               expect(page).to have_link(translated(budget.title), href: router.budget_path(budget))
             end
 
             it "does not show activity log entry to another user" do
               relogin_as another_user, scope: :user
-              page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
+              page.visit decidim.profile_activity_path(nickname: user.nickname)
               expect(page).to have_content(user.name)
               expect(page).to have_current_path "/#{I18n.locale}/profiles/#{user.nickname}/activity"
               expect(page).to have_no_content("New budgeting vote at")

--- a/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
+++ b/decidim-comments/spec/events/decidim/comments/user_mentioned_event_spec.rb
@@ -10,9 +10,13 @@ describe Decidim::Comments::UserMentionedEvent do
   let(:event_name) { "decidim.events.comments.user_mentioned" }
   let(:ca_comment_content) { "<div><p>Un commentaire pour #{author_link}</p></div>" }
   let(:en_comment_content) { "<div><p>Comment mentioning some user, #{author_link}</p></div>" }
-  let(:author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/#{I18n.locale}/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
+  let(:author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/en/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
   let(:parsed_body) { Decidim::ContentProcessor.parse("Comment mentioning some user, @#{author.nickname}", current_organization: organization) }
-  let(:parsed_ca_body) { Decidim::ContentProcessor.parse("Un commentaire pour @#{author.nickname}", current_organization: organization) }
+  let(:parsed_ca_body) do
+    I18n.with_locale(:ca) do
+      Decidim::ContentProcessor.parse("Un commentaire pour @#{author.nickname}", current_organization: organization)
+    end
+  end
   let(:body) { { en: parsed_body.rewrite, machine_translations: { ca: parsed_ca_body.rewrite } } }
 
   let(:participatory_process) { create(:participatory_process, organization:) }
@@ -51,7 +55,7 @@ describe Decidim::Comments::UserMentionedEvent do
     let(:machine_translated) { ca_comment_content }
     let(:translatable) { true }
 
-    let(:untranslated_content) { "<div><p>Comment mentioning some user, #{ca_author_link}</p></div>" }
+    let(:untranslated_content) { "<div><p>Comment mentioning some user, #{author_link}</p></div>" }
     let(:ca_author_link) { "<a href=\"http://#{organization.host}:#{Capybara.server_port}/ca/profiles/#{author.nickname}\" data-external-link=\"false\" target=\"_blank\" rel=\"nofollow noopener noreferrer ugc\">@#{author.nickname}</a>" }
 
     it_behaves_like "a translated event"

--- a/decidim-conferences/app/cells/decidim/conferences/conference_g_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/conference_g_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def resource_path
-        Decidim::Conferences::Engine.routes.url_helpers.conference_path(model, locale: current_locale)
+        Decidim::Conferences::Engine.routes.url_helpers.conference_path(model)
       end
 
       def resource_image_url

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -17,7 +17,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Conferences::Engine.routes.url_helpers.conferences_path(locale: current_locale)
+          Decidim::Conferences::Engine.routes.url_helpers.conferences_path()
         end
 
         def max_results

--- a/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/content_blocks/highlighted_conferences_cell.rb
@@ -17,7 +17,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Conferences::Engine.routes.url_helpers.conferences_path()
+          Decidim::Conferences::Engine.routes.url_helpers.conferences_path
         end
 
         def max_results

--- a/decidim-conferences/app/cells/decidim/conferences/registration_type/join_conference.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type/join_conference.erb
@@ -1,7 +1,7 @@
 <% if conference.registrations_enabled? %>
   <% if conference.has_registration_for_user_and_registration_type?(current_user, model) %>
     <% if allowed? %>
-      <%= button_to conference_registration_type_conference_registration_path(conference, model, locale: current_locale),
+      <%= button_to conference_registration_type_conference_registration_path(conference, model),
                     method: :delete,
                     class: "#{button_classes} bg-success text-white border-transparent conference__registration-button",
                     data: { disable: true } do %>

--- a/decidim-conferences/app/cells/decidim/conferences/registration_type/registration_confirm.erb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type/registration_confirm.erb
@@ -10,6 +10,6 @@
 
   <div class="flex justify-between mt-16">
     <button class="button button__lg button__transparent-secondary" data-dialog-close="<%= model.id %>"><%= t("cancel", scope: "decidim.conferences.conference.registration_confirm") %></button>
-    <%= button_to t("confirm", scope: "decidim.conferences.conference.registration_confirm"), conference_registration_type_conference_registration_path(conference, model, locale: current_locale), class: "button button__lg button__secondary" %>
+    <%= button_to t("confirm", scope: "decidim.conferences.conference.registration_confirm"), conference_registration_type_conference_registration_path(conference, model), class: "button button__lg button__secondary" %>
   </div>
 <% end %>

--- a/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
+++ b/decidim-conferences/app/cells/decidim/conferences/registration_type_cell.rb
@@ -24,7 +24,7 @@ module Decidim
       def price
         return if model.price.blank? || model.price.zero?
 
-        number_to_currency(model.price, locale: I18n.locale, unit: Decidim.currency_unit)
+        number_to_currency(model.price, unit: Decidim.currency_unit)
       end
 
       def allowed?

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_program_controller.rb
@@ -55,7 +55,7 @@ module Decidim
 
         context_breadcrumb_items << {
           label: t("conference_program.index.title", scope: "decidim"),
-          url: decidim_conferences.conference_conference_program_path(current_participatory_space, meeting_component, locale: I18n.locale),
+          url: decidim_conferences.conference_conference_program_path(current_participatory_space, meeting_component),
           active: true,
           resource: meeting_component
         }

--- a/decidim-conferences/app/controllers/decidim/conferences/conference_registrations_controller.rb
+++ b/decidim-conferences/app/controllers/decidim/conferences/conference_registrations_controller.rb
@@ -83,7 +83,7 @@ module Decidim
         return redirect_to(conference_path(conference)) if referer =~ /invitation_token/
         return redirect_to(conference_path(conference)) if referer =~ %r{users/sign_in}
 
-        redirect_back_or_to(conference_path(conference, locale: current_locale))
+        redirect_back_or_to(conference_path(conference))
       end
     end
   end

--- a/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
+++ b/decidim-conferences/app/helpers/decidim/conferences/conference_helper.rb
@@ -23,7 +23,7 @@ module Decidim
           if participatory_space.speakers.published.exists?
             items << {
               name: t("layouts.decidim.conferences_nav.conference_speaker_menu_item"),
-              url: decidim_conferences.conference_conference_speakers_path(participatory_space, locale: current_locale)
+              url: decidim_conferences.conference_conference_speakers_path(participatory_space)
             }
           end
 
@@ -43,21 +43,21 @@ module Decidim
 
             items << {
               name: decidim_escape_translated(component.name),
-              url: decidim_conferences.conference_conference_program_path(participatory_space, locale: current_locale, id: component.id)
+              url: decidim_conferences.conference_conference_program_path(participatory_space, id: component.id)
             }
           end
 
           if participatory_space.partners.exists?
             items << {
               name: t("layouts.decidim.conferences_nav.conference_partners_menu_item"),
-              url: decidim_conferences.conference_path(participatory_space, locale: current_locale, anchor: "conference-partners-main_promotor")
+              url: decidim_conferences.conference_path(participatory_space, anchor: "conference-partners-main_promotor")
             }
           end
 
           if meeting_components.exists?
             items << {
               name: t("layouts.decidim.conferences_nav.venues"),
-              url: decidim_conferences.conference_path(participatory_space, locale: current_locale, anchor: "venues")
+              url: decidim_conferences.conference_path(participatory_space, anchor: "venues")
             }
           end
 
@@ -71,7 +71,7 @@ module Decidim
           if participatory_space.attachments.any? || participatory_space.media_links.any?
             items << {
               name: t("layouts.decidim.conferences_nav.media"),
-              url: decidim_conferences.conference_media_path(participatory_space, locale: current_locale)
+              url: decidim_conferences.conference_media_path(participatory_space)
             }
           end
         end

--- a/decidim-conferences/app/views/decidim/conferences/admin/conferences/_actions.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/admin/conferences/_actions.html.erb
@@ -38,7 +38,7 @@
 
       <% if allowed_to? :preview, :conference, conference: conference %>
         <li class="dropdown__item">
-          <%= link_to decidim_conferences.conference_path(conference, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+          <%= link_to decidim_conferences.conference_path(conference), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
             <%= icon "eye-line" %>
             <%= t("decidim.admin.actions.preview") %>
           <% end %>

--- a/decidim-conferences/app/views/decidim/conferences/conference_registration_mailer/confirmation.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_registration_mailer/confirmation.html.erb
@@ -1,6 +1,6 @@
 <p class="email-greeting"><%= t(".confirmed_html", title: translated_attribute(@conference.title), url: @locator.url) %></p>
 
-<p class="email-instructions"><%= t(".details_1", registration_type: translated_attribute(@registration_type.title), price: number_to_currency((@registration_type.price || 0), locale: I18n.locale, unit: Decidim.currency_unit)) %></p>
+<p class="email-instructions"><%= t(".details_1", registration_type: translated_attribute(@registration_type.title), price: number_to_currency((@registration_type.price || 0), unit: Decidim.currency_unit)) %></p>
 
 <ul>
   <% @registration_type.conference_meetings.order(:start_time).each do |conference_meeting| %>

--- a/decidim-conferences/app/views/decidim/conferences/conference_registration_mailer/pending_validation.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conference_registration_mailer/pending_validation.html.erb
@@ -1,6 +1,6 @@
 <p class="email-greeting"><%= t(".pending_html", title: translated_attribute(@conference.title), url: @locator.url) %></p>
 
-<p class="email-instructions"><%= t(".details", registration_type: translated_attribute(@registration_type.title), price: number_to_currency((@registration_type.price || 0), locale: I18n.locale, unit: Decidim.currency_unit)) %></p>
+<p class="email-instructions"><%= t(".details", registration_type: translated_attribute(@registration_type.title), price: number_to_currency((@registration_type.price || 0), unit: Decidim.currency_unit)) %></p>
 
 <ul>
   <% @registration_type.conference_meetings.order(:start_time).each do |conference_meeting| %>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/_conference_hero.html.erb
@@ -13,15 +13,15 @@
       </p>
       <% if current_participatory_space.registrations_enabled? %>
         <% if current_participatory_space.has_registration_for?(current_user) %>
-          <%= link_to t("layouts.decidim.conference_hero.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__primary" %>
+          <%= link_to t("layouts.decidim.conference_hero.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
         <% elsif current_participatory_space.has_published_registration_types? %>
-          <%= link_to t("layouts.decidim.conference_hero.register"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__secondary" %>
+          <%= link_to t("layouts.decidim.conference_hero.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
         <% end %>
       <% end %>
 
       <% component_meeting = current_participatory_space.components.where(manifest_name: "meetings").published.first || self.try(:current_component) %>
       <% if component_meeting.present? %>
-        <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id, locale: current_locale), class: "button button__lg button__transparent" %>
+        <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class: "button button__lg button__transparent" %>
       <% end %>
     </div>
   </div>

--- a/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
+++ b/decidim-conferences/app/views/decidim/conferences/conferences/show.html.erb
@@ -2,7 +2,7 @@
   title: translated_attribute(current_participatory_space.title),
   image_url: resolve_meta_image_url(current_participatory_space),
   description: translated_attribute(current_participatory_space.short_description),
-  url: conference_url(current_participatory_space, locale: current_locale),
+  url: conference_url(current_participatory_space),
   resource: current_participatory_space) %>
 
 <%
@@ -58,14 +58,14 @@ edit_link(
       <div>
         <% if current_participatory_space.registrations_enabled? %>
           <% if current_participatory_space.has_registration_for?(current_user) %>
-            <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__primary" %>
+            <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
           <% elsif current_participatory_space.has_published_registration_types? %>
-            <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__secondary" %>
+            <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
           <% end %>
         <% end %>
         <% current_participatory_space.components.where(manifest_name: "meetings").each do |component_meeting| %>
           <% if component_meeting.published? || component_meeting == self.try(:current_component) %>
-            <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id, locale: I18n.locale), class: "button button__lg button__transparent-secondary" %>
+            <%= link_to translated_attribute(component_meeting.name), decidim_conferences.conference_conference_program_path(current_participatory_space, id: component_meeting.id), class: "button button__lg button__transparent-secondary" %>
           <% end %>
         <% end %>
       </div>
@@ -98,9 +98,9 @@ edit_link(
             </div>
             <div>
               <% if current_participatory_space.has_registration_for?(current_user) %>
-                <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__primary" %>
+                <%= link_to t("decidim.conferences.conferences.show.manage_registration"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__primary" %>
               <% elsif current_participatory_space.has_published_registration_types? %>
-                <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space, locale: current_locale), class: "button button__lg button__secondary" %>
+                <%= link_to t("decidim.conferences.conferences.show.register"), decidim_conferences.conference_registration_types_path(current_participatory_space), class: "button button__lg button__secondary" %>
               <% end %>
             </div>
           </div>

--- a/decidim-conferences/app/views/layouts/decidim/admin/conference.html.erb
+++ b/decidim-conferences/app/views/layouts/decidim/admin/conference.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <%= link_to decidim_conferences.conference_path(current_participatory_space, locale: current_locale), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
+    <%= link_to decidim_conferences.conference_path(current_participatory_space), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
       <%= icon "eye-line" %>
       <span>
         <%= t("see_conference", scope: "decidim.admin.menu.conferences_submenu") %>

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(locale: current_locale),
+                        decidim_conferences.conferences_path(),
                         position: 2.8,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(locale: current_locale),
+                        decidim_conferences.conferences_path(),
                         position: 2.8,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(locale: current_locale),
+                        decidim_conferences.conferences_path(),
                         position: 50,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive

--- a/decidim-conferences/lib/decidim/conferences/menu.rb
+++ b/decidim-conferences/lib/decidim/conferences/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(),
+                        decidim_conferences.conferences_path,
                         position: 2.8,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(),
+                        decidim_conferences.conferences_path,
                         position: 2.8,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :conferences,
                         I18n.t("menu.conferences", scope: "decidim"),
-                        decidim_conferences.conferences_path(),
+                        decidim_conferences.conferences_path,
                         position: 50,
                         if: Decidim::Conference.where(organization: current_organization).published.any?,
                         active: :inclusive

--- a/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
@@ -28,14 +28,14 @@ module Decidim
       describe "GET show" do
         context "when conference has no meetings" do
           it "returns 404" do
-            expect { get :show, params: { conference_slug: conference.slug, id: component.id } }
+            expect { get :show, params: { conference_slug: conference.slug, id: component.id, locale: I18n.locale } }
               .to raise_error(ActionController::RoutingError)
           end
         end
 
         context "when conference has an invalid component id" do
           it "returns 404" do
-            expect { get :show, params: { conference_slug: conference.slug, id: 999 } }
+            expect { get :show, params: { conference_slug: conference.slug, id: 999, locale: I18n.locale } }
               .to raise_error(ActionController::RoutingError)
           end
         end
@@ -52,7 +52,7 @@ module Decidim
 
           context "when user has permissions" do
             it "displays list of program" do
-              get :show, params: { conference_slug: conference.slug, id: component.id }
+              get :show, params: { conference_slug: conference.slug, id: component.id, locale: I18n.locale }
 
               expect(controller.helpers.collection).to match_array(meetings)
             end

--- a/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_program_controller_spec.rb
@@ -28,14 +28,14 @@ module Decidim
       describe "GET show" do
         context "when conference has no meetings" do
           it "returns 404" do
-            expect { get :show, params: { locale: I18n.locale, conference_slug: conference.slug, id: component.id } }
+            expect { get :show, params: { conference_slug: conference.slug, id: component.id } }
               .to raise_error(ActionController::RoutingError)
           end
         end
 
         context "when conference has an invalid component id" do
           it "returns 404" do
-            expect { get :show, params: { locale: I18n.locale, conference_slug: conference.slug, id: 999 } }
+            expect { get :show, params: { conference_slug: conference.slug, id: 999 } }
               .to raise_error(ActionController::RoutingError)
           end
         end
@@ -52,7 +52,7 @@ module Decidim
 
           context "when user has permissions" do
             it "displays list of program" do
-              get :show, params: { locale: I18n.locale, conference_slug: conference.slug, id: component.id }
+              get :show, params: { conference_slug: conference.slug, id: component.id }
 
               expect(controller.helpers.collection).to match_array(meetings)
             end

--- a/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       describe "GET index" do
         context "when conference has no speakers" do
           it "redirects to 404" do
-            expect { get :index, params: { conference_slug: conference.slug } }
+            expect { get :index, params: { conference_slug: conference.slug, locale: I18n.locale } }
               .to raise_error(ActionController::RoutingError)
           end
         end
@@ -36,7 +36,7 @@ module Decidim
 
           context "when user has permissions" do
             it "displays list of speakers" do
-              get :index, params: { conference_slug: conference.slug }
+              get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
 
               expect(controller.helpers.collection).to contain_exactly(speaker1, speaker2)
             end

--- a/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conference_speakers_controller_spec.rb
@@ -24,7 +24,7 @@ module Decidim
       describe "GET index" do
         context "when conference has no speakers" do
           it "redirects to 404" do
-            expect { get :index, params: { conference_slug: conference.slug, locale: I18n.locale } }
+            expect { get :index, params: { conference_slug: conference.slug } }
               .to raise_error(ActionController::RoutingError)
           end
         end
@@ -36,7 +36,7 @@ module Decidim
 
           context "when user has permissions" do
             it "displays list of speakers" do
-              get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
+              get :index, params: { conference_slug: conference.slug }
 
               expect(controller.helpers.collection).to contain_exactly(speaker1, speaker2)
             end

--- a/decidim-conferences/spec/controllers/conferences_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conferences_controller_spec.rb
@@ -55,7 +55,7 @@ module Decidim
       describe "GET show" do
         context "when the conference is unpublished" do
           it "redirects to sign in path" do
-            get :show, params: { slug: unpublished_conference.slug, locale: I18n.locale }
+            get :show, params: { slug: unpublished_conference.slug }
 
             expect(response).to redirect_to(new_user_session_path)
           end
@@ -68,7 +68,7 @@ module Decidim
             end
 
             it "redirects to root path" do
-              get :show, params: { slug: unpublished_conference.slug, locale: I18n.locale }
+              get :show, params: { slug: unpublished_conference.slug }
 
               expect(response).to redirect_to(root_path)
             end

--- a/decidim-conferences/spec/controllers/conferences_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/conferences_controller_spec.rb
@@ -55,7 +55,7 @@ module Decidim
       describe "GET show" do
         context "when the conference is unpublished" do
           it "redirects to sign in path" do
-            get :show, params: { slug: unpublished_conference.slug }
+            get :show, params: { slug: unpublished_conference.slug, locale: I18n.locale }
 
             expect(response).to redirect_to(new_user_session_path)
           end
@@ -68,7 +68,7 @@ module Decidim
             end
 
             it "redirects to root path" do
-              get :show, params: { slug: unpublished_conference.slug }
+              get :show, params: { slug: unpublished_conference.slug, locale: I18n.locale }
 
               expect(response).to redirect_to(root_path)
             end

--- a/decidim-conferences/spec/controllers/registration_types_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/registration_types_controller_spec.rb
@@ -29,7 +29,7 @@ module Decidim
       describe "index" do
         context "when registration_types is present" do
           it "does not raise an error" do
-            get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
+            get :index, params: { conference_slug: conference.slug }
             expect(response).to have_http_status(:success)
           end
         end
@@ -39,7 +39,7 @@ module Decidim
 
           context "and current_participatory_space registrations is enabled" do
             it "does raise an error" do
-              expect { get :index, params: { conference_slug: conference.slug, locale: I18n.locale } }
+              expect { get :index, params: { conference_slug: conference.slug } }
                 .to raise_error(ActionController::RoutingError)
             end
           end
@@ -48,7 +48,7 @@ module Decidim
             let(:registrations_enabled) { false }
 
             it "does not raise an error" do
-              get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
+              get :index, params: { conference_slug: conference.slug }
               expect(response).to have_http_status(:success)
             end
           end

--- a/decidim-conferences/spec/controllers/registration_types_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/registration_types_controller_spec.rb
@@ -29,7 +29,7 @@ module Decidim
       describe "index" do
         context "when registration_types is present" do
           it "does not raise an error" do
-            get :index, params: { conference_slug: conference.slug }
+            get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
             expect(response).to have_http_status(:success)
           end
         end
@@ -39,7 +39,7 @@ module Decidim
 
           context "and current_participatory_space registrations is enabled" do
             it "does raise an error" do
-              expect { get :index, params: { conference_slug: conference.slug } }
+              expect { get :index, params: { conference_slug: conference.slug, locale: I18n.locale } }
                 .to raise_error(ActionController::RoutingError)
             end
           end
@@ -48,7 +48,7 @@ module Decidim
             let(:registrations_enabled) { false }
 
             it "does not raise an error" do
-              get :index, params: { conference_slug: conference.slug }
+              get :index, params: { conference_slug: conference.slug, locale: I18n.locale }
               expect(response).to have_http_status(:success)
             end
           end

--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -196,7 +196,7 @@ shared_examples "manage conference components" do
       let(:published_at) { Time.current }
 
       it "hides the component from the menu" do
-        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_path(conference)
         expect(page).to have_content decidim_escape_translated(component.name)
 
         visit decidim_admin_conferences.components_path(conference)
@@ -211,7 +211,7 @@ shared_examples "manage conference components" do
           expect(page).to have_css("a", text: "Unpublish")
         end
 
-        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_path(conference)
         expect(page).to have_no_content decidim_escape_translated(component.name)
       end
     end

--- a/decidim-conferences/spec/shared/manage_conferences_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conferences_examples.rb
@@ -158,7 +158,7 @@ shared_examples "manage conferences" do
         end
 
         page.within_window(new_window) do
-          expect(page).to have_current_path decidim_conferences.conference_path(conference, locale: I18n.locale)
+          expect(page).to have_current_path decidim_conferences.conference_path(conference)
           expect(page).to have_content(translated(conference.title))
         end
       end

--- a/decidim-conferences/spec/system/admin/admin_access_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_access_spec.rb
@@ -13,7 +13,7 @@ describe "AdminAccess" do
     let(:role) { create(:conference_admin, :confirmed, organization:, conference: participatory_space) }
     let(:target_path) { decidim_admin_conferences.edit_conference_path(participatory_space) }
     let(:unauthorized_target_path) { decidim_admin_conferences.edit_conference_path(other_participatory_space) }
-    let(:participatory_space_path) { decidim_conferences.conference_path(participatory_space, locale: I18n.locale) }
+    let(:participatory_space_path) { decidim_conferences.conference_path(participatory_space) }
 
     it_behaves_like "admin participatory space access"
     it_behaves_like "admin participatory space edit button"

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages conference publication" do
   include_context "when admin administrating a conference"
 
   let(:admin_page_path) { decidim_admin_conferences.conferences_path }
-  let(:public_collection_path) { decidim_conferences.conferences_path(locale: I18n.locale) }
+  let(:public_collection_path) { decidim_conferences.conferences_path() }
   let(:title) { "My space" }
   let!(:participatory_space) { conference }
   let(:publish_callout_message) { "Conference successfully published." }

--- a/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
+++ b/decidim-conferences/spec/system/admin/admin_manages_conferences_publication_spec.rb
@@ -6,7 +6,7 @@ describe "Admin manages conference publication" do
   include_context "when admin administrating a conference"
 
   let(:admin_page_path) { decidim_admin_conferences.conferences_path }
-  let(:public_collection_path) { decidim_conferences.conferences_path() }
+  let(:public_collection_path) { decidim_conferences.conferences_path }
   let(:title) { "My space" }
   let!(:participatory_space) { conference }
   let(:publish_callout_message) { "Conference successfully published." }

--- a/decidim-conferences/spec/system/conference_program_spec.rb
+++ b/decidim-conferences/spec/system/conference_program_spec.rb
@@ -17,13 +17,13 @@ describe "Conference program" do
 
   context "when there are no meetings and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_conference_program_path(conference, component, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_conference_program_path(conference, component) }
     end
   end
 
   context "when there are no meeting and accessing from the conference homepage" do
     it "the menu link is not shown" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
 
       within "aside .conference__nav-container" do
         expect(page).to have_no_content(translated_attribute(component.name))
@@ -33,7 +33,7 @@ describe "Conference program" do
 
   context "when the conference does not exist" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_conference_program_path(conference_slug: 999_999_999, id: component.id, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_conference_program_path(conference_slug: 999_999_999, id: component.id) }
     end
   end
 
@@ -44,20 +44,20 @@ describe "Conference program" do
 
     before do
       meetings.each { |meeting| meeting.update(taxonomies: [taxonomy]) }
-      visit decidim_conferences.conference_conference_program_path(conference, component, locale: I18n.locale)
+      visit decidim_conferences.conference_conference_program_path(conference, component)
     end
 
     context "and accessing from the conference homepage" do
       context "when rendering" do
         it "the menu link is shown" do
-          visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+          visit decidim_conferences.conference_path(conference)
 
           within "aside .conference__nav-container" do
             expect(page).to have_content(decidim_escape_translated(component.name))
             click_on decidim_escape_translated(component.name)
           end
 
-          expect(page).to have_current_path decidim_conferences.conference_conference_program_path(conference, component, locale: I18n.locale)
+          expect(page).to have_current_path decidim_conferences.conference_conference_program_path(conference, component)
         end
       end
 

--- a/decidim-conferences/spec/system/conference_registrations_spec.rb
+++ b/decidim-conferences/spec/system/conference_registrations_spec.rb
@@ -27,15 +27,15 @@ describe "Conference registrations" do
   let(:registration_type) { registration_types.first }
 
   def visit_conference
-    visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+    visit decidim_conferences.conference_path(conference)
   end
 
   def visit_conference_registration_types
-    visit decidim_conferences.conference_registration_types_path(conference, locale: I18n.locale)
+    visit decidim_conferences.conference_registration_types_path(conference)
   end
 
   def visit_conference_registration_type
-    visit decidim_conferences.conference_registration_type_conference_registration_path(conference_slug: conference, registration_type_id: registration_type, locale: I18n.locale)
+    visit decidim_conferences.conference_registration_type_conference_registration_path(conference_slug: conference, registration_type_id: registration_type)
   end
 
   before do

--- a/decidim-conferences/spec/system/conference_social_share_spec.rb
+++ b/decidim-conferences/spec/system/conference_social_share_spec.rb
@@ -106,19 +106,19 @@ describe "Social shares" do
   end
 
   context "when visiting the conference speakers" do
-    let(:resource) { decidim_conferences.conference_conference_speakers_path(conference, component) }
+    let(:resource) { decidim_conferences.conference_conference_speakers_path(conference) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end
 
   context "when visiting the media page" do
-    let(:resource) { decidim_conferences.conference_media_path(conference, component) }
+    let(:resource) { decidim_conferences.conference_media_path(conference) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end
 
   context "when visiting registration types" do
-    let(:resource) { decidim_conferences.conference_registration_types_path(conference, component) }
+    let(:resource) { decidim_conferences.conference_registration_types_path(conference) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end

--- a/decidim-conferences/spec/system/conference_social_share_spec.rb
+++ b/decidim-conferences/spec/system/conference_social_share_spec.rb
@@ -94,31 +94,31 @@ describe "Social shares" do
   end
 
   context "when listing all conferences" do
-    let(:resource) { decidim_conferences.conferences_path(locale: I18n.locale) }
+    let(:resource) { decidim_conferences.conferences_path() }
 
     it_behaves_like "a social share meta tag", "icon.png"
   end
 
   context "when visiting the conference program" do
-    let(:resource) { decidim_conferences.conference_conference_program_path(conference, component, locale: I18n.locale) }
+    let(:resource) { decidim_conferences.conference_conference_program_path(conference, component) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end
 
   context "when visiting the conference speakers" do
-    let(:resource) { decidim_conferences.conference_conference_speakers_path(conference, component, locale: I18n.locale) }
+    let(:resource) { decidim_conferences.conference_conference_speakers_path(conference, component) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end
 
   context "when visiting the media page" do
-    let(:resource) { decidim_conferences.conference_media_path(conference, component, locale: I18n.locale) }
+    let(:resource) { decidim_conferences.conference_media_path(conference, component) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end
 
   context "when visiting registration types" do
-    let(:resource) { decidim_conferences.conference_registration_types_path(conference, component, locale: I18n.locale) }
+    let(:resource) { decidim_conferences.conference_registration_types_path(conference, component) }
 
     it_behaves_like "a social share meta tag", "city2.jpeg"
   end

--- a/decidim-conferences/spec/system/conference_social_share_spec.rb
+++ b/decidim-conferences/spec/system/conference_social_share_spec.rb
@@ -94,7 +94,7 @@ describe "Social shares" do
   end
 
   context "when listing all conferences" do
-    let(:resource) { decidim_conferences.conferences_path() }
+    let(:resource) { decidim_conferences.conferences_path }
 
     it_behaves_like "a social share meta tag", "icon.png"
   end

--- a/decidim-conferences/spec/system/conference_speakers_spec.rb
+++ b/decidim-conferences/spec/system/conference_speakers_spec.rb
@@ -12,13 +12,13 @@ describe "Conference speakers" do
 
   context "when there are no conference speakers and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_conference_speakers_path(conference) }
     end
   end
 
   context "when there are no conference speakers and accessing from the conference homepage" do
     it "the menu link is not shown" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
 
       expect(page).to have_no_content("Speakers")
     end
@@ -26,7 +26,7 @@ describe "Conference speakers" do
 
   context "when the conference does not exist" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_conference_speakers_path(conference_slug: 999_999_999, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_conference_speakers_path(conference_slug: 999_999_999) }
     end
   end
 
@@ -34,19 +34,19 @@ describe "Conference speakers" do
     let!(:conference_speakers) { create_list(:conference_speaker, 2, :published, conference:) }
 
     before do
-      visit decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_conference_speakers_path(conference)
     end
 
     context "and accessing from the conference homepage" do
       it "the menu link is shown" do
-        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_path(conference)
 
         within ".conference__nav-container" do
           expect(page).to have_content("Speakers")
           click_on "Speakers"
         end
 
-        expect(page).to have_current_path decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+        expect(page).to have_current_path decidim_conferences.conference_conference_speakers_path(conference)
       end
     end
 
@@ -69,7 +69,7 @@ describe "Conference speakers" do
 
     before do
       login_as user, scope: :user
-      visit decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_conference_speakers_path(conference)
     end
 
     context "when there are some unpublished speakers" do
@@ -91,7 +91,7 @@ describe "Conference speakers" do
           click_link_or_button "Publish"
         end
 
-        visit decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_conference_speakers_path(conference)
 
         within "#conference_speakers-grid" do
           expect(page).to have_css("[data-conference-speaker]", count: 2)
@@ -103,7 +103,7 @@ describe "Conference speakers" do
       before do
         speaker2.update!(published_at: Time.current)
         speaker3.update!(published_at: Time.current)
-        visit decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_conference_speakers_path(conference)
       end
 
       it "is shown in the public list" do
@@ -124,7 +124,7 @@ describe "Conference speakers" do
           click_link_or_button "Unpublish"
         end
 
-        visit decidim_conferences.conference_conference_speakers_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_conference_speakers_path(conference)
 
         within "#conference_speakers-grid" do
           expect(page).to have_css("[data-conference-speaker]", count: 2)

--- a/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
+++ b/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
@@ -14,7 +14,7 @@ describe "Conferences Breadcrumb" do
   end
 
   scenario "shows breadcrumb with only conference" do
-    visit decidim_conferences.conference_path(participatory_space, locale: I18n.locale)
+    visit decidim_conferences.conference_path(participatory_space)
 
     within ".menu-bar" do
       expect(page).to have_content("Conferences")
@@ -52,7 +52,7 @@ describe "Conferences Breadcrumb" do
     end
 
     scenario "shows breadcrumb with conference and program" do
-      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
+      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component)
 
       within ".menu-bar" do
         expect(page).to have_content("Conferences")
@@ -62,7 +62,7 @@ describe "Conferences Breadcrumb" do
     end
 
     scenario "shows breadcrumb with conference, program, and meeting" do
-      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component, locale: I18n.locale)
+      visit decidim_conferences.conference_conference_program_path(participatory_space, meetings_component)
       click_on decidim_sanitize_translated(meeting.title)
 
       within ".menu-bar" do

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -24,7 +24,7 @@ describe "Conferences" do
 
   context "when there are no conferences and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conferences_path() }
+      let(:target_path) { decidim_conferences.conferences_path }
     end
   end
 
@@ -42,7 +42,7 @@ describe "Conferences" do
 
     context "and directly accessing from URL" do
       it_behaves_like "a 404 page" do
-        let(:target_path) { decidim_conferences.conferences_path() }
+        let(:target_path) { decidim_conferences.conferences_path }
       end
     end
   end
@@ -53,11 +53,11 @@ describe "Conferences" do
     let!(:unpublished_conference) { create(:conference, :unpublished, organization:) }
 
     before do
-      visit decidim_conferences.conferences_path()
+      visit decidim_conferences.conferences_path
     end
 
     it_behaves_like "shows contextual help" do
-      let(:index_path) { decidim_conferences.conferences_path() }
+      let(:index_path) { decidim_conferences.conferences_path }
       let(:manifest_name) { :conferences }
     end
 

--- a/decidim-conferences/spec/system/conferences_spec.rb
+++ b/decidim-conferences/spec/system/conferences_spec.rb
@@ -24,13 +24,13 @@ describe "Conferences" do
 
   context "when there are no conferences and directly accessing from URL" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conferences_path(locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conferences_path() }
     end
   end
 
   context "when the conference does not exist" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_path(99_999_999, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_path(99_999_999) }
     end
   end
 
@@ -42,7 +42,7 @@ describe "Conferences" do
 
     context "and directly accessing from URL" do
       it_behaves_like "a 404 page" do
-        let(:target_path) { decidim_conferences.conferences_path(locale: I18n.locale) }
+        let(:target_path) { decidim_conferences.conferences_path() }
       end
     end
   end
@@ -53,11 +53,11 @@ describe "Conferences" do
     let!(:unpublished_conference) { create(:conference, :unpublished, organization:) }
 
     before do
-      visit decidim_conferences.conferences_path(locale: I18n.locale)
+      visit decidim_conferences.conferences_path()
     end
 
     it_behaves_like "shows contextual help" do
-      let(:index_path) { decidim_conferences.conferences_path(locale: I18n.locale) }
+      let(:index_path) { decidim_conferences.conferences_path() }
       let(:manifest_name) { :conferences }
     end
 
@@ -86,7 +86,7 @@ describe "Conferences" do
       within "#conferences-grid" do
         first("[id^='conference']", text: translated(conference.title, locale: :en)).click
 
-        expect(page).to have_current_path decidim_conferences.conference_path(conference, locale: I18n.locale)
+        expect(page).to have_current_path decidim_conferences.conference_path(conference)
       end
     end
   end
@@ -95,7 +95,7 @@ describe "Conferences" do
     let(:conference) { base_conference }
     let!(:user) { create(:user, :confirmed, organization:) }
     let(:followable) { conference }
-    let(:followable_path) { decidim_conferences.conference_path(conference, locale: I18n.locale) }
+    let(:followable_path) { decidim_conferences.conference_path(conference) }
   end
 
   describe "when going to the conference page" do
@@ -107,7 +107,7 @@ describe "Conferences" do
       create_list(:proposal, 3, component: proposals_component)
       allow(Decidim).to receive(:component_manifests).and_return([proposals_component.manifest, meetings_component.manifest])
 
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
     end
 
     it "has a sidebar" do
@@ -119,7 +119,7 @@ describe "Conferences" do
         meetings.empty?
         allow(Decidim).to receive(:address).and_return("foo bar")
 
-        visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+        visit decidim_conferences.conference_path(conference)
       end
 
       context "when the meeting component is not published" do
@@ -224,7 +224,7 @@ describe "Conferences" do
           create(:meeting, :published, :in_person, address: "", location_hints: nil, location: "", component: other_meetings_component)
           create_list(:meeting, 3, :published, :in_person, component: meetings_component)
 
-          visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+          visit decidim_conferences.conference_path(conference)
 
           expect(page).to have_css(".conference__map-address", count: 3)
         end
@@ -236,7 +236,7 @@ describe "Conferences" do
     let!(:conference) { base_conference }
 
     before do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
     end
 
     it "has no sidebar" do

--- a/decidim-conferences/spec/system/media_spec.rb
+++ b/decidim-conferences/spec/system/media_spec.rb
@@ -7,7 +7,7 @@ describe "Conferences" do
   let!(:conference) { create(:conference, organization:) }
 
   def visit_conference
-    visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+    visit decidim_conferences.conference_path(conference)
   end
 
   before do
@@ -16,7 +16,7 @@ describe "Conferences" do
 
   context "when there are no attachments and media links" do
     it_behaves_like "a 404 page" do
-      let(:target_path) { decidim_conferences.conference_media_path(conference, locale: I18n.locale) }
+      let(:target_path) { decidim_conferences.conference_media_path(conference) }
     end
   end
 
@@ -34,11 +34,11 @@ describe "Conferences" do
     let!(:media_link) { create(:media_link, conference:) }
 
     before do
-      visit decidim_conferences.conference_media_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_media_path(conference)
     end
 
     it "the menu link is shown" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
 
       within "aside .conference__nav-container" do
         expect(page).to have_content("Media")
@@ -60,7 +60,7 @@ describe "Conferences" do
     let!(:image) { create(:attachment, attached_to: conference) }
 
     before do
-      visit decidim_conferences.conference_media_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_media_path(conference)
     end
 
     it "shows them" do
@@ -81,7 +81,7 @@ describe "Conferences" do
     let!(:fist_image) { create(:attachment, attached_to: conference, weight: 1) }
 
     before do
-      visit decidim_conferences.conference_media_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_media_path(conference)
     end
 
     it "shows them ordered" do

--- a/decidim-conferences/spec/system/partners_spec.rb
+++ b/decidim-conferences/spec/system/partners_spec.rb
@@ -13,7 +13,7 @@ describe "Conference partners" do
 
   context "when there are no partners" do
     it "the menu link is not shown" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
       expect(page).to have_no_content("Partners")
     end
   end
@@ -23,7 +23,7 @@ describe "Conference partners" do
     let!(:collaborators) { create_list(:partner, 2, :collaborator, conference:) }
 
     it "the menu link is shown" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
 
       within "aside .conference__nav-container" do
         expect(page).to have_content("Partners")
@@ -32,7 +32,7 @@ describe "Conference partners" do
     end
 
     it "lists all conference partners" do
-      visit decidim_conferences.conference_path(conference, locale: I18n.locale)
+      visit decidim_conferences.conference_path(conference)
 
       within "#conference-partners-main_promotor" do
         expect(page).to have_content("Organizers")

--- a/decidim-conferences/spec/system/preview_conference_with_share_token_spec.rb
+++ b/decidim-conferences/spec/system/preview_conference_with_share_token_spec.rb
@@ -5,7 +5,7 @@ require "spec_helper"
 describe "Preview conference with share token" do
   let(:organization) { create(:organization) }
   let!(:participatory_space) { create(:conference, organization:, published_at: nil) }
-  let(:resource_path) { decidim_conferences.conference_path(participatory_space, locale: I18n.locale) }
+  let(:resource_path) { decidim_conferences.conference_path(participatory_space) }
 
   it_behaves_like "preview participatory space with a share_token"
 end

--- a/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
@@ -42,7 +42,7 @@ module Decidim
         if model.settings.cta_button_path.present?
           translated_attribute(model.settings.cta_button_path)
         elsif Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?
-          decidim_participatory_processes.participatory_processes_path()
+          decidim_participatory_processes.participatory_processes_path
         elsif current_user
           decidim.account_path
         elsif current_organization.sign_up_enabled?

--- a/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/hero_cell.rb
@@ -42,7 +42,7 @@ module Decidim
         if model.settings.cta_button_path.present?
           translated_attribute(model.settings.cta_button_path)
         elsif Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?
-          decidim_participatory_processes.participatory_processes_path(locale: current_locale)
+          decidim_participatory_processes.participatory_processes_path()
         elsif current_user
           decidim.account_path
         elsif current_organization.sign_up_enabled?

--- a/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/how_to_participate/show.erb
@@ -37,7 +37,7 @@
       </div>
     </div>
   </div>
-  <%= link_to decidim.pages_path(locale: current_locale), class: "button button__sm md:button__lg button__secondary mt-6" do %>
+  <%= link_to decidim.pages_path(), class: "button button__sm md:button__lg button__secondary mt-6" do %>
     <%= t("more_info", scope: "decidim.pages.home.extended", resource_name: current_organization_name) %>
     <%= icon "arrow-right-line", class: "fill-current" %>
   <% end %>

--- a/decidim-core/app/cells/decidim/footer_topics_cell.rb
+++ b/decidim-core/app/cells/decidim/footer_topics_cell.rb
@@ -25,7 +25,7 @@ module Decidim
 
         {
           title: decidim_escape_translated(topic.title),
-          path: decidim.page_path(topic.pages.first, locale: current_locale)
+          path: decidim.page_path(topic.pages.first)
         }
       end.compact
     end

--- a/decidim-core/app/cells/decidim/profile_cell.rb
+++ b/decidim-core/app/cells/decidim/profile_cell.rb
@@ -78,7 +78,7 @@ module Decidim
     # i18n-tasks-use t("decidim.profiles.show.followers")
     def tab_item(key)
       values = TABS_ITEMS[key].dup
-      values[:path] = send(values[:path], nickname: profile_holder.nickname, locale: current_locale)
+      values[:path] = send(values[:path], nickname: profile_holder.nickname)
       values[:text] = t(key, scope: "decidim.profiles.show")
       values
     end

--- a/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
+++ b/decidim-core/app/cells/decidim/resource_types_filter_cell.rb
@@ -31,7 +31,7 @@ module Decidim
       if options[:source] == :last_activities
         last_activities_path(filter: { with_resource_type: resource_type })
       else
-        profile_activity_path(nickname: params[:nickname], locale: current_locale, filter: { resource_type: })
+        profile_activity_path(nickname: params[:nickname], filter: { resource_type: })
       end
     end
 

--- a/decidim-core/app/cells/decidim/user_profile_cell.rb
+++ b/decidim-core/app/cells/decidim/user_profile_cell.rb
@@ -20,7 +20,7 @@ module Decidim
     end
 
     def resource_path
-      user.try(:profile_url) || decidim.profile_path(user.nickname, locale: I18n.locale)
+      user.try(:profile_url) || decidim.profile_path(user.nickname)
     end
 
     def presented_resource

--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -30,7 +30,7 @@ module Decidim
           conversation = conversation_between(current_user, @form.recipient)
         end
 
-        return redirect_back_or_to(profile_path(current_user.nickname, locale: current_locale)) if @form.recipient.empty?
+        return redirect_back_or_to(profile_path(current_user.nickname)) if @form.recipient.empty?
 
         return redirect_to conversation_path(conversation) if conversation
 

--- a/decidim-core/app/helpers/decidim/component_path_helper.rb
+++ b/decidim-core/app/helpers/decidim/component_path_helper.rb
@@ -10,7 +10,7 @@ module Decidim
     # Returns a relative url.
     def main_component_path(component, desired_params = {})
       current_params = try(:params) || {}
-      current_params = current_params.merge()
+      current_params = current_params.merge(locale: I18n.locale)
                                      .merge(desired_params)
 
       EngineRouter.main_proxy(component).root_path(locale: current_params[:locale])
@@ -23,7 +23,7 @@ module Decidim
     # Returns an absolute url.
     def main_component_url(component, desired_params = {})
       current_params = try(:params) || {}
-      current_params = current_params.merge()
+      current_params = current_params.merge(locale: I18n.locale)
                                      .merge(desired_params)
 
       EngineRouter.main_proxy(component).root_url(locale: current_params[:locale])

--- a/decidim-core/app/helpers/decidim/component_path_helper.rb
+++ b/decidim-core/app/helpers/decidim/component_path_helper.rb
@@ -10,7 +10,7 @@ module Decidim
     # Returns a relative url.
     def main_component_path(component, desired_params = {})
       current_params = try(:params) || {}
-      current_params = current_params.merge(locale: I18n.locale)
+      current_params = current_params.merge()
                                      .merge(desired_params)
 
       EngineRouter.main_proxy(component).root_path(locale: current_params[:locale])
@@ -23,7 +23,7 @@ module Decidim
     # Returns an absolute url.
     def main_component_url(component, desired_params = {})
       current_params = try(:params) || {}
-      current_params = current_params.merge(locale: I18n.locale)
+      current_params = current_params.merge()
                                      .merge(desired_params)
 
       EngineRouter.main_proxy(component).root_url(locale: current_params[:locale])

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -73,7 +73,7 @@ module Decidim
 
     def author_profile_url
       @author_profile_url ||= if @author.is_a?(Decidim::UserBaseEntity) && !@author.deleted?
-                                decidim.profile_url(@author.nickname, locale: I18n.locale,
+                                decidim.profile_url(@author.nickname,
                                                                       host: @organization.host)
                               end
     end

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -74,7 +74,7 @@ module Decidim
     def author_profile_url
       @author_profile_url ||= if @author.is_a?(Decidim::UserBaseEntity) && !@author.deleted?
                                 decidim.profile_url(@author.nickname,
-             host: @organization.host)
+                                                    host: @organization.host)
                               end
     end
 

--- a/decidim-core/app/mailers/decidim/reported_mailer.rb
+++ b/decidim-core/app/mailers/decidim/reported_mailer.rb
@@ -74,7 +74,7 @@ module Decidim
     def author_profile_url
       @author_profile_url ||= if @author.is_a?(Decidim::UserBaseEntity) && !@author.deleted?
                                 decidim.profile_url(@author.nickname,
-                                                                      host: @organization.host)
+             host: @organization.host)
                               end
     end
 

--- a/decidim-core/app/presenters/decidim/log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/user_presenter.rb
@@ -77,7 +77,7 @@ module Decidim
       #
       # Returns an HTML-safe String.
       def user_path
-        h.decidim.profile_path(present_user_nickname, locale: I18n.locale)
+        h.decidim.profile_path(present_user_nickname)
       end
     end
   end

--- a/decidim-core/app/presenters/decidim/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/user_presenter.rb
@@ -31,7 +31,7 @@ module Decidim
     def profile_url
       return "" if respond_to?(:deleted?) && deleted?
 
-      decidim.profile_url(__getobj__.nickname, locale: I18n.locale)
+      decidim.profile_url(__getobj__.nickname)
     end
 
     def avatar
@@ -52,7 +52,7 @@ module Decidim
     def profile_path
       return "" if respond_to?(:deleted?) && deleted?
 
-      decidim.profile_path(__getobj__.nickname, locale: I18n.locale)
+      decidim.profile_path(__getobj__.nickname)
     end
 
     def direct_messages_enabled?(context)

--- a/decidim-core/app/serializers/decidim/exporters/serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/serializer.rb
@@ -62,7 +62,7 @@ module Decidim
       def profile_url(user)
         return "" if user.respond_to?(:deleted?) && user.deleted?
 
-        EngineRouter.new("decidim", { host: }).profile_url(user.nickname, locale: I18n.locale)
+        EngineRouter.new("decidim", { host: }).profile_url(user.nickname)
       end
 
       def root_url

--- a/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
+++ b/decidim-core/app/views/decidim/devise/invitations/edit.html.erb
@@ -30,7 +30,7 @@
         <% end %>
       </div>
 
-      <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-and-conditions", locale: I18n.locale), target: "_blank" %>
+      <% link = link_to t("terms", scope: "decidim.devise.registrations.new"), page_path("terms-and-conditions"), target: "_blank" %>
       <% label = t("tos_agreement", scope: "decidim.devise.registrations.new", link:) %>
       <%= f.check_box :tos_agreement, label:, required: "required", label_options: { class: "form__wrapper-checkbox-label" } %>
     </div>

--- a/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/shared/_tos_fields.html.erb
@@ -7,7 +7,7 @@
       <%= cell content_block.manifest.cell, content_block %>
     <% end %>
   </div>
-  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service", locale: current_locale))), label_options: { class: "form__wrapper-checkbox-label" }, "aria-describedby": "terms_of_service_summary" %>
+  <%= form.check_box :tos_agreement, label: t("decidim.devise.registrations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" }, "aria-describedby": "terms_of_service_summary" %>
 </div>
 
 <div id="card__newsletter" class="form__wrapper-block">

--- a/decidim-core/app/views/decidim/pages/_tabbed.html.erb
+++ b/decidim-core/app/views/decidim/pages/_tabbed.html.erb
@@ -21,7 +21,7 @@
       <ul id="dropdown-menu-pages" class="vertical-tabs__list">
         <% pages.each do |sibling| %>
           <li class="<%= "is-active" if page == sibling %>">
-            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug, locale: current_locale), "aria-current": ("page" if page == sibling) %>
+            <%= link_to translated_attribute(sibling.title), page_path(sibling.slug), "aria-current": ("page" if page == sibling) %>
           </li>
         <% end %>
       </ul>

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -29,7 +29,7 @@ edit_link(
                 <div class="page__accordion-trigger">
                   <div>
                     <h3 id="accordion-title-<%= ix %>" class="page__accordion-trigger-title">
-                      <%= link_to translated_attribute(topic.title), page_path(topic.pages.first, locale: current_locale) %>
+                      <%= link_to translated_attribute(topic.title), page_path(topic.pages.first) %>
                     </h3>
                     <p class="page__accordion-trigger-snippet"><%= translated_attribute topic.description %></p>
                   </div>
@@ -42,7 +42,7 @@ edit_link(
                 <div id="accordion-panel-<%= ix %>" class="page__accordion-panel" aria-hidden="true">
                   <ul role="menu">
                     <% topic.pages.each do |page| %>
-                      <li role="menuitem"><%= link_to translated_attribute(page.title), page_path(page, locale: current_locale), class: "text-secondary" %></li>
+                      <li role="menuitem"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary" %></li>
                     <% end %>
                   </ul>
                 </div>
@@ -60,7 +60,7 @@ edit_link(
           <% @orphan_pages.each do |page| %>
             <div class="page__accordion">
               <h3 class="page__accordion-trigger-title">
-                <%= link_to translated_attribute(page.title), page_path(page, locale: current_locale) %>
+                <%= link_to translated_attribute(page.title), page_path(page) %>
               </h3>
               <p class="page__accordion-trigger-snippet"><%== strip_tags html_truncate(translated_attribute(page.content), length: 140, separator: "...") %></p>
             </div>

--- a/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_user_menu.html.erb
@@ -1,6 +1,6 @@
 <li role="presentation"><%= link_to t(".profile"), decidim.account_path, role: "menuitem" %></li>
 <% if current_user.nickname.present? && !current_user.managed? %>
-  <li role="presentation"><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname, locale: current_locale), role: "menuitem" %></li>
+  <li role="presentation"><%= link_to t(".public_profile"), decidim.profile_path(current_user.nickname), role: "menuitem" %></li>
 <% end %>
 <li role="presentation"><%= link_to t(".notifications"), decidim.notifications_path, role: "menuitem" %></li>
 <li role="presentation"><%= link_to t(".conversations"), decidim.conversations_path, role: "menuitem" %></li>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_legal.html.erb
@@ -1,6 +1,6 @@
 <ul class="flex flex-col gap-6 md:flex-row md:gap-10 text-sm text-white [&_a]:underline">
   <li>
-    <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service", locale: current_locale) %>
+    <%= link_to t("layouts.decidim.footer.terms_of_service"), decidim.page_path("terms-of-service") %>
   </li>
   <li>
     <a href="#" role="button" data-dialog-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a>

--- a/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
+++ b/decidim-core/app/views/layouts/decidim/footer/_main_links.html.erb
@@ -5,7 +5,7 @@
   <ul class="space-y-4 break-inside-avoid">
     <% if current_user %>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.configuration"), decidim.account_path %></li>
-      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname, locale: current_locale) %></li>
+      <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.public_profile"), decidim.profile_path(current_user.nickname) %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.notifications"), decidim.notifications_path %></li>
       <li class="font-semibold underline"><%= link_to t("layouts.decidim.user_menu.conversations"), decidim.conversations_path %></li>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_dropdown.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 </li>
 <li class="dropdown__item">
-  <%= link_to decidim.profile_path(current_user.nickname, locale: current_locale), class: "dropdown__button" do %>
+  <%= link_to decidim.profile_path(current_user.nickname), class: "dropdown__button" do %>
     <%= icon "account-circle-line" %>
     <span><%= t("layouts.decidim.user_menu.public_profile") %></span>
   <% end %>

--- a/decidim-core/lib/decidim/api/types/static_page_type.rb
+++ b/decidim-core/lib/decidim/api/types/static_page_type.rb
@@ -15,7 +15,7 @@ module Decidim
       field :url, GraphQL::Types::String, "The URL of this page", null: false
 
       def url
-        Decidim::EngineRouter.new("decidim", { host: object.organization.host }).page_url(object, locale: I18n.locale)
+        Decidim::EngineRouter.new("decidim", { host: object.organization.host }).page_url(object)
       end
     end
   end

--- a/decidim-core/lib/decidim/gamification/base_event.rb
+++ b/decidim-core/lib/decidim/gamification/base_event.rb
@@ -8,13 +8,12 @@ module Decidim
       delegate :url_helpers, to: "Decidim::Core::Engine.routes"
 
       def resource_path
-        url_helpers.profile_badges_path(nickname: user.nickname, locale: I18n.locale)
+        url_helpers.profile_badges_path(nickname: user.nickname)
       end
 
       def resource_url
         url_helpers.profile_badges_url(
           nickname: user.nickname,
-          locale: I18n.locale,
           host: user.organization.host
         )
       end

--- a/decidim-core/spec/system/follow_users_spec.rb
+++ b/decidim-core/spec/system/follow_users_spec.rb
@@ -15,7 +15,7 @@ describe "Follow users" do
   context "when not following the user" do
     context "when user clicks the Follow button" do
       it "makes the user follow the user" do
-        visit decidim.profile_path(followable.nickname, locale: I18n.locale)
+        visit decidim.profile_path(followable.nickname)
         expect do
           click_on "Follow"
           expect(page).to have_content(/stop following/i)
@@ -31,7 +31,7 @@ describe "Follow users" do
 
     context "when user clicks the Follow button" do
       it "makes the user follow the user" do
-        visit decidim.profile_path(followable.nickname, locale: I18n.locale)
+        visit decidim.profile_path(followable.nickname)
         expect do
           click_on "Stop following"
           expect(page).to have_content "Follow"

--- a/decidim-core/spec/system/gamification_spec.rb
+++ b/decidim-core/spec/system/gamification_spec.rb
@@ -18,7 +18,7 @@ describe "Gamification" do
       end
 
       it "shows a list of badges" do
-        visit decidim.profile_path(user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(user.nickname)
         click_on "Badges"
         within "div[data-badge='test']" do
           expect(page).to have_content "Level 2"
@@ -31,7 +31,7 @@ describe "Gamification" do
     let!(:user) { create(:user, organization:) }
 
     it "can be reached from the profile's badges page" do
-      visit decidim.profile_path(user.nickname, locale: I18n.locale)
+      visit decidim.profile_path(user.nickname)
       click_on "Badges"
       within ".profile__badge-banner" do
         click_on "See all available badges"

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -263,7 +263,7 @@ describe "Conversations" do
       let(:recipient) { create(:user, :confirmed, organization:) }
 
       before do
-        visit decidim.profile_path(recipient.nickname, locale: I18n.locale)
+        visit decidim.profile_path(recipient.nickname)
       end
 
       it "has a contact link" do

--- a/decidim-core/spec/system/user_activity_spec.rb
+++ b/decidim-core/spec/system/user_activity_spec.rb
@@ -73,7 +73,7 @@ describe "User activity" do
         allow_any_instance_of(Decidim::ActivityCell).to receive(:resource_link_path).and_return("/example/path")
         # rubocop:enable RSpec/AnyInstance
 
-        page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
+        page.visit decidim.profile_activity_path(nickname: user.nickname)
         within "#activities-container" do
           expect(page).to have_css("[data-activity]", count: 3)
 
@@ -88,7 +88,7 @@ describe "User activity" do
 
   describe "accessing the user activity page" do
     before do
-      page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
+      page.visit decidim.profile_activity_path(nickname: user.nickname)
     end
 
     it "displays the activities at the home page" do
@@ -119,7 +119,7 @@ describe "User activity" do
     context "when accessing a nonexistent profile" do
       before do
         allow(page.config).to receive(:raise_server_errors).and_return(false)
-        visit decidim.profile_activity_path(nickname: "invalid_nickname", locale: I18n.locale)
+        visit decidim.profile_activity_path(nickname: "invalid_nickname")
       end
 
       it "displays an error message" do

--- a/decidim-core/spec/system/user_profile_spec.rb
+++ b/decidim-core/spec/system/user_profile_spec.rb
@@ -12,11 +12,11 @@ describe "Profile" do
   context "when has casing in the nickname" do
     before do
       switch_to_host(user.organization.host)
-      visit decidim.profile_path(nickname: user.nickname.upcase, locale: I18n.locale)
+      visit decidim.profile_path(nickname: user.nickname.upcase)
     end
 
     it "downcases the path" do
-      expect(page).to have_current_path(decidim.profile_activity_path(nickname: user.nickname.downcase, locale: I18n.locale))
+      expect(page).to have_current_path(decidim.profile_activity_path(nickname: user.nickname.downcase))
     end
   end
 
@@ -52,7 +52,7 @@ describe "Profile" do
 
   context "when navigating publicly" do
     before do
-      visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+      visit decidim.profile_path(nickname: user.nickname)
     end
 
     it "is not indexable by crawlers" do
@@ -72,13 +72,13 @@ describe "Profile" do
       it "displays the correct links for profile activity" do
         visit current_path
         within "#filters" do
-          expect(page).to have_link("All activity types", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "all" }))
-          expect(page).to have_link("Proposal", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Proposals::Proposal" }))
-          expect(page).to have_link("Comment", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Comments::Comment" }))
-          expect(page).to have_link("Debate", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Debates::Debate" }))
-          expect(page).to have_link("Initiative", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Initiative" }))
-          expect(page).to have_link("Meeting", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Meetings::Meeting" }))
-          expect(page).to have_link("Post", href: decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale, filter: { resource_type: "Decidim::Blogs::Post" }))
+          expect(page).to have_link("All activity types", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "all" }))
+          expect(page).to have_link("Proposal", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Proposals::Proposal" }))
+          expect(page).to have_link("Comment", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Comments::Comment" }))
+          expect(page).to have_link("Debate", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Debates::Debate" }))
+          expect(page).to have_link("Initiative", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Initiative" }))
+          expect(page).to have_link("Meeting", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Meetings::Meeting" }))
+          expect(page).to have_link("Post", href: decidim.profile_activity_path(nickname: user.nickname, filter: { resource_type: "Decidim::Blogs::Post" }))
         end
 
         expect(page).to have_content("New comment")
@@ -147,7 +147,7 @@ describe "Profile" do
       end
 
       it "shows the number of followers and following" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
         within(".profile__details") do
           expect(page).to have_content("1 follower")
           expect(page).to have_content("2 follows")
@@ -155,7 +155,7 @@ describe "Profile" do
       end
 
       it "lists the followers" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
         click_on "Followers"
 
         expect(page).to have_content(other_user.name)
@@ -163,7 +163,7 @@ describe "Profile" do
       end
 
       it "lists the followings" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
         click_on "Follows"
 
         expect(page).to have_no_content("Some of the resources followed are not public.")
@@ -181,7 +181,7 @@ describe "Profile" do
         end
 
         it "lists only the public followings" do
-          visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+          visit decidim.profile_path(nickname: user.nickname)
           within(".profile__details") do
             expect(page).to have_content("3 follows")
           end
@@ -203,7 +203,7 @@ describe "Profile" do
         end
 
         it "lists only the unblocked followings" do
-          visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+          visit decidim.profile_path(nickname: user.nickname)
 
           click_on "Follows"
           expect(page).to have_content("Some of the resources followed are not public.")
@@ -221,7 +221,7 @@ describe "Profile" do
         end
 
         it "lists only the unblocked followers" do
-          visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+          visit decidim.profile_path(nickname: user.nickname)
 
           click_on "Followers"
           expect(page).to have_content(translated(other_user.name))
@@ -235,7 +235,7 @@ describe "Profile" do
         before do
           user.organization.update(badges_enabled: true)
           Decidim::Gamification.set_score(user, :test, 10)
-          visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+          visit decidim.profile_path(nickname: user.nickname)
         end
 
         it "shows a badges tab" do
@@ -246,7 +246,7 @@ describe "Profile" do
       context "when badges are disabled" do
         before do
           user.organization.update(badges_enabled: false)
-          visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+          visit decidim.profile_path(nickname: user.nickname)
         end
 
         it "shows a badges tab" do
@@ -261,7 +261,7 @@ describe "Profile" do
 
     context "when user is not a member of any participatory space" do
       it "does not show the member of section" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
 
         expect(page).to have_no_content("Member of")
       end
@@ -272,7 +272,7 @@ describe "Profile" do
       let!(:member) { create(:member, :published, user:, participatory_space: assembly) }
 
       it "shows the member of section with the assembly link" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
 
         expect(page).to have_content("Member of")
         expect(page).to have_link(translated(assembly.title), href: %r{/assemblies/#{assembly.slug}})
@@ -284,7 +284,7 @@ describe "Profile" do
       let!(:member) { create(:member, :published, user:, participatory_space: participatory_process) }
 
       it "shows the member of section with the process link" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
 
         expect(page).to have_content("Member of")
         expect(page).to have_link(translated(participatory_process.title), href: %r{/processes/#{participatory_process.slug}})
@@ -298,7 +298,7 @@ describe "Profile" do
       let!(:process_member) { create(:member, :published, user:, participatory_space: participatory_process) }
 
       it "shows a single member of section with both links" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
 
         expect(page).to have_content("Member of")
         expect(page).to have_link(translated(assembly.title), href: %r{/assemblies/#{assembly.slug}})
@@ -306,7 +306,7 @@ describe "Profile" do
       end
 
       it "shows only one member of header" do
-        visit decidim.profile_path(nickname: user.nickname, locale: I18n.locale)
+        visit decidim.profile_path(nickname: user.nickname)
 
         expect(page).to have_css("div.font-semibold", text: "Member of", count: 1)
       end

--- a/decidim-core/spec/system/user_report_spec.rb
+++ b/decidim-core/spec/system/user_report_spec.rb
@@ -6,7 +6,7 @@ describe "Report User" do
   let(:user) { create(:user, :confirmed) }
   let!(:users) { create_list(:user, 3, :confirmed, organization: user.organization) }
   let(:reportable) { users.first }
-  let(:reportable_path) { decidim.profile_path(reportable.nickname, locale: I18n.locale) }
+  let(:reportable_path) { decidim.profile_path(reportable.nickname) }
 
   before do
     switch_to_host(user.organization.host)
@@ -15,7 +15,7 @@ describe "Report User" do
   context "when the user is blocked" do
     let(:user) { create(:user, :confirmed, :blocked) }
     let(:admin) { create(:user, :admin, :confirmed, organization: user.organization) }
-    let(:reportable_path) { decidim.profile_path(user.nickname, locale: I18n.locale) }
+    let(:reportable_path) { decidim.profile_path(user.nickname) }
 
     before do
       switch_to_host(user.organization.host)

--- a/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
+++ b/decidim-debates/spec/lib/decidim/debates/debate_serializer_spec.rb
@@ -206,7 +206,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
       end
 
       def root_url

--- a/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
+++ b/decidim-debates/spec/serializers/decidim/debates/download_your_data_debate_serializer_spec.rb
@@ -179,7 +179,7 @@ module Decidim
     end
 
     def profile_url(nickname)
-      Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
+      Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
     end
 
     def host

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
@@ -19,7 +19,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Initiatives::Engine.routes.url_helpers.initiatives_path(locale: current_locale)
+          Decidim::Initiatives::Engine.routes.url_helpers.initiatives_path()
         end
 
         private

--- a/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/content_blocks/highlighted_initiatives_cell.rb
@@ -19,7 +19,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::Initiatives::Engine.routes.url_helpers.initiatives_path()
+          Decidim::Initiatives::Engine.routes.url_helpers.initiatives_path
         end
 
         private

--- a/decidim-initiatives/app/cells/decidim/initiatives/initiative_g_cell.rb
+++ b/decidim-initiatives/app/cells/decidim/initiatives/initiative_g_cell.rb
@@ -9,9 +9,9 @@ module Decidim
 
       def resource_path
         if resource.state == "created" || resource.state == "validating"
-          Decidim::Initiatives::Engine.routes.url_helpers.load_initiative_draft_create_initiative_index_path(initiative_id: resource.id, locale: current_locale)
+          Decidim::Initiatives::Engine.routes.url_helpers.load_initiative_draft_create_initiative_index_path(initiative_id: resource.id)
         else
-          Decidim::Initiatives::Engine.routes.url_helpers.initiative_path(model, locale: current_locale)
+          Decidim::Initiatives::Engine.routes.url_helpers.initiative_path(model)
         end
       end
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
@@ -70,9 +70,9 @@ module Decidim
 
       def redirect_page
         if request.referer&.include?("create_initiative")
-          promotal_committee_create_initiative_index_path(locale: I18n.locale)
+          promotal_committee_create_initiative_index_path()
         else
-          edit_initiative_path(current_initiative, locale: I18n.locale)
+          edit_initiative_path(current_initiative)
         end
       end
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/committee_requests_controller.rb
@@ -70,7 +70,7 @@ module Decidim
 
       def redirect_page
         if request.referer&.include?("create_initiative")
-          promotal_committee_create_initiative_index_path()
+          promotal_committee_create_initiative_index_path
         else
           edit_initiative_path(current_initiative)
         end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiative_signatures_controller.rb
@@ -175,19 +175,19 @@ module Decidim
       attr_reader :wizard_steps
 
       def fill_personal_data_path
-        fill_personal_data_initiative_signatures_path(current_initiative, locale: current_locale)
+        fill_personal_data_initiative_signatures_path(current_initiative)
       end
 
       def sms_code_path
-        sms_code_initiative_signatures_path(current_initiative, locale: current_locale)
+        sms_code_initiative_signatures_path(current_initiative)
       end
 
       def finish_path
-        finish_initiative_signatures_path(current_initiative, locale: current_locale)
+        finish_initiative_signatures_path(current_initiative)
       end
 
       def sms_phone_number_path
-        sms_phone_number_initiative_signatures_path(current_initiative, locale: current_locale)
+        sms_phone_number_initiative_signatures_path(current_initiative)
       end
 
       def build_vote_form(parameters)
@@ -300,7 +300,6 @@ module Decidim
       def create_ephemeral_user
         form = Decidim::EphemeralUserForm.new(
           organization: current_organization,
-          locale: current_locale,
           onboarding_data: current_initiative_onboarding_data
         )
         CreateEphemeralUser.call(form) do
@@ -315,8 +314,8 @@ module Decidim
           "model" => current_initiative.to_gid,
           "permissions_holder" => initiative_type.to_gid,
           "action" => "vote",
-          "redirect_path" => initiative_path(current_initiative, locale: current_locale),
-          "authorization_path" => initiative_signatures_path(current_initiative, locale: current_locale)
+          "redirect_path" => initiative_path(current_initiative),
+          "authorization_path" => initiative_signatures_path(current_initiative)
         }
       end
     end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -66,7 +66,7 @@ module Decidim
 
         SendInitiativeToTechnicalValidation.call(current_initiative, current_user) do
           on(:ok) do
-            redirect_to EngineRouter.main_proxy(current_initiative).initiatives_path(initiative_slug: nil, locale: current_locale), flash: {
+            redirect_to EngineRouter.main_proxy(current_initiative).initiatives_path(initiative_slug: nil), flash: {
               notice: I18n.t(
                 "success",
                 scope: "decidim.initiatives.admin.initiatives.edit"
@@ -100,7 +100,7 @@ module Decidim
         UpdateInitiative.call(current_initiative, @form) do
           on(:ok) do |initiative|
             flash[:notice] = I18n.t("success", scope: "decidim.initiatives.update")
-            redirect_to initiative_path(initiative, locale: current_locale)
+            redirect_to initiative_path(initiative)
           end
 
           on(:invalid) do
@@ -120,7 +120,7 @@ module Decidim
         end
 
         flash[:notice] = I18n.t("initiatives.discard.success", scope: "decidim.initiatives.admin")
-        redirect_to decidim_initiatives.initiatives_path(locale: current_locale)
+        redirect_to decidim_initiatives.initiatives_path()
       end
 
       def print

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -120,7 +120,7 @@ module Decidim
         end
 
         flash[:notice] = I18n.t("initiatives.discard.success", scope: "decidim.initiatives.admin")
-        redirect_to decidim_initiatives.initiatives_path()
+        redirect_to decidim_initiatives.initiatives_path
       end
 
       def print

--- a/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
+++ b/decidim-initiatives/app/mailers/decidim/initiatives/initiatives_mailer.rb
@@ -45,7 +45,7 @@ module Decidim
             state: I18n.t(initiative.state, scope: "decidim.initiatives.admin_states")
           )
 
-          @link = initiative_url(initiative, locale: I18n.locale, host: @organization.host)
+          @link = initiative_url(initiative, host: @organization.host)
 
           mail(to: "#{user.name} <#{user.email}>", subject: @subject)
         end
@@ -56,7 +56,7 @@ module Decidim
         return if user.email.blank?
 
         @organization = initiative.organization
-        @link = initiative_url(initiative, locale: I18n.locale, host: @organization.host)
+        @link = initiative_url(initiative, host: @organization.host)
 
         with_user(user) do
           @body = I18n.t(

--- a/decidim-initiatives/app/views/decidim/initiatives/_modal.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/_modal.html.erb
@@ -7,7 +7,7 @@
     <p id="dialog-desc-not-authorized-modal"><%= t(".not_authorized.explanation") %></p>
   </div>
   <div data-dialog-actions>
-    <%= link_to t(".not_authorized.authorizations_page"), decidim_verifications.authorizations_path(redirect_url: create_initiative_url(:select_initiative_type, locale: current_locale)), class: "button button__sm md:button__lg button__secondary" %>
+    <%= link_to t(".not_authorized.authorizations_page"), decidim_verifications.authorizations_path(redirect_url: create_initiative_url(:select_initiative_type)), class: "button button__sm md:button__lg button__secondary" %>
     <button data-dialog-close="not-authorized-modal" class="button button__sm md:button__lg button__secondary">
       <%= t("ok", scope: "decidim.budgets.projects.budget_excess") %>
     </button>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/committee_requests/index.html.erb
@@ -13,7 +13,7 @@
 
     <div class="row column">
       <div data-committee_link>
-        <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>
+        <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>
         <%= icon_link_to "clipboard-line", "#", t(".invite_to_committee_help"), class: "card--list__data__icon invite-users-link" %>
       </div>
     </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -50,10 +50,10 @@
                             disabled: !@form.signature_type_updatable?,
                             "data-scope-selector": "initiative_decidim_scope_id",
                             "data-scope-id": form.object.decidim_scope_id.to_s,
-                            "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url(locale: I18n.locale),
+                            "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url(),
                             "data-signature-types-selector": "initiative_signature_type",
                             "data-signature-type": current_initiative.signature_type,
-                            "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url(locale: I18n.locale)
+                            "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url()
                           } %>
         </div>
         <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -83,7 +83,7 @@
 
                   <% if allowed_to? :print, :initiative, initiative: initiative %>
                     <li class="dropdown__item">
-                      <%= link_to decidim_initiatives.print_initiative_path(initiative, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+                      <%= link_to decidim_initiatives.print_initiative_path(initiative), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
                         <%= icon "printer-line" %>
                         <%= t(".print") %>
                       <% end %>
@@ -94,7 +94,7 @@
 
                   <% if allowed_to? :preview, :initiative, initiative: initiative %>
                     <li class="dropdown__item">
-                      <%= link_to decidim_initiatives.initiative_path(initiative.to_param, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+                      <%= link_to decidim_initiatives.initiative_path(initiative.to_param), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
                         <%= icon "eye-line" %>
                         <%= t(".preview") %>
                       <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/committee_requests/new.html.erb
@@ -2,7 +2,7 @@
                            image_url: resolve_meta_image_url(current_initiative),
                            description: translated_attribute(current_initiative.description),
                            title: translated_attribute(current_initiative.title),
-                           url: initiative_url(current_initiative.id, locale: current_locale)
+                           url: initiative_url(current_initiative.id)
                          }) %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
@@ -23,7 +23,7 @@
     <%= cell("decidim/announcement", t("decidim.initiatives.committee_requests.new.help_text"), callout_class: "secondary") %>
 
     <div class="form__wrapper-block">
-      <%= logged_link_to t("continue", scope: "decidim.initiatives.committee_requests.new"), spawn_initiative_committee_requests_path(current_initiative, locale: current_locale), class: "button button__sm md:button__lg button__secondary", data: current_user.blank? ? { dialog_open: "loginModal" } : {} %>
+      <%= logged_link_to t("continue", scope: "decidim.initiatives.committee_requests.new"), spawn_initiative_committee_requests_path(current_initiative), class: "button button__sm md:button__lg button__secondary", data: current_user.blank? ? { dialog_open: "loginModal" } : {} %>
     </div>
   </div>
 <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_committee_member.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_committee_member.html.erb
@@ -4,7 +4,7 @@
   <div>
     <% if allowed_to? :approve, :initiative_committee_member, initiative: current_initiative, request: request %>
       <%= link_to(
-              approve_initiative_committee_request_path(current_initiative, request, locale: current_locale),
+              approve_initiative_committee_request_path(current_initiative, request),
               data: { confirm: t(".confirm_approve") },
               class: "button button__xs button__transparent-secondary"
             ) do %>
@@ -14,7 +14,7 @@
     <% end %>
     <% if allowed_to? :revoke, :initiative_committee_member, initiative: current_initiative, request: request %>
       <%= link_to(
-              revoke_initiative_committee_request_path(current_initiative, request, locale: current_locale),
+              revoke_initiative_committee_request_path(current_initiative, request),
               method: :delete,
               data: { confirm: t(".confirm_revoke") },
               class: "button button__xs button__transparent-secondary"

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_return_to_initiatives_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_return_to_initiatives_button.html.erb
@@ -1,3 +1,3 @@
 <p class="block mt-4 text-with-links">
-  <%= t(".return_initiatives_html", initiatives_path: initiatives_path(locale: current_locale)) %>
+  <%= t(".return_initiatives_html", initiatives_path: initiatives_path()) %>
 </p>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_send_to_technical_validation_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_send_to_technical_validation_button.html.erb
@@ -1,6 +1,6 @@
 <% if current_initiative.enough_committee_members? %>
   <%= link_to t(".button"),
-              decidim_initiatives.send_to_technical_validation_initiative_path(current_initiative, locale: current_locale),
+              decidim_initiatives.send_to_technical_validation_initiative_path(current_initiative),
               class: "button button__sm md:button__lg button__secondary",
               data: { confirm: t(".confirm") } %>
 <% else %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_share_committee_link.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/_share_committee_link.html.erb
@@ -4,18 +4,18 @@
   </span>
   <span class="help-text mb-2">
     <%= t ".invite_to_committee_help_2", committee_size: current_initiative.minimum_committee_members %>
-    <%= link_to t(".more_information"), decidim.page_path("initiatives", locale: current_locale), target: "_blank" %>
+    <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>
   </span>
   <div class="initiative__form__committee">
     <span>
-      <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>
+      <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>
     </span>
     <div class="ml-auto fill-secondary inline-block">
       <button type="button" class="button button__sm button__text-secondary" data-controller="clipboard-copy" data-clipboard-copy="#urlShareLink-committee">
         <%= render_committee_tooltip %>
         <span class="sr-only"><%= t("decidim.shared.share_modal.copy_share_link") %></span>
       </button>
-      <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>" readonly>
+      <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>" readonly>
     </div>
   </div>
 </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -2,12 +2,12 @@
 <% announcement_body = capture do %>
   <div class="max-w-full prose">
     <%= t("fill_data_help", scope: "decidim.initiatives.create_initiative.fill_data").html_safe %>
-    <%= link_to t(".more_information"), decidim.page_path("initiatives", locale: current_locale), target: "_blank", class: "button button__sm button__text-secondary block text-left" %>
+    <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank", class: "button button__sm button__text-secondary block text-left" %>
   </div>
 <% end %>
 
 <%= cell("decidim/announcement", { body: announcement_body }, callout_class: "secondary") %>
-<%= decidim_form_for(@form, url: fill_data_create_initiative_index_path(locale: current_locale), method: :put, html: { class: "form-defaults new_initiative_form" }) do |f| %>
+<%= decidim_form_for(@form, url: fill_data_create_initiative_index_path(), method: :put, html: { class: "form-defaults new_initiative_form" }) do |f| %>
   <div class="form__wrapper">
     <%= form_required_explanation %>
 
@@ -63,7 +63,7 @@
 
     <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
       <% if current_initiative %>
-        <%= link_to discard_initiative_path(current_initiative, locale: current_locale), class: "button button__sm md:button__lg button__text-secondary", method: :delete, data: { confirm: t(".confirm_discard") } do %>
+        <%= link_to discard_initiative_path(current_initiative), class: "button button__sm md:button__lg button__text-secondary", method: :delete, data: { confirm: t(".confirm_discard") } do %>
           <%= icon "delete-bin-line", class: "fill-current" %>
           <%= t(".discard") %>
         <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/finish.html.erb
@@ -24,9 +24,9 @@
 
 <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
   <% if is_validating %>
-    <%= link_to t(".go_to_initiatives"), decidim_initiatives.initiatives_path(locale: current_locale), class: "button button__sm md:button__lg button__secondary" %>
+    <%= link_to t(".go_to_initiatives"), decidim_initiatives.initiatives_path(), class: "button button__sm md:button__lg button__secondary" %>
   <% else %>
-    <%= link_to fill_data_create_initiative_index_path(locale: current_locale), class: "button button__sm md:button__lg button__text-secondary" do %>
+    <%= link_to fill_data_create_initiative_index_path(), class: "button button__sm md:button__lg button__text-secondary" do %>
       <%= icon "arrow-left-line", class: "fill-current" %>
       <%= t("back", scope: "decidim.initiatives.create_initiative.previous_form") %>
     <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/promotal_committee.html.erb
@@ -34,7 +34,7 @@
 </div>
 
 <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-  <%= link_to fill_data_create_initiative_index_path(locale: current_locale), class: "button button__sm md:button__lg button__text-secondary" do %>
+  <%= link_to fill_data_create_initiative_index_path(), class: "button button__sm md:button__lg button__text-secondary" do %>
     <%= icon "arrow-left-line", class: "fill-current" %>
     <%= t("back", scope: "decidim.initiatives.create_initiative.previous_form") %>
   <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -3,7 +3,7 @@
 <% announcement_body = capture do %>
   <%= t("select_initiative_type_help_html", scope: "decidim.initiatives.create_initiative.select_initiative_type") %>
   <br>
-  <%= link_to t("more_information", scope: "decidim.initiatives.create_initiative.select_initiative_type"), decidim.page_path("initiatives", locale: current_locale), target: "_blank", class: "button button__sm button__text-secondary block text-left" %>
+  <%= link_to t("more_information", scope: "decidim.initiatives.create_initiative.select_initiative_type"), decidim.page_path("initiatives"), target: "_blank", class: "button button__sm button__text-secondary block text-left" %>
 <% end %>
 
 <%= cell("decidim/announcement", { body: announcement_body }, callout_class: "secondary") %>
@@ -11,7 +11,7 @@
 <h3 class="title-decorator text-2xl mt-8"><%= t(".subtitle") %></h3>
 
 <div class="initiatives__selection" id="select-initiative-type">
-  <%= decidim_form_for(@form, url: select_initiative_type_create_initiative_index_path(locale: current_locale), method: :put, html: { id: "new_initiative_form", class: "form-defaults " }) do |f| %>
+  <%= decidim_form_for(@form, url: select_initiative_type_create_initiative_index_path(), method: :put, html: { id: "new_initiative_form", class: "form-defaults " }) do |f| %>
     <% initiative_types_each do |type| %>
       <% is_allowed = allowed_to?(:create, :initiative, { initiative_type: type }) %>
 
@@ -33,8 +33,8 @@
           <p>
             <%= action_authorized_link_to(
                 :create,
-                fill_data_create_initiative_index_path(initiative: { type_id: type.id }, locale: current_locale),
-                authorizations_modal_path: authorization_create_modal_initiative_path(type, locale: current_locale),
+                fill_data_create_initiative_index_path(initiative: { type_id: type.id }),
+                authorizations_modal_path: authorization_create_modal_initiative_path(type),
                 permissions_holder: type,
                 class: "button button__sm button__transparent-secondary",
                 "data-dialog-open": "not-authorized-modal",
@@ -47,7 +47,7 @@
 
         <p>
           <%= link_to t("consult_existing_initiatives", scope: "decidim.initiatives.create_initiative.select_initiative_type"),
-                      initiatives_path(filter: { with_any_type: type.id },locale: current_locale), target: "_blank" %>
+                      initiatives_path(filter: { with_any_type: type.id }), target: "_blank" %>
         </p>
       <% end %>
     <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiative_signatures/finish.html.erb
@@ -11,7 +11,7 @@
 </div>
 
 <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
-  <%= link_to initiative_path(current_initiative, locale: current_locale), class: "button button__sm md:button__lg button__secondary mr-auto !ml-0" do %>
+  <%= link_to initiative_path(current_initiative), class: "button button__sm md:button__lg button__secondary mr-auto !ml-0" do %>
     <%= icon "arrow-left-line", class: "fill-current" %>
     <%= t("back_to_initiative", scope: "decidim.initiatives.initiative_signatures.finish") %>
   <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_committee_members.html.erb
@@ -6,14 +6,14 @@
 
   <div class="initiative__form__committee">
     <span>
-      <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>
+      <%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>
     </span>
     <div class="ml-auto fill-secondary inline-block">
       <button type="button" class="button button__sm button__text-secondary" data-controller="clipboard-copy" data-clipboard-copy="#urlShareLink-committee">
         <%= render_committee_tooltip %>
         <span class="sr-only"><%= t("decidim.shared.share_modal.copy_share_link") %></span>
       </button>
-      <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>" readonly>
+      <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>" readonly>
     </div>
   </div>
 </div>
@@ -28,7 +28,7 @@
         <%= card_for request.user %>
         <% if allowed_to? :approve, :initiative_committee_member, initiative: current_initiative, request: request %>
           <%= link_to(
-                  approve_initiative_committee_request_path(current_initiative, request, locale: current_locale),
+                  approve_initiative_committee_request_path(current_initiative, request),
                   data: { confirm: t(".confirm_approve") },
                   class: "button button__sm button__transparent-secondary"
                 ) do %>
@@ -38,7 +38,7 @@
         <% end %>
         <% if allowed_to? :revoke, :initiative_committee_member, initiative: current_initiative, request: request %>
           <%= link_to(
-                  revoke_initiative_committee_request_path(current_initiative, request, locale: current_locale),
+                  revoke_initiative_committee_request_path(current_initiative, request),
                   method: :delete,
                   data: { confirm: t(".confirm_revoke") },
                   class: "button button__sm button__transparent-secondary"

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_new_initiative_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_new_initiative_button.html.erb
@@ -7,24 +7,24 @@
           <%= icon "add-fill" %>
         </button>
       <% else %>
-        <%= link_to create_initiative_path(:select_initiative_type, locale: current_locale), class: "!px-4 title-action__action button button__xl button__secondary w-full" do %>
+        <%= link_to create_initiative_path(:select_initiative_type), class: "!px-4 title-action__action button button__xl button__secondary w-full" do %>
           <%= t("new_initiative", scope: "decidim.initiatives.initiatives.index_header") %>
           <%= icon "add-fill" %>
         <% end %>
       <% end %>
     <% else %>
-      <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type, locale: current_locale) } %>
+      <% content_for(:redirect_after_login) { create_initiative_url(:select_initiative_type) } %>
       <button type="button" class="button button__xl button__secondary w-full" data-dialog-open="loginModal" aria-controls="loginModal" aria-haspopup="dialog" tabindex="0">
         <%= t("new_initiative", scope: "decidim.initiatives.initiatives.index_header") %>
         <%= icon "add-fill" %>
       </button>
     <% end %>
   <% elsif (initiative_type = available_initiative_types.first).present? %>
-    <% content_for(:redirect_after_login) { fill_data_create_initiative_index_path(initiative: { type_id: initiative_type.id }, locale: current_locale) } unless current_user %>
+    <% content_for(:redirect_after_login) { fill_data_create_initiative_index_path(initiative: { type_id: initiative_type.id }) } unless current_user %>
     <%= action_authorized_link_to(
           :create,
-          fill_data_create_initiative_index_path(initiative: { type_id: initiative_type.id }, locale: current_locale),
-          authorizations_modal_path: authorization_create_modal_initiative_path(initiative_type, locale: current_locale),
+          fill_data_create_initiative_index_path(initiative: { type_id: initiative_type.id }),
+          authorizations_modal_path: authorization_create_modal_initiative_path(initiative_type),
           permissions_holder: initiative_type,
           "data-dialog-open": allowed_to?(:create, :initiative, { initiative_type: }) ? "" : "not-authorized-modal",
           class: "!px-4 title-action__action button button__xl button__secondary w-full"

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_button.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_vote_button.html.erb
@@ -37,10 +37,10 @@
     <%= action_authorized_link_to(
       :vote,
       t("vote", scope: "decidim.initiatives.initiatives.vote_cabin"),
-      steps ? initiative_signatures_path(initiative_slug: current_initiative.slug, locale: current_locale) : initiative_path(current_initiative, locale: current_locale),
+      steps ? initiative_signatures_path(initiative_slug: current_initiative.slug) : initiative_path(current_initiative),
       resource: current_initiative,
       permissions_holder: current_initiative.type,
-      authorizations_modal_path: authorization_sign_modal_initiative_path(current_initiative, locale: current_locale),
+      authorizations_modal_path: authorization_sign_modal_initiative_path(current_initiative),
       class: "button button__xl w-full button__secondary"
     ) %>
   <% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/edit.html.erb
@@ -5,7 +5,7 @@
     <h1 class="title-decorator inline-block text-left"><%= t("title", scope: "decidim.initiatives.edit") %></h1>
   </div>
 
-  <%= decidim_form_for @form, url: initiative_path(current_initiative, locale: current_locale), html: { class: "form__wrapper edit_initiative" } do |f| %>
+  <%= decidim_form_for @form, url: initiative_path(current_initiative), html: { class: "form__wrapper edit_initiative" } do |f| %>
     <%= render partial: "form", object: f %>
 
     <div class="form__wrapper-block flex-col-reverse md:flex-row justify-between">
@@ -49,7 +49,7 @@
 
       <% if allowed_to? :discard, :initiative, initiative: current_initiative %>
         <%= link_to t("discard", scope: "decidim.initiatives.edit"),
-                    discard_initiative_path(current_initiative, locale: current_locale),
+                    discard_initiative_path(current_initiative),
                     method: :delete,
                     class: "button button__sm md:button__lg button__secondary",
                     data: { confirm: t("confirm", scope: "decidim.initiatives.edit") } %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -1,7 +1,7 @@
 <% add_decidim_meta_tags(
   description: translated_attribute(current_initiative.description),
   title: translated_attribute(current_initiative.title),
-  url: initiative_url(current_initiative.id, locale: current_locale),
+  url: initiative_url(current_initiative.id),
   resource: current_initiative) %>
 
 <%
@@ -25,13 +25,13 @@ edit_link(
         <section class="layout-aside__section layout-aside__buttons">
           <% if allowed_to? :edit, :initiative, initiative: current_initiative %>
             <%= link_to t(".edit"),
-                        edit_initiative_path(current_initiative, locale: current_locale),
+                        edit_initiative_path(current_initiative),
                         class: "button button__xl w-full button__secondary" %>
           <% end %>
 
           <% if allowed_to? :send_to_technical_validation, :initiative, initiative: current_initiative %>
             <%= link_to t(".send_to_technical_validation"),
-                        send_to_technical_validation_initiative_path(current_initiative, locale: current_locale),
+                        send_to_technical_validation_initiative_path(current_initiative),
                         class: "button button__xl w-full button__secondary mt-4",
                         data: { confirm: t(".confirm") } %>
           <% end %>
@@ -59,7 +59,7 @@ edit_link(
             <%= t("title", scope: "decidim.initiatives.admin.committee_requests.index") %>
           </span>
           <div class="ml-auto fill-secondary inline-block">
-            <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative, locale: current_locale) %>" readonly>
+            <input id="urlShareLink-committee" type="text" class="!hidden" value="<%= decidim_initiatives.new_initiative_committee_request_url(current_initiative) %>" readonly>
             <button type="button" class="button button__sm button__text-secondary" data-controller="clipboard-copy" data-clipboard-copy="#urlShareLink-committee">
               <%= render_committee_tooltip %>
               <span class="sr-only"><%= t("decidim.shared.share_modal.copy_share_link") %></span>
@@ -160,8 +160,8 @@ edit_link(
   <% else %>
     <%= cell("decidim/announcement", t(".before_send_to_technical_validation_announcement",
                                        count: current_initiative.missing_committee_members,
-                                       href: link_to(new_initiative_committee_request_url(current_initiative, locale: current_locale),
-                                                     new_initiative_committee_request_path(current_initiative, locale: current_locale))), callout_class: "warning") %>
+                                       href: link_to(new_initiative_committee_request_url(current_initiative),
+                                                     new_initiative_committee_request_path(current_initiative))), callout_class: "warning") %>
   <% end %>
 <% end %>
 
@@ -204,6 +204,6 @@ edit_link(
   <%= comments_for current_initiative if current_initiative.commentable? && current_initiative.published? %>
   <ul class="metadata__container layout-main__section" data-metadata-footer>
     <%= content_tag :li, resource_reference(current_initiative), class: "metadata__item" %>
-    <%= content_tag :li, resource_version(current_initiative, versions_path: initiative_version_path(current_initiative, current_initiative.versions.count, locale: current_locale)), class: "metadata__item" %>
+    <%= content_tag :li, resource_version(current_initiative, versions_path: initiative_version_path(current_initiative, current_initiative.versions.count)), class: "metadata__item" %>
   </ul>
 </section>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives_mailer/notify_creation.html.erb
@@ -1,6 +1,6 @@
 <p>
 <%= t "decidim.initiatives.initiatives_mailer.creation_subject", title: translated_attribute(@initiative.title) %>.
-<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", locale: current_locale, host: @organization.host) %>
+<%= link_to t("decidim.initiatives.initiatives_mailer.more_information"), decidim.page_url("initiatives", host: @organization.host) %>
 </p>
 
 <% if @initiative.promoting_committee_enabled? %>
@@ -9,8 +9,8 @@
             member_count: Decidim::Initiatives.minimum_committee_members %>
     </p>
     <p>
-      <%= link_to decidim_initiatives.new_initiative_committee_request_url(@initiative, locale: current_locale, host: @organization.host),
-                  decidim_initiatives.new_initiative_committee_request_url(@initiative, locale: current_locale, host: @organization.host) %>
+      <%= link_to decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host),
+                  decidim_initiatives.new_initiative_committee_request_url(@initiative, host: @organization.host) %>
     </p>
 <% end %>
 <br><br>
@@ -18,5 +18,5 @@
 <p>
   <%= t("check_initiative_details", scope: "decidim.initiatives.initiatives_mailer.initiative_link") %>
   <%= link_to t("here", scope: "decidim.initiatives.initiatives_mailer.initiative_link"),
-              decidim_initiatives.initiative_url(@initiative, locale: current_locale, host: @organization.host) %>
+              decidim_initiatives.initiative_url(@initiative, host: @organization.host) %>
 </p>

--- a/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/admin/initiative.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <%= link_to decidim_initiatives.initiative_path(current_participatory_space, locale: current_locale), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
+    <%= link_to decidim_initiatives.initiative_path(current_participatory_space), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
       <%= icon "eye-line" %>
       <span>
         <%= t("see_initiative", scope: "decidim.admin.menu.initiatives_menu") %>

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(),
+                        decidim_initiatives.initiatives_path,
                         position: 2.4,
                         active: %r{^/#{current_locale}/(initiatives|create_initiative)},
                         if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(),
+                        decidim_initiatives.initiatives_path,
                         position: 2.4,
                         active: %r{^/#{current_locale}/(initiatives|create_initiative)},
                         if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(),
+                        decidim_initiatives.initiatives_path,
                         position: 30,
                         active: :inclusive,
                         if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?

--- a/decidim-initiatives/lib/decidim/initiatives/menu.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(locale: current_locale),
+                        decidim_initiatives.initiatives_path(),
                         position: 2.4,
                         active: %r{^/#{current_locale}/(initiatives|create_initiative)},
                         if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(locale: current_locale),
+                        decidim_initiatives.initiatives_path(),
                         position: 2.4,
                         active: %r{^/#{current_locale}/(initiatives|create_initiative)},
                         if: !Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).all.empty?
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :initiatives,
                         I18n.t("menu.initiatives", scope: "decidim"),
-                        decidim_initiatives.initiatives_path(locale: current_locale),
+                        decidim_initiatives.initiatives_path(),
                         position: 30,
                         active: :inclusive,
                         if: Decidim::InitiativesType.joins(:scopes).where(organization: current_organization).any?

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/initiatives_controller_spec.rb
@@ -131,8 +131,8 @@ describe Decidim::Initiatives::InitiativesController do
         put :update,
             params: {
               slug: created_initiative.to_param,
-              initiative: valid_attributes,
-              locale: I18n.locale
+              locale: I18n.locale,
+              initiative: valid_attributes
             }
         expect(flash[:alert]).to be_nil
         expect(response).to have_http_status(:found)
@@ -146,8 +146,8 @@ describe Decidim::Initiatives::InitiativesController do
         put :update,
             params: {
               slug: created_initiative.to_param,
-              initiative: invalid_attributes,
-              locale: I18n.locale
+              locale: I18n.locale,
+              initiative: invalid_attributes
             }
 
         expect(flash[:alert]).not_to be_empty
@@ -177,8 +177,8 @@ describe Decidim::Initiatives::InitiativesController do
           it "displays the editing form with errors" do
             put :update, params: {
               slug: created_initiative.to_param,
-              initiative: invalid_attributes,
-              locale: I18n.locale
+              locale: I18n.locale,
+              initiative: invalid_attributes
             }
 
             expect(flash[:alert]).not_to be_empty

--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -232,14 +232,14 @@ module Decidim
 
         breadcrumb = {
           label: translated_attribute(meeting.title),
-          url: Decidim::EngineRouter.main_proxy(current_component).meeting_path(meeting, locale: current_locale),
+          url: Decidim::EngineRouter.main_proxy(current_component).meeting_path(meeting),
           active: false
         }
 
         # If this meeting is being accessed from within a conference program context,
         # add program breadcrumb to maintain proper navigation hierarchy
         if conference_context?
-          program_path = decidim_conferences.conference_conference_program_path(current_participatory_space, current_component, locale: I18n.locale)
+          program_path = decidim_conferences.conference_conference_program_path(current_participatory_space, current_component)
 
           context_breadcrumb_items << {
             label: t("conference_program.index.title", scope: "decidim"),

--- a/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_manages_meetings_spec.rb
@@ -728,8 +728,7 @@ describe "Admin manages meetings" do
       visit decidim_participatory_process_meetings.meeting_path(
         participatory_process_slug: meeting.participatory_space.slug,
         component_id: meeting.component.id,
-        id: meeting.id,
-        locale: I18n.locale
+        id: meeting.id
       )
 
       within ".meeting__agenda-item__description" do

--- a/decidim-meetings/spec/system/explore_versions_spec.rb
+++ b/decidim-meetings/spec/system/explore_versions_spec.rb
@@ -10,7 +10,6 @@ describe "Explore versions", versioning: true do
     decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      locale: I18n.locale,
       id: meeting.id
     )
   end

--- a/decidim-meetings/spec/system/live_meeting_access_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_access_spec.rb
@@ -11,8 +11,7 @@ describe "Meeting live event access" do
     decidim_participatory_process_meetings.meeting_live_event_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      meeting_id: meeting.id,
-      locale: I18n.locale
+      meeting_id: meeting.id
     )
   end
 

--- a/decidim-meetings/spec/system/live_meeting_spec.rb
+++ b/decidim-meetings/spec/system/live_meeting_spec.rb
@@ -12,16 +12,14 @@ describe "Meeting live event" do
     decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      id: meeting.id,
-      locale: I18n.locale
+      id: meeting.id
     )
   end
   let(:meeting_live_event_path) do
     decidim_participatory_process_meetings.meeting_live_event_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      meeting_id: meeting.id,
-      locale: I18n.locale
+      meeting_id: meeting.id
     )
   end
 

--- a/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_administrate_spec.rb
@@ -29,8 +29,7 @@ describe "Meeting poll administration" do
     decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      id: meeting.id,
-      locale: I18n.locale
+      id: meeting.id
     )
   end
   let(:body_multiple_option_question) do

--- a/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
+++ b/decidim-meetings/spec/system/meeting_questions_reply_poll_spec.rb
@@ -17,7 +17,6 @@ describe "Meeting poll response" do
     decidim_participatory_process_meetings.meeting_path(
       participatory_process_slug: participatory_process.slug,
       component_id: component.id,
-      locale: I18n.locale,
       id: meeting.id
     )
   end

--- a/decidim-meetings/spec/system/meetings_breadcrumbs_spec.rb
+++ b/decidim-meetings/spec/system/meetings_breadcrumbs_spec.rb
@@ -38,7 +38,6 @@ describe "Meetings Breadcrumb" do
       decidim_participatory_process_meetings.meeting_path(
         participatory_process_slug: participatory_process.slug,
         component_id: component.id,
-        locale: I18n.locale,
         id: meeting.id
       )
     end

--- a/decidim-meetings/spec/system/show_spec.rb
+++ b/decidim-meetings/spec/system/show_spec.rb
@@ -24,8 +24,7 @@ describe "show" do
         decidim_participatory_process_meetings.meeting_path(
           participatory_process_slug: component.participatory_space.slug,
           component_id: component.id,
-          id: 999_999,
-          locale: I18n.locale
+          id: 999_999
         )
       end
     end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
@@ -21,7 +21,7 @@ module Decidim
         end
 
         def info_url
-          decidim.page_path("democratic-quality-indicators")
+          decidim.page_path("democratic-quality-indicators", locale: current_locale)
         end
       end
     end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/democratic_quality_stats_cell.rb
@@ -21,7 +21,7 @@ module Decidim
         end
 
         def info_url
-          decidim.page_path("democratic-quality-indicators", locale: I18n.locale)
+          decidim.page_path("democratic-quality-indicators")
         end
       end
     end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/extra_data_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/extra_data_cell.rb
@@ -50,7 +50,7 @@ module Decidim
             icon: "archive-line",
             text: link_to(
               decidim_escape_translated(participatory_process_group.title).html_safe,
-              decidim_participatory_processes.participatory_process_group_path(participatory_process_group, locale: I18n.locale)
+              decidim_participatory_processes.participatory_process_group_path(participatory_process_group)
             )
           }
         end

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_processes_path()
+          Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_processes_path
         end
 
         def max_results

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/content_blocks/highlighted_processes_cell.rb
@@ -15,7 +15,7 @@ module Decidim
         end
 
         def all_path
-          Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_processes_path(locale: I18n.locale)
+          Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_processes_path()
         end
 
         def max_results

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_g_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_g_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def resource_path
-        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path(model, locale: current_locale)
+        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path(model)
       end
 
       def resource_image_url

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_g_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_g_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def resource_path
-        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_group_path(model, locale: current_locale)
+        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_group_path(model)
       end
 
       def resource_image_url

--- a/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_s_cell.rb
+++ b/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_group_s_cell.rb
@@ -8,7 +8,7 @@ module Decidim
       private
 
       def resource_path
-        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_group_path(model, locale: current_locale)
+        Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_group_path(model)
       end
 
       def metadata_cell

--- a/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/participatory_process_breadcrumb.rb
+++ b/decidim-participatory_processes/app/controllers/concerns/decidim/participatory_processes/participatory_process_breadcrumb.rb
@@ -17,7 +17,7 @@ module Decidim
           items << {
             label: translated_attribute(current_participatory_space.participatory_process_group.title),
             active: false,
-            url: decidim_participatory_processes.participatory_process_group_path(current_participatory_space.participatory_process_group, locale: current_locale),
+            url: decidim_participatory_processes.participatory_process_group_path(current_participatory_space.participatory_process_group),
             resource: current_participatory_space.participatory_process_group
           }
         end

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/members_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/members_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         raise ActionController::RoutingError, "No members for this participatory process" if members.none?
 
         enforce_permission_to :list, :members
-        redirect_to decidim_participatory_processes.participatory_process_path(current_participatory_space, locale: current_locale) unless can_visit_index?
+        redirect_to decidim_participatory_processes.participatory_process_path(current_participatory_space) unless can_visit_index?
       end
 
       private

--- a/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
+++ b/decidim-participatory_processes/app/controllers/decidim/participatory_processes/participatory_process_groups_controller.rb
@@ -54,7 +54,7 @@ module Decidim
       def set_controller_breadcrumb
         context_breadcrumb_items << {
           label: translated_attribute(group.title),
-          url: participatory_process_group_path(group, locale: current_locale),
+          url: participatory_process_group_path(group),
           active: true,
           resource: group
         }

--- a/decidim-participatory_processes/app/events/decidim/participatory_process_step_activated_event.rb
+++ b/decidim-participatory_processes/app/events/decidim/participatory_process_step_activated_event.rb
@@ -5,14 +5,13 @@ module Decidim
     include Rails.application.routes.mounted_helpers
 
     def resource_path
-      @resource_path ||= decidim_participatory_processes.participatory_process_path(participatory_space, locale: I18n.locale, display_steps: true)
+      @resource_path ||= decidim_participatory_processes.participatory_process_path(participatory_space, display_steps: true)
     end
 
     def resource_url
       @resource_url ||= decidim_participatory_processes
                         .participatory_process_url(
                           participatory_space,
-                          locale: I18n.locale,
                           display_steps: true,
                           host: participatory_space.organization.host
                         )

--- a/decidim-participatory_processes/app/events/decidim/participatory_process_step_changed_event.rb
+++ b/decidim-participatory_processes/app/events/decidim/participatory_process_step_changed_event.rb
@@ -5,14 +5,13 @@ module Decidim
     include Rails.application.routes.mounted_helpers
 
     def resource_path
-      @resource_path ||= decidim_participatory_processes.participatory_process_path(participatory_space, locale: I18n.locale, display_steps: true)
+      @resource_path ||= decidim_participatory_processes.participatory_process_path(participatory_space, display_steps: true)
     end
 
     def resource_url
       @resource_url ||= decidim_participatory_processes
                         .participatory_process_url(
                           participatory_space,
-                          locale: I18n.locale,
                           display_steps: true,
                           host: participatory_space.organization.host
                         )

--- a/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
+++ b/decidim-participatory_processes/app/helpers/decidim/participatory_processes/participatory_process_helper.rb
@@ -57,8 +57,8 @@ module Decidim
           *(if participatory_space.members_public_page?
               [{
                 name: t("member_menu_item", scope: "layouts.decidim.participatory_process_navigation"),
-                url: decidim_participatory_processes.participatory_process_members_path(participatory_space, locale: current_locale),
-                active: is_active_link?(decidim_participatory_processes.participatory_process_members_path(participatory_space, locale: current_locale), :inclusive)
+                url: decidim_participatory_processes.participatory_process_members_path(participatory_space),
+                active: is_active_link?(decidim_participatory_processes.participatory_process_members_path(participatory_space), :inclusive)
               }]
             end
            )

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_process_groups/index.html.erb
@@ -53,7 +53,7 @@
                   <% end %>
 
                   <li class="dropdown__item">
-                    <%= link_to decidim_participatory_processes.participatory_process_group_path(group, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+                    <%= link_to decidim_participatory_processes.participatory_process_group_path(group), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
                       <%= icon "eye-line" %> <%= t("actions.preview", scope: "decidim.admin") %>
                     <% end %>
                   </li>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_process_row.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_process_row.html.erb
@@ -80,7 +80,7 @@
 
           <% if allowed_to? :preview, :process, process: process %>
             <li class="dropdown__item">
-              <%= link_to decidim_participatory_processes.participatory_process_path(process, locale: current_locale), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+              <%= link_to decidim_participatory_processes.participatory_process_path(process), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
                 <%= icon "eye-line" %>
                 <%= t("actions.preview", scope: "decidim.admin") %>
               <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/participatory_processes/show.html.erb
@@ -2,7 +2,7 @@
   title: translated_attribute(current_participatory_space.title),
   image_url: resolve_meta_image_url(current_participatory_space),
   description: translated_attribute(current_participatory_space.short_description),
-  url: participatory_process_url(current_participatory_space, locale: current_locale),
+  url: participatory_process_url(current_participatory_space),
   resource: current_participatory_space) %>
 
 <%

--- a/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process.html.erb
+++ b/decidim-participatory_processes/app/views/layouts/decidim/admin/participatory_process.html.erb
@@ -2,7 +2,7 @@
 
 <% content_for :breadcrumb_context_menu do %>
   <div class="process-title-content-breadcrumb-container-right">
-    <%= link_to decidim_participatory_processes.participatory_process_path(current_participatory_space, locale: current_locale), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
+    <%= link_to decidim_participatory_processes.participatory_process_path(current_participatory_space), class: "button button__sm button__transparent process-title-content-breadcrumb-container-right-link", target: "_blank", data: { "external-link": false } do %>
       <%= icon "eye-line" %>
       <span>
         <%= t("see_process", scope: "decidim.admin.actions") %>

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(),
+                        decidim_participatory_processes.participatory_processes_path,
                         position: 2,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(),
+                        decidim_participatory_processes.participatory_processes_path,
                         position: 2,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(),
+                        decidim_participatory_processes.participatory_processes_path,
                         position: 10,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}

--- a/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
+++ b/decidim-participatory_processes/lib/decidim/participatory_processes/menu.rb
@@ -7,7 +7,7 @@ module Decidim
         Decidim.menu :menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(locale: current_locale),
+                        decidim_participatory_processes.participatory_processes_path(),
                         position: 2,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}
@@ -18,7 +18,7 @@ module Decidim
         Decidim.menu :mobile_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(locale: current_locale),
+                        decidim_participatory_processes.participatory_processes_path(),
                         position: 2,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}
@@ -29,7 +29,7 @@ module Decidim
         Decidim.menu :home_content_block_menu do |menu|
           menu.add_item :participatory_processes,
                         I18n.t("menu.processes", scope: "decidim"),
-                        decidim_participatory_processes.participatory_processes_path(locale: current_locale),
+                        decidim_participatory_processes.participatory_processes_path(),
                         position: 10,
                         if: Decidim::ParticipatoryProcess.where(organization: current_organization).published.any?,
                         active: %r{^/#{current_locale}/process(es|_groups)}

--- a/decidim-participatory_processes/spec/controllers/admin/members_csv_imports_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/members_csv_imports_controller_spec.rb
@@ -28,7 +28,7 @@ module Decidim
 
         it "suppress the existing users" do
           expect do
-            delete :destroy_all, params: { participatory_process_slug: member.participatory_space.slug, locale: I18n.locale }
+            delete :destroy_all, params: { participatory_process_slug: member.participatory_space.slug }
           end.to change { Decidim::ParticipatorySpace::Member.by_participatory_space(member.participatory_space).count }.by(-1)
         end
       end

--- a/decidim-participatory_processes/spec/controllers/members_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/members_controller_spec.rb
@@ -9,7 +9,7 @@ module Decidim
       routes { Decidim::ParticipatoryProcesses::Engine.routes }
 
       let(:organization) { create(:organization) }
-      let(:destination_path) { decidim_participatory_processes.participatory_process_path(participatory_space, locale: I18n.locale) }
+      let(:destination_path) { decidim_participatory_processes.participatory_process_path(participatory_space) }
       let(:slug_param) { "participatory_process_slug" }
       let(:slug) { participatory_space.slug }
 

--- a/decidim-participatory_processes/spec/events/decidim/participatory_process_step_activated_event_spec.rb
+++ b/decidim-participatory_processes/spec/events/decidim/participatory_process_step_activated_event_spec.rb
@@ -12,7 +12,7 @@ describe Decidim::ParticipatoryProcessStepActivatedEvent do
   let(:participatory_space) { resource.participatory_process }
   let(:resource) { create(:participatory_process_step) }
   let(:resource_path) do
-    decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale, display_steps: true)
+    decidim_participatory_processes.participatory_process_path(participatory_process, display_steps: true)
   end
 
   let(:resource_url) do

--- a/decidim-participatory_processes/spec/events/decidim/participatory_process_step_changed_event_spec.rb
+++ b/decidim-participatory_processes/spec/events/decidim/participatory_process_step_changed_event_spec.rb
@@ -12,14 +12,13 @@ describe Decidim::ParticipatoryProcessStepChangedEvent do
   let(:participatory_space) { resource.participatory_process }
   let(:resource) { create(:participatory_process_step) }
   let(:resource_path) do
-    decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale, display_steps: true)
+    decidim_participatory_processes.participatory_process_path(participatory_process, display_steps: true)
   end
 
   let(:resource_url) do
     decidim_participatory_processes
       .participatory_process_url(
         participatory_process,
-        locale: I18n.locale,
         display_steps: true,
         host: participatory_process.organization.host
       )

--- a/decidim-proposals/app/events/decidim/proposals/coauthor_accepted_invite_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/coauthor_accepted_invite_event.rb
@@ -14,11 +14,11 @@ module Decidim
       delegate :name, to: :coauthor, prefix: true, allow_nil: true
 
       def author_path
-        profile_path(author.nickname, locale: I18n.locale)
+        profile_path(author.nickname)
       end
 
       def coauthor_path
-        profile_path(coauthor.nickname, locale: I18n.locale) if coauthor
+        profile_path(coauthor.nickname) if coauthor
       end
 
       def author

--- a/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
+++ b/decidim-proposals/app/events/decidim/proposals/publish_proposal_event.rb
@@ -15,7 +15,7 @@ module Decidim
       def i18n_options
         return super if author.blank?
 
-        author_path = link_to("@#{author.nickname}", profile_path(author.nickname, locale: I18n.locale))
+        author_path = link_to("@#{author.nickname}", profile_path(author.nickname))
         author_string = "#{author.name} #{author_path}"
         super.merge({ author: author_string })
       end

--- a/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
@@ -418,7 +418,7 @@ module Decidim
       end
 
       def profile_url(nickname)
-        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, locale: I18n.locale, host:, port: Capybara.server_port)
+        Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
       end
 
       def meeting_url(meeting)

--- a/decidim-proposals/spec/system/proposals_breadcrumbs_spec.rb
+++ b/decidim-proposals/spec/system/proposals_breadcrumbs_spec.rb
@@ -17,7 +17,7 @@ describe "Proposals Breadcrumb" do
 
   describe "index" do
     it "shows the correct information in breadcrumb (space, component)" do
-      visit router.root_path()
+      visit router.root_path
 
       within ".menu-bar" do
         expect(page).to have_content(translated(component.participatory_space.title))

--- a/decidim-proposals/spec/system/proposals_breadcrumbs_spec.rb
+++ b/decidim-proposals/spec/system/proposals_breadcrumbs_spec.rb
@@ -17,7 +17,7 @@ describe "Proposals Breadcrumb" do
 
   describe "index" do
     it "shows the correct information in breadcrumb (space, component)" do
-      visit router.root_path(locale: I18n.locale)
+      visit router.root_path()
 
       within ".menu-bar" do
         expect(page).to have_content(translated(component.participatory_space.title))
@@ -28,7 +28,7 @@ describe "Proposals Breadcrumb" do
 
   describe "show" do
     it "shows the correct information in breadcrumb (space, component, proposal)" do
-      visit router.proposal_path(proposal, locale: I18n.locale)
+      visit router.proposal_path(proposal)
 
       within ".menu-bar" do
         expect(page).to have_content(translated(component.participatory_space.title))
@@ -72,7 +72,7 @@ describe "Proposals Breadcrumb" do
     let(:command) { Decidim::Amendable::Accept.new(form) }
 
     before do
-      visit router.proposal_path(proposal, locale: I18n.locale)
+      visit router.proposal_path(proposal)
       command.call
       click_on "see other versions"
       click_on("Version 2 of 2")
@@ -106,7 +106,7 @@ describe "Proposals Breadcrumb" do
     end
 
     it "shows the correct information in breadcrumb (space, component, amendment)" do
-      visit router.proposal_path(emendation, locale: I18n.locale)
+      visit router.proposal_path(emendation)
 
       within ".menu-bar" do
         expect(page).to have_content(translated(component.participatory_space.title))

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -222,7 +222,7 @@ describe "Respond a survey" do
     let(:router) { Decidim::EngineRouter.main_proxy(component) }
 
     it "shows action log entry" do
-      page.visit decidim.profile_activity_path(nickname: user.nickname, locale: I18n.locale)
+      page.visit decidim.profile_activity_path(nickname: user.nickname)
       expect(page).to have_content("New survey: #{translated(survey.questionnaire.title)}")
       expect(page).to have_content(translated(survey.component.participatory_space.title))
       expect(page).to have_link(translated(survey.questionnaire.title), href: router.survey_path(survey))

--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -152,7 +152,7 @@ module Decidim
         authorizations = action_authorized_to(onboarding_manager.action, **onboarding_manager.action_authorized_resources)
         return unless authorizations.ephemeral?
 
-        form = Decidim::EphemeralUserForm.new(organization: current_organization, locale: current_locale)
+        form = Decidim::EphemeralUserForm.new(organization: current_organization)
         CreateEphemeralUser.call(form) do
           on(:ok) do |ephemeral_user|
             sign_in(ephemeral_user)

--- a/decidim-verifications/app/views/decidim/verifications/authorizations/_tos_acceptance_field.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/authorizations/_tos_acceptance_field.html.erb
@@ -7,5 +7,5 @@
     <% end %>
   </div>
 
-  <%= form.check_box :tos_agreement, label: t("decidim.verifications.authorizations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service", locale: current_locale))), label_options: { class: "form__wrapper-checkbox-label" } %>
+  <%= form.check_box :tos_agreement, label: t("decidim.verifications.authorizations.new.tos_agreement", link: link_to(t("decidim.devise.registrations.new.terms"), decidim.page_path("terms-of-service"))), label_options: { class: "form__wrapper-checkbox-label" } %>
 </div>

--- a/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
+++ b/decidim-verifications/spec/events/decidim/verifications/managed_user_error_event_spec.rb
@@ -11,11 +11,11 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
   let(:admin_router) { Decidim::EngineRouter.new("decidim_admin", host: resource.current_user.organization.host) }
 
   let(:resource_title) { resource.current_user.name }
-  let(:resource_path) { profile_path(resource.current_user.nickname, locale: I18n.locale) }
-  let(:resource_url) { profile_url(resource.current_user.nickname, locale: I18n.locale, host: resource.current_user.organization.host, port: Capybara.server_port) }
-  let(:notification_title) { "The participant <a href=\"#{profile_path(resource.current_user.nickname, locale: I18n.locale)}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"#{profile_path(resource.managed_user.nickname, locale: I18n.locale)}\">#{resource.managed_user.name}</a>)." }
+  let(:resource_path) { profile_path(resource.current_user.nickname) }
+  let(:resource_url) { profile_url(resource.current_user.nickname, host: resource.current_user.organization.host, port: Capybara.server_port) }
+  let(:notification_title) { "The participant <a href=\"#{profile_path(resource.current_user.nickname)}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"#{profile_path(resource.managed_user.nickname)}\">#{resource.managed_user.name}</a>)." }
   let(:email_subject) { "Failed verification attempt against another participant" }
-  let(:email_intro) { "The participant <a href=\"#{profile_url(resource.current_user.nickname, locale: I18n.locale, host: resource.current_user.organization.host, port: Capybara.server_port)}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"#{profile_url(resource.managed_user.nickname, locale: I18n.locale, host: resource.current_user.organization.host, port: Capybara.server_port)}\">#{resource.managed_user.name}</a>)." }
+  let(:email_intro) { "The participant <a href=\"#{profile_url(resource.current_user.nickname, host: resource.current_user.organization.host, port: Capybara.server_port)}\">#{resource.current_user.name}</a> has tried to verify themselves with the data of another participant (<a href=\"#{profile_url(resource.managed_user.nickname, host: resource.current_user.organization.host, port: Capybara.server_port)}\">#{resource.managed_user.name}</a>)." }
   let(:email_outro) { "Check the <a href=\"#{admin_router.conflicts_url}\">Verifications's conflicts list</a> and contact the participant to verify their details and solve the issue." }
 
   it_behaves_like "a simple event email"
@@ -27,7 +27,7 @@ describe Decidim::Verifications::ManagedUserErrorEvent do
     end
 
     it "includes managed_user_profile" do
-      expect(subject.default_i18n_options[:managed_user_path]).to eq(profile_path(resource.managed_user.nickname, locale: I18n.locale))
+      expect(subject.default_i18n_options[:managed_user_path]).to eq(profile_path(resource.managed_user.nickname))
     end
   end
 end

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -40,7 +40,7 @@ describe "Authorizations", with_authorization_workflows: %w(dummy_authorization_
         click_on "Example authorization"
 
         click_on "start exploring"
-        expect(page).to have_current_path decidim.root_path()
+        expect(page).to have_current_path decidim.root_path
 
         expect(page).to have_content("How do I take part in a process?")
       end

--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -40,7 +40,7 @@ describe "Authorizations", with_authorization_workflows: %w(dummy_authorization_
         click_on "Example authorization"
 
         click_on "start exploring"
-        expect(page).to have_current_path decidim.root_path(locale: I18n.locale)
+        expect(page).to have_current_path decidim.root_path()
 
         expect(page).to have_content("How do I take part in a process?")
       end


### PR DESCRIPTION
#### :tophat: What? Why?

On #14432 we introduced the locale in the URL by doing it explicilty (i.e. in all the URL helpers we had to introduce the locale, like `root_path` needed to be changed to `root_path(locale: I18n.locale)`). This made lots of code and specs that need to be changed to this new pattern. Then on #16512 we keep going for that direction. so we had even more URLs with this change. 

But with #16544 we changed this approach so it is implicit and in more URLs: we don't need to add the locale argument in all the calls anymore.

This PR cleans-up these changes to make it behave as it was. The idea is to be compatible with the old calls, as that makes much easier the whole backport process: we don't have inconsistencies in these calls  between v0.30, v0.31 and develop (v0.32).  

#### :pushpin: Related Issues
 
- Related to #14432 
- Related to #16512
- Related to #16544 

#### Testing

Everything should be green and the app should behave as it was before

:hearts: Thank you!
