### PR TITLE
Skip for development the SECRET_KEY_BASE env var check in system

### DIFF
--- a/decidim-system/app/cells/decidim/system/system_checks_cell.rb
+++ b/decidim-system/app/cells/decidim/system/system_checks_cell.rb
@@ -23,6 +23,8 @@ module Decidim
       end
 
       def correct_secret_key_base?
+        return true if Rails.env.development?
+
         Rails.application.secret_key_base&.length == 128
       end
 

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -120,6 +120,7 @@ module Decidim
       # We need a valid secret key base for encrypting the SMTP password with it
       # It is also necessary for other things in Rails (like Cookies encryption)
       def validate_secret_key_base_for_encryption
+        return if Rails.env.development?
         return if Rails.application.secret_key_base&.length == 128
 
         errors.add(:password, I18n.t("activemodel.errors.models.organization.attributes.password.secret_key"))

--- a/decidim-system/spec/cells/decidim/system/system_checks_cell_spec.rb
+++ b/decidim-system/spec/cells/decidim/system/system_checks_cell_spec.rb
@@ -52,6 +52,18 @@ describe Decidim::System::SystemChecksCell, type: :cell do
         expect(subject).to have_content "Please save to the SECRET_KEY_BASE environment variable and restart the server"
       end
     end
+
+    context "when in development and the secret key is nil" do
+      let(:secret_key) { nil }
+
+      before do
+        allow(Rails.env).to receive(:development?).and_return(true)
+      end
+
+      it "shows the success message" do
+        expect(subject).to have_content "The secret key is configured correctly"
+      end
+    end
   end
 
   describe "active_job_queue_check" do

--- a/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
@@ -126,6 +126,26 @@ module Decidim::System
     end
 
     describe "validations" do
+      describe "secret key base validation" do
+        context "when in development" do
+          before do
+            allow(Rails.application).to receive(:secret_key_base).and_return(nil)
+            allow(Rails.env).to receive(:development?).and_return(true)
+          end
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when not in development" do
+          before do
+            allow(Rails.application).to receive(:secret_key_base).and_return(nil)
+            allow(Rails.env).to receive(:development?).and_return(false)
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+
       describe "organization_admin_email" do
         context "when organization_admin_email is blank" do
           before { subject.organization_admin_email = "" }

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -126,6 +126,26 @@ module Decidim::System
     end
 
     describe "validations" do
+      describe "secret key base validation" do
+        context "when in development" do
+          before do
+            allow(Rails.application).to receive(:secret_key_base).and_return(nil)
+            allow(Rails.env).to receive(:development?).and_return(true)
+          end
+
+          it { is_expected.to be_valid }
+        end
+
+        context "when not in development" do
+          before do
+            allow(Rails.application).to receive(:secret_key_base).and_return(nil)
+            allow(Rails.env).to receive(:development?).and_return(false)
+          end
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+
       describe "organization name presence" do
         let(:organization) { create(:organization, default_locale: "en") }
 


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago we added a few checks for the SECRET_KEY_BASE env var in the system panel: 

- One in the dashboard, checking for the env var (only informative)  (#12846)
- Another one for the creation/update of the Organization in the system panel (#12847) 

This second one makes it really awkward to work with these forms in `development`, as by default Rails doesn't have this env var (it generates a file in `tmp/`inside the app). This PR relaxes these checks as they don't really apply for development, so it is less painful to work with these forms. 

#### :pushpin: Related Issues
 
- Related to #12846 and #12847

#### Testing

##### The bug

1. Sign in on http://localhost:3000/system/ with system@example.org and decidim123456789
2. Go to the dashboard, see that you have the error "The secret key is not defined correctly"
3. Create a new organization, see that you have an error, and when you click in "Show advanced settings" on the SMTP settings, Password field you have the error "You need to define the SECRET_KEY_BASE environment variable to be able to save this field"  

##### The fix

1. Sign in on http://localhost:3000/system/ with system@example.org and decidim123456789
2. Go to the dashboard, see that you don't have the error anymore
3. Create a new organization, see that it works

### :camera: Screenshots

#### Before

<img width="1763" height="466" alt="image" src="https://github.com/user-attachments/assets/ac418356-ff6e-4a05-8379-993fb1cf9ddf" />
<img width="1341" height="430" alt="image" src="https://github.com/user-attachments/assets/2f27f9e4-7ecd-48ea-a4b4-ea65412e226a" />
<img width="1163" height="679" alt="image" src="https://github.com/user-attachments/assets/15cc2a1d-77c3-400e-91be-d7f3b7dc12d7" />

#### After

<img width="1801" height="427" alt="image" src="https://github.com/user-attachments/assets/463d478d-2518-45ac-a72d-530d7d631290" />
<img width="1766" height="733" alt="image" src="https://github.com/user-attachments/assets/72cbf3d4-4cbe-48a2-a697-88b6834bc555" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage verifying configuration validation behaves differently in development vs production.

* **Chores**
  * Validation updated so local/development environments no longer block setup or organization registration due to a missing encryption key; production continues to enforce the stricter requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->