### PR TITLE
Clarify admin access for access modes in help text

### DIFF
--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -242,8 +242,8 @@ en:
               label: Access
               options:
                 open: Everyone can see the assembly and participate.
-                restricted: Only members can see and participate.
-                transparent: Everyone can see the assembly, but only members can participate.
+                restricted: Only members and administrators can see and participate.
+                transparent: Everyone can see the assembly, but only members and administrators can participate.
               set_this_space_as: Set this space as
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1551,8 +1551,8 @@ en:
         members: Members
     participatory_spaces:
       show:
-        restricted_space: This is a restricted space. Only members can view it and participate.
-        transparent_space: This is a transparent space. Anyone can view the content, but only members can participate.
+        restricted_space: This is a restricted space. Only members and administrators can view it and participate.
+        transparent_space: This is a transparent space. Anyone can view the content, but only members and administrators can participate.
     passwords:
       update:
         error: There was a problem updating the password.

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -520,8 +520,8 @@ en:
               label: Access
               options:
                 open: Everyone can see the process and participate.
-                restricted: Only members can see and participate.
-                transparent: Everyone can see the process, but only members can participate.
+                restricted: Only members and administrators can see and participate.
+                transparent: Everyone can see the process, but only members and administrators can participate.
               set_this_space_as: Set this space as
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             duration: Duration


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session: "As an admin, I can participate in a Restricted Space"

> With the new feature of “Acces”, If i selected “Restricted”, space is only visible for members. But, as an admin, I can see the process. But, I’m not a member, so I shouldn’t participate in 

Reported by:  @paarals  

NOTE: even though according to @paarals the expected behavior would be that an admin don't participate, this opens a can of worms of bugs and how the permissions work internally on Decidim. I'd prefer to be much more conservative and just clarify this through the help text instead of having to radically change all the permissions (and breaking the app in the process) 

#### :pushpin: Related Issues

- Related to #15720 

#### Testing

1. Make a new space (participatory process/assembly)
2. In the access zone, put “Has members” and “Restricted” 
3. Don’t put your e-mail in “Members” 
4. As a super-admin or a process-admin, I can see the space (ok) 
5. As a super-admin or process, I can participate (comment, proposal, etc)  


### :camera: Screenshots

#### Before

<img width="711" height="377" alt="image" src="https://github.com/user-attachments/assets/6b0088c5-1b77-4566-9e2c-a3ff981b1de5" />

#### After

<img width="741" height="410" alt="image" src="https://github.com/user-attachments/assets/c27153d5-1bf2-44e6-a54d-aa233ec0872c" />

<img width="1582" height="884" alt="image" src="https://github.com/user-attachments/assets/3055d7c8-4365-436d-8e4d-9baa072be56f" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified English wording for assembly access options to state that both members and administrators are included for restricted access, and that transparent assemblies are visible to everyone while only members and administrators can participate.
  * Updated participatory process and participatory space access descriptions to match the above visibility and participation phrasing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16821?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->