### PR TITLE
Fix modify responses on survey

### DIFF
--- a/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
+++ b/decidim-forms/app/forms/decidim/forms/questionnaire_form.rb
@@ -30,7 +30,7 @@ module Decidim
 
       def add_responses!(questionnaire:, session_token:, ip_hash:)
         self.responses = questionnaire.questions.map do |question|
-          ResponseForm.from_model(Decidim::Forms::Response.where(question:, user: current_user, session_token:, ip_hash:).first_or_initialize)
+          ResponseForm.from_model(Decidim::Forms::Response.where(question:, user: current_user, session_token:, ip_hash:).first_or_initialize).with_context(context)
         end
       end
 

--- a/decidim-surveys/spec/system/survey_spec.rb
+++ b/decidim-surveys/spec/system/survey_spec.rb
@@ -198,6 +198,42 @@ describe "Respond a survey" do
         it_behaves_like "has embedded video in description", :question_description
       end
     end
+
+    context "when the survey allows to edit responses, and question has display conditions" do
+      let!(:question_two) do
+        create(:questionnaire_question,
+               questionnaire:,
+               question_type: "short_response",
+               position: 1,
+               options: [])
+      end
+      let!(:display_condition) do
+        create(:display_condition,
+               condition_type: "not_responded",
+               question: question_two,
+               condition_question: question)
+      end
+
+      before do
+        survey.update!(
+          allow_responses: true,
+          allow_editing_responses: true
+        )
+        login_as user, scope: :user
+        visit_component
+        click_on translated_attribute(questionnaire.title)
+        fill_in "questionnaire_responses_0", with: "test"
+        check "questionnaire_tos_agreement"
+        click_on "Submit"
+        expect(page).to have_callout("Survey successfully responded.")
+      end
+
+      it "allows to edit the responses" do
+        click_on "Edit your responses"
+        expect(page).to have_content(translated_attribute(survey.title))
+        expect(page).to have_content(translated_attribute(question.body))
+      end
+    end
   end
 
   context "when survey has a custom announcement" do


### PR DESCRIPTION
#### :tophat: What? Why?
This PR corrects a bug that prevents from editing responses of survey where there were questions with display condition (cf screenshot 1).
It adds missing context in add_responses! method.

This bug also exists in 0.31 version of decidim.

#### Testing

1. As an admin, create a new survey, add 2 questions. Add a display condition on the question 2 depending on question one. 
2. In the settings, allow the users to modify their responses.
3. As a user, answer the survey
4. As a user, click on "Edit your responses"
5. See that you have access to the edit page (cf screenshot 2)


### :camera: Screenshots
ONE
<img width="1290" height="697" alt="Capture d’écran 2026-05-13 à 16 00 58" src="https://github.com/user-attachments/assets/4b42df7b-11a0-4142-a4b5-b62f26c942b3" />


TWO
<img width="1256" height="858" alt="Capture d’écran 2026-05-13 à 16 03 22" src="https://github.com/user-attachments/assets/60c31c54-bee3-4da5-969e-b40daa7ef60c" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where response forms were not properly initialized with the required context, ensuring responses are handled correctly.

* **Tests**
  * Added test coverage for response editing functionality in surveys with conditional display questions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16794)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->