### PR TITLE
Fix floating help with the access modes alert on mobile

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_floating_help.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_floating_help.scss
@@ -1,5 +1,5 @@
 [data-floating-help] {
-  @apply absolute z-10 top-5 md:top-10 right-0 [&_button]:bg-background [&_button]:px-2 [&_button]:rounded-r-none [&_svg]:text-gray [&_svg]:fill-current;
+  @apply absolute z-10 top-20 md:top-10 right-0 [&_button]:bg-background [&_button]:px-2 [&_button]:rounded-r-none [&_svg]:text-gray [&_svg]:fill-current;
 
   &:hover {
     @apply [&_svg]:text-white [&_button]:text-white [&_button]:bg-secondary [&_button]:no-underline;


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session: "In mobile, help and restricted space announcement overlaps "

> With the new feature of “Acces”, If i selected “Restricted”, space is only visible for members. As a member I can access via mobile. When I access, I can’t see the whole information of restriction announcement

Reported by:  @paarals  
 
#### :pushpin: Related Issues

- Related to #15720 

#### Testing

1. Make a new space (participatory process/assembly)
2. In the access zone, put “Has members” and “Restricted” 
3. Access as a member
4. See overlaps 

### :camera: Screenshots

#### Before

<img width="747" height="902" alt="image" src="https://github.com/user-attachments/assets/c4f285e2-7cdd-49fc-bc26-b6ece02b1ba2" />

#### After
 
<img width="861" height="841" alt="image" src="https://github.com/user-attachments/assets/bf277090-e4b6-4f8f-8ad7-4fa2396ffe0f" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical positioning of floating help elements to enhance visibility and improve layout spacing across different screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16823)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->