### PR TITLE
Prevent start date validation on manual start when editing published elections

### DIFF
--- a/decidim-elections/app/forms/decidim/elections/admin/election_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/election_form.rb
@@ -50,7 +50,7 @@ module Decidim
         end
 
         def scheduled_election?
-          election&.scheduled?
+          !manual_start? && election&.scheduled?
         end
       end
     end

--- a/decidim-elections/app/forms/decidim/elections/admin/election_form.rb
+++ b/decidim-elections/app/forms/decidim/elections/admin/election_form.rb
@@ -25,7 +25,7 @@ module Decidim
         validates :title, translatable_presence: true
         validates :results_availability, inclusion: { in: Decidim::Elections::Election::RESULTS_AVAILABILITY_OPTIONS }
         validates :start_at, date: { before: :end_at }, unless: :manual_start?
-        validates :start_at, date: { after: proc { Time.current } }, if: :scheduled_election?
+        validates :start_at, date: { after: proc { Time.current } }, if: ->(f) { f.election&.scheduled? && f.start_at.present? }
         validates :manual_start, acceptance: true, if: :per_question_not_started?
         validates :end_at, presence: true
         validates :end_at, date: { after: :start_at }, if: ->(f) { f.start_at.present? && f.end_at.present? }
@@ -50,7 +50,7 @@ module Decidim
         end
 
         def scheduled_election?
-          !manual_start? && election&.scheduled?
+          election&.scheduled?
         end
       end
     end

--- a/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
@@ -194,13 +194,32 @@ module Decidim::Elections
         it { is_expected.to be_valid }
       end
 
-      context "when election is published and scheduled but manual_start is true" do
-        let(:election) { create(:election, :published, component:, start_at: 3.days.from_now, end_at: 4.days.from_now) }
+      context "when editing a published election configured for manual start" do
+        let(:election) { create(:election, :published, component:, start_at: nil, end_at: 4.days.from_now) }
         let(:manual_start) { true }
         let(:start_at) { nil }
-        let(:end_at) { 2.days.from_now }
 
-        it { is_expected.to be_valid }
+        context "and end_at is valid (in the future)" do
+          let(:end_at) { 2.days.from_now }
+
+          it { is_expected.to be_valid }
+
+          it "does not validate start_at when it is nil" do
+            expect(subject.valid?).to be true
+            expect(subject.errors[:start_at]).to be_empty
+          end
+        end
+
+        context "and end_at is set in the past" do
+          let(:end_at) { 1.day.ago }
+
+          it { is_expected.not_to be_valid }
+
+          it "still validates end_at to prevent moving the election into a finished state" do
+            subject.valid?
+            expect(subject.errors[:end_at]).not_to be_empty
+          end
+        end
       end
 
       context "when election is not published" do

--- a/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
+++ b/decidim-elections/spec/forms/decidim/elections/admin/election_form_spec.rb
@@ -194,6 +194,15 @@ module Decidim::Elections
         it { is_expected.to be_valid }
       end
 
+      context "when election is published and scheduled but manual_start is true" do
+        let(:election) { create(:election, :published, component:, start_at: 3.days.from_now, end_at: 4.days.from_now) }
+        let(:manual_start) { true }
+        let(:start_at) { nil }
+        let(:end_at) { 2.days.from_now }
+
+        it { is_expected.to be_valid }
+      end
+
       context "when election is not published" do
         let(:election) { create(:election, component:, start_at: 3.days.from_now, end_at: 4.days.from_now) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

This solves a little bug when editing Elections that have been published.
Currently the `ElectionForm` validates the `start_at` to be a date even if the election has been marked as "manual start". This only happens for published elections.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Create and election and publish it, (set it to manual start)
2. Edit the election, just press save on the first tab
3. See the error that the election cannot be updated. Note that you don't see the error because the "start_at" field is hidden due that "manual start" is checked

### :camera: Screenshots
If you unmark the "manual start" after trying to save, you will see the error:
<img width="1928" height="1030" alt="imatge" src="https://github.com/user-attachments/assets/afb51eae-5909-401f-adb7-3574d72abbab" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted scheduling validation so published elections configured for manual start no longer require a start date when editing, preventing incorrect validation failures.

* **Tests**
  * Added specs covering published elections with manual start to ensure correct validation behavior for start and end dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16788)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->