### PR TITLE
Add CHANGELOG.md to spellchecker exclusions

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -89,6 +89,7 @@
 ^\Q.erb-lint.yml\E$
 ^\Q.erb_lint.yml\E$
 ^\Q.spelling.yml\E$
+^\QCHANGELOG.md\E$
 ^\Qpubliccode.yml\E$
 ^\Qdecidim-accountability/spec/fixtures/valid_result.csv\E$
 ^\Qdecidim-assemblies/app/packs/src/decidim/assemblies/orgchart.js\E$


### PR DESCRIPTION
#### :tophat: What? Why?

While working with the v0.32.0.rc1 publication and the patch releases for this month (v0.31.4 and  v0.30.8) I noticed a minor inconvenience: there are some spellchecker offenses in the CHANGELOG.md file from the PR titles. 

I think we should exclude this file from all the versions to be consistent.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16640 for `release/0.30-stable` -> mind that here it doesn't happen because it was already added at https://github.com/decidim/decidim/pull/14109
- Related to #16641 for `release/0.31-stable` 
- Related to #16643 for `release/0.32-stable`)

#### Testing

Going to al lthese PRs this rule for the spelling exclusion should be consistent  

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling checker configuration to exclude the changelog file from spell-check validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->