### PR TITLE
(Deprecated) Make the access mode labels aware of i18n

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -193,7 +193,7 @@
           <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.transparent") %>
           <% Decidim::Assembly::ACCESS_MODES.keys.each do |mode| %>
             <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
+              <%= form.radio_button :access_mode, mode, label: t(mode, scope: "decidim.assemblies.admin.assemblies.form.access.options_labels") %>
               <span><%= t(mode, scope: "decidim.assemblies.admin.assemblies.form.access.options") %></span>
              <% end %>
           <% end %>

--- a/decidim-assemblies/config/locales/en.yml
+++ b/decidim-assemblies/config/locales/en.yml
@@ -240,6 +240,10 @@ en:
           form:
             access:
               label: Access
+              options_labels:
+                open: Open
+                restricted: Restricted
+                transparent: Transparent
               options:
                 open: Everyone can see the assembly and participate.
                 restricted: Only members can see and participate.

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -170,7 +170,7 @@
           <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.transparent") %>
           <% Decidim::ParticipatoryProcess::ACCESS_MODES.keys.each do |mode| %>
             <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
+              <%= form.radio_button :access_mode, mode, label: t(mode, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options_labels") %>
               <span><%= t(mode, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options") %></span>
              <% end %>
           <% end %>

--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -518,6 +518,10 @@ en:
           form:
             access:
               label: Access
+              options_labels:
+                open: Open
+                restricted: Restricted
+                transparent: Transparent
               options:
                 open: Everyone can see the process and participate.
                 restricted: Only members can see and participate.


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session: "Missing translation in the Access modes values"

> When I go to edit a space and it has members and I have a non-english locale, I see that there are some missing translations (Open, Transparent, Restricted)

Reported by:  @andreslucena 😄 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/issues/15720

#### Testing

1. Sign in as administrator
2. Go to edit a process
3. Change the locale to Catalan 
4. See the Access mode section in the form 

To check the fix, change one of the new labels in en.yml and see that it changes 

### :camera: Screenshots

<img width="1087" height="848" alt="image" src="https://github.com/user-attachments/assets/9f7ff88e-edc4-44a9-a59d-62ea7a50b611" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Access mode options in assembly and participatory process configuration forms now display with properly translated, consistent labels for "Open," "Restricted," and "Transparent" modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16822)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->