### PR TITLE
Escape elections questions titles

### DIFF
--- a/decidim-elections/app/helpers/decidim/elections/application_helper.rb
+++ b/decidim-elections/app/helpers/decidim/elections/application_helper.rb
@@ -44,7 +44,7 @@ module Decidim
           if question.max_choices.present? && question.question_type == "multiple_option"
             title += " (#{t("decidim.elections.votes.question.max_choices", count: question.max_choices)})"
           end
-          title.html_safe
+          title
         end
       end
 

--- a/decidim-elections/spec/system/user_votes_in_an_election_spec.rb
+++ b/decidim-elections/spec/system/user_votes_in_an_election_spec.rb
@@ -6,8 +6,8 @@ require "decidim/elections/test/vote_examples"
 describe "Dashboard" do
   let(:user) { create(:user, :confirmed, organization:) }
   let!(:election) { create(:election, :published, :ongoing, :with_internal_users_census, census_settings:) }
-  let!(:question1) { create(:election_question, :with_response_options, skip_injection: true, election:, question_type: "single_option") }
-  let!(:question2) { create(:election_question, :with_response_options, skip_injection: true, election:, question_type: "multiple_option") }
+  let!(:question1) { create(:election_question, :with_response_options, election:, question_type: "single_option") }
+  let!(:question2) { create(:election_question, :with_response_options, election:, question_type: "multiple_option") }
   let(:organization) { election.organization }
   let(:census_settings) do
     {

--- a/decidim-elections/spec/system/user_votes_in_an_per_question_election_spec.rb
+++ b/decidim-elections/spec/system/user_votes_in_an_per_question_election_spec.rb
@@ -21,8 +21,8 @@ describe "Dashboard" do
   let(:receipt_election_votes_path) { Decidim::EngineRouter.main_proxy(election.component).receipt_election_per_question_votes_path(election_id: election.id) }
   let(:confirm_election_votes_path) { Decidim::EngineRouter.main_proxy(election.component).confirm_election_per_question_votes_path(election_id: election.id) }
   let(:new_election_normal_vote_path) { Decidim::EngineRouter.main_proxy(election.component).new_election_vote_path(election_id: election.id) }
-  let!(:question1) { create(:election_question, :with_response_options, :voting_enabled, skip_injection: true, question_type: "single_option", election:, position: 1) }
-  let!(:question2) { create(:election_question, :with_response_options, election:, skip_injection: true, position: 2) }
+  let!(:question1) { create(:election_question, :with_response_options, :voting_enabled, question_type: "single_option", election:, position: 1) }
+  let!(:question2) { create(:election_question, :with_response_options, election:, position: 2) }
   let(:voter_uid) { user.to_global_id.to_s }
 
   def election_vote_path(question)
@@ -62,8 +62,8 @@ describe "Dashboard" do
   end
 
   context "when navigating through already voted questions" do
-    let!(:question2) { create(:election_question, :with_response_options, :voting_enabled, election:, skip_injection: true, position: 2) }
-    let!(:question3) { create(:election_question, :with_response_options, election:, skip_injection: true, position: 3) }
+    let!(:question2) { create(:election_question, :with_response_options, :voting_enabled, election:, position: 2) }
+    let!(:question3) { create(:election_question, :with_response_options, election:, position: 3) }
 
     before do
       login_as user, scope: :user
@@ -74,8 +74,8 @@ describe "Dashboard" do
   end
 
   context "when editing votes from receipt page" do
-    let!(:question1) { create(:election_question, :with_response_options, :voting_enabled, skip_injection: true, question_type: "single_option", election:, position: 1) }
-    let!(:question2) { create(:election_question, :with_response_options, :voting_enabled, election:, skip_injection: true, position: 2) }
+    let!(:question1) { create(:election_question, :with_response_options, :voting_enabled, question_type: "single_option", election:, position: 1) }
+    let!(:question2) { create(:election_question, :with_response_options, :voting_enabled, election:, position: 2) }
 
     before do
       login_as user, scope: :user


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that we were marking the title in the elections' questions as `html_safe`. 

This PR fixes it. 

#### Testing

All the specs should pass 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved question title rendering by adjusting HTML escaping behavior to rely on template-based rendering instead of explicit safe HTML marking.

* **Tests**
  * Updated test setup for election question creation to ensure proper injection behavior during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->