### PR TITLE
Fix double-escaping on mobile menu navigation links

### DIFF
--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
@@ -7,7 +7,7 @@
       <span class="cursor-pointer truncate flex items-center gap-x-2">
         <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
         <% if previous_item %>
-          <% item_label = decidim_escape_translated(previous_item[:label]) %>
+          <% item_label = translated_attribute(previous_item[:label]) %>
           <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
             <%= link_to(item_label, previous_item[:url], class: "menu-bar__breadcrumb-item") %>
           <% else %>

--- a/decidim-core/spec/system/menu_spec.rb
+++ b/decidim-core/spec/system/menu_spec.rb
@@ -68,6 +68,40 @@ describe "Menu" do
     end
   end
 
+  describe "when there are special characters (', &) in the nav links" do
+    let(:component_name) { "People's Budget & Ideas" }
+    let(:participatory_space) { create(:participatory_process, organization:) }
+    let(:proposal_component) { create(:proposal_component, name: { en: component_name }, participatory_space:) }
+    let(:proposal) { create(:proposal, component: proposal_component) }
+    let(:proposal_path) { Decidim::ResourceLocatorPresenter.new(proposal).path }
+
+    context "when it is a desktop device" do
+      it "renders the component name correctly" do
+        visit proposal_path
+        within ".menu-bar__breadcrumb-desktop" do
+          expect(page).to have_content(component_name)
+          expect(page).to have_no_content("&#39;")
+          expect(page).to have_no_content("&amp;#39;")
+        end
+      end
+    end
+
+    context "when it is a mobile device" do
+      before do
+        driven_by(:iphone)
+      end
+
+      it "renders the component name correctly" do
+        visit proposal_path
+        within ".menu-bar__breadcrumb-mobile" do
+          expect(page).to have_content(component_name)
+          expect(page).to have_no_content("&#39;")
+          expect(page).to have_no_content("&amp;#39;")
+        end
+      end
+    end
+  end
+
   context "when the admin_insights_menu is displayed" do
     let(:user) { create(:user, :admin, :confirmed, organization:) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing https://github.com/decidim/decidim/pull/15978 I noticed that it is exactly the same problem as #16419, so I went ahead and fix it.

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/13873 

#### Testing

1. Sign in as admin 
2. Edit a process and change its title to `Création d'un réseau & café - "EL Club" <script>alert(4)</script>`
3. On the frontend, navigate to a component
4. Change the resolution to kick the mobile resolution
5. (Before) see that it is broken
6. (After) see that it is fixed

### :camera: Screenshots

#### Before

<img width="2009" height="635" alt="image" src="https://github.com/user-attachments/assets/ec2c2c43-1b65-4b2b-a5ac-67983667e975" />

#### After

<img width="2011" height="648" alt="image" src="https://github.com/user-attachments/assets/92860d50-cb01-4b57-9937-d66549c11bc1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed special character rendering in mobile navigation breadcrumbs, ensuring component names containing apostrophes and ampersands now display correctly as plain text instead of showing unwanted encoded characters.

* **Tests**
  * Added test coverage for special characters in navigation breadcrumb display across desktop and mobile views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16810)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->