### PR TITLE
Backport 'Fix browser freeze when editing filters with many taxonomy items' to v0.30

### DIFF
--- a/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.js
+++ b/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.js
@@ -3,10 +3,15 @@
  * appearing prematurely in input fields.
  *
  * The primary goal is to hide error messages until the input field loses focus.
+ *
+ * It also patches the checkbox group validation to avoid browser freezes in
+ * very large checkbox groups.
  */
 
 class AbideFormValidatorFixer {
   initialize() {
+    this.patchCheckboxValidation();
+
     const forms = document.querySelectorAll("main [data-live-validate='true']");
 
     forms.forEach((form) => {
@@ -14,6 +19,64 @@ class AbideFormValidatorFixer {
         this.setupForm(form);
       }
     });
+  }
+
+  patchCheckboxValidation() {
+    const abidePrototype = window.Foundation?.Abide?.prototype;
+
+    if (!abidePrototype || abidePrototype.validateCheckbox?.__decidimPatched) {
+      return;
+    }
+
+    abidePrototype.validateCheckbox = function(groupName) {
+      const $group = this.$element.find(`:checkbox[name="${groupName}"]`);
+      let valid = false;
+      let required = false;
+      let minRequired = 1;
+      let checked = 0;
+
+      $group.each((_i, element) => {
+        if ($(element).attr("required")) {
+          required = true;
+        }
+      });
+
+      if (!required) {
+        valid = true;
+      }
+
+      if (!valid) {
+        $group.each((_i, element) => {
+          if ($(element).prop("checked")) {
+            checked += 1;
+          }
+
+          if (typeof $(element).attr("data-min-required") !== "undefined") {
+            minRequired = parseInt($(element).attr("data-min-required"), 10);
+          }
+        });
+
+        if (checked >= minRequired) {
+          valid = true;
+        }
+      }
+
+      if (this.initialized !== true && minRequired > 1) {
+        return true;
+      }
+
+      if (valid) {
+        this.removeCheckboxErrorClasses(groupName);
+      } else {
+        $group.each((_i, element) => {
+          this.addErrorClasses($(element), ["required"]);
+        });
+      }
+
+      return valid;
+    };
+
+    abidePrototype.validateCheckbox.__decidimPatched = true;
   }
 
   isElementVisible(element) {
@@ -42,3 +105,5 @@ document.addEventListener("DOMContentLoaded", () => {
   const validatorFixer = new AbideFormValidatorFixer();
   validatorFixer.initialize();
 });
+
+export default AbideFormValidatorFixer;

--- a/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.test.js
+++ b/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.test.js
@@ -1,0 +1,74 @@
+/* global jest */
+
+import AbideFormValidatorFixer from "src/decidim/abide_form_validator_fixer";
+
+describe("AbideFormValidatorFixer", () => {
+  let originalFoundation;
+
+  beforeEach(() => {
+    originalFoundation = window.Foundation;
+
+    class MockAbide {}
+
+    MockAbide.prototype.validateCheckbox = function() {
+      return false;
+    };
+
+    window.Foundation = { Abide: MockAbide };
+  });
+
+  afterEach(() => {
+    window.Foundation = originalFoundation;
+    document.body.innerHTML = "";
+  });
+
+  it("removes checkbox group error classes once when the group is valid", () => {
+    const fixer = new AbideFormValidatorFixer();
+    fixer.patchCheckboxValidation();
+
+    const form = document.createElement("form");
+    form.innerHTML = `
+      <input type="checkbox" name="largeGroup" value="1" required checked>
+      <input type="checkbox" name="largeGroup" value="2" required>
+      <input type="checkbox" name="largeGroup" value="3" required>
+    `;
+
+    const abideInstance = {
+      $element: window.$(form),
+      initialized: true,
+      addErrorClasses: jest.fn(),
+      removeCheckboxErrorClasses: jest.fn()
+    };
+
+    const valid = window.Foundation.Abide.prototype.validateCheckbox.call(abideInstance, "largeGroup");
+
+    expect(valid).toBe(true);
+    expect(abideInstance.removeCheckboxErrorClasses).toHaveBeenCalledTimes(1);
+    expect(abideInstance.addErrorClasses).not.toHaveBeenCalled();
+  });
+
+  it("adds error classes per checkbox when the group is invalid", () => {
+    const fixer = new AbideFormValidatorFixer();
+    fixer.patchCheckboxValidation();
+
+    const form = document.createElement("form");
+    form.innerHTML = `
+      <input type="checkbox" name="largeGroup" value="1" required>
+      <input type="checkbox" name="largeGroup" value="2" required>
+      <input type="checkbox" name="largeGroup" value="3" required>
+    `;
+
+    const abideInstance = {
+      $element: window.$(form),
+      initialized: true,
+      addErrorClasses: jest.fn(),
+      removeCheckboxErrorClasses: jest.fn()
+    };
+
+    const valid = window.Foundation.Abide.prototype.validateCheckbox.call(abideInstance, "largeGroup");
+
+    expect(valid).toBe(false);
+    expect(abideInstance.addErrorClasses).toHaveBeenCalledTimes(3);
+    expect(abideInstance.removeCheckboxErrorClasses).not.toHaveBeenCalled();
+  });
+});

--- a/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.test.js
+++ b/decidim-core/app/packs/src/decidim/abide_form_validator_fixer.test.js
@@ -3,7 +3,7 @@
 import AbideFormValidatorFixer from "src/decidim/abide_form_validator_fixer";
 
 describe("AbideFormValidatorFixer", () => {
-  let originalFoundation;
+  let originalFoundation = null;
 
   beforeEach(() => {
     originalFoundation = window.Foundation;
@@ -40,7 +40,7 @@ describe("AbideFormValidatorFixer", () => {
       removeCheckboxErrorClasses: jest.fn()
     };
 
-    const valid = window.Foundation.Abide.prototype.validateCheckbox.call(abideInstance, "largeGroup");
+    const valid = Reflect.apply(window.Foundation.Abide.prototype.validateCheckbox, abideInstance, ["largeGroup"]);
 
     expect(valid).toBe(true);
     expect(abideInstance.removeCheckboxErrorClasses).toHaveBeenCalledTimes(1);
@@ -65,7 +65,7 @@ describe("AbideFormValidatorFixer", () => {
       removeCheckboxErrorClasses: jest.fn()
     };
 
-    const valid = window.Foundation.Abide.prototype.validateCheckbox.call(abideInstance, "largeGroup");
+    const valid = Reflect.apply(window.Foundation.Abide.prototype.validateCheckbox, abideInstance, ["largeGroup"]);
 
     expect(valid).toBe(false);
     expect(abideInstance.addErrorClasses).toHaveBeenCalledTimes(3);


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #16761 to v0.30

Mind that in case the change is important in comparison to the original PR and the other backports of this fix, as we don't have the Stimulus controller in this version. 

It should be handled as a new review and its fix. 

#### Testing

``` 
git checkout release/0.30-stable
bundle exec rake development_app
```

0. Checking the bug
1. Add a large number of taxonomies and taxonomy filter items (~1,200) using a script
2. Log in as admin and go to "Settings" -> "Taxonomies"
3. Select a taxonomy with a large number of items and click "Edit"
4. Try checking or unchecking any of the checkboxes in the filter items list. See the bug
5. Check out this branch  `gh pr checkout 16817`
6. Restart the development server
4. Try again checking or unchecking any of the checkboxes in the filter items list. It should work correctly now.

Run the script 

```ruby
NUM_ITEMS = 1200
ORG = Decidim::Organization.first
ROOT_TAXONOMY = Decidim::Taxonomy.roots.first
FILTER = ROOT_TAXONOMY.taxonomy_filters.first

NUM_ITEMS.times do |i|
  begin
    # Create a child taxonomy (non-root)
    child = Decidim::Taxonomy.create!(
      name: { "en" => "Test #{i}" },
      parent: ROOT_TAXONOMY,
      decidim_organization_id: ORG.id
    )
    # Link the child taxonomy to the filter
    Decidim::TaxonomyFilterItem.create!(
      taxonomy_filter: FILTER,
      taxonomy_item: child
    )
    puts "✅ Created child taxonomy ##{child.id} and linked to filter ##{FILTER.id}"
  rescue => e
    puts "❌ Failed at ##{i}: #{e.message}"
  end
end
``` 

:hearts: Thank you!