### PR TITLE
Fix spec for full app generator spec

### DIFF
--- a/decidim-generators/spec/runtime/full_app_generator_spec.rb
+++ b/decidim-generators/spec/runtime/full_app_generator_spec.rb
@@ -13,7 +13,7 @@ module Decidim
       after { FileUtils.rm_rf(test_app) }
 
       context "with a full featured application" do
-        let(:command) { "decidim #{test_app} --recreate_db --demo" }
+        let(:command) { "decidim #{test_app} --recreate_db --demo --path #{repo_root}" }
 
         it_behaves_like "a new development application"
         it_behaves_like "an application with extra configurable env vars"


### PR DESCRIPTION
#### :tophat: What? Why?

On #16729 I have a final error, that is basically the typical syncronization error that we have between the branch and some of the generators.

I think at least on this case this could be mitigated by just running against the version of this current PR instead of having to do the manual change (by updating the `Decidim::Generators.edge_git_branch` method and the other typical changes that we do on these kind of reviews).

As I want to have that in v0.30 but I don't want to introduce differences on these kind of things between versions, I think it is good to have it in all the supported versions.  
 
#### Testing

Everything should be green
 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test command configuration for application generator testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->