### PR TITLE
Fix organization access check for logged in API user

### DIFF
--- a/decidim-api/app/controllers/decidim/api/queries_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/queries_controller.rb
@@ -87,7 +87,7 @@ module Decidim
 
       def organization_user(user)
         return if user.blank? || current_organization.blank?
-        return unless user.organization == current_organization
+        return unless user.decidim_organization_id == current_organization.id
 
         user
       end

--- a/decidim-api/app/controllers/decidim/api/queries_controller.rb
+++ b/decidim-api/app/controllers/decidim/api/queries_controller.rb
@@ -36,7 +36,7 @@ module Decidim
       end
 
       def api_user
-        @api_user = current_api_user || current_user
+        @api_user ||= organization_user(current_api_user || current_user)
       end
 
       # Determines the scopes for the user for API requests.
@@ -83,6 +83,13 @@ module Decidim
         else
           raise ArgumentError, "Unexpected parameter: #{variables_param}"
         end
+      end
+
+      def organization_user(user)
+        return if user.blank? || current_organization.blank?
+        return unless user.organization == current_organization
+
+        user
       end
     end
   end

--- a/decidim-api/spec/controllers/queries_controller_spec.rb
+++ b/decidim-api/spec/controllers/queries_controller_spec.rb
@@ -72,6 +72,21 @@ module Decidim
             expect(response).to have_http_status(:success)
           end
         end
+
+        context "when the signed in user belongs to another organization" do
+          let(:current_user) { create(:user, :confirmed, :admin, organization: create(:organization)) }
+
+          before do
+            sign_in current_user
+          end
+
+          it "does not expose the session" do
+            post :create, params: { query: "{ session { user { id } } }" }, format: :json
+
+            parsed_response = JSON.parse(response.body)["data"]
+            expect(parsed_response).to match("session" => nil)
+          end
+        end
       end
     end
   end

--- a/decidim-api/spec/requests/apiauth_spec.rb
+++ b/decidim-api/spec/requests/apiauth_spec.rb
@@ -74,6 +74,17 @@ RSpec.describe "Api authentication" do
           }
         )
       end
+
+      it "does not expose the session from another organization" do
+        authorization = response.headers["Authorization"]
+        other_organization = create(:organization)
+
+        host! other_organization.host
+        post "/api", params: { query: "{session { user { id nickname } } }" }, headers: { HTTP_AUTHORIZATION: authorization }
+
+        parsed_response = JSON.parse(response.body)["data"]
+        expect(parsed_response).to match("session" => nil)
+      end
     end
 
     context "when not signed in" do


### PR DESCRIPTION
#### :tophat: What? Why?
While checking #16673, i have noticed that when using a JWT token, an user from organization A, can load his session request into organization B. This creating confusion.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16673  
- Related to #14225

#### Testing
Everything should be green. 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security issue preventing cross-organization session data exposure in API requests. The API now properly validates that authenticated users can only access session information for their own organization, improving data isolation and security.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16756)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->