### PR TITLE
Fix flaky spec on `category.erb`

### DIFF
--- a/decidim-core/app/cells/decidim/data_consent/category.erb
+++ b/decidim-core/app/cells/decidim/data_consent/category.erb
@@ -13,12 +13,12 @@
       <%= icon "close-line", class: "cookies__category-toggle-icon" %>
     </label>
 
-    <div id="accordion-trigger-<%= category[:slug] %>" role="group" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
-      <h3 id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
-        <%= category[:title] %>
-      </h3>
+    <h3 id="accordion-title-<%= category[:slug] %>" class="cookies__category-trigger-title">
+      <%= category[:title] %>
+    </h3>
 
-      <span>
+    <div id="accordion-trigger-<%= category[:slug] %>" role="group" data-controls="accordion-panel-<%= category[:slug] %>" aria-labelledby="accordion-title-<%= category[:slug] %>">
+      <span aria-hidden="true">
         <%= icon "arrow-down-s-line", class: "cookies__category-trigger-arrow" %>
         <%= icon "arrow-up-s-line", class: "cookies__category-trigger-arrow" %>
       </span>


### PR DESCRIPTION
#### :tophat: What? Why?
Yesterday we started seeing a new flaky in the pipeline, this time related to the cookie / data consent feature. 

Locally I couldn't reproduce it. 

#### :pushpin: Related Issues

- Related to  https://github.com/decidim/decidim/actions/runs/25315997206/job/74223666071?pr=16680
- Related to https://github.com/decidim/decidim/pull/16668 (as an example of another PR that has these same failures)

#### Testing

1. Go to the bottom of any page, and click in the Cookie settings. Everything should work the same
2. Pipeline should be green

#### Screenshot

<img width="2228" height="1514" alt="image" src="https://github.com/user-attachments/assets/a1870d96-485a-4acb-8e6b-a09bf3c881b7" />

#### Stacktrace

```

Failures:

  1) Explore versions when showing version behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       ######
       line 619: The element “h3” must not appear as a descendant of an element with the attribute “role=button”.


           <div id="accordion-trigger-essential" data-controls="accordion-panel-essential" aria-labelledby="accordion-title-essential" role="button" tabindex="0" aria-controls="accordion-panel-essential" aria-expanded="false" aria-disabled="false">
       >>      <h3 id="accordion-title-essential" class="cookies__category-trigger-title">
               Essential
             </h3>


       ######
       line 714: The element “h3” must not appear as a descendant of an element with the attribute “role=button”.


           <div id="accordion-trigger-preferences" data-controls="accordion-panel-preferences" aria-labelledby="accordion-title-preferences" role="button" tabindex="0" aria-controls="accordion-panel-preferences" aria-expanded="false" aria-disabled="false">
       >>      <h3 id="accordion-title-preferences" class="cookies__category-trigger-title">
               Preferences
             </h3>


       ######
       line 745: The element “h3” must not appear as a descendant of an element with the attribute “role=button”.


           <div id="accordion-trigger-analytics" data-controls="accordion-panel-analytics" aria-labelledby="accordion-title-analytics" role="button" tabindex="0" aria-controls="accordion-panel-analytics" aria-expanded="false" aria-disabled="false">
       >>      <h3 id="accordion-title-analytics" class="cookies__category-trigger-title">
               Analytics and statistics
             </h3>


       ######
       line 776: The element “h3” must not appear as a descendant of an element with the attribute “role=button”.


           <div id="accordion-trigger-marketing" data-controls="accordion-panel-marketing" aria-labelledby="accordion-title-marketing" role="button" tabindex="0" aria-controls="accordion-panel-marketing" aria-expanded="false" aria-disabled="false">
       >>      <h3 id="accordion-title-marketing" class="cookies__category-trigger-title">
               Marketing
             </h3>

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_html_validation_767.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_explore_versions_when_showing_version_behaves_like_accessible_page_passes_html_validation_767.html


     Shared Example Group: "accessible page" called from ./spec/system/explore_versions_spec.rb:62
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:132:in 'block (2 levels) in <top (required)>'

Finished in 6 minutes 10 seconds (files took 17.26 seconds to load)
80 examples, 1 failure

Failed examples:

rspec ./spec/system/explore_versions_spec.rb[1:3:1:2] # Explore versions when showing version behaves like accessible page passes HTML validation
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of the data consent category component by properly ordering form elements and their associated labels for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->