### PR TITLE
Clean-up the releases notes after v0.31.4 publication

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,7 +42,6 @@ You can read more about this change on PR [#XXXX](https://github.com/decidim/dec
 ## 3. One time actions
 
 These are one time actions that need to be done after the code is updated in the production database.
- 
 ### 3.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ You can read more about this change on PR [#XXXX](https://github.com/decidim/dec
 ## 3. One time actions
 
 These are one time actions that need to be done after the code is updated in the production database.
+
 ### 3.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ the instructions for all the patch releases in GitHub:
 - <https://github.com/decidim/decidim/releases/tag/v0.31.1>
 - <https://github.com/decidim/decidim/releases/tag/v0.31.2>
 - <https://github.com/decidim/decidim/releases/tag/v0.31.3>
+- <https://github.com/decidim/decidim/releases/tag/v0.31.4>
 
 ## 1. Upgrade notes
 
@@ -27,7 +28,6 @@ Note that there were several big updates in this version, most notably Rails and
 bundle update decidim
 bin/rails decidim:upgrade
 bin/rails db:migrate
-sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
 bin/rails data:migrate
 ```
 
@@ -42,40 +42,8 @@ You can read more about this change on PR [#XXXX](https://github.com/decidim/dec
 ## 3. One time actions
 
 These are one time actions that need to be done after the code is updated in the production database.
-
-### 3.1. Fix the "SMTP_STARTTLS_AUTO" env var in `production.rb`
-
-It was detected a bug with the enable_starttls_auto configuration for the Action Mailer (SMTP) configuration. For fixing it you need to replace in `config/environments/production.rb`
-
-If your `config/environments/production.rb` contains an SMTP configuration like this:
-
-```ruby
-config.action_mailer.smtp_settings = {
-  # ... other settings ...
-  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO").to_boolean_string,
-  # ... other settings ...
-}
-```
-
-You should update it to:
-
-```ruby
-config.action_mailer.smtp_settings = {
-  # ... other settings ...
-  :enable_starttls_auto => Decidim::Env.new("SMTP_STARTTLS_AUTO", true).present?,
-  # ... other settings ...
-}
-```
-
-You can do this with the following command:
-
-```bash
-sed -i 's/Env.new("SMTP_STARTTLS_AUTO").to_boolean_string/Env.new("SMTP_STARTTLS_AUTO", true).present?/' config/environments/production.rb
-```
-
-You can read more about this change on PR [#16491](https://github.com/decidim/decidim/pull/16491).
-
-### 3.2. [[TITLE OF THE ACTION]]
+ 
+### 3.1. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 


### PR DESCRIPTION
#### :tophat: What? Why?

This PR clean-ups the release notes file after  the release, so we only have the things that are necessary to do for the release if there's any (i.e. for the future v0.31.5 for instance) 

#### :pushpin: Related Issues

- Related to #16564 (what I did for the last release)

#### Testing

There shouldn't be any pending instructions to do in the apps, as the release was published today and we don't have any backport with release notes. 

:hearts: Thank you!
