### PR TITLE
Enforce permission check on admins' CSV census

### DIFF
--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_controller.rb
@@ -18,9 +18,13 @@ module Decidim
 
           helper_method :csv_census_data, :last_login
 
-          def index; end
+          def index
+            enforce_permission_to :index, :authorization
+          end
 
           def destroy
+            enforce_permission_to :create, :authorization
+
             Decidim::Commands::DestroyResource.call(census_data, current_user) do
               on(:ok) do
                 flash[:notice] = I18n.t("census.destroy.success", scope: "decidim.verifications.csv_census.admin")
@@ -30,12 +34,15 @@ module Decidim
           end
 
           def new_import
+            enforce_permission_to :create, :authorization
+
             @form = form(CensusDataForm).from_params(params)
             @status = Status.new(current_organization)
           end
 
           def create_import
             enforce_permission_to :create, :authorization
+
             @form = form(CensusDataForm).from_params(params)
             @status = Status.new(current_organization)
 
@@ -76,6 +83,7 @@ module Decidim
 
           def show_instructions
             enforce_permission_to :index, :authorization
+
             render :instructions
           end
 

--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_controller.rb
@@ -23,7 +23,7 @@ module Decidim
           end
 
           def destroy
-            enforce_permission_to :create, :authorization
+            enforce_permission_to :destroy, :authorization
 
             Decidim::Commands::DestroyResource.call(census_data, current_user) do
               on(:ok) do

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
@@ -8,6 +8,7 @@ module Decidim::Verifications::CsvCensus::Admin
 
     let(:user) { create(:user, :admin, :confirmed, organization:) }
     let(:organization) { create(:organization) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:csv_datum) { create(:csv_datum, organization:) }
 
     before do
@@ -20,9 +21,27 @@ module Decidim::Verifications::CsvCensus::Admin
         allow(controller).to receive(:csv_census_active?).and_return(true)
       end
 
+      it "enforces permission to index authorizations" do
+        expect(controller).to receive(:enforce_permission_to).with(:index, :authorization)
+
+        get :index
+      end
+
       it "renders the index template" do
         get :index
         expect(response).to render_template(:index)
+      end
+    end
+
+    describe "DELETE #destroy" do
+      before do
+        allow(controller).to receive(:csv_census_active?).and_return(true)
+      end
+
+      it "enforces permission to destroy authorizations" do
+        expect(controller).to receive(:enforce_permission_to).with(:destroy, :authorization)
+
+        delete :destroy, params: { id: csv_datum.id }
       end
     end
 
@@ -31,11 +50,67 @@ module Decidim::Verifications::CsvCensus::Admin
         allow(controller).to receive(:csv_census_active?).and_return(true)
       end
 
+      it "enforces permission to create authorizations" do
+        expect(controller).to receive(:enforce_permission_to).with(:create, :authorization)
+
+        get :new_import
+      end
+
       it "assigns a new form" do
         get :new_import
 
         expect(response).to render_template(:new_import)
         expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusDataForm)
+      end
+    end
+
+    describe "POST #create_import" do
+      before do
+        allow(controller).to receive(:csv_census_active?).and_return(true)
+
+        form_errors = instance_double(ActiveModel::Errors, any?: true, full_messages: ["File can't be blank"])
+        form = instance_double(Decidim::Verifications::CsvCensus::Admin::CensusDataForm, validate_csv: nil, errors: form_errors)
+        form_builder = double(from_params: form)
+
+        allow(controller).to receive(:form).and_return(form_builder)
+      end
+
+      it "enforces permission to create authorizations" do
+        expect(controller).to receive(:enforce_permission_to).with(:create, :authorization)
+
+        post :create_import
+      end
+    end
+
+    context "when user is a process admin" do
+      let(:user) { create(:process_admin, :confirmed, organization:, participatory_process:) }
+
+      before do
+        allow(controller).to receive(:csv_census_active?).and_return(true)
+      end
+
+      it "does not allow index" do
+        get :index
+
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it "does not allow destroy" do
+        delete :destroy, params: { id: csv_datum.id }
+
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it "does not allow new_import" do
+        get :new_import
+
+        expect(response).to have_http_status(:redirect)
+      end
+
+      it "does not allow create_import" do
+        post :create_import
+
+        expect(response).to have_http_status(:redirect)
       end
     end
   end

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
@@ -12,15 +12,12 @@ module Decidim::Verifications::CsvCensus::Admin
     let(:csv_datum) { create(:csv_datum, organization:) }
 
     before do
+      allow(controller).to receive(:csv_census_active?).and_return(true)
       request.env["decidim.current_organization"] = user.organization
       sign_in user, scope: :user
     end
 
     describe "GET #index" do
-      before do
-        allow(controller).to receive(:csv_census_active?).and_return(true)
-      end
-
       it "enforces permission to index authorizations" do
         expect(controller).to receive(:enforce_permission_to).with(:index, :authorization)
 
@@ -34,10 +31,6 @@ module Decidim::Verifications::CsvCensus::Admin
     end
 
     describe "DELETE #destroy" do
-      before do
-        allow(controller).to receive(:csv_census_active?).and_return(true)
-      end
-
       it "enforces permission to destroy authorizations" do
         expect(controller).to receive(:enforce_permission_to).with(:destroy, :authorization)
 
@@ -46,10 +39,6 @@ module Decidim::Verifications::CsvCensus::Admin
     end
 
     describe "GET #new_import" do
-      before do
-        allow(controller).to receive(:csv_census_active?).and_return(true)
-      end
-
       it "enforces permission to create authorizations" do
         expect(controller).to receive(:enforce_permission_to).with(:create, :authorization)
 
@@ -66,8 +55,6 @@ module Decidim::Verifications::CsvCensus::Admin
 
     describe "POST #create_import" do
       before do
-        allow(controller).to receive(:csv_census_active?).and_return(true)
-
         form_errors = instance_double(ActiveModel::Errors, any?: true, full_messages: ["File cannot be blank"])
         form = instance_double(Decidim::Verifications::CsvCensus::Admin::CensusDataForm, validate_csv: nil, errors: form_errors)
         form_builder = double(from_params: form)
@@ -84,10 +71,6 @@ module Decidim::Verifications::CsvCensus::Admin
 
     context "when user is a process admin" do
       let(:user) { create(:process_admin, :confirmed, organization:, participatory_process:) }
-
-      before do
-        allow(controller).to receive(:csv_census_active?).and_return(true)
-      end
 
       it "does not allow index" do
         get :index

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_controller_spec.rb
@@ -68,7 +68,7 @@ module Decidim::Verifications::CsvCensus::Admin
       before do
         allow(controller).to receive(:csv_census_active?).and_return(true)
 
-        form_errors = instance_double(ActiveModel::Errors, any?: true, full_messages: ["File can't be blank"])
+        form_errors = instance_double(ActiveModel::Errors, any?: true, full_messages: ["File cannot be blank"])
         form = instance_double(Decidim::Verifications::CsvCensus::Admin::CensusDataForm, validate_csv: nil, errors: form_errors)
         form_builder = double(from_params: form)
 


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected a missing permission enforce in the CSV census from decidim-verifications.

This PR adds it. 

#### Testing

Everything should be green. 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened authorization in the CSV census admin area: listing, deletion and import flows now enforce permissions to prevent unauthorized access and actions.
* **Tests**
  * Expanded controller specs to verify the new permission checks, include import-form error scenarios, and add process-admin contexts for denied access cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->