### PR TITLE
Fix Service Worker registration on page load

### DIFF
--- a/decidim-core/app/packs/src/decidim/sw/loader.js
+++ b/decidim-core/app/packs/src/decidim/sw/loader.js
@@ -1,5 +1,5 @@
 // check if the browser supports serviceWorker at all
-window.addEventListener("load", async () => {
+const registerServiceWorker = async () => {
   if ("serviceWorker" in navigator) {
     await navigator.serviceWorker.register("/sw.js", { scope: "/" });
 
@@ -15,4 +15,10 @@ window.addEventListener("load", async () => {
   } else {
     console.log("Your browser does not support service workers 🤷‍♀️");
   }
-});
+};
+
+if (document.readyState === "complete") {
+  registerServiceWorker();
+} else {
+  window.addEventListener("load", registerServiceWorker, { once: true });
+}

--- a/decidim-core/app/packs/src/decidim/sw/loader.js
+++ b/decidim-core/app/packs/src/decidim/sw/loader.js
@@ -1,8 +1,12 @@
 // check if the browser supports serviceWorker at all
 const registerServiceWorker = async () => {
   if ("serviceWorker" in navigator) {
-    await navigator.serviceWorker.register("/sw.js", { scope: "/" });
-
+    try {
+      await navigator.serviceWorker.register("/sw.js", { scope: "/" });
+    } catch (error) {
+      console.error("Service Worker registration failed:", error);
+      return;
+    }
     const mandatoryElements = document.querySelector(".js-sw-mandatory");
     // Opera uses Opera for versions <= 12 and OPR for versions > 12
     const isOperaMini =


### PR DESCRIPTION
#### :tophat: What? Why?

While checking out https://github.com/decidim/decidim/pull/16697 I found that [PWABuilder doesn't like how we register the Service Worker](https://www.pwabuilder.com/reportcard?site=https://nightly.decidim.org/), as it isn't being detected: 

<img width="1515" height="735" alt="image" src="https://github.com/user-attachments/assets/6d227498-a82f-4d16-adf9-64779cbb689e" />

#### :pushpin: Related Issues
 
- Related to #16697

#### Testing

##### For the bug

1; Go to https://www.pwabuilder.com/reportcard?site=https://nightly.decidim.org/ 
2. See that it says:

>  PWABuilder has analyzed your site and did not find a Service Worker. Having a Service Worker is highly recommended as it enables powerful features that can enhance your PWA. You can generate a Service Worker below or use our documentation to make your own. 

##### For the fix

1. Check out this branch
2. Open the web developers tool of your browser
3. Open the Application tab
4. See that the SW is working correctly (Running)
<img width="1779" height="959" alt="image" src="https://github.com/user-attachments/assets/ad324939-7792-49e3-bdab-c821ba6a44dd" />

---

As the fix isn't actually running against PWABuilder, my idea is to deploy to nightly once this is merged and then run again PWABuilder hoping that this solves it 🤞🏽  

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved service worker registration to run as soon as the page is ready, ensuring more reliable and timely initialization without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->