### PR TITLE
Check that the endpoint is supported on Web Push notifications

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -296,6 +296,7 @@ EXISTINGCITY
 faketoken
 Fal
 fcell
+fcm
 FEDER
 felipe
 fhtagn
@@ -557,6 +558,7 @@ modqule
 mongoid
 morphdom
 Mostrar
+mozilla
 mpassid
 mrc
 mri

--- a/decidim-core/app/controllers/decidim/notifications_subscriptions_controller.rb
+++ b/decidim-core/app/controllers/decidim/notifications_subscriptions_controller.rb
@@ -3,6 +3,8 @@
 module Decidim
   # The controller to handle the subscriptions to push notifications
   class NotificationsSubscriptionsController < Decidim::ApplicationController
+    rescue_from Decidim::NotificationsSubscriptionsPersistor::UnsupportedPushSubscriptionEndpointError, with: :unsupported_browser
+
     def create
       Decidim::NotificationsSubscriptionsPersistor.new(current_user).add_subscription(params)
       head :ok
@@ -11,6 +13,12 @@ module Decidim
     def destroy
       Decidim::NotificationsSubscriptionsPersistor.new(current_user).delete_subscription(params[:auth])
       head :ok
+    end
+
+    private
+
+    def unsupported_browser
+      render json: { error: I18n.t("notifications_settings.show.push_notifications_unsupported_browser", scope: "decidim") }, status: :unprocessable_content
     end
   end
 end

--- a/decidim-core/app/packs/src/decidim/sw/push-permissions.js
+++ b/decidim-core/app/packs/src/decidim/sw/push-permissions.js
@@ -2,20 +2,23 @@ document.addEventListener("turbo:load", async () => {
   const GRANTED_PERMISSION = "granted"
 
   const hideReminder = function() {
-    const reminder = document.querySelector("#push-notifications-reminder")
+    const reminder = document.querySelector("[data-push-notifications-reminder]")
+    if (!reminder) return
+
     reminder.classList.add("hide")
   }
 
   const showError = (message) => {
-    const container = document.querySelector(".push-notifications")
+    const container = document.querySelector("[data-push-notifications-container]")
     if (!container) return
 
-    const existingError = container.querySelector(".push-notifications__error")
+    const existingError = container.querySelector("[data-push-notifications-error]")
     if (existingError) {
       existingError.remove()
     }
 
     const errorElement = document.createElement("div")
+    errorElement.dataset.pushNotificationsError = "true"
     errorElement.classList.add("flash", "alert", "push-notifications__error")
     errorElement.innerText = message
     container.prepend(errorElement)
@@ -25,7 +28,7 @@ document.addEventListener("turbo:load", async () => {
     const permission = await window.Notification.requestPermission();
 
     if (registration && permission === GRANTED_PERMISSION) {
-      const vapidElement = document.querySelector("#vapidPublicKey")
+      const vapidElement = document.querySelector("[data-push-vapid-public-key]")
       // element could not exist in DOM
       if (vapidElement) {
         const vapidPublicKeyElement = JSON.parse(vapidElement.value)
@@ -77,10 +80,13 @@ document.addEventListener("turbo:load", async () => {
       hideReminder()
       if (currentSubscription) {
         const auth = currentSubscription.toJSON().keys.auth
-        const subKeys = JSON.parse(document.querySelector("#subKeys").value)
-        // Subscribed && browser notifications enabled
-        if (subKeys.includes(auth)) {
-          toggleChecked = true
+        const subKeysElement = document.querySelector("[data-push-sub-keys]")
+        if (subKeysElement) {
+          const subKeys = JSON.parse(subKeysElement.value)
+          // Subscribed && browser notifications enabled
+          if (subKeys.includes(auth)) {
+            toggleChecked = true
+          }
         }
       }
     }
@@ -88,7 +94,7 @@ document.addEventListener("turbo:load", async () => {
   }
 
   if ("serviceWorker" in navigator) {
-    const toggle = document.getElementById("allow_push_notifications")
+    const toggle = document.querySelector("[data-push-notifications-toggle]")
 
     if (toggle) {
       const registration = await navigator.serviceWorker.ready

--- a/decidim-core/app/packs/src/decidim/sw/push-permissions.js
+++ b/decidim-core/app/packs/src/decidim/sw/push-permissions.js
@@ -6,6 +6,21 @@ document.addEventListener("turbo:load", async () => {
     reminder.classList.add("hide")
   }
 
+  const showError = (message) => {
+    const container = document.querySelector(".push-notifications")
+    if (!container) return
+
+    const existingError = container.querySelector(".push-notifications__error")
+    if (existingError) {
+      existingError.remove()
+    }
+
+    const errorElement = document.createElement("div")
+    errorElement.classList.add("flash", "alert", "push-notifications__error")
+    errorElement.innerText = message
+    container.prepend(errorElement)
+  }
+
   const subscribeToNotifications = async (registration) => {
     const permission = await window.Notification.requestPermission();
 
@@ -20,7 +35,7 @@ document.addEventListener("turbo:load", async () => {
         });
 
         if (subscription) {
-          await fetch("/notifications_subscriptions", {
+          const response = await fetch("/notifications_subscriptions", {
             headers: {
               "Content-Type": "application/json",
               "X-CSRF-Token": document.querySelector("meta[name=csrf-token]")?.content
@@ -28,6 +43,11 @@ document.addEventListener("turbo:load", async () => {
             method: "POST",
             body: JSON.stringify(subscription)
           });
+
+          if (!response.ok) {
+            const body = await response.json()
+            throw new Error(body.error)
+          }
         }
       }
       hideReminder()
@@ -76,10 +96,15 @@ document.addEventListener("turbo:load", async () => {
       setToggleState(registration, toggle)
 
       toggle.addEventListener("change", async ({ target }) => {
-        if (target.checked) {
-          await subscribeToNotifications(registration);
-        } else {
-          await unsubscribeFromNotifications(registration)
+        try {
+          if (target.checked) {
+            await subscribeToNotifications(registration)
+          } else {
+            await unsubscribeFromNotifications(registration)
+          }
+        } catch (error) {
+          target.checked = false
+          showError(error.message)
         }
       })
     }

--- a/decidim-core/app/packs/src/decidim/sw/push-permissions.js
+++ b/decidim-core/app/packs/src/decidim/sw/push-permissions.js
@@ -3,14 +3,18 @@ document.addEventListener("turbo:load", async () => {
 
   const hideReminder = function() {
     const reminder = document.querySelector("[data-push-notifications-reminder]")
-    if (!reminder) return
+    if (!reminder) {
+      return;
+    }
 
     reminder.classList.add("hide")
   }
 
   const showError = (message) => {
     const container = document.querySelector("[data-push-notifications-container]")
-    if (!container) return
+    if (!container) {
+      return;
+    }
 
     const existingError = container.querySelector("[data-push-notifications-error]")
     if (existingError) {

--- a/decidim-core/app/services/decidim/notifications_subscriptions_persistor.rb
+++ b/decidim-core/app/services/decidim/notifications_subscriptions_persistor.rb
@@ -4,6 +4,10 @@ module Decidim
   # This class manages the creation and deletion of user notifications
 
   class NotificationsSubscriptionsPersistor
+    include PushSubscriptionEndpointValidator
+
+    class UnsupportedPushSubscriptionEndpointError < StandardError; end
+
     attr_reader :user
 
     def initialize(user)
@@ -11,6 +15,8 @@ module Decidim
     end
 
     def add_subscription(params)
+      raise UnsupportedPushSubscriptionEndpointError unless supported_push_subscription_endpoint?(params[:endpoint])
+
       subscriptions = user.notification_settings["subscriptions"] || {}
       filtered_params = filter_params(params)
       new_subscription = { filtered_params[:auth] => filtered_params }

--- a/decidim-core/app/services/decidim/push_subscription_endpoint_validator.rb
+++ b/decidim-core/app/services/decidim/push_subscription_endpoint_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Shared validation for browser push subscription endpoints.
+  module PushSubscriptionEndpointValidator
+    private
+
+    def supported_push_subscription_endpoint?(endpoint)
+      return false if endpoint.blank?
+
+      uri = URI.parse(endpoint)
+      return false unless uri.is_a?(URI::HTTP)
+
+      host = uri.host&.downcase
+      return false if host.blank?
+
+      allowed_push_subscription_endpoint_patterns.any? { |pattern| pattern.match?(host) }
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # Override this method to customize the browser push endpoint allowlist.
+    def allowed_push_subscription_endpoint_patterns
+      [
+        /\A(?:.*\.)?push\.services\.mozilla\.com\z/,
+        /\A(?:.*\.)?fcm\.googleapis\.com\z/,
+        /\A(?:.*\.)?android\.googleapis\.com\z/,
+        /\A(?:.*\.)?push\.apple\.com\z/,
+        /\A(?:.*\.)?opera\.com\z/,
+        /\A(?:.*\.)?notify\.windows\.com\z/
+      ]
+    end
+  end
+end

--- a/decidim-core/app/services/decidim/push_subscription_endpoint_validator.rb
+++ b/decidim-core/app/services/decidim/push_subscription_endpoint_validator.rb
@@ -9,7 +9,7 @@ module Decidim
       return false if endpoint.blank?
 
       uri = URI.parse(endpoint)
-      return false unless uri.is_a?(URI::HTTP)
+      return false unless uri.is_a?(URI::HTTPS)
 
       host = uri.host&.downcase
       return false if host.blank?

--- a/decidim-core/app/services/decidim/send_push_notification.rb
+++ b/decidim-core/app/services/decidim/send_push_notification.rb
@@ -10,6 +10,7 @@ module Decidim
 
   class SendPushNotification
     include ActionView::Helpers::UrlHelper
+    include PushSubscriptionEndpointValidator
 
     # Send the push notification. Returns `nil` if the user did not allowed push notifications
     # or if the subscription to push notifications does not exist
@@ -24,9 +25,12 @@ module Decidim
       raise ArgumentError, "Need to provide a title if the notification is a PushNotificationMessage" if notification.is_a?(Decidim::PushNotificationMessage) && title.nil?
 
       user = notification.user
+      subscriptions = user.notifications_subscriptions.values.select do |subscription|
+        supported_push_subscription_endpoint?(subscription["endpoint"])
+      end
 
       I18n.with_locale(user.locale || user.organization.default_locale) do
-        user.notifications_subscriptions.values.map do |subscription|
+        subscriptions.map do |subscription|
           payload = build_payload(message_params(notification, title), subscription)
           # Capture webpush exceptions in order to avoid this call to be repeated by the background job runner
           # Webpush::Error class is the parent class of all defined errors

--- a/decidim-core/app/views/decidim/notifications_settings/show.html.erb
+++ b/decidim-core/app/views/decidim/notifications_settings/show.html.erb
@@ -167,11 +167,11 @@
       <% end %>
 
       <% if @notifications_settings.meet_push_notifications_requirements? %>
-        <div class="push-notifications js-sw-mandatory">
+        <div class="push-notifications js-sw-mandatory" data-push-notifications-container>
           <label>
             <%= t("push_notifications", scope: "decidim.notifications_settings.show") %>
           </label>
-          <p id="push-notifications-reminder" class="push-notifications__reminder block my-4">
+          <p id="push-notifications-reminder" class="push-notifications__reminder block my-4" data-push-notifications-reminder>
             <%= t("push_notifications_reminder", scope: "decidim.notifications_settings.show") %>
           </p>
           <div class="toggle__switch-trigger">
@@ -180,6 +180,7 @@
                 <input
                   id="allow_push_notifications"
                   type="checkbox"
+                  data-push-notifications-toggle
                   name="allow_push_notifications">
                 <span class="toggle__switch-toggle-content">
                 </span>
@@ -193,8 +194,8 @@
           </div>
         </div>
 
-        <input id="vapidPublicKey" name="vapid_public_key" type="hidden" value="<%= Base64.urlsafe_decode64(Decidim.vapid_public_key.to_s).bytes.to_json %>">
-        <input id="subKeys" name="sub_key" type="hidden" value="<%= current_user.notifications_subscriptions.keys.to_json %>">
+        <input id="vapidPublicKey" name="vapid_public_key" data-push-vapid-public-key type="hidden" value="<%= Base64.urlsafe_decode64(Decidim.vapid_public_key.to_s).bytes.to_json %>">
+        <input id="subKeys" name="sub_key" data-push-sub-keys type="hidden" value="<%= current_user.notifications_subscriptions.keys.to_json %>">
       <% end %>
 
       <div class="form__wrapper-block">

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1348,6 +1348,7 @@ en:
         own_activity: My own activity, like when someone comments in my proposal or mentions me
         push_notifications: Push notifications
         push_notifications_reminder: To get notifications from the platform, you will need to allow them in your browser settings first.
+        push_notifications_unsupported_browser: Your browser isn't supported.
         receive_notifications_about: I want to get notifications about
         update_notifications_settings: Save changes
       update:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1348,7 +1348,7 @@ en:
         own_activity: My own activity, like when someone comments in my proposal or mentions me
         push_notifications: Push notifications
         push_notifications_reminder: To get notifications from the platform, you will need to allow them in your browser settings first.
-        push_notifications_unsupported_browser: Your browser isn't supported.
+        push_notifications_unsupported_browser: Your browser is not supported.
         receive_notifications_about: I want to get notifications about
         update_notifications_settings: Save changes
       update:

--- a/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
@@ -26,6 +26,37 @@ module Decidim
         }
       end
 
+      context "when endpoint is supported" do
+        let(:params) do
+          {
+            endpoint: "https://fcm.googleapis.com/fcm/send/abc123",
+            keys: {
+              auth: "auth_code_121",
+              p256dh: "a_p256dh"
+            }
+          }
+        end
+
+        it "returns ok" do
+          post :create, params: params
+
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "stores the subscription in user notification settings" do
+          post :create, params: params
+
+          subscriptions = user.reload.notification_settings["subscriptions"]
+          expect(subscriptions).to eq(
+            "auth_code_121" => {
+              "auth" => "auth_code_121",
+              "p256dh" => "a_p256dh",
+              "endpoint" => "https://fcm.googleapis.com/fcm/send/abc123"
+            }
+          )
+        end
+      end
+
       it "returns unprocessable content when endpoint is not supported" do
         post :create, params: params
 

--- a/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  describe NotificationsSubscriptionsController do
+    routes { Decidim::Core::Engine.routes }
+
+    let(:organization) { create(:organization) }
+    let(:user) { create(:user, :confirmed, organization:) }
+
+    before do
+      request.env["devise.mapping"] = ::Devise.mappings[:user]
+      request.env["decidim.current_organization"] = organization
+      sign_in user
+    end
+
+    describe "POST #create" do
+      let(:params) do
+        {
+          endpoint: "https://example.org/subscription",
+          keys: {
+            auth: "auth_code_121",
+            p256dh: "a_p256dh"
+          }
+        }
+      end
+
+      it "returns unprocessable content when endpoint is not supported" do
+        post :create, params: params
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(JSON.parse(response.body)).to eq(
+          "error" => I18n.t("notifications_settings.show.push_notifications_unsupported_browser", scope: "decidim")
+        )
+      end
+    end
+  end
+end

--- a/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
@@ -64,6 +64,8 @@ module Decidim
         expect(JSON.parse(response.body)).to eq(
           "error" => I18n.t("notifications_settings.show.push_notifications_unsupported_browser", scope: "decidim")
         )
+        subscriptions = user.reload.notification_settings["subscriptions"]
+        expect(subscriptions).to be_nil
       end
     end
   end

--- a/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/notifications_subscriptions_controller_spec.rb
@@ -38,13 +38,13 @@ module Decidim
         end
 
         it "returns ok" do
-          post :create, params: params
+          post(:create, params:)
 
           expect(response).to have_http_status(:ok)
         end
 
         it "stores the subscription in user notification settings" do
-          post :create, params: params
+          post(:create, params:)
 
           subscriptions = user.reload.notification_settings["subscriptions"]
           expect(subscriptions).to eq(
@@ -58,7 +58,7 @@ module Decidim
       end
 
       it "returns unprocessable content when endpoint is not supported" do
-        post :create, params: params
+        post(:create, params:)
 
         expect(response).to have_http_status(:unprocessable_content)
         expect(JSON.parse(response.body)).to eq(

--- a/decidim-core/spec/services/decidim/notifications_subscriptions_persistor_spec.rb
+++ b/decidim-core/spec/services/decidim/notifications_subscriptions_persistor_spec.rb
@@ -7,7 +7,7 @@ module Decidim
     subject { described_class.new(user) }
 
     let(:organization) { create(:organization) }
-    let(:params) { { endpoint: "https://example.es", keys: { auth: "auth_code_121", p256dh: "a_p256dh" } } }
+    let(:params) { { endpoint: "https://fcm.googleapis.com/fcm/send/id", keys: { auth: "auth_code_121", p256dh: "a_p256dh" } } }
 
     describe "#add_subscription" do
       context "when no subscriptions" do
@@ -37,6 +37,17 @@ module Decidim
           expect(user.notifications_subscriptions["auth_code_121"]["endpoint"]).to eq(params[:endpoint])
           expect(user.notifications_subscriptions["auth_code_121"]["auth"]).to eq(params[:keys][:auth])
           expect(user.notifications_subscriptions["auth_code_121"]["p256dh"]).to eq(params[:keys][:p256dh])
+        end
+      end
+
+      context "when endpoint is not supported" do
+        let(:user) { create(:user, organization:) }
+        let(:params) { { endpoint: "https://example.org/subscription", keys: { auth: "auth_code_121", p256dh: "a_p256dh" } } }
+
+        it "raises an unsupported endpoint error" do
+          expect do
+            subject.add_subscription(params)
+          end.to raise_error(Decidim::NotificationsSubscriptionsPersistor::UnsupportedPushSubscriptionEndpointError)
         end
       end
     end

--- a/decidim-core/spec/services/decidim/send_push_notification_spec.rb
+++ b/decidim-core/spec/services/decidim/send_push_notification_spec.rb
@@ -52,9 +52,9 @@ describe Decidim::SendPushNotification do
     context "with subscriptions" do
       let(:subscriptions) do
         {
-          "auth_key_1" => { "auth" => "auth_key_1", "p256dh" => "p256dh_1", "endpoint" => "endpoint_1" },
-          "auth_key_2" => { "auth" => "auth_key_2", "p256dh" => "p256dh_2", "endpoint" => "endpoint_2" },
-          "auth_key_3" => { "auth" => "auth_key_3", "p256dh" => "p256dh_3", "endpoint" => "endpoint_3" }
+          "auth_key_1" => { "auth" => "auth_key_1", "p256dh" => "p256dh_1", "endpoint" => "https://fcm.googleapis.com/fcm/send/id_1" },
+          "auth_key_2" => { "auth" => "auth_key_2", "p256dh" => "p256dh_2", "endpoint" => "https://updates.push.services.mozilla.com/wpush/v2/id_2" },
+          "auth_key_3" => { "auth" => "auth_key_3", "p256dh" => "p256dh_3", "endpoint" => "https://web.push.apple.com/id_3" }
         }
       end
 
@@ -99,11 +99,39 @@ describe Decidim::SendPushNotification do
           expect(responses.all? { |response| response.code == "201" }).to be(true)
           expect(responses.all? { |response| response.message == "Created" }).to be(true)
         end
+
+        context "when one subscription endpoint is not supported" do
+          let(:subscriptions) do
+            {
+              "auth_key_1" => { "auth" => "auth_key_1", "p256dh" => "p256dh_1", "endpoint" => "https://fcm.googleapis.com/fcm/send/id_1" },
+              "auth_key_2" => { "auth" => "auth_key_2", "p256dh" => "p256dh_2", "endpoint" => "https://example.org/subscriptions/id_2" }
+            }
+          end
+
+          it "skips unsupported endpoints" do
+            notification_payload = {
+              message:,
+              endpoint: subscriptions["auth_key_1"]["endpoint"],
+              p256dh: subscriptions["auth_key_1"]["p256dh"],
+              auth: subscriptions["auth_key_1"]["auth"],
+              vapid: a_hash_including(
+                public_key: "public_key",
+                private_key: "private_key"
+              )
+            }
+
+            expect(WebPush).to receive(:payload_send).with(notification_payload).once.and_return(double("result", message: "Created", code: "201"))
+
+            responses = subject.perform(notification, title)
+            expect(responses.size).to eq(1)
+            expect(responses.first.code).to eq("201")
+          end
+        end
       end
     end
 
     context "with subscription" do
-      let(:subscriptions) { { "auth_key_1" => { "auth" => "auth_key_1", "p256dh" => "p256dh_1", "endpoint" => "endpoint_1" } } }
+      let(:subscriptions) { { "auth_key_1" => { "auth" => "auth_key_1", "p256dh" => "p256dh_1", "endpoint" => "https://fcm.googleapis.com/fcm/send/id_1" } } }
 
       describe "#perform" do
         it "returns 201 and created if the message is sent ok" do

--- a/decidim-core/spec/system/account_spec.rb
+++ b/decidim-core/spec/system/account_spec.rb
@@ -380,10 +380,11 @@ describe "Account" do
 
       context "when on the account page" do
         it "enables push notifications if supported browser" do
-          expect(page.find_by_id("allow_push_notifications", visible: false).checked?).to be(false)
+          toggle = page.find("[data-push-notifications-toggle]", visible: :all)
+          expect(toggle).not_to be_checked
 
           sleep 2
-          page.find("[for='allow_push_notifications']").click
+          toggle.check(allow_label_click: true)
 
           # Wait for the browser to be subscribed
           sleep 5
@@ -394,7 +395,7 @@ describe "Account" do
 
           expect(page).to have_callout("Your notifications settings were successfully updated.")
 
-          find_by_id("allow_push_notifications", visible: false).execute_script("this.checked = true")
+          find("[data-push-notifications-toggle]", visible: :all).execute_script("this.checked = true")
         end
       end
     end
@@ -409,7 +410,7 @@ describe "Account" do
       end
 
       it "does not show the push notifications switch" do
-        expect(page).to have_no_selector(".push-notifications")
+        expect(page).to have_no_selector("[data-push-notifications-container]")
       end
     end
 
@@ -423,7 +424,7 @@ describe "Account" do
       end
 
       it "does not show the push notifications switch" do
-        expect(page).to have_no_selector(".push-notifications")
+        expect(page).to have_no_selector("[data-push-notifications-container]")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

We're missing some validations in the suscriptions notifications controllers for the WebPush: we're accepting the client supplied endpoint. 

This PR fixes it by introducing a check on the most popular providers for these kind of notifications: 

- Mozilla
- Google
- Apple
- Opera
- Windows

In case the provider isn't supported, it shows an error message. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/16706
 
#### Testing

Everything should be green

### :camera: Screenshots 

<img width="951" height="801" alt="image" src="https://github.com/user-attachments/assets/d66522a6-5e59-451b-a358-97921542eefa" />

### Initial prompt:

```
On the Push Notifications feature there isn't any kind of validation on
the endpoints provided by the participant.
We should validate that these endpoitns correspond with the main
providers (Mozilla, Google, Apple, Opera, Brave, Edge, etc) and if not
give some kind of error to the participant (like "Your browser isn't
supported"). This allow list should be done through a method, so it is
easy to override by implementers in case they need to add a new one.
This should be checked both in the persistor and also in the send event
of the push notifications.
```

Co-authored-by: GPT-5.3-Codex (OpenCode) <andreslucena+ai@users.noreply.github.com>

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Push subscription endpoints are now validated; unsupported browsers return a clear error.

* **Bug Fixes**
  * Sending of push notifications skips unsupported subscription endpoints to avoid delivery errors.

* **Refactor**
  * Push notifications UI now uses data-attribute hooks for more reliable interaction.

* **Documentation**
  * Added user-facing message for unsupported browsers.

* **Tests**
  * Expanded specs and system tests covering validation, error handling, and updated UI selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->