### PR TITLE
Fix multitenant access bug on ID documents verification

### DIFF
--- a/decidim-verifications/app/controllers/concerns/decidim/verifications/admin/pending_authorization_loader.rb
+++ b/decidim-verifications/app/controllers/concerns/decidim/verifications/admin/pending_authorization_loader.rb
@@ -11,12 +11,11 @@ module Decidim
         included do
           def load_pending_authorization!(name, pending_authorization_id)
             Authorizations.new(organization: current_organization, name:, granted: false)
-              .query
-              .find(pending_authorization_id)
+                          .query
+                          .find(pending_authorization_id)
           end
         end
       end
     end
   end
 end
-

--- a/decidim-verifications/app/controllers/concerns/decidim/verifications/admin/pending_authorization_loader.rb
+++ b/decidim-verifications/app/controllers/concerns/decidim/verifications/admin/pending_authorization_loader.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Verifications
+    module Admin
+      module PendingAuthorizationLoader
+        extend ActiveSupport::Concern
+
+        included do
+          def load_pending_authorization!(name, pending_authorization_id)
+            Authorizations.new(organization: current_organization, name:, granted: false)
+              .query
+              .find(pending_authorization_id)
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
@@ -13,6 +13,7 @@ module Decidim
           before_action :load_pending_authorization
 
           include Decidim::Admin::WorkflowsBreadcrumb
+          include Decidim::Verifications::Admin::PendingAuthorizationLoader
 
           add_breadcrumb_item_from_menu :workflows_menu
 
@@ -43,7 +44,7 @@ module Decidim
           private
 
           def load_pending_authorization
-            @pending_authorization = Authorization.find(params[:pending_authorization_id])
+            @pending_authorization = load_pending_authorization!("id_documents", params[:pending_authorization_id])
           end
         end
       end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/rejections_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/rejections_controller.rb
@@ -13,6 +13,7 @@ module Decidim
           before_action :load_pending_authorization
 
           include Decidim::Admin::WorkflowsBreadcrumb
+          include Decidim::Verifications::Admin::PendingAuthorizationLoader
 
           add_breadcrumb_item_from_menu :workflows_menu
 
@@ -32,7 +33,7 @@ module Decidim
           private
 
           def load_pending_authorization
-            @pending_authorization = Authorization.find(params[:pending_authorization_id])
+            @pending_authorization = load_pending_authorization!("id_documents", params[:pending_authorization_id])
           end
         end
       end

--- a/decidim-verifications/app/controllers/decidim/verifications/postal_letter/admin/postages_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/postal_letter/admin/postages_controller.rb
@@ -13,6 +13,7 @@ module Decidim
           before_action :load_pending_authorization
 
           include Decidim::Admin::WorkflowsBreadcrumb
+          include Decidim::Verifications::Admin::PendingAuthorizationLoader
 
           add_breadcrumb_item_from_menu :workflows_menu
 
@@ -36,7 +37,7 @@ module Decidim
           private
 
           def load_pending_authorization
-            @pending_authorization = Authorization.find(params[:pending_authorization_id])
+            @pending_authorization = load_pending_authorization!("postal_letter", params[:pending_authorization_id])
           end
         end
       end

--- a/decidim-verifications/spec/controllers/decidim/verifications/id_documents/admin/confirmations_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/id_documents/admin/confirmations_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications::IdDocuments::Admin
+  describe ConfirmationsController do
+    routes { Decidim::Verifications::IdDocuments::AdminEngine.routes }
+
+    let(:organization) { create(:organization, available_authorizations: ["id_documents"]) }
+    let(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+    let(:other_organization) { create(:organization, available_authorizations: ["id_documents"]) }
+    let(:other_authorization) { create(:authorization, :pending, name: "id_documents", user: create(:user, :confirmed, organization: other_organization)) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in admin, scope: :user
+    end
+
+    describe "GET #new" do
+      it "raises not found when pending authorization belongs to another organization" do
+        expect do
+          get :new, params: { pending_authorization_id: other_authorization.id }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/controllers/decidim/verifications/id_documents/admin/rejections_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/id_documents/admin/rejections_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications::IdDocuments::Admin
+  describe RejectionsController do
+    routes { Decidim::Verifications::IdDocuments::AdminEngine.routes }
+
+    let(:organization) { create(:organization, available_authorizations: ["id_documents"]) }
+    let(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+    let(:other_organization) { create(:organization, available_authorizations: ["id_documents"]) }
+    let(:other_authorization) { create(:authorization, :pending, name: "id_documents", user: create(:user, :confirmed, organization: other_organization)) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in admin, scope: :user
+    end
+
+    describe "POST #create" do
+      it "raises not found when pending authorization belongs to another organization" do
+        expect do
+          post :create, params: { pending_authorization_id: other_authorization.id }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/controllers/decidim/verifications/postal_letter/admin/postages_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/postal_letter/admin/postages_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Verifications::PostalLetter::Admin
+  describe PostagesController do
+    routes { Decidim::Verifications::PostalLetter::AdminEngine.routes }
+
+    let(:organization) { create(:organization, available_authorizations: ["postal_letter"]) }
+    let(:admin) { create(:user, :admin, :confirmed, organization:) }
+
+    let(:other_organization) { create(:organization, available_authorizations: ["postal_letter"]) }
+    let(:other_authorization) { create(:authorization, :pending, name: "postal_letter", user: create(:user, :confirmed, organization: other_organization)) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in admin, scope: :user
+    end
+
+    describe "POST #create" do
+      it "raises not found when pending authorization belongs to another organization" do
+        expect do
+          post :create, params: { pending_authorization_id: other_authorization.id }
+        end.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -92,6 +92,22 @@ describe "Identity document online review" do
     end
   end
 
+  context "when there are other organizations" do
+    let!(:other_organization) do
+      create(:organization, available_authorizations: ["id_documents"])
+    end
+    let(:other_admin) { create(:user, :admin, :confirmed, organization: other_organization) }
+
+    before do
+      switch_to_host(other_organization.host)
+      login_as other_admin, scope: :user
+    end
+
+    it_behaves_like "a 404 page" do
+      let(:target_path) { decidim_admin_id_documents.new_pending_authorization_confirmation_path(authorization.id) }
+    end
+  end
+
   private
 
   def submit_verification_form(doc_type:, doc_number:)


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected an access error with the multitenants and admins' verifications URLs. 

This PR fixes this.  

#### Testing

Everything should be green

#### Authorship

Author: Andrés Pereira de Lucena with GPT-5.3-Codex (OpenCode)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened authorization access controls for verification workflows, ensuring administrators can only access pending authorizations within their organization
  * Added proper error handling when attempting to access out-of-scope authorizations

* **Tests**
  * Added comprehensive test coverage for organization-scoped authorization verification across multiple verification types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->