### PR TITLE
Add no-duplicate-heading rule to markdownlint config

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -9,3 +9,5 @@ no-bare-urls: false
 no-inline-html: false
 
 no-duplicate-header: false
+
+no-duplicate-heading: false


### PR DESCRIPTION
#### :tophat: What? Why?

On the new version of markdownlint there's a new rule, `no-duplicate-heading` that is incompatible with our CHANGELOG.md file. This PR adds it to our configuration in develop, so it is consistent with our configuration on v0.32 

#### :pushpin: Related Issues
 
- Related to https://github.com/DavidAnson/markdownlint/blob/main/doc/md024.md 
- Related to https://github.com/decidim/decidim/pull/16773 

#### Testing

1. Copy the CHANGELOG.md from https://github.com/decidim/decidim/pull/16773 
2. Run ` npm exec markdownlint CHANGELOG.md`
3. There shouldn't be any offense

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated markdown linting configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16774)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->