### PR TITLE
Fix flaky admin manages newsletters specs

### DIFF
--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -257,7 +257,14 @@ describe "Admin manages newsletters" do
 
           within(".newsletter_deliver") do
             choose("Send to verified users")
-            select_verification_type(verification_type_first.name) # Одна авторизация передается как строка
+          end
+
+          within "#recipients_count" do
+            expect(page).to have_content(0)
+          end
+
+          within(".newsletter_deliver") do
+            select_verification_type(verification_type_first.name) # One authorization is passed as a string
           end
 
           within "#recipients_count" do
@@ -293,7 +300,14 @@ describe "Admin manages newsletters" do
 
           within(".newsletter_deliver") do
             choose("Send to verified users")
-            select_verification_type([verification_type_first.name, verification_type_last.name]) # Несколько авторизаций передаются как массив
+          end
+
+          within "#recipients_count" do
+            expect(page).to have_content(0)
+          end
+
+          within(".newsletter_deliver") do
+            select_verification_type([verification_type_first.name, verification_type_last.name]) # Multiple authorizations are passed as an array
           end
 
           within "#recipients_count" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed some admin manages newsletters specs behaving in a flaky way, so fixed those.

The reason is that in case there are multiple requests done for the recipients count endpoint, the request finishing order may change, as there is no control on the order of these requests.

At the same time I also noticed this endpoint is **always** called twice when something changes on the form. This might also be the reason for the flaky tests but did not investigate it further, just fixed the spec.

The spec is fixed by expecting the state of the previous request, as in that case it is ensured the previous request has already finished. In real life situations, I believe this would be rather rare to happen and would only happen in case there is some delay with the internet connection.

Example failed run:
https://github.com/decidim/decidim/actions/runs/25860033438/job/75987256801?pr=11036

Relevant test output:

```
Failures:

  1) Admin manages newsletters select newsletter recipients when verified users selected with one verification type sends newsletter to users verified with one type
     Failure/Error: expect(page).to have_content(recipients_count)
       expected to find text "1" in "0"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_newsletters_select_newsletter_recipients_when_verified_users_selected_with_one_verification_type_sends_newsletter_to_users_verified_with_one_type_674.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_newsletters_select_newsletter_recipients_when_verified_users_selected_with_one_verification_type_sends_newsletter_to_users_verified_with_one_type_674.html


     # ./spec/system/admin_manages_newsletters_spec.rb:264:in 'block (6 levels) in <top (required)>'
     # ./spec/system/admin_manages_newsletters_spec.rb:263:in 'block (5 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in 'block (2 levels) in <top (required)>'

Finished in 9 minutes 28 seconds (files took 17.96 seconds to load)
100 examples, 1 failure

Failed examples:

rspec ./spec/system/admin_manages_newsletters_spec.rb:255 # Admin manages newsletters select newsletter recipients when verified users selected with one verification type sends newsletter to users verified with one type
```

#### :pushpin: Related Issues
- Related to #11036

#### Testing
Run the failed test enough many times to detect any flaky failures:

```bash
for i in {1..100}; do bundle exec rspec ./spec/system/admin_manages_newsletters_spec.rb -e "select newsletter recipients when verified users selected" || break ; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced system tests for newsletter recipient selection, ensuring the recipients counter correctly reflects verification status filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16812)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->