### PR TITLE
Prevent using JWT against other organizations

### DIFF
--- a/decidim-api/lib/devise/models/api_authenticatable.rb
+++ b/decidim-api/lib/devise/models/api_authenticatable.rb
@@ -22,7 +22,13 @@ module Devise
         end
 
         def find_for_api_authentication(conditions)
-          find_for_authentication(conditions)
+          organization = conditions.dig(:env, "decidim.current_organization")
+          return unless organization
+
+          find_for_authentication(
+            api_key: conditions[:api_key],
+            decidim_organization_id: organization.id
+          )
         end
       end
     end

--- a/decidim-api/lib/devise/strategies/api_authenticatable.rb
+++ b/decidim-api/lib/devise/strategies/api_authenticatable.rb
@@ -9,7 +9,7 @@ module Devise
         key = authentication_hash[:key]
         secret = authentication_hash[:secret]
 
-        resource = mapping.to.find_for_api_authentication(api_key: key, env: )
+        resource = mapping.to.find_for_api_authentication(api_key: key, env:)
         validation_status = validate(resource) { resource.valid_api_secret?(secret) }
 
         success!(resource) if validation_status

--- a/decidim-api/lib/devise/strategies/api_authenticatable.rb
+++ b/decidim-api/lib/devise/strategies/api_authenticatable.rb
@@ -9,7 +9,7 @@ module Devise
         key = authentication_hash[:key]
         secret = authentication_hash[:secret]
 
-        resource = mapping.to.find_for_api_authentication(api_key: key)
+        resource = mapping.to.find_for_api_authentication(api_key: key, env: )
         validation_status = validate(resource) { resource.valid_api_secret?(secret) }
 
         success!(resource) if validation_status

--- a/decidim-api/spec/requests/apiauth_spec.rb
+++ b/decidim-api/spec/requests/apiauth_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe "Api authentication" do
         expect(parsed_response).to match("data" => { "session" => nil })
       end
     end
+
+    context "when there are other organizations" do
+      let!(:other_organization) { create(:organization) }
+
+      it "does not sign in" do
+        host! other_organization.host
+
+        post(sign_in_path, params:)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.headers["Authorization"]).not_to be_present
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body["jwt_token"]).not_to be_present
+      end
+
+      it "does not authenticate with the same key from another organization" do
+        host! other_organization.host
+        create(:api_user, organization: other_organization, api_key: key, api_secret: "other-secret")
+
+        post(sign_in_path, params:)
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.headers["Authorization"]).not_to be_present
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body["jwt_token"]).not_to be_present
+      end
+    end
   end
 
   context "with normal user" do


### PR DESCRIPTION
#### :tophat: What? Why?

Yet another cross organization access bug, this time with the JWT from the API access (configured in system panel).
 
#### Testing

All specs should pass

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented organization-scoped API authentication so requests are validated within the context of the current organization, preventing cross-organization access and avoiding exposure of authentication tokens or headers.

* **Tests**
  * Added request specs verifying multi-organization isolation for API sign-in, ensuring forbidden responses when organization context differs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->