### PR TITLE
Fix one word hostnames for development

### DIFF
--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -141,7 +141,7 @@ module Decidim
       #
       # Valid formats:
       # - Fully Qualified Domain Names (FQDN): example.org, sub.example.org, my-site.example.org
-      # - Localhost: localhost (common for development)
+      # - One word hostnames in development: localhost, my-machine
       # - IPv4 addresses: 127.0.0.1, 192.168.1.1
       # - IPv6 addresses: ::1, 2001:db8::1, [::1]
       #
@@ -163,9 +163,6 @@ module Decidim
           # Each label: alphanumeric start/end, alphanumerics and hyphens inside, max 63 chars.
           (?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}
           |
-          # Localhost: common development hostname.
-          localhost
-          |
           # IPv4: four octets (0-255 each).
           (?:(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)
           |
@@ -175,10 +172,12 @@ module Decidim
         \z
       }x
 
+      SINGLE_LABEL_HOST_FORMAT_REGEX = %r{\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\z}
+
       def validate_host_format
         return if host.blank?
 
-        return if host.match?(HOST_FORMAT_REGEX)
+        return if valid_host_format?(host)
 
         errors.add(:host, :invalid)
       end
@@ -187,11 +186,18 @@ module Decidim
         return if secondary_hosts.blank?
 
         clean_secondary_hosts.each do |secondary_host|
-          next if secondary_host.match?(HOST_FORMAT_REGEX)
+          next if valid_host_format?(secondary_host)
 
           errors.add(:secondary_hosts, :invalid)
           break
         end
+      end
+
+      def valid_host_format?(value)
+        return true if value.match?(HOST_FORMAT_REGEX)
+        return false unless Rails.env.development?
+
+        value.match?(SINGLE_LABEL_HOST_FORMAT_REGEX)
       end
     end
   end

--- a/decidim-system/app/forms/decidim/system/base_organization_form.rb
+++ b/decidim-system/app/forms/decidim/system/base_organization_form.rb
@@ -172,7 +172,7 @@ module Decidim
         \z
       }x
 
-      SINGLE_LABEL_HOST_FORMAT_REGEX = %r{\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\z}
+      SINGLE_LABEL_HOST_FORMAT_REGEX = /\A[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\z/
 
       def validate_host_format
         return if host.blank?

--- a/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/register_organization_form_spec.rb
@@ -386,6 +386,15 @@ module Decidim::System
         context "when host is localhost" do
           before { subject.host = "localhost" }
 
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when host is a single-label hostname in development" do
+          before do
+            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+            subject.host = "localhost"
+          end
+
           it { is_expected.to be_valid }
         end
 
@@ -509,6 +518,15 @@ module Decidim::System
 
         context "when secondary_hosts is localhost" do
           before { subject.secondary_hosts = "localhost" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when secondary_hosts is a single-label hostname in development" do
+          before do
+            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+            subject.secondary_hosts = "localhost"
+          end
 
           it { is_expected.to be_valid }
         end

--- a/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb
@@ -373,6 +373,15 @@ module Decidim::System
         context "when host is localhost" do
           before { subject.host = "localhost" }
 
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when host is a single-label hostname in development" do
+          before do
+            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+            subject.host = "localhost"
+          end
+
           it { is_expected.to be_valid }
         end
 
@@ -490,6 +499,15 @@ module Decidim::System
 
         context "when secondary_hosts is localhost" do
           before { subject.secondary_hosts = "localhost" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "when secondary_hosts is a single-label hostname in development" do
+          before do
+            allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new("development"))
+            subject.secondary_hosts = "localhost"
+          end
 
           it { is_expected.to be_valid }
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Back on #16499, I added some improvements on the validation of hosts formats in System.

The problem is that for development, most of the times you'd want a quick setup (like using just the default `localhost` or your hostname, that already solves to `localhost`/127.0.0.1/loopback interface). 

With the current rules this was a validation error, so with this change I make it to allow one word hostnames for development. 

#### :pushpin: Related Issues

- Related to #16499 
- Related to #16651 (as you'd need that one first so it is easier to review this one) 

#### Testing

1. Sign in on system panel
2. Create a new organization with the hostname of your machine
3. (Before) see that it fails
4. (After) see that it succeeds  

### :camera: Screenshots

<img width="910" height="773" alt="image" src="https://github.com/user-attachments/assets/0f5c8f98-8a62-4bf3-a079-ca040239e9bc" />

### Authorship

Author: Andrés Perira de Lucena with GPT-5.3-Codex (OpenCode)

Prompt:

"""
On the BaseOrganizationForm of decidim-system we added some verifications of the host format. The problem is that in development environment the host name can be a bit more relaxed: for instance localhost or the hostname of the host where the application is running, as that resolves to 127.0.0.1.
"""

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-label hostnames like "localhost" are accepted only in development; production and test require fully qualified domain names or IP addresses.

* **Tests**
  * Validation tests updated to assert environment-specific hostname acceptance, including development-only cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->