### PR TITLE
Enforce permission check on admins' CSV census records

### DIFF
--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_records_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/admin/census_records_controller.rb
@@ -10,10 +10,14 @@ module Decidim
           helper_method :csv_census_data
 
           def new_record
+            enforce_permission_to :create, :authorization
+
             @form = form(Admin::CensusForm).instance
           end
 
           def create_record
+            enforce_permission_to :create, :authorization
+
             @form = form(Admin::CensusForm).from_params(params)
             Admin::CreateCensusRecord.call(@form) do
               on(:ok) do
@@ -28,10 +32,14 @@ module Decidim
           end
 
           def edit_record
+            enforce_permission_to :update, :authorization
+
             @form = form(Admin::CensusForm).from_model(census_data)
           end
 
           def update_record
+            enforce_permission_to :update, :authorization
+
             @form = form(Admin::CensusForm).from_params(params)
 
             Admin::UpdateCensusRecord.call(@form, census_data) do

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -49,9 +49,25 @@ module Decidim::Verifications::CsvCensus::Admin
         end
       end
 
+      describe "POST #create_record" do
+        it "prohibits creating new records by using redirect" do
+          post :create_record, params: { id: csv_datum.id }
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
       describe "GET #edit_record" do
         it "prohibits display edit record page using redirect" do
           get :edit_record, params: { id: csv_datum.id }
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      describe "PATCH #update_record" do
+        it "prohibits record update page using redirect" do
+          patch :edit_record, params: { id: csv_datum.id }
 
           expect(response).to have_http_status(:redirect)
         end

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -7,6 +7,7 @@ module Decidim::Verifications::CsvCensus::Admin
     routes { Decidim::Verifications::CsvCensus::AdminEngine.routes }
 
     let(:organization) { create(:organization) }
+    let(:participatory_process) { create(:participatory_process, organization:) }
     let(:csv_datum) { create(:csv_datum, organization:) }
 
     before do
@@ -39,7 +40,7 @@ module Decidim::Verifications::CsvCensus::Admin
     end
 
     context "when user is NOT admin" do
-      let(:user) { create(:user, :confirmed, organization:) }
+      let(:user) { create(:process_admin, :confirmed, organization:, participatory_process:) }
 
       describe "GET #new_record" do
         it "prohibits display new record page using redirect" do

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -28,6 +28,17 @@ module Decidim::Verifications::CsvCensus::Admin
         end
       end
 
+      describe "POST #create_record" do
+        it "prohibits creating new records by using redirect" do
+          expect(controller).to receive(:enforce_permission_to).with(:create, :authorization).and_call_original
+
+          post :create_record, params: { census: { email: "test@example.org" } }
+
+          expect(response).to have_http_status(:ok)
+          expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+        end
+      end
+
       describe "GET #edit_record" do
         it "renders the edit_record template" do
           expect(controller).to receive(:enforce_permission_to).with(:update, :authorization).and_call_original
@@ -35,6 +46,18 @@ module Decidim::Verifications::CsvCensus::Admin
           get :edit_record, params: { id: csv_datum.id }
           expect(response).to render_template(:edit_record)
           expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+        end
+      end
+
+      describe "PATCH #update_record" do
+        it "prohibits record update page using redirect" do
+          expect(controller).to receive(:enforce_permission_to).with(:update, :authorization).and_call_original
+
+          patch :update_record, params: { id: csv_datum.id, census: { email: "test@example.org" } }
+
+          expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+          expect(response).to have_http_status(:ok)
+          expect(csv_datum.reload.email).to eq("test@example.org")
         end
       end
     end

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -6,7 +6,6 @@ module Decidim::Verifications::CsvCensus::Admin
   describe CensusRecordsController do
     routes { Decidim::Verifications::CsvCensus::AdminEngine.routes }
 
-    let(:user) { create(:user, :admin, :confirmed, organization:) }
     let(:organization) { create(:organization) }
     let(:csv_datum) { create(:csv_datum, organization:) }
 
@@ -15,19 +14,47 @@ module Decidim::Verifications::CsvCensus::Admin
       sign_in user, scope: :user
     end
 
-    describe "GET #new_record" do
-      it "renders the new_record template" do
-        get :new_record
-        expect(response).to render_template(:new_record)
-        expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+    context "when user is admin" do
+      let(:user) { create(:user, :admin, :confirmed, organization:) }
+
+      describe "GET #new_record" do
+        it "renders the new_record template" do
+          expect(controller).to receive(:enforce_permission_to).with(:create, :authorization).and_call_original
+
+          get :new_record
+          expect(response).to render_template(:new_record)
+          expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+        end
+      end
+
+      describe "GET #edit_record" do
+        it "renders the edit_record template" do
+          expect(controller).to receive(:enforce_permission_to).with(:update, :authorization).and_call_original
+
+          get :edit_record, params: { id: csv_datum.id }
+          expect(response).to render_template(:edit_record)
+          expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+        end
       end
     end
 
-    describe "GET #edit_record" do
-      it "renders the edit_record template" do
-        get :edit_record, params: { id: csv_datum.id }
-        expect(response).to render_template(:edit_record)
-        expect(assigns(:form)).to be_a(Decidim::Verifications::CsvCensus::Admin::CensusForm)
+    context "when user is NOT admin" do
+      let(:user) { create(:user, :confirmed, organization:) }
+
+      describe "GET #new_record" do
+        it "renders the new_record template" do
+          get :new_record
+
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      describe "GET #edit_record" do
+        it "renders the edit_record template" do
+          get :edit_record, params: { id: csv_datum.id }
+
+          expect(response).to have_http_status(:redirect)
+        end
       end
     end
   end

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -68,7 +68,7 @@ module Decidim::Verifications::CsvCensus::Admin
 
       describe "PATCH #update_record" do
         it "prohibits record update page using redirect" do
-          patch :edit_record, params: { id: csv_datum.id }
+          patch :update_record, params: { id: csv_datum.id }
 
           expect(response).to have_http_status(:redirect)
         end

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -29,7 +29,7 @@ module Decidim::Verifications::CsvCensus::Admin
       end
 
       describe "POST #create_record" do
-        it "prohibits creating new records by using redirect" do
+        it "creates the new record" do
           expect(controller).to receive(:enforce_permission_to).with(:create, :authorization).and_call_original
 
           post :create_record, params: { census: { email: "test@example.org" } }
@@ -50,7 +50,7 @@ module Decidim::Verifications::CsvCensus::Admin
       end
 
       describe "PATCH #update_record" do
-        it "prohibits record update page using redirect" do
+        it "updates the record" do
           expect(controller).to receive(:enforce_permission_to).with(:update, :authorization).and_call_original
 
           patch :update_record, params: { id: csv_datum.id, census: { email: "test@example.org" } }

--- a/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/verifications/csv_census/admin/census_records_controller_spec.rb
@@ -42,7 +42,7 @@ module Decidim::Verifications::CsvCensus::Admin
       let(:user) { create(:user, :confirmed, organization:) }
 
       describe "GET #new_record" do
-        it "renders the new_record template" do
+        it "prohibits display new record page using redirect" do
           get :new_record
 
           expect(response).to have_http_status(:redirect)
@@ -50,7 +50,7 @@ module Decidim::Verifications::CsvCensus::Admin
       end
 
       describe "GET #edit_record" do
-        it "renders the edit_record template" do
+        it "prohibits display edit record page using redirect" do
           get :edit_record, params: { id: csv_datum.id }
 
           expect(response).to have_http_status(:redirect)


### PR DESCRIPTION
#### :tophat: What? Why?
While checking the recent implementation of #16674, i have noticed that we are also missing the permission enforce in the CSV census records functionality from decidim-verifications. 

This PR adds it. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16674
- Related to #13850

#### Testing
Everything should be green.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authorization checks added to admin census record workflows to block unauthorized access to the new/edit create and update flows, improving data protection.

* **Tests**
  * Specs expanded into admin and non-admin contexts to validate permission enforcement for create/update paths and confirm unauthorized users are redirected while admins can access and persist changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16703)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->