### PR TITLE
Fix browser freeze when editing filters with many taxonomy items

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.js
+++ b/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.js
@@ -419,13 +419,13 @@ class FormValidator {
       return true;
     }
 
-    checkboxGroup.forEach((checkboxElement) => {
-      if (isValid) {
-        this.removeInputErrorClasses(checkboxElement);
-      } else {
+    if (isValid) {
+      this.removeCheckboxGroupErrorClasses(groupName);
+    } else {
+      checkboxGroup.forEach((checkboxElement) => {
         this.addInputErrorClasses(checkboxElement, ["required"]);
-      }
-    });
+      });
+    }
 
     return isValid;
   }

--- a/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.test.js
@@ -1,4 +1,4 @@
-/* eslint max-lines: ["error", 690] */
+/* eslint max-lines: ["error", 712] */
 /* global jest */
 /**
  * @jest-environment jsdom

--- a/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/form_validator/form_validator.test.js
@@ -253,6 +253,28 @@ describe("FormValidator", () => {
       const isValidTwo = validatorInstance.validateCheckboxGroup("multiCheckboxes");
       expect(isValidTwo).toBe(true);
     });
+
+    it("should remove error classes once for the group, not per checkbox", () => {
+      formElement.innerHTML = `
+        <fieldset>
+          <input type="checkbox" id="cb-1" name="largeGroup" value="1" required>
+          <input type="checkbox" id="cb-2" name="largeGroup" value="2" required>
+          <input type="checkbox" id="cb-3" name="largeGroup" value="3" required>
+        </fieldset>
+        <button type="submit">Submit</button>
+      `;
+      validatorInstance = new FormValidator(formElement);
+      formElement.querySelector("#cb-1").checked = true;
+
+      const removeGroupSpy = jest.spyOn(validatorInstance, "removeCheckboxGroupErrorClasses");
+      const removeInputSpy = jest.spyOn(validatorInstance, "removeInputErrorClasses");
+
+      const isValid = validatorInstance.validateCheckboxGroup("largeGroup");
+
+      expect(isValid).toBe(true);
+      expect(removeGroupSpy).toHaveBeenCalledTimes(1);
+      expect(removeInputSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe("Custom Validators", () => {


### PR DESCRIPTION
#### :tophat: What? Why?
The root cause of this bug was in the form validator. After deciding the group was valid (in 'validateCheckboxGroup'), it iterated all n members and called removeInputErrorClasses(checkbox) on each, which for checkboxes delegates to removeCheckboxGroupErrorClasses(name) and re-iterates the whole group. That's an O(n²) helper called n times — roughly 1.7 billion DOM operations per click at n=1,200. The fix calls the group-scoped helper once on the valid path; output is identical (the operation is idempotent across the group) and per-click work drops from O(n³) to O(n²), making interactions instant.

#### :pushpin: Related Issues
- Fixes #16327

#### Testing
1. Add a large number of taxonomies and taxonomy filter items (~1,200) using a script
2. Log in as admin and go to "Settings" -> "Taxonomies"
3. Select a taxonomy with a large number of items and click "Edit"
4. Try checking or unchecking any of the checkboxes in the filter items list. It should work correctly now.

### :camera: Screenshots

https://github.com/user-attachments/assets/06f060ac-51f8-45cb-8628-f0664d19fd50



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox-group validation: when a group is valid, error indicators are cleared at the group level; when invalid, individual checkboxes are still marked as required.

* **Tests**
  * Added a test confirming group-level error cleanup is performed once and that checkbox-group validity is detected when a box is checked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16761)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->