### PR TITLE
Make the access mode labels aware of i18n

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -188,6 +188,9 @@
           <%= t("access.set_this_space_as", scope: "decidim.assemblies.admin.assemblies.form") %>
         </legend>
         <div class="radio-group">
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.open") %>
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.restricted") %>
+          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.transparent") %>
           <%= form.collection_radio_buttons :access_mode,
                                             Decidim::Assembly::ACCESS_MODES.keys,
                                             ->(mode) { mode },

--- a/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/admin/assemblies/_form.html.erb
@@ -188,14 +188,17 @@
           <%= t("access.set_this_space_as", scope: "decidim.assemblies.admin.assemblies.form") %>
         </legend>
         <div class="radio-group">
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.open") %>
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.restricted") %>
-          <%# i18n-tasks-use t("decidim.assemblies.admin.assemblies.form.access.options.transparent") %>
-          <% Decidim::Assembly::ACCESS_MODES.keys.each do |mode| %>
-            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
-              <span><%= t(mode, scope: "decidim.assemblies.admin.assemblies.form.access.options") %></span>
-             <% end %>
+          <%= form.collection_radio_buttons :access_mode,
+                                            Decidim::Assembly::ACCESS_MODES.keys,
+                                            ->(mode) { mode },
+                                            ->(mode) { t(mode, scope: "decidim.admin.assemblies.index.access_modes") } do |builder| %>
+            <%= builder.label(for: nil, class: "form__wrapper-checkbox-label") do %>
+              <%= builder.radio_button(id: nil, label: false) %>
+              <span>
+                <strong class="font-semibold"><%= builder.text %></strong>
+                <%= t(builder.value, scope: "decidim.assemblies.admin.assemblies.form.access.options") %>
+              </span>
+            <% end %>
           <% end %>
         </div>
       </fieldset>

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -139,7 +139,7 @@ describe "Admin manages assemblies" do
           click_on translated(assembly3.title)
         end
 
-        expect(page).to have_checked_field("assembly_access_mode_transparent")
+        expect(page).to have_css('input[name="assembly[access_mode]"][value="transparent"]:checked', visible: :all)
       end
     end
   end

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -165,14 +165,17 @@
           <%= t("access.set_this_space_as", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
         </legend>
         <div class="radio-group">
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.open") %>
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.restricted") %>
-          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.transparent") %>
-          <% Decidim::ParticipatoryProcess::ACCESS_MODES.keys.each do |mode| %>
-            <%= label_tag nil, class: "form__wrapper-checkbox-label" do %>
-              <%= form.radio_button :access_mode, mode %>
-              <span><%= t(mode, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options") %></span>
-             <% end %>
+          <%= form.collection_radio_buttons :access_mode,
+                                            Decidim::ParticipatoryProcess::ACCESS_MODES.keys,
+                                            ->(mode) { mode },
+                                            ->(mode) { t(mode, scope: "decidim.admin.participatory_processes.index.access_modes") } do |builder| %>
+            <%= builder.label(for: nil, class: "form__wrapper-checkbox-label") do %>
+              <%= builder.radio_button(id: nil, label: false) %>
+              <span>
+                <strong class="font-semibold"><%= builder.text %></strong>
+                <%= t(builder.value, scope: "decidim.participatory_processes.admin.participatory_processes.form.access.options") %>
+              </span>
+            <% end %>
           <% end %>
         </div>
       </fieldset>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/admin/participatory_processes/_form.html.erb
@@ -165,6 +165,9 @@
           <%= t("access.set_this_space_as", scope: "decidim.participatory_processes.admin.participatory_processes.form") %>
         </legend>
         <div class="radio-group">
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.open") %>
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.restricted") %>
+          <%# i18n-tasks-use t("decidim.participatory_processes.admin.participatory_processes.form.access.options.transparent") %>
           <%= form.collection_radio_buttons :access_mode,
                                             Decidim::ParticipatoryProcess::ACCESS_MODES.keys,
                                             ->(mode) { mode },


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session: "Missing translation in the Access modes values"

> When I go to edit a space and it has members and I have a non-english locale, I see that there are some missing translations (Open, Transparent, Restricted)

Reported by:  @andreslucena 😄 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/issues/15720

#### Testing

1. Sign in as administrator
2. Go to edit a process
3. Change the locale to Catalan 
4. See the Access mode section in the form 

To check the fix, change one of the new labels in en.yml and see that it changes 

### :camera: Screenshots

<img width="1574" height="831" alt="image" src="https://github.com/user-attachments/assets/a637d0fa-b67a-45de-a3d8-ad86be3b8493" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved presentation and organization of access-mode choices in assembly and participatory process admin forms, with clearer option labels and structured radio layouts.
* **Tests**
  * Updated system test to more reliably assert the selected access-mode radio input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16827?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->