### PR TITLE
Do not truncate the `schema_migrations` and `ar_internal_metadata` tables during tests

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
@@ -14,10 +14,10 @@ RSpec.shared_context "with concurrency" do
     connection = ActiveRecord::Base.connection
     connection.disable_referential_integrity do
       connection.tables.each do |table_name|
-        next if table_name == "schema_migrations"
-        next if connection.select_value("SELECT COUNT(*) FROM #{table_name}").zero?
+        next if table_name.in?(%w(schema_migrations ar_internal_metadata))
+        next if connection.select_value("SELECT COUNT(*) FROM #{connection.quote_table_name(table_name)}").zero?
 
-        connection.execute("TRUNCATE #{table_name} CASCADE")
+        connection.execute("TRUNCATE #{connection.quote_table_name(table_name)} CASCADE")
       end
     end
   end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/concurrency.rb
@@ -14,6 +14,7 @@ RSpec.shared_context "with concurrency" do
     connection = ActiveRecord::Base.connection
     connection.disable_referential_integrity do
       connection.tables.each do |table_name|
+        next if table_name == "schema_migrations"
         next if connection.select_value("SELECT COUNT(*) FROM #{table_name}").zero?
 
         connection.execute("TRUNCATE #{table_name} CASCADE")


### PR DESCRIPTION
#### :tophat: What? Why?
During the concurrency testing case, the `schema_migrations` table was also truncated (and as pointed out by AI, `ar_internal_metadata`) causing the test app to be in possibly broken state.

Noticed this while doing something else but though to fix it here too. It's nothing too serious as you can fix this also by regenerating the test app but in case you want to use the same app, you'd need to drop the database and recreate it to run any further migrations.

This would happen as follows:

1. You first created the test app
2. You ran the tests containing concurrency testing (only single case right now)
3. You pulled newer code from upstream
4. You wanted to apply the newly added migrations to the test app
5. The migration process would be broken as there is no record of which migrations have already run

#### Testing
1. Create the test app
2. Run the affected test case `cd decidim-projects && bundle exec rspec ./spec/requests/line_items_spec.rb -e "POST create with concurrent requests"`
3. See that the `schema_migrations` table was not truncated (e.g. through `psql`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved concurrent test cleanup to avoid clearing migration and internal metadata when transactional tests are disabled, while preserving safe truncation of other test data to maintain reliable test isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16819)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16819)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->