### PR TITLE
Improve taxonomy filter update performance

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/create_taxonomy_filter.rb
+++ b/decidim-admin/app/commands/decidim/admin/create_taxonomy_filter.rb
@@ -5,19 +5,33 @@ module Decidim
     # A command with all the business logic to create a new taxonomy filter in the
     # system.
     class CreateTaxonomyFilter < Decidim::Commands::CreateResource
-      fetch_form_attributes :root_taxonomy_id, :filter_items, :internal_name, :name, :participatory_space_manifests
+      fetch_form_attributes :root_taxonomy_id, :internal_name, :name, :participatory_space_manifests
 
       protected
 
       def resource_class = Decidim::TaxonomyFilter
 
+      def run_after_hooks
+        create_filter_items!
+      end
+
       def extra_params
         {
           extra: {
             taxonomy_name: form.root_taxonomy.name,
-            filter_items_count: form.filter_items.count
+            filter_items_count: selected_taxonomy_item_ids.size
           }
         }
+      end
+
+      private
+
+      def create_filter_items!
+        selected_taxonomy_item_ids.each { |taxonomy_item_id| resource.filter_items.create!(taxonomy_item_id:) }
+      end
+
+      def selected_taxonomy_item_ids
+        form.taxonomy_items.map(&:to_i).uniq
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/update_taxonomy_filter.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_taxonomy_filter.rb
@@ -2,26 +2,44 @@
 
 module Decidim
   module Admin
-    # A command with all the business logic to create a new taxonomy filter in the
-    # system.
+    # A command with all the business logic to update an existing taxonomy filter
+    # in the system.
     class UpdateTaxonomyFilter < Decidim::Commands::UpdateResource
-      fetch_form_attributes :filter_items, :internal_name, :name, :participatory_space_manifests
+      fetch_form_attributes :internal_name, :name, :participatory_space_manifests
 
       protected
 
       def resource_class = Decidim::TaxonomyFilter
 
-      def run_before_hooks
-        resource.filter_items.destroy_all
+      def run_after_hooks
+        sync_filter_items!
       end
 
       def extra_params
         {
           extra: {
             taxonomy_name: resource.root_taxonomy.name,
-            filter_items_count: form.filter_items.count
+            filter_items_count: selected_taxonomy_item_ids.size
           }
         }
+      end
+
+      private
+
+      def sync_filter_items!
+        removed_ids = current_taxonomy_item_ids - selected_taxonomy_item_ids
+        added_ids   = selected_taxonomy_item_ids - current_taxonomy_item_ids
+
+        resource.filter_items.where(taxonomy_item_id: removed_ids).destroy_all if removed_ids.any?
+        added_ids.each { |taxonomy_item_id| resource.filter_items.create!(taxonomy_item_id:) }
+      end
+
+      def current_taxonomy_item_ids
+        resource.filter_items.pluck(:taxonomy_item_id)
+      end
+
+      def selected_taxonomy_item_ids
+        form.taxonomy_items.map(&:to_i).uniq
       end
     end
   end

--- a/decidim-admin/app/commands/decidim/admin/update_taxonomy_filter.rb
+++ b/decidim-admin/app/commands/decidim/admin/update_taxonomy_filter.rb
@@ -28,7 +28,7 @@ module Decidim
 
       def sync_filter_items!
         removed_ids = current_taxonomy_item_ids - selected_taxonomy_item_ids
-        added_ids   = selected_taxonomy_item_ids - current_taxonomy_item_ids
+        added_ids = selected_taxonomy_item_ids - current_taxonomy_item_ids
 
         resource.filter_items.where(taxonomy_item_id: removed_ids).destroy_all if removed_ids.any?
         added_ids.each { |taxonomy_item_id| resource.filter_items.create!(taxonomy_item_id:) }

--- a/decidim-admin/app/forms/decidim/admin/taxonomy_filter_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/taxonomy_filter_form.rb
@@ -44,7 +44,7 @@ module Decidim
       def items_collection
         return [] unless root_taxonomy
 
-        @items_collection ||= map_items_collection(root_taxonomy)
+        @items_collection ||= build_items_collection
       end
 
       def root_taxonomy
@@ -62,12 +62,17 @@ module Decidim
 
       private
 
-      def map_items_collection(taxonomy)
-        taxonomy.children.map do |item|
+      def build_items_collection
+        children_by_parent_id = root_taxonomy.all_children.group_by(&:parent_id)
+        build_subtree(root_taxonomy.id, children_by_parent_id)
+      end
+
+      def build_subtree(parent_id, children_by_parent_id)
+        Array(children_by_parent_id[parent_id]).map do |item|
           Item.new(
             name: translated_attribute(item.name),
             value: item.id,
-            children: map_items_collection(item)
+            children: build_subtree(item.id, children_by_parent_id)
           )
         end
       end

--- a/decidim-admin/app/forms/decidim/admin/taxonomy_filter_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/taxonomy_filter_form.rb
@@ -73,11 +73,8 @@ module Decidim
       end
 
       def valid_taxonomy_items
-        return if taxonomy_items.all? do |item|
-          next unless root_taxonomy
-
-          root_taxonomy.all_children.map(&:id).include?(item.to_i)
-        end
+        valid_ids = root_taxonomy ? root_taxonomy.all_children.pluck(:id).to_set : Set.new
+        return if taxonomy_items.all? { |item| valid_ids.include?(item.to_i) }
 
         errors.add(:taxonomy_items, :invalid)
       end

--- a/decidim-admin/spec/commands/decidim/admin/create_taxonomy_filter_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/create_taxonomy_filter_spec.rb
@@ -72,12 +72,17 @@ module Decidim::Admin
           .with(
             Decidim::TaxonomyFilter,
             form.current_user,
-            hash_including(:root_taxonomy_id, :name, :internal_name, :filter_items, :participatory_space_manifests),
+            hash_including(:root_taxonomy_id, :name, :internal_name, :participatory_space_manifests),
             hash_including(extra: hash_including(:filter_items_count, :taxonomy_name))
           )
           .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
+      end
+
+      it "keeps filter_items_count counter cache accurate" do
+        subject.call
+        expect(last_taxonomy_filter.filter_items_count).to eq(taxonomy_items.size)
       end
     end
   end

--- a/decidim-admin/spec/commands/decidim/admin/update_taxonomy_filter_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_taxonomy_filter_spec.rb
@@ -61,12 +61,66 @@ module Decidim::Admin
           .with(
             taxonomy_filter,
             form.current_user,
-            hash_including(:name, :internal_name, :filter_items, :participatory_space_manifests),
+            hash_including(:name, :internal_name, :participatory_space_manifests),
             hash_including(extra: hash_including(:filter_items_count, :taxonomy_name))
           )
           .and_call_original
 
         expect { subject.call }.to change(Decidim::ActionLog, :count)
+      end
+    end
+
+    context "when syncing filter items" do
+      let!(:existing_items) { create_list(:taxonomy, 3, parent: root_taxonomy, organization:) }
+      let!(:taxonomy_filter) do
+        filter = create(:taxonomy_filter, root_taxonomy:)
+        existing_items.each { |item| create(:taxonomy_filter_item, taxonomy_filter: filter, taxonomy_item: item) }
+        filter
+      end
+      let(:new_item) { create(:taxonomy, parent: root_taxonomy, organization:) }
+
+      context "with a partial change (one removed, one added)" do
+        let(:taxonomies) { [existing_items[0], existing_items[1], new_item] }
+
+        it "removes only deselected items and inserts only newly selected items" do
+          subject.call
+          expect(taxonomy_filter.reload.filter_items.pluck(:taxonomy_item_id))
+            .to contain_exactly(existing_items[0].id, existing_items[1].id, new_item.id)
+        end
+
+        it "keeps filter_items_count counter cache accurate" do
+          subject.call
+          expect(taxonomy_filter.reload.filter_items_count).to eq(3)
+        end
+
+        it "keeps per-taxonomy filter_items_count counters accurate" do
+          subject.call
+          expect(existing_items[0].reload.filter_items_count).to eq(1)
+          expect(existing_items[2].reload.filter_items_count).to eq(0)
+          expect(new_item.reload.filter_items_count).to eq(1)
+        end
+      end
+
+      context "when no items changed" do
+        let(:taxonomies) { existing_items }
+
+        it "does not recreate existing filter items" do
+          original_ids = taxonomy_filter.filter_items.pluck(:id)
+          subject.call
+          expect(taxonomy_filter.filter_items.reload.pluck(:id)).to match_array(original_ids)
+        end
+      end
+
+      context "with a large filter" do
+        let(:existing_items) { create_list(:taxonomy, 50, parent: root_taxonomy, organization:) }
+        let(:taxonomies) { existing_items + [new_item] }
+
+        it "preserves existing filter item rows when adding new ones" do
+          original_ids = taxonomy_filter.filter_items.pluck(:id)
+          subject.call
+          preserved_ids = taxonomy_filter.filter_items.reload.where(taxonomy_item_id: existing_items.map(&:id)).pluck(:id)
+          expect(preserved_ids).to match_array(original_ids)
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Before this change, saving a taxonomy filter destroyed all of its items and created them again every time, even if only one checkbox was toggled. With around 1,200 items this took ~50 seconds.

This PR changes the Update and Create commands to compare the current items with the selected ones and only touch what actually changed: it destroys the items that were unchecked and creates the items that were newly checked. Everything else stays untouched. Editing a 1,200-item filter is now near-instant.

#### :pushpin: Related Issues
- Fixes #16802

#### Testing
Check the related issue to see how to replicate the error and test this fix.

### :camera: Screenshots
https://github.com/user-attachments/assets/cb8271c8-e034-40fc-9198-efbb10df386d


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed taxonomy filter item handling so selected items are saved and removed correctly on create and update.
  * Improved validation to prevent invalid taxonomy selections.

* **Improvements**
  * Incremental sync on updates to avoid full recreation and improve performance.
  * Filter counts and audit payload now report accurate selected-item counts and taxonomy name.
  * Rebuilt taxonomy items tree construction for more efficient rendering.

* **Tests**
  * Added specs covering sync behavior, preservation of existing items, and counter accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16829?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->