### PR TITLE
Fix locale setup in devise controllers

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -100,6 +100,7 @@ Brakus
 breadcrumb
 browserstack
 bugfixing
+busques
 Butlletins
 byebug
 bytesize
@@ -421,6 +422,7 @@ infoa
 infob
 informables
 iniciar
+iniciat
 inodes
 inputdialog
 inputname
@@ -904,6 +906,7 @@ traslatable
 trashable
 trgm
 trobada
+trobat
 tsearch
 turbolinks
 Twilio

--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -41,6 +41,9 @@ module Decidim
 
       layout "layouts/decidim/application"
 
+      # Devise uses prepend_before_action instead of before_action, so we need to use it to set the current locale before Devise's own before_actions.
+      prepend_before_action :set_current_locale
+
       # Saves the location before loading each page so we can return to the
       # right page.
       before_action :store_current_location
@@ -57,6 +60,10 @@ module Decidim
         return if redirect_url.blank? || !request.format.html?
 
         store_location_for(:user, redirect_url)
+      end
+
+      def set_current_locale
+        I18n.locale = Decidim::LocaleRouterDetector.new(request, params).locale
       end
     end
   end

--- a/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
+++ b/decidim-core/app/controllers/concerns/decidim/devise_controllers.rb
@@ -41,8 +41,9 @@ module Decidim
 
       layout "layouts/decidim/application"
 
-      # Devise uses prepend_before_action instead of before_action, so we need to use it to set the current locale before Devise's own before_actions.
-      prepend_before_action :set_current_locale
+      # Ensure locale is set before Devise's own prepended callbacks and reset
+      # after the request finishes.
+      prepend_around_action :set_current_locale
 
       # Saves the location before loading each page so we can return to the
       # right page.
@@ -62,8 +63,9 @@ module Decidim
         store_location_for(:user, redirect_url)
       end
 
-      def set_current_locale
-        I18n.locale = Decidim::LocaleRouterDetector.new(request, params).locale
+      def set_current_locale(&)
+        locale = Decidim::LocaleRouterDetector.new(request, params).locale
+        I18n.with_locale(locale, &)
       end
     end
   end

--- a/decidim-core/spec/system/locales_spec.rb
+++ b/decidim-core/spec/system/locales_spec.rb
@@ -69,15 +69,35 @@ describe "Locales" do
       let(:user) { create(:user, :confirmed, locale: "ca", organization:) }
 
       before do
+        allow(Rails.application).to \
+          receive(:env_config).with(no_args).and_wrap_original do |m, *|
+          m.call.merge(
+            "action_dispatch.show_exceptions" => true,
+            "action_dispatch.show_detailed_exceptions" => false
+          )
+        end
+
         login_as user, scope: :user
 
         # Prevent flaky spec, where sometimes the language is not changed before the visit
         sleep 2
-        visit decidim.root_redirect_path
       end
 
       it "uses the user's locale" do
+        visit decidim.root_redirect_path
         expect(page).to have_content("Menú")
+      end
+
+      it "displays not found messages with the right locale" do
+        visit decidim_admin.root_path
+
+        expect(page).to have_content("No s'ha trobat la pàgina que busques")
+      end
+
+      it "displays devise messages with the right locale" do
+        visit decidim.new_user_session_path(locale: "ca")
+
+        expect(page).to have_content("Ja has iniciat la sessió.")
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Certain controllers (at this point I've found session controllers that inherit from Devise controllers) do not make use of the LocaleSwitcher class as that uses a `around_action` and that controllers might process the http response using `prepend` hooks.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16777

#### Testing
1. Login into a Decidim instance,  change language to other thant english
2. visit /YOUR_LANGUAGE/users/sign_in
3. See messages in english, also note that the global language has changed to english.


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling during authentication so the interface reliably shows the user's preferred language when signing in.

* **Tests**
  * Adjusted locale system tests to more robustly validate locale behavior across authentication flows.

* **Chores**
  * Added new expected entries to the spelling/suggestions list to prevent false positives for known terms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16789)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->