### PR TITLE
Fix spacing in content block settings forms

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/static_page/section_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/static_page/section_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :editor, :content, label: %>
+  <div class="row column">
+    <%= settings_fields.translated :editor, :content, label: %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/static_page/summary_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/static_page/summary_settings_form/show.erb
@@ -1,3 +1,5 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :editor, :summary, label: %>
+  <div class="row column">
+    <%= settings_fields.translated :editor, :summary, label: %>
+  </div>
 <% end %>

--- a/decidim-core/app/cells/decidim/content_blocks/static_page/two_pane_section_settings_form/show.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/static_page/two_pane_section_settings_form/show.erb
@@ -1,4 +1,6 @@
 <% form.fields_for :settings, form.object.settings do |settings_fields| %>
-  <%= settings_fields.translated :editor, :left_column, label: label_left_column %>
-  <%= settings_fields.translated :editor, :right_column, label: label_right_column %>
+  <div class="row column">
+    <%= settings_fields.translated :editor, :left_column, label: label_left_column %>
+    <%= settings_fields.translated :editor, :right_column, label: label_right_column %>
+  </div>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?
While checking https://github.com/decidim/decidim/pull/16451, i noticed there are some Settings forms that are not properly displayed. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to https://github.com/decidim/decidim/pull/16451

#### Testing
1. On your local, visit the admin section 
2. Go to pages
3. Go to terms of service page, click edit 
4. In the footer, you will see a content block section 
5. Add all 3 content blocks to your screen 
6. Customize 
7. See the form is literaly bound to border 
8. Apply patch 
9. See new spacing.

**Note to reviewer**: The files are formatted like the other component settings form (with the div inside the `fields_for` bit) 

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

Before:
<img width="2319" height="499" alt="image" src="https://github.com/user-attachments/assets/3ea8aad7-38a6-4d84-9f6b-d127ac000086" />

After 
<img width="2319" height="472" alt="image" src="https://github.com/user-attachments/assets/f80f166d-2934-4b86-a3b6-95a44ec945c5" />


Before: 
<img width="2319" height="499" alt="image" src="https://github.com/user-attachments/assets/eaf8dff1-2411-413a-bc68-e8719b9e773a" />

After 
<img width="2319" height="472" alt="image" src="https://github.com/user-attachments/assets/d14d9fa1-45a8-4860-b84c-70ea5f12b0d3" />

Before: 
<img width="2319" height="746" alt="image" src="https://github.com/user-attachments/assets/6ad1a6de-2004-4231-ad7a-273c174063be" />

After
<img width="2319" height="684" alt="image" src="https://github.com/user-attachments/assets/0a80f35c-6d94-48cd-804f-244ea8cb1b13" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout structure of static page content block admin forms by adding container elements to editor fields in section settings, summary settings, and two-pane section settings forms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16764)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->