### PR TITLE
Add export button to CollaborativeTexts

### DIFF
--- a/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
+++ b/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
@@ -10,7 +10,7 @@ module Decidim
           return permission_action if permission_action.subject != :collaborative_text
 
           case permission_action.action
-          when :update, :read, :create, :destroy
+          when :update, :read, :create, :destroy, :export
             allow!
           end
 

--- a/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
+++ b/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
@@ -7,12 +7,10 @@ module Decidim
         def permissions
           return permission_action if permission_action.scope != :admin
 
-          allow! if permission_action.action == :export && permission_action.subject == :component_data
-
           return permission_action if permission_action.subject != :collaborative_text
 
           case permission_action.action
-          when :update, :read, :create, :destroy
+          when :update, :read, :create, :destroy, :export
             allow!
           end
 

--- a/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
+++ b/decidim-collaborative_texts/app/permissions/decidim/collaborative_texts/admin/permissions.rb
@@ -7,10 +7,12 @@ module Decidim
         def permissions
           return permission_action if permission_action.scope != :admin
 
+          allow! if permission_action.action == :export && permission_action.subject == :component_data
+
           return permission_action if permission_action.subject != :collaborative_text
 
           case permission_action.action
-          when :update, :read, :create, :destroy, :export
+          when :update, :read, :create, :destroy
             allow!
           end
 

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
-    <%= export_dropdown(current_component, @document.id) %>
+    <%= export_dropdown(current_component, @document.id) if allowed_to? :export, :collaborative_text %>
   </h1>
 </div>
 <div class="item__edit item__edit-1col">

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
-    <%= export_dropdown(current_component, @document.id) if allowed_to? :export, :collaborative_text %>
+    <%= export_dropdown(current_component, @document.id) if allowed_to? :export, :component_data %>
   </h1>
 </div>
 <div class="item__edit item__edit-1col">

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
@@ -2,6 +2,7 @@
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
+    <%= export_dropdown(current_component, @document.id) %>
   </h1>
 </div>
 <div class="item__edit item__edit-1col">

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/admin/documents/edit.html.erb
@@ -2,7 +2,7 @@
 <div class="item_show__header">
   <h1 class="item_show__header-title">
     <%= t(".title") %>
-    <%= export_dropdown(current_component, @document.id) if allowed_to? :export, :component_data %>
+    <%= export_dropdown(current_component, @document.id) if allowed_to? :export, :collaborative_text %>
   </h1>
 </div>
 <div class="item__edit item__edit-1col">

--- a/decidim-collaborative_texts/config/locales/en.yml
+++ b/decidim-collaborative_texts/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
           update_settings:
             invalid: There was a problem updating the document.
             success: Document successfully updated.
+        exports:
+          document_suggestions: Suggestions
         index:
           published: Published
           unpublished: Unpublished

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts.rb
@@ -9,5 +9,6 @@ require "decidim/collaborative_texts/component"
 module Decidim
   # Base module for the collaborative_texts engine.
   module CollaborativeTexts
+    autoload :SuggestionSerializer, "decidim/collaborative_texts/suggestion_serializer"
   end
 end

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
@@ -60,6 +60,7 @@ Decidim.register_component(:collaborative_texts) do |component|
     exports.collection do |component, _user, resource_id|
       documents_constraint = { decidim_component_id: component.id }
       documents_constraint[:id] = resource_id if resource_id.present?
+
       Decidim::CollaborativeTexts::Suggestion
         .joins(:document)
         .where(decidim_collaborative_texts_documents: documents_constraint)

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
@@ -58,12 +58,12 @@ Decidim.register_component(:collaborative_texts) do |component|
 
   component.exports :document_suggestions do |exports|
     exports.collection do |component, _user, resource_id|
-      scope = Decidim::CollaborativeTexts::Suggestion
-              .joins(:document)
-              .where(decidim_collaborative_texts_documents: { decidim_component_id: component.id })
-              .includes(:document_version, document: [:component])
-
-      resource_id ? scope.where(document: { id: resource_id }) : scope
+      documents_constraint = { decidim_component_id: component.id }
+      documents_constraint[:id] = resource_id if resource_id.present?
+      Decidim::CollaborativeTexts::Suggestion
+        .joins(:document)
+        .where(decidim_collaborative_texts_documents: documents_constraint)
+        .includes(:document_version, document: [:component])
     end
 
     exports.serializer Decidim::CollaborativeTexts::SuggestionSerializer

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/component.rb
@@ -56,7 +56,18 @@ Decidim.register_component(:collaborative_texts) do |component|
     resource.searchable = true
   end
 
-  # component.exports ...
+  component.exports :document_suggestions do |exports|
+    exports.collection do |component, _user, resource_id|
+      scope = Decidim::CollaborativeTexts::Suggestion
+              .joins(:document)
+              .where(decidim_collaborative_texts_documents: { decidim_component_id: component.id })
+              .includes(:document_version, document: [:component])
+
+      resource_id ? scope.where(document: { id: resource_id }) : scope
+    end
+
+    exports.serializer Decidim::CollaborativeTexts::SuggestionSerializer
+  end
 
   component.seeds do |participatory_space|
     require "decidim/collaborative_texts/seeds"

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
@@ -11,8 +11,10 @@ module Decidim
           id: resource.id,
           document_id: resource.document.id,
           document_title: resource.document.title,
-          original_text: resource.changeset["original"]&.join(" ")&.strip,
-          replacement_text: resource.changeset["replace"]&.join(" ")&.strip,
+          original_text: resource.changeset["original"]&.join("\n")&.strip,
+          replacement_text: resource.changeset["replace"]&.join("\n")&.strip,
+          first_node: resource.changeset["firstNode"],
+          last_node: resource.changeset["lastNode"],
           author: author_fields,
           status: resource.status,
           created_at: resource.created_at,
@@ -23,6 +25,8 @@ module Decidim
       private
 
       def author_fields
+        return {} unless resource.author
+
         {
           id: resource.author.id,
           name: author_name(resource.author),

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
@@ -30,12 +30,16 @@ module Decidim
         {
           id: resource.author.id,
           name: author_name(resource.author),
-          email: resource.author.try(:email)
+          url: profile_url(resource.author)
         }
       end
 
       def author_name(author)
-        translated_attribute(author.name)
+        if author.respond_to?(:name)
+          translated_attribute(author.name) # is a Decidim::User or Decidim::Organization
+        elsif author.respond_to?(:title)
+          translated_attribute(author.title) # is a Decidim::Meetings::Meeting
+        end
       end
     end
   end

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
@@ -9,8 +9,8 @@ module Decidim
       def serialize
         {
           id: resource.id,
-          document_id: resource.document.id,
-          document_title: resource.document.title,
+          document_id: resource.document&.id,
+          document_title: resource.document&.title,
           original_text: resource.changeset["original"]&.join("\n")&.strip,
           replacement_text: resource.changeset["replace"]&.join("\n")&.strip,
           first_node: resource.changeset["firstNode"],

--- a/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
+++ b/decidim-collaborative_texts/lib/decidim/collaborative_texts/suggestion_serializer.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Decidim
+  module CollaborativeTexts
+    class SuggestionSerializer < Decidim::Exporters::Serializer
+      include Decidim::ApplicationHelper
+      include Decidim::TranslationsHelper
+
+      def serialize
+        {
+          id: resource.id,
+          document_id: resource.document.id,
+          document_title: resource.document.title,
+          original_text: resource.changeset["original"]&.join(" ")&.strip,
+          replacement_text: resource.changeset["replace"]&.join(" ")&.strip,
+          author: author_fields,
+          status: resource.status,
+          created_at: resource.created_at,
+          updated_at: resource.updated_at
+        }
+      end
+
+      private
+
+      def author_fields
+        {
+          id: resource.author.id,
+          name: author_name(resource.author),
+          email: resource.author.try(:email)
+        }
+      end
+
+      def author_name(author)
+        translated_attribute(author.name)
+      end
+    end
+  end
+end

--- a/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
+++ b/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
@@ -45,10 +45,6 @@ module Decidim
           it "serializes the author name" do
             expect(serialized[:author]).to include(name: "Jane Doe")
           end
-
-          it "serializes the author email" do
-            expect(serialized[:author]).to include(email: author.email)
-          end
         end
 
         it "serializes created_at" do

--- a/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
+++ b/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module CollaborativeTexts
+    describe SuggestionSerializer do
+      subject { described_class.new(suggestion) }
+
+      let(:suggestion) { create(:collaborative_text_suggestion) }
+      let(:serialized) { subject.serialize }
+
+      describe "#serialize" do
+        it "serializes the id" do
+          expect(serialized).to include(id: suggestion.id)
+        end
+
+        it "serializes the document id" do
+          expect(serialized).to include(document_id: suggestion.document.id)
+        end
+
+        it "serializes the status" do
+          expect(serialized).to include(status: suggestion.status)
+        end
+
+        it "serializes the original text" do
+          expect(serialized[:original_text]).to eq(
+            suggestion.changeset["original"]&.join(" ")&.strip
+          )
+        end
+
+        it "serializes the replacement text" do
+          expect(serialized[:replacement_text]).to eq(
+            suggestion.changeset["replace"]&.join(" ")&.strip
+          )
+        end
+
+        describe "author" do
+          let(:component) { create(:collaborative_text_component) }
+          let(:document) { create(:collaborative_text_document, component:) }
+          let(:version) { create(:collaborative_text_version, document:) }
+          let(:author) { create(:user, :confirmed, name: "Jane Doe", organization: component.organization) }
+          let(:suggestion) { create(:collaborative_text_suggestion, document_version: version, author:) }
+
+          it "serializes the author name" do
+            expect(serialized[:author]).to include(name: "Jane Doe")
+          end
+
+          it "serializes the author email" do
+            expect(serialized[:author]).to include(email: author.email)
+          end
+        end
+
+        it "serializes created_at" do
+          expect(serialized).to include(created_at: suggestion.created_at)
+        end
+
+        it "serializes updated_at" do
+          expect(serialized).to include(updated_at: suggestion.updated_at)
+        end
+      end
+    end
+  end
+end

--- a/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
+++ b/decidim-collaborative_texts/spec/lib/decidim/collaborative_texts/suggestion_serializer_spec.rb
@@ -45,6 +45,14 @@ module Decidim
           it "serializes the author name" do
             expect(serialized[:author]).to include(name: "Jane Doe")
           end
+
+          it "serializes the author id" do
+            expect(serialized[:author]).to include(id: author.id)
+          end
+
+          it "serializes the author profile url" do
+            expect(serialized[:author]).to include(url: profile_url(author.nickname))
+          end
         end
 
         it "serializes created_at" do
@@ -53,6 +61,14 @@ module Decidim
 
         it "serializes updated_at" do
           expect(serialized).to include(updated_at: suggestion.updated_at)
+        end
+
+        def profile_url(nickname)
+          Decidim::Core::Engine.routes.url_helpers.profile_url(nickname, host:, port: Capybara.server_port)
+        end
+
+        def host
+          suggestion.organization.host
         end
       end
     end

--- a/decidim-collaborative_texts/spec/system/admin/admin_edits_document_spec.rb
+++ b/decidim-collaborative_texts/spec/system/admin/admin_edits_document_spec.rb
@@ -88,6 +88,15 @@ describe "Admin edits documents" do
       expect(document.body).not_to eq("<p>body edited</p>")
     end
 
+    it "shows the export dropdown button" do
+      within("tr", text: "This is my document new title") do
+        find("button[data-controller='dropdown']").click
+        click_on "Edit"
+      end
+
+      expect(page).to have_button(I18n.t("decidim.admin.actions.export_all"))
+    end
+
     it "can discard suggestions by creating a new version" do
       expect(document.current_version.suggestions.count).to eq(1)
       within("tr", text: "This is my document new title") do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR is about creating an Export suggestions dropdown button in collaborative texts.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes [#102](https://github.com/openpoke/decidim/issues/102)

#### Testing
*Describe the best way to test or validate your PR.*

1. Log in as an admin
2. Go to Processes/Assemblies/Conferences
3. Click on the CollaborativeTexts component.
4. You can click or edit one of the documents.
5. See the Export all button

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1486" height="576" alt="image" src="https://github.com/user-attachments/assets/696b2b31-b5ba-4106-9a07-c68816ebec94" />
exports

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export of document suggestions added and an export dropdown appears on the collaborative texts admin document edit page.
* **Localization**
  * Added missing "Suggestions" translation for collaborative texts exports.
* **Permissions**
  * Admin export action for collaborative texts enabled.
* **Tests**
  * Specs added for export dropdown presence and suggestion export serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->