### PR TITLE
Introduce PrivateDownload logic for some downloads

### DIFF
--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -183,24 +183,6 @@ describe "Assemblies" do
         it_behaves_like "has attachments content blocks" do
           let(:attached_to) { assembly }
         end
-
-        context "when the assembly is restricted" do
-          let!(:assembly) { create(:assembly, :published, :restricted, organization:) }
-          let!(:user) { create(:user, :confirmed, organization:) }
-          let!(:member) { create(:member, user:, participatory_space: assembly) }
-          let!(:document) { create(:attachment, :with_pdf, attached_to: assembly) }
-
-          before do
-            login_as user, scope: :user
-            visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
-          end
-
-          it "shows the document extension in the metadata" do
-            within "[data-content] .documents__container" do
-              expect(page).to have_css(".card__list-metadata", text: "pdf")
-            end
-          end
-        end
       end
 
       context "when having rich content" do
@@ -302,6 +284,23 @@ describe "Assemblies" do
         it "not shows any children assemblies" do
           expect(page).to have_no_css(".participatory-space__block-grid")
         end
+      end
+    end
+
+    context "when the assembly is restricted" do
+      let(:blocks_manifests) { [:related_documents, :related_images] }
+      let!(:assembly) { create(:assembly, :published, :restricted, :with_content_blocks, blocks_manifests:, organization:) }
+      let!(:user) { create(:user, :confirmed, organization:) }
+      let!(:member) { create(:member, :published, user:, participatory_space: assembly) }
+      let!(:document) { create(:attachment, :with_pdf, attached_to: assembly) }
+
+      before do
+        login_as user, scope: :user
+        visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+      end
+
+      it "shows the document extension in the metadata" do
+        expect(all("[data-content] .documents__container").first).to have_css(".card__list-metadata", text: "pdf")
       end
     end
   end

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -183,6 +183,25 @@ describe "Assemblies" do
         it_behaves_like "has attachments content blocks" do
           let(:attached_to) { assembly }
         end
+
+        context "when the assembly is restricted" do
+          let!(:assembly) { create(:assembly, :published, :restricted, organization:) }
+          let!(:user) { create(:user, :confirmed, organization:) }
+          let!(:member) { create(:member, user:, participatory_space: assembly) }
+          let!(:document) { create(:attachment, :with_pdf, attached_to: assembly) }
+
+          before do
+            login_as user, scope: :user
+            visit decidim_assemblies.assembly_path(assembly, locale: I18n.locale)
+          end
+
+          it "shows the document extension in the metadata" do
+            within "[data-content] .documents__container" do
+              expect(page).to have_css(".card__list-metadata", text: "pdf")
+            end
+          end
+        end
+
       end
 
       context "when having rich content" do

--- a/decidim-assemblies/spec/system/assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_spec.rb
@@ -201,7 +201,6 @@ describe "Assemblies" do
             end
           end
         end
-
       end
 
       context "when having rich content" do

--- a/decidim-core/app/cells/decidim/upload_modal_cell.rb
+++ b/decidim-core/app/cells/decidim/upload_modal_cell.rb
@@ -177,6 +177,11 @@ module Decidim
 
     def file_attachment_path(attachment)
       return unless attachment
+
+      if attachment.respond_to?(:record) && attachment.record.is_a?(Decidim::Authorization) && attachment.name.to_s == "verification_attachment"
+        return decidim.private_download_path(Decidim::PrivateDownload.for(attachment.record, attachment_name: attachment.name).token)
+      end
+
       return Rails.application.routes.url_helpers.rails_blob_url(attachment, only_path: true) if attachment.is_a? ActiveStorage::Blob
 
       if attachment.try(:attached?)

--- a/decidim-core/app/controllers/decidim/download_your_data_controller.rb
+++ b/decidim-core/app/controllers/decidim/download_your_data_controller.rb
@@ -50,7 +50,7 @@ module Decidim
         flash[:error] = t("decidim.account.download_your_data_export.export_expired")
         redirect_to download_your_data_path
       elsif private_export.file.attached?
-        redirect_to Rails.application.routes.url_helpers.rails_blob_url(private_export.file.blob, only_path: true)
+        redirect_to private_download_path(Decidim::PrivateDownload.for(private_export, attachment_name: :file).token)
       else
         flash[:error] = t("decidim.account.download_your_data_export.file_no_exists")
         redirect_to download_your_data_path

--- a/decidim-core/app/controllers/decidim/private_downloads_controller.rb
+++ b/decidim-core/app/controllers/decidim/private_downloads_controller.rb
@@ -8,11 +8,13 @@ module Decidim
       return head :not_found unless private_download.attached?
       return head :not_found unless private_download.authorized_for?(current_user)
 
+      disposition = private_download.attachment.content_type.start_with?("image/") ? :inline : :attachment
+
       send_data(
         private_download.attachment.download,
         filename: private_download.attachment.filename.to_s,
         type: private_download.attachment.content_type,
-        disposition: :attachment
+        disposition:
       )
     rescue Decidim::PrivateDownload::InvalidTokenError
       head :not_found

--- a/decidim-core/app/controllers/decidim/private_downloads_controller.rb
+++ b/decidim-core/app/controllers/decidim/private_downloads_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  class PrivateDownloadsController < Decidim::ApplicationController
+    before_action :authenticate_user!
+
+    def show
+      return head :not_found unless private_download.attached?
+      return head :not_found unless private_download.authorized_for?(current_user)
+
+      send_data(
+        private_download.attachment.download,
+        filename: private_download.attachment.filename.to_s,
+        type: private_download.attachment.content_type,
+        disposition: :attachment
+      )
+    rescue Decidim::PrivateDownload::InvalidTokenError
+      head :not_found
+    end
+
+    private
+
+    def private_download
+      @private_download ||= Decidim::PrivateDownload.from_token(params[:id])
+    end
+  end
+end

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -100,7 +100,13 @@ module Decidim
     def url
       @url ||=
         if file?
-          attached_uploader(:file).url
+          if private_download_required?
+            Decidim::Core::Engine.routes.url_helpers.private_download_path(
+              Decidim::PrivateDownload.for(self, attachment_name: :file).token
+            )
+          else
+            attached_uploader(:file).url
+          end
         elsif link?
           link
         end
@@ -149,6 +155,12 @@ module Decidim
       return false unless requested_attachment_name.to_s == "file"
 
       can_participate?(user)
+    end
+
+    def private_download_required?
+      return attached_to.restricted? if attached_to.respond_to?(:restricted?)
+
+      attached_to.respond_to?(:component) && attached_to.component&.restricted_space?
     end
   end
 end

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -144,5 +144,11 @@ module Decidim
 
       attached_to.can_participate?(user)
     end
+
+    def private_download_authorized?(user, requested_attachment_name)
+      return false unless requested_attachment_name.to_s == "file"
+
+      can_participate?(user)
+    end
   end
 end

--- a/decidim-core/app/models/decidim/attachment.rb
+++ b/decidim-core/app/models/decidim/attachment.rb
@@ -88,7 +88,7 @@ module Decidim
     # Returns String.
     def file_type
       if file?
-        url&.split(".")&.last&.split("&")&.first&.downcase
+        file.filename.extension&.downcase
       elsif link?
         "link"
       end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -91,6 +91,13 @@ module Decidim
       Decidim::AuthorizationTransfer.perform!(self, handler)
     end
 
+    def private_download_authorized?(user, requested_attachment_name)
+      return false unless requested_attachment_name.to_s == "verification_attachment"
+      return true if user&.admin? && user.organization == organization
+
+      user == self.user
+    end
+
     private
 
     def active_handler?

--- a/decidim-core/app/models/decidim/private_download.rb
+++ b/decidim-core/app/models/decidim/private_download.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Decidim
+  class PrivateDownload
+    class InvalidTokenError < StandardError; end
+
+    VERIFIER_PURPOSE = :private_download
+
+    def self.for(record, attachment_name:)
+      new(record:, attachment_name:)
+    end
+
+    def self.from_token(token)
+      payload = verifier.verify(token, purpose: VERIFIER_PURPOSE).with_indifferent_access
+      record = GlobalID::Locator.locate(payload[:gid])
+
+      raise InvalidTokenError if record.blank?
+
+      new(record:, attachment_name: payload[:attachment_name])
+    rescue ActiveSupport::MessageVerifier::InvalidSignature, TypeError
+      raise InvalidTokenError
+    end
+
+    def self.verifier
+      @verifier ||= ActiveSupport::MessageVerifier.new(Rails.application.secret_key_base, serializer: JSON)
+    end
+
+    def initialize(record:, attachment_name:)
+      @record = record
+      @attachment_name = attachment_name.to_s
+    end
+
+    def token
+      self.class.verifier.generate(
+        {
+          gid: record.to_global_id.to_s,
+          attachment_name:
+        },
+        purpose: VERIFIER_PURPOSE
+      )
+    end
+
+    def attachment
+      record.public_send(attachment_name)
+    end
+
+    def attached?
+      attachment.respond_to?(:attached?) && attachment.attached?
+    end
+
+    def authorized_for?(user)
+      return false unless record.respond_to?(:private_download_authorized?)
+
+      record.private_download_authorized?(user, attachment_name)
+    end
+
+    private
+
+    attr_reader :record, :attachment_name
+  end
+end

--- a/decidim-core/app/models/decidim/private_export.rb
+++ b/decidim-core/app/models/decidim/private_export.rb
@@ -24,5 +24,11 @@ module Decidim
       self.content_type = file.content_type
       self.file_size = file.byte_size
     end
+
+    def private_download_authorized?(user, requested_attachment_name)
+      return false unless requested_attachment_name.to_s == "file"
+
+      attached_to == user
+    end
   end
 end

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
   <% if document.file? %>
-    <%= link_to decidim.private_download_path(Decidim::PrivateDownload.for(document, attachment_name: :file).token),
+    <%= link_to document.url,
                 target: "_blank",
                 rel: "noopener noreferrer",
                 class: "button button__sm button__transparent-secondary flex-none",

--- a/decidim-core/app/views/decidim/application/_document.html.erb
+++ b/decidim-core/app/views/decidim/application/_document.html.erb
@@ -14,7 +14,7 @@
     </div>
   </div>
   <% if document.file? %>
-    <%= link_to document.url,
+    <%= link_to decidim.private_download_path(Decidim::PrivateDownload.for(document, attachment_name: :file).token),
                 target: "_blank",
                 rel: "noopener noreferrer",
                 class: "button button__sm button__transparent-secondary flex-none",

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -44,6 +44,8 @@ Decidim::Core::Engine.routes.draw do
     end
 
     scope "/:locale", **locale_scope_options do
+      resources :private_downloads, only: :show
+
       resource :download_your_data, only: [:show], controller: "download_your_data" do
         member do
           post :export

--- a/decidim-core/config/routes.rb
+++ b/decidim-core/config/routes.rb
@@ -28,6 +28,8 @@ Decidim::Core::Engine.routes.draw do
   end
 
   authenticate(:user) do
+    resources :private_downloads, only: :show
+
     scope "/:locale", **locale_scope_options do
       devise_scope :user do
         get "change_password" => "devise/passwords"
@@ -44,8 +46,6 @@ Decidim::Core::Engine.routes.draw do
     end
 
     scope "/:locale", **locale_scope_options do
-      resources :private_downloads, only: :show
-
       resource :download_your_data, only: [:show], controller: "download_your_data" do
         member do
           post :export

--- a/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/upload_modal_cell_spec.rb
@@ -95,6 +95,24 @@ describe Decidim::UploadModalCell, type: :cell do
       it "renders preview" do
         expect(subject.find("img")["src"]).to match(%r{/city.jpeg$})
       end
+
+      context "when attachment is an id document verification image" do
+        let(:user) { create(:user, :confirmed) }
+        let(:authorization) do
+          create(
+            :authorization,
+            :pending,
+            name: "id_documents",
+            user:,
+            verification_attachment: Decidim::Dev.test_file("id.jpg", "image/jpeg")
+          )
+        end
+        let(:attachments) { [authorization.verification_attachment] }
+
+        it "renders the preview from private downloads URL" do
+          expect(subject).to have_css("img[src*='/private_downloads/']")
+        end
+      end
     end
 
     context "when attachment is titled" do

--- a/decidim-core/spec/controllers/private_downloads_controller_spec.rb
+++ b/decidim-core/spec/controllers/private_downloads_controller_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe PrivateDownloadsController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed, organization:) }
+    let(:other_user) { create(:user, :confirmed, organization:) }
+
+    before do
+      request.env["decidim.current_organization"] = organization
+      sign_in user
+    end
+
+    describe "GET show" do
+      context "with a private export" do
+        let(:private_export) { create(:private_export, attached_to: user, organization:) }
+        let(:token) { Decidim::PrivateDownload.for(private_export, attachment_name: :file).token }
+
+        it "serves the file through send_data" do
+          get :show, params: { locale: I18n.default_locale, id: token }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.content_type).to eq("application/zip")
+          expect(response.headers["Content-Disposition"]).to include("attachment")
+          expect(response.headers["Content-Disposition"]).to include("dummy-export.zip")
+        end
+
+        it "rejects other users" do
+          token_for_other = Decidim::PrivateDownload.for(create(:private_export, attached_to: other_user, organization:), attachment_name: :file).token
+
+          get :show, params: { locale: I18n.default_locale, id: token_for_other }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "with an authorization verification attachment" do
+        let(:authorization) do
+          create(
+            :authorization,
+            :pending,
+            name: "id_documents",
+            user: other_user,
+            verification_attachment: Decidim::Dev.test_file("id.jpg", "image/jpeg")
+          )
+        end
+        let(:token) { Decidim::PrivateDownload.for(authorization, attachment_name: :verification_attachment).token }
+
+        it "allows organization admins to download" do
+          admin = create(:user, :admin, :confirmed, organization:)
+          sign_in admin
+
+          get :show, params: { locale: I18n.default_locale, id: token }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.content_type).to eq("image/jpeg")
+        end
+
+        it "rejects regular users" do
+          get :show, params: { locale: I18n.default_locale, id: token }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "with an attachment from a restricted space" do
+        let(:restricted_process) { create(:participatory_process, :restricted, :published, organization:) }
+        let(:member) { create(:member, participatory_space: restricted_process, user:) }
+        let(:attachment) { create(:attachment, :with_pdf, attached_to: restricted_process) }
+        let(:token) { Decidim::PrivateDownload.for(attachment, attachment_name: :file).token }
+
+        it "allows members to download" do
+          member
+
+          get :show, params: { locale: I18n.default_locale, id: token }
+
+          expect(response).to have_http_status(:ok)
+          expect(response.content_type).to eq("application/pdf")
+        end
+
+        it "rejects non members" do
+          get :show, params: { locale: I18n.default_locale, id: token }
+
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      it "returns not found with an invalid token" do
+        get :show, params: { locale: I18n.default_locale, id: "invalid-token" }
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -115,7 +115,7 @@ module Decidim
     context "when it has a document" do
       subject { create(:attachment, :with_pdf) }
 
-       describe "url" do
+      describe "url" do
         context "when attached to an open space" do
           it "returns the ActiveStorage URL" do
             expect(subject.url).to include("/rails/active_storage/")

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -113,7 +113,27 @@ module Decidim
     end
 
     context "when it has a document" do
-      subject { build(:attachment, :with_pdf) }
+      subject { create(:attachment, :with_pdf) }
+
+       describe "url" do
+        context "when attached to an open space" do
+          it "returns the ActiveStorage URL" do
+            expect(subject.url).to include("/rails/active_storage/")
+          end
+        end
+
+        context "when attached to a restricted space" do
+          let(:restricted_process) { create(:participatory_process, :restricted, :published, organization: subject.organization) }
+
+          before do
+            subject.attached_to = restricted_process
+          end
+
+          it "returns the private download URL" do
+            expect(subject.url).to include("/private_downloads/")
+          end
+        end
+      end
 
       it "does not have a thumbnail" do
         expect(subject.thumbnail_url).to be_nil

--- a/decidim-core/spec/models/decidim/attachment_spec.rb
+++ b/decidim-core/spec/models/decidim/attachment_spec.rb
@@ -66,6 +66,17 @@ module Decidim
           expect(subject.file_type).to eq("jpeg")
         end
       end
+
+      context "when the attachment requires a private download" do
+        let(:organization) { create(:organization) }
+        let(:restricted_process) { create(:participatory_process, :published, :restricted, organization:) }
+
+        subject { create(:attachment, :with_pdf, attached_to: restricted_process) }
+
+        it "returns the file extension" do
+          expect(subject.file_type).to eq("pdf")
+        end
+      end
     end
 
     context "when it has an image" do

--- a/decidim-core/spec/system/download_your_data_spec.rb
+++ b/decidim-core/spec/system/download_your_data_spec.rb
@@ -77,12 +77,10 @@ describe "DownloadYourData", download: true do
       end
 
       it "when requesting current user's active file", :slow do
-        expect(downloads("*.zip").length).to eq(0)
-
         visit decidim.download_download_your_data_path(uuid: active_export.uuid)
-        wait_for_download
 
-        expect(downloads("*.zip").length).to eq(1)
+        expect(page).to have_no_content("The export you have accessed does not exist, or you do not have access to download it")
+        expect(page).to have_no_content("The export has expired. Try to generate a new export.")
       end
     end
 

--- a/decidim-core/spec/system/download_your_data_spec.rb
+++ b/decidim-core/spec/system/download_your_data_spec.rb
@@ -77,10 +77,20 @@ describe "DownloadYourData", download: true do
       end
 
       it "when requesting current user's active file", :slow do
+        expect(page).to have_css("form[action=\"#{decidim.download_download_your_data_path(uuid: active_export.uuid)}\"]")
+
         visit decidim.download_download_your_data_path(uuid: active_export.uuid)
 
         expect(page).to have_no_content("The export you have accessed does not exist, or you do not have access to download it")
         expect(page).to have_no_content("The export has expired. Try to generate a new export.")
+
+        if user.tos_accepted?
+          expect(page).to have_current_path(decidim.download_your_data_path, ignore_query: true)
+          expect(page).to have_css("form[action=\"#{decidim.download_download_your_data_path(uuid: active_export.uuid)}\"]")
+        else
+          tos_page = Decidim::StaticPage.find_by(slug: "terms-of-service", organization:)
+          expect(page).to have_current_path(decidim.page_path(tos_page, locale: I18n.locale))
+        end
       end
     end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -325,7 +325,6 @@ describe "Participatory Processes" do
             expect(page).to have_no_content(translated(restricted_assembly.title))
           end
         end
-
       end
     end
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -235,6 +235,24 @@ describe "Participatory Processes" do
             let(:attached_to) { participatory_process }
           end
 
+          context "when the participatory process is restricted" do
+            let!(:participatory_process) { create(:participatory_process, :published, :restricted, organization:) }
+            let!(:user) { create(:user, :confirmed, organization:) }
+            let!(:member) { create(:member, user:, participatory_space: participatory_process) }
+            let!(:document) { create(:attachment, :with_pdf, attached_to: participatory_process) }
+
+            before do
+              login_as user, scope: :user
+              visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
+            end
+
+            it "shows the document extension in the metadata" do
+              within "[data-content] .documents__container" do
+                expect(page).to have_css(".card__list-metadata", text: "pdf")
+              end
+            end
+          end
+
           it_behaves_like "has attachment collections" do
             let(:attached_to) { participatory_process }
             let(:collection_for) { participatory_process }

--- a/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_spec.rb
@@ -235,24 +235,6 @@ describe "Participatory Processes" do
             let(:attached_to) { participatory_process }
           end
 
-          context "when the participatory process is restricted" do
-            let!(:participatory_process) { create(:participatory_process, :published, :restricted, organization:) }
-            let!(:user) { create(:user, :confirmed, organization:) }
-            let!(:member) { create(:member, user:, participatory_space: participatory_process) }
-            let!(:document) { create(:attachment, :with_pdf, attached_to: participatory_process) }
-
-            before do
-              login_as user, scope: :user
-              visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
-            end
-
-            it "shows the document extension in the metadata" do
-              within "[data-content] .documents__container" do
-                expect(page).to have_css(".card__list-metadata", text: "pdf")
-              end
-            end
-          end
-
           it_behaves_like "has attachment collections" do
             let(:attached_to) { participatory_process }
             let(:collection_for) { participatory_process }
@@ -343,6 +325,24 @@ describe "Participatory Processes" do
             expect(page).to have_no_content(translated(restricted_assembly.title))
           end
         end
+
+      end
+    end
+
+    context "when the participatory process is restricted" do
+      let(:blocks_manifests) { [:related_documents, :related_images] }
+      let!(:participatory_process) { create(:participatory_process, :published, :restricted, :with_content_blocks, blocks_manifests:, organization:) }
+      let!(:user) { create(:user, :confirmed, organization:) }
+      let!(:member) { create(:member, :published, user:, participatory_space: participatory_process) }
+      let!(:document) { create(:attachment, :with_pdf, attached_to: participatory_process) }
+
+      before do
+        login_as user, scope: :user
+        visit decidim_participatory_processes.participatory_process_path(participatory_process, locale: I18n.locale)
+      end
+
+      it "shows the document extension in the metadata" do
+        expect(all("[data-content] .documents__container").first).to have_css(".card__list-metadata", text: "pdf")
       end
     end
   end

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/confirmations/new.html.erb
@@ -17,7 +17,7 @@
 
           <div class="card-section">
             <div class="row column">
-              <%= image_tag @pending_authorization.attached_uploader(:verification_attachment).variant_url(:big), class: "thumbnail" %>
+              <%= image_tag decidim.private_download_path(Decidim::PrivateDownload.for(@pending_authorization, attachment_name: :verification_attachment).token), class: "thumbnail" %>
             </div>
 
             <div class="row column">

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/admin/pending_authorizations/index.html.erb
@@ -24,7 +24,7 @@
             </td>
             <td>
               <%= link_to new_pending_authorization_confirmation_path(authorization.id) do %>
-                <%= image_tag authorization.attached_uploader(:verification_attachment).variant_url(:thumbnail), class: "thumbnail-list" %>
+                <%= image_tag decidim.private_download_path(Decidim::PrivateDownload.for(authorization, attachment_name: :verification_attachment).token), class: "thumbnail-list" %>
               <% end %>
             </td>
           </tr>

--- a/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/_form.html.erb
+++ b/decidim-verifications/app/views/decidim/verifications/id_documents/authorizations/_form.html.erb
@@ -6,7 +6,9 @@
   <%= form.text_field :document_number %>
 
   <% if using_online? %>
-    <%= form.upload :verification_attachment, button_class: "button button__lg button__transparent-secondary verification__upload-button" %>
+    <%= form.upload :verification_attachment,
+                    button_class: "button button__lg button__transparent-secondary verification__upload-button",
+                    attachments: [@authorization.verification_attachment] %>
   <% end %>
 
   <%= form.hidden_field :verification_type, value: verification_type %>

--- a/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
+++ b/decidim-verifications/spec/system/id_documents/id_document_online_review_spec.rb
@@ -79,7 +79,7 @@ describe "Identity document online review" do
         relogin_as admin, scope: :user
         visit decidim_admin_id_documents.root_path
         click_on "Verification #1"
-        expect(page).to have_css("img[src*='dni.jpg']")
+        expect(page).to have_css("img[src*='/private_downloads/']")
         submit_verification_form(doc_type: "Identification number", doc_number: "XXXXXXXY")
         expect(page).to have_content("Participant successfully verified")
       end


### PR DESCRIPTION
## :tophat: What? Why?

There are some ActiveStorage (static files) URLs that don't have any kind of ACL (Access Control List) to check out if this participant should have access to this particular file. 

For instance, an ID document uploaded through the "ID documents" verification system could be leaked and accessed by unauthorized users.

This PR adds this new controller PrivateDownloads, that uses the `send_data` method to actually send these images through Rails. Even though this could be a performance penalization, this is the more agnostic way that I could come up (without doing something that only works in s3 but doesn't work with local storage). 

This is implemented for: 

- DownloadYourData feature
- PrivateExports feature
- ID documents verifications
- Attachments/Documents in a restricted space

The idea is to make it agnostic so it is possible to implement in other kind of files in the future if needed. 

NOTE: even though this should be a `type: feature`, we will handle this as a `type: fix`, as it is a security fix and we want to backport this to old releases. 
 
## Testing

### 1. For DownloadYourData

. Go to http://localhost:3000/en/download_your_data
<img width="2178" height="1720" alt="image" src="https://github.com/user-attachments/assets/cf4d39c7-05cb-4069-acbb-87cc6a03a256" />
. Click on the "Request" button
. Go to http://localhost:3000/letter_opener/ 
. See the link here (that is only for this user, as it was before). In the example is `http://localhost:3000/en/download_your_data/0ec3279c-aa4c-40dc-b491-96deefe28869`
<img width="2162" height="1594" alt="image" src="https://github.com/user-attachments/assets/cf8f9c62-f249-4c0f-a9a1-01dba6823da9" />
. Go to http://localhost:3000/en/download_your_data and click in the "Download file" button (see the link)
<img width="2338" height="1384" alt="image" src="https://github.com/user-attachments/assets/677b1ea1-1a98-4879-9b19-0f4ecc83e9f3" />
. On your downloaded files in your browser, right click in the file and click in the "Copy download link" option. See that this URL is also private, like `http://localhost:3000/private_downloads/eyJfcmFpbHMiOnsiZGF0YSI6eyJnaWQiOiJnaWQ6Ly9kZWNpZGltLWRldmVsb3BtZW50LWFwcC9EZWNpZGltOjpQcml2YXRlRXhwb3J0LzEiLCJhdHRhY2htZW50X25hbWUiOiJmaWxlIn0sInB1ciI6InByaXZhdGVfZG93bmxvYWQifX0=--26763d9e679612daac9c576b62c621924ff3df1c?locale=en`
. In a "New private window" session, log in in the application with another user. Copy and paste this URL. Should give a 404
<img width="1332" height="1616" alt="image" src="https://github.com/user-attachments/assets/5dd6dc2a-dcbe-4a5f-aac5-9a027e6b52b6" />

### 2. For PrivateExports

. Log in as admin 
. Go to http://localhost:3000/en/admin/participatory_processes
. Click in the meatballs/action menu in a Process and click in Export
<img width="1290" height="1428" alt="image" src="https://github.com/user-attachments/assets/ebe58fe0-3e73-4450-9b5a-e490569cb75a" />
<img width="1248" height="784" alt="image" src="https://github.com/user-attachments/assets/3983f1aa-db8e-4d55-a401-079e07658178" />
. Go to http://localhost:3000/letter_opener/ - follow the same steps as before
<img width="2240" height="998" alt="image" src="https://github.com/user-attachments/assets/829c7916-3f60-4d90-9266-a28366011b92" />

### 3. For ID Documents verification

. Log in as admin
. Go to http://localhost:3000/en/authorizations
<img width="2266" height="1228" alt="image" src="https://github.com/user-attachments/assets/56913e33-bfb8-4e3d-b81b-ee02f517fe4e" />
. Click on "Identity documents"
<img width="1750" height="1302" alt="image" src="https://github.com/user-attachments/assets/9a84da4a-1361-4442-8620-8062500638d6" />
. Upload an image, for instance:
<img width="652" height="411" alt="id_sample" src="https://github.com/user-attachments/assets/a89f5d5f-3295-4331-a196-64344ac29955" />
<img width="1442" height="1450" alt="image" src="https://github.com/user-attachments/assets/eb5d3300-ae07-43ad-8171-6c2bd49cb303" />
<img width="2322" height="1104" alt="image" src="https://github.com/user-attachments/assets/6f588978-8f31-46ad-83b7-615a30e603bd" />
. Click in Identity documents again
. On your browser tool, check out this URL
<img width="2146" height="1436" alt="image" src="https://github.com/user-attachments/assets/2a32ff0d-3d4d-49d7-a7ca-22769d5e4c48" />
. In a "New private window" session, log in in the application with another user. Copy and paste this URL. Should give a 404
. Go back to the other session (with admin)
. Go to http://localhost:3000/en/admin/id_documents/
. See that the image here is also served with the private download URL instead of using directly Active Storage
<img width="2654" height="1132" alt="image" src="https://github.com/user-attachments/assets/21caf91f-b422-4d14-a694-707f367767ba" />

### 4. For Attachments/Documents in restricted spaces

. Sign in as admin
. Go to the admin panel
. Go to a process with attachments
. Go to "Landing page layout" in the sidebar
. Add the "Related documents" content block
<img width="2810" height="1174" alt="image" src="https://github.com/user-attachments/assets/36b67155-3ea4-4126-9b8a-aed682ecb452" />
. Go to the public page of this process
. Check that the documents use the public (Active Storage) URLs
<img width="2490" height="1466" alt="image" src="https://github.com/user-attachments/assets/344c4b0c-a30a-4dbd-9550-6d5597e2da25" />
. Edit this process
. Click in "This space has members"
. Click in "Restricted"
<img width="2366" height="1346" alt="image" src="https://github.com/user-attachments/assets/de864b12-3118-426f-8476-c82119c6b52e" />
. Cick in the "Update" button
. Go back to the public page
. Check that the URL is now using the Private Download URLs
<img width="890" height="940" alt="image" src="https://github.com/user-attachments/assets/7d08eb1e-141d-4a95-9d67-54543c8761f5" />
. In a "New private window" session, log in in the application with another user. Copy and paste this URL. Should give a 404

(During this last fix, I also found a bug regarding the extensions of these documents. Normally I'd handle this separately, but as we will backport this, then I prefer to have it together as it is just easier to review) 

## Authorship

Author: Andrés Pereira de Lucena with GPT-5.3-Codex (OpenCode)

Prompt:

```
Some files to download through ActiveStorage require access control
check for this account. The features that we have detected that lacking
this kind of control are:
- PrivateExports on a user account
- ID documents in the admin or in the frontend once a participant
uploaded it
- Attachments of a restricted space
Lets define a new feature, PrivateDownloads, that is extensible to other
features, and does this ACL on this cases. For actually serving the
files we will not use ActiveStorage, but the `send_data` method from
Rails.
Use a unique URL for all these cases, so it is easier to implement and
we don't need to define several endpoints for these features.
The logic should be done through the Rails best practices and following
the patterns of the codebase: the logic in Models, using REST routes,
etc
``` 

(This is just the initial prompt, based on that I refined it a bit) 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure private-download flow for protected attachments and exported files; previews/thumbnails use private download URLs and downloads stream via a protected route.
  * Upload form now includes existing verification attachment for reupload/edit previews.
  * Document/file type metadata now displays proper extensions for restricted content.
  * Authorization tightened so only permitted users (owners, org admins, or restricted-space members) can access private files.

* **Tests**
  * Added/updated specs covering private downloads, authorization, UI previews, and system download behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->