### PR TITLE
Fix census permissions in surveys

### DIFF
--- a/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
+++ b/decidim-surveys/app/controllers/decidim/surveys/surveys_controller.rb
@@ -30,7 +30,7 @@ module Decidim
       end
 
       def check_permissions
-        render :no_permission unless action_authorized_to(:response, resource: survey).ok?
+        render :no_permission unless action_authorized_to(:respond, resource: survey).ok?
       end
 
       def questionnaire_for

--- a/decidim-surveys/app/helpers/decidim/surveys/survey_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/survey_helper.rb
@@ -24,7 +24,7 @@ module Decidim
       end
 
       def authorizations
-        @authorizations ||= action_authorized_to(:response, resource: questionnaire_for)
+        @authorizations ||= action_authorized_to(:respond, resource: questionnaire_for)
       end
 
       def filter_date_values

--- a/decidim-surveys/app/views/decidim/surveys/surveys/no_permission.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/no_permission.html.erb
@@ -1,9 +1,45 @@
-<div class="row">
-  <div class="columns large-6">
-    <div class="card">
-      <div>
-        <%= cell "decidim/authorization_modal", authorizations %>
-      </div>
+<% add_decidim_meta_tags({
+                           title: translated_attribute(questionnaire.title),
+                           description: translated_attribute(questionnaire.description)
+                         }) %>
+
+<%= render layout: "layouts/decidim/shared/layout_center" do %>
+  <main data-dialog-container class="text-center mt-8">
+    <div class="flex justify-center">
+      <%= icon "lock-line", class: "w-20 h-20" %>
     </div>
-  </div>
-</div>
+    <h1 tabindex="-1" class="h1">
+      <%= t("#{authorizations.global_code || :missing}.title", scope: "decidim.authorization_modals.content") %>
+    </h1>
+    <div class="authorization-modal__verification-container">
+      <% authorizations.statuses.each do |status| %>
+        <% next if status.ok? %>
+        <% next if authorizations.global_code && status.code != (authorizations.global_code || :missing) %>
+
+        <div class="authorization-modal__verification">
+          <p>
+            <%= t(
+                  "#{status.code}.explanation",
+                  authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers"),
+                  scope: "decidim.authorization_modals.content"
+                ) %>
+          </p>
+
+          <% if status.data[:action].present? %>
+            <%= action_authorized_link_to(
+                  :respond,
+                  t(
+                    "#{status.code}.#{status.data[:action]}",
+                    authorization: t("#{status.handler_name}.name", scope: "decidim.authorization_handlers"),
+                    scope: "decidim.authorization_modals.content"
+                  ),
+                  survey_path(questionnaire_for),
+                  class: "button button__lg button__secondary",
+                  resource: questionnaire_for
+                ) %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </main>
+<% end %>

--- a/decidim-surveys/app/views/decidim/surveys/surveys/no_permission.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/surveys/no_permission.html.erb
@@ -4,7 +4,7 @@
                          }) %>
 
 <%= render layout: "layouts/decidim/shared/layout_center" do %>
-  <main data-dialog-container class="text-center mt-8">
+  <div class="text-center mt-8">
     <div class="flex justify-center">
       <%= icon "lock-line", class: "w-20 h-20" %>
     </div>
@@ -41,5 +41,5 @@
         </div>
       <% end %>
     </div>
-  </main>
+  </div>
 <% end %>

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -126,7 +126,7 @@ describe "Respond a survey" do
   context "when the survey requires permissions to be responded" do
     before do
       permissions = {
-        response: {
+        respond: {
           authorization_handlers: {
             "dummy_authorization_handler" => { "options" => {} }
           }

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -146,6 +146,42 @@ describe "Respond a survey" do
     end
   end
 
+  context "when the survey requires an ephemeral authorization to be responded" do
+    let!(:organization) do
+      create(:organization, available_authorizations: %w(ephemeral_dummy_authorization_handler dummy_authorization_handler))
+    end
+
+    before do
+      permissions = {
+        respond: {
+          authorization_handlers: {
+            "ephemeral_dummy_authorization_handler" => { "options" => { "allowed_postal_codes" => "1234, 4567" } }
+          }
+        }
+      }
+
+      component.update!(permissions:)
+      survey.update!(allow_responses: true, starts_at: 1.week.ago, ends_at: 1.day.from_now)
+      visit_component
+      choose "All"
+      click_on translated_attribute(questionnaire.title)
+    end
+
+    it "renders the inline authorization page with a verification call to action" do
+      expect(page).to have_content("Authorization required")
+      expect(page).to have_link(text: /Authorize with/)
+    end
+
+    it "lets an unregistered user verify their identity without signing in" do
+      expect do
+        click_on "Authorize with \"Ephemeral example authorization\""
+      end.to change { Decidim::User.ephemeral.count }.by(1)
+
+      expect(page).to have_css("h1", text: "Verify with Ephemeral example authorization")
+      expect(page).to have_no_css("#loginModal", visible: :visible)
+    end
+  end
+
   context "when the survey allow responses" do
     context "when the survey is closed by start and end dates" do
       before do

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -168,7 +168,7 @@ describe "Respond a survey" do
     end
 
     it "renders the inline authorization page with a verification call to action" do
-      expect(page).to have_content("Authorization required")
+      expect(page).to have_text("Authorization required")
       expect(page).to have_link(text: /Authorize with/)
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Fixes configured authorizations not enforced in surveys.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #16670

#### Testing
1. In a development app, go to admin → Participatory Processes → pick or create a process.
2. Add a "Surveys" component.
3. Open the component's "Permissions" → for the "Respond" action, select any handler (e.g. "Ephemeral example authorization (Direct)") and save.
4. Create a survey inside the component, add at least one question, and publish the survey.
5. Open the survey's public URL in a private/incognito window (logged out).
6. Observe: the survey form is not rendered and the "Authorize with 'Ephemeral example authorization'" button is shown.

### :camera: Screenshots
**Example 1**

Survey with "Ephemeral example authorization" configured for the Respond action:

<img width="1864" height="798" alt="image" src="https://github.com/user-attachments/assets/98d1c6c3-b6b0-45fc-af8c-841d54683778" />

An unregistered user can see the 'Authorize with Ephemeral example authorization' button:

<img width="1293" height="727" alt="image" src="https://github.com/user-attachments/assets/0f94c73c-d0a2-41a6-a0f9-1ca1a2f41608" />

**Example 2**

Survey with "Example authorization" configured for the Respond action:

<img width="1811" height="773" alt="image" src="https://github.com/user-attachments/assets/f0a2b9de-fd1c-42ae-bf7d-5c6bde730499" />

A logged user without any authorization cannot respond:

<img width="1177" height="766" alt="image" src="https://github.com/user-attachments/assets/13229d9d-d2c6-44e5-81db-3f61406ebed9" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Aligned survey permission checks to use the correct response authorization so access control and verification behave consistently.

* **UX Improvements**
  * Redesigned authorization-denied screen: centered layout, translated title/description, lock icon, clearer verification steps, and contextual "respond" links to guide users.

* **Tests**
  * Added/updated system tests for authorization flows, including an ephemeral authorization scenario that shows an "Authorize with …" link and allows starting verification without prior registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->