### PR TITLE
Fix push notifications configuration and registration

### DIFF
--- a/decidim-core/app/packs/src/decidim/sw/push-permissions.js
+++ b/decidim-core/app/packs/src/decidim/sw/push-permissions.js
@@ -1,4 +1,4 @@
-window.addEventListener("turbo:load", async () => {
+document.addEventListener("turbo:load", async () => {
   const GRANTED_PERMISSION = "granted"
 
   const hideReminder = function() {

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -178,7 +178,6 @@
             <label class="toggle__switch-toggle" for="allow_push_notifications">
               <span>
                 <input
-                  <%== %(checked="checked") if @notifications_settings.meet_push_notifications_requirements? %>
                   id="allow_push_notifications"
                   type="checkbox"
                   name="allow_push_notifications">
@@ -194,8 +193,8 @@
           </div>
         </div>
 
-        <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Decidim.vapid_public_key.to_s).bytes %>">
-        <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys %>">
+        <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Decidim.vapid_public_key.to_s).bytes.to_json %>">
+        <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys.to_json %>">
       <% end %>
 
       <div class="form__wrapper-block">

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -380,7 +380,7 @@ describe "Account" do
 
       context "when on the account page" do
         it "enables push notifications if supported browser" do
-          expect(page).to have_unchecked_field("allow_push_notifications")
+          expect(page.find("#allow_push_notifications", visible: false).checked?).to be(false)
 
           sleep 2
           page.find("[for='allow_push_notifications']").click

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -380,7 +380,7 @@ describe "Account" do
 
       context "when on the account page" do
         it "enables push notifications if supported browser" do
-          expect(page.find("#allow_push_notifications", visible: false).checked?).to be(false)
+          expect(page.find_by_id("allow_push_notifications", visible: false).checked?).to be(false)
 
           sleep 2
           page.find("[for='allow_push_notifications']").click

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -380,6 +380,8 @@ describe "Account" do
 
       context "when on the account page" do
         it "enables push notifications if supported browser" do
+          expect(page).to have_unchecked_field("allow_push_notifications")
+
           sleep 2
           page.find("[for='allow_push_notifications']").click
 


### PR DESCRIPTION
#### :tophat: What? Why?

While checking some issues with the Web Push notifications, I found that this feature is actually broken for sometime, as it isn't loading correctly

This PR fixes it.

It also fixes another bug with the checkbox, as it is shown checked even though the user didn't checked anything (as it was actually checking for the feature server-side, when it should be just letting the client do this check).

#### :pushpin: Related Issues
 
- Fixes #15508 

#### Testing

##### The bug

1. Enable the VAPID keys so this feature works:
1.1. Run this command:  `bin/rails decidim:pwa:generate_vapid_keys`
1.2. Configure the keys in your environment variables
1.3. Restart the server
2. Log in
3. Go to http://localhost:3000/en/notifications_settings
4. (First bug) See that it is checked already
5. (Second bug) See that it doesn't matter if you check it or not, you don't get any browser prompt to actually give permissions to send the notifications

##### The fix

Follow the same steps, but see it work :)

1. Enable the VAPID keys so this feature works:
1.1. Run this command:  `bin/rails decidim:pwa:generate_vapid_keys`
1.2. Configure the keys in your environment variables
1.3. Restart the server
2. Log in
3. Go to http://localhost:3000/en/notifications_settings
4. See that it isn't checked
5. Check it
6. See that your browser prompts to actually give permissions to send the notifications
7. Accept this prompt
8. In another browser, log in with another participant account
9. Generate an action for a notification for the other participant account 

### :camera: Screenshots

<img width="974" height="529" alt="image" src="https://github.com/user-attachments/assets/ded0fb4d-a3c1-4106-8637-ead52ed7da19" />

### Prompt

```
We have currently a bug with the WebPush noticiations in the
notifications settings form: the check is always shown when the server
has configured the notifications, but it should only be shown checked
when the user has actually checked and has given permissions with the
browser.
``` 

Co-authored-by: GPT-5.4 Mini (OpenCode)
<andreslucena+ai@users.noreply.github.com>

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed push notification permission handling so it behaves correctly across page navigation.

* **Changes**
  * Push notifications settings: the "allow push notifications" checkbox no longer auto-checks.
  * Notification subscription data is now encoded and submitted as JSON arrays for reliable form handling.

* **Tests**
  * System test asserts the push notifications checkbox is initially unchecked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->