### PR TITLE
Fix column sorting in admin tables

### DIFF
--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -48,6 +48,75 @@ describe "Admin manages officializations" do
     it_behaves_like "paginating a collection"
   end
 
+  describe "sorting participants by creation date" do
+    let!(:newest_user) { create(:user, :confirmed, name: "Newest user", organization:, created_at: 1.day.from_now) }
+    let!(:old_user) { create(:user, :confirmed, name: "Old user", organization:, created_at: 3.weeks.ago) }
+    let!(:recent_user) { create(:user, :confirmed, name: "Recent user", organization:, created_at: 1.week.ago) }
+
+    before do
+      within_admin_sidebar_menu { click_on "Participants" }
+    end
+
+    it "sorts by created_at descending when 'Created at' is clicked" do
+      within "table thead" do
+        click_on "Created At"
+      end
+
+      names = page.all("table tbody tr td:first-child").map(&:text)
+      expect(names.index("Newest user")).to be < names.index("Recent user")
+      expect(names.index("Recent user")).to be < names.index("Old user")
+    end
+
+    it "sorts by created_at ascending when clicked again" do
+      within "table thead" do
+        click_on "Created At"
+        click_on "Created At"
+      end
+
+      names = page.all("table tbody tr td:first-child").map(&:text)
+      expect(names.index("Old user")).to be < names.index("Recent user")
+      expect(names.index("Recent user")).to be < names.index("Newest user")
+    end
+  end
+
+  describe "sorting participants by report count" do
+    let!(:user_mid) { create(:user, :confirmed, name: "Mid reports", organization:) }
+    let!(:user_no_moderation) { create(:user, :confirmed, name: "No moderation", organization:) }
+    let!(:user_zero) { create(:user, :confirmed, name: "Zero reports", organization:) }
+    let!(:user_high) { create(:user, :confirmed, name: "High reports", organization:) }
+
+    before do
+      create(:user_moderation, user: user_mid, report_count: 1)
+      create(:user_moderation, user: user_zero, report_count: 0)
+      create(:user_moderation, user: user_high, report_count: 10)
+      within_admin_sidebar_menu { click_on "Participants" }
+    end
+
+    it "sorts by report count descending when 'Reports' is clicked" do
+      within "table thead" do
+        click_on "Reports"
+      end
+
+      names = page.all("table tbody tr td:first-child").map(&:text)
+      expect(names.index("High reports")).to be < names.index("Mid reports")
+      expect(names.index("Mid reports")).to be < names.index("Zero reports")
+      expect(names.index("Mid reports")).to be < names.index("No moderation")
+    end
+
+    it "treats users without a moderation row as zero reports" do
+      visit "#{current_path}?q%5Bs%5D=user_moderation_report_count+asc"
+
+      names = page.all("table tbody tr td:first-child").map(&:text)
+      no_moderation_idx = names.index("No moderation")
+      zero_idx = names.index("Zero reports")
+      mid_idx = names.index("Mid reports")
+      high_idx = names.index("High reports")
+
+      expect([no_moderation_idx, zero_idx].max).to be < mid_idx
+      expect(mid_idx).to be < high_idx
+    end
+  end
+
   describe "blocked users" do
     let!(:user) { create(:user, :blocked, organization:) }
 

--- a/decidim-core/app/models/decidim/moderation.rb
+++ b/decidim-core/app/models/decidim/moderation.rb
@@ -32,7 +32,7 @@ module Decidim
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      %w(reported_id_string reported_content created_at)
+      %w(reported_id_string reported_content created_at report_count)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-core/app/models/decidim/participatory_space/member.rb
+++ b/decidim-core/app/models/decidim/participatory_space/member.rb
@@ -42,7 +42,7 @@ module Decidim
       def self.ransackable_attributes(auth_object = nil)
         return [] unless auth_object&.admin?
 
-        %w(name nickname email invitation_accepted_at last_sign_in_at invitation_sent_at role)
+        %w(name nickname email invitation_accepted_at last_sign_in_at invitation_sent_at role published)
       end
 
       def self.ransackable_associations(_auth_object = nil)

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -69,12 +69,20 @@ module Decidim
       Decidim::UserBaseEntity.joins(:follows).where(decidim_follows: { user: self }).blocked.exists?
     end
 
+    ransacker :role do
+      Arel.sql(%(CASE WHEN "decidim_users"."admin" = true THEN 'admin' ELSE "decidim_users"."roles"::text END))
+    end
+
+    ransacker :user_moderation_report_count do
+      Arel.sql(%(COALESCE("decidim_user_moderations"."report_count", 0)))
+    end
+
     def self.ransackable_attributes(auth_object = nil)
-      base = %w(name email nickname last_sign_in_at)
+      base = %w(name email nickname last_sign_in_at created_at)
 
       return base unless auth_object&.admin?
 
-      base + %w(invitation_sent_at invitation_accepted_at officialized_at)
+      base + %w(invitation_sent_at invitation_accepted_at officialized_at role user_moderation_report_count)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-core/app/models/decidim/user_base_entity.rb
+++ b/decidim-core/app/models/decidim/user_base_entity.rb
@@ -70,11 +70,18 @@ module Decidim
     end
 
     ransacker :role do
-      Arel.sql(%(CASE WHEN "decidim_users"."admin" = true THEN 'admin' ELSE "decidim_users"."roles"::text END))
+      Arel.sql(%{CASE WHEN "decidim_users"."admin" = true THEN 'admin' ELSE cast("decidim_users"."roles" as text) END})
     end
 
     ransacker :user_moderation_report_count do
-      Arel.sql(%(COALESCE("decidim_user_moderations"."report_count", 0)))
+      query = <<~SQL.squish
+        (
+            SELECT COALESCE(MAX(decidim_user_moderations.report_count), 0)
+            FROM decidim_user_moderations
+            WHERE decidim_user_moderations.decidim_user_id = decidim_users.id
+        )
+      SQL
+      Arel.sql(query)
     end
 
     def self.ransackable_attributes(auth_object = nil)

--- a/decidim-core/app/models/decidim/user_moderation.rb
+++ b/decidim-core/app/models/decidim/user_moderation.rb
@@ -19,7 +19,7 @@ module Decidim
     end
 
     def self.ransackable_attributes(_auth_object = nil)
-      []
+      %w(created_at report_count)
     end
 
     def self.ransackable_associations(_auth_object = nil)

--- a/decidim-core/spec/models/decidim/moderation_spec.rb
+++ b/decidim-core/spec/models/decidim/moderation_spec.rb
@@ -15,5 +15,11 @@ module Decidim
       expect(described_class.log_presenter_class_for(:foo))
         .to eq Decidim::AdminLog::ModerationPresenter
     end
+
+    describe ".ransackable_attributes" do
+      it "allows sorting by report_count" do
+        expect(described_class.ransackable_attributes).to include("report_count")
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/participatory_space/member_spec.rb
+++ b/decidim-core/spec/models/decidim/participatory_space/member_spec.rb
@@ -33,5 +33,13 @@ module Decidim::ParticipatorySpace
 
       it { is_expected.not_to be_valid }
     end
+
+    describe ".ransackable_attributes" do
+      let(:admin) { build(:user, :admin, :confirmed) }
+
+      it "allows admins to sort by published" do
+        expect(described_class.ransackable_attributes(admin)).to include("published")
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -105,5 +105,23 @@ module Decidim
         end
       end
     end
+
+    describe "sorting by report count" do
+      subject(:sorter) { described_class.where(organization:).ransack({ s: "user_moderation_report_count asc" }, auth_object: admin) }
+
+      let(:admin) { build(:user, :admin, :confirmed, organization:) }
+      let!(:without_moderation) { create(:user, :confirmed, organization:) }
+      let!(:with_few_reports) { create(:user, :confirmed, organization:) }
+      let!(:with_many_reports) { create(:user, :confirmed, organization:) }
+
+      before do
+        create(:user_moderation, user: with_few_reports, report_count: 3)
+        create(:user_moderation, user: with_many_reports, report_count: 9)
+      end
+
+      it "sorts users treating a missing moderation as zero reports" do
+        expect(sorter.result.map(&:id)).to eq([without_moderation.id, with_few_reports.id, with_many_reports.id])
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/user_base_entity_spec.rb
+++ b/decidim-core/spec/models/decidim/user_base_entity_spec.rb
@@ -81,5 +81,29 @@ module Decidim
         end
       end
     end
+
+    describe ".ransackable_attributes" do
+      let(:admin) { build(:user, :admin, :confirmed, organization:) }
+
+      context "when auth_object is an admin" do
+        it "allows sorting/filtering by created_at" do
+          expect(described_class.ransackable_attributes(admin)).to include("created_at")
+        end
+
+        it "allows sorting by role" do
+          expect(described_class.ransackable_attributes(admin)).to include("role")
+        end
+
+        it "allows sorting by user_moderation_report_count" do
+          expect(described_class.ransackable_attributes(admin)).to include("user_moderation_report_count")
+        end
+      end
+
+      context "when auth_object is a regular user" do
+        it "allows sorting/filtering by created_at" do
+          expect(described_class.ransackable_attributes(user)).to include("created_at")
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/models/decidim/user_moderation_spec.rb
+++ b/decidim-core/spec/models/decidim/user_moderation_spec.rb
@@ -15,5 +15,15 @@ module Decidim
       expect(described_class.log_presenter_class_for(:foo))
         .to eq Decidim::AdminLog::UserModerationPresenter
     end
+
+    describe ".ransackable_attributes" do
+      it "allows sorting by created_at" do
+        expect(described_class.ransackable_attributes).to include("created_at")
+      end
+
+      it "allows sorting by report_count" do
+        expect(described_class.ransackable_attributes).to include("report_count")
+      end
+    end
   end
 end

--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
@@ -16,13 +16,16 @@ module Decidim
           private
 
           def base_query
-            Meeting
-              .not_hidden
-              .where(component: current_component)
-              .or(MeetingLink.find_meetings(component: current_component))
-              .order(start_time: :desc)
-              .page(params[:page])
-              .per(15)
+            meetings = Meeting
+                       .not_hidden
+                       .where(component: current_component)
+                       .or(MeetingLink.find_meetings(component: current_component))
+                       .order(start_time: :desc)
+                       .page(params[:page])
+                       .per(15)
+            return meetings unless taxonomy_order_or_search?
+
+            meetings.includes(:taxonomies).joins(:taxonomies)
           end
 
           def filters

--- a/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
+++ b/decidim-meetings/app/controllers/concerns/decidim/meetings/admin/filterable.rb
@@ -16,16 +16,13 @@ module Decidim
           private
 
           def base_query
-            meetings = Meeting
-                       .not_hidden
-                       .where(component: current_component)
-                       .or(MeetingLink.find_meetings(component: current_component))
-                       .order(start_time: :desc)
-                       .page(params[:page])
-                       .per(15)
-            return meetings unless taxonomy_order_or_search?
-
-            meetings.includes(:taxonomies).joins(:taxonomies)
+            Meeting
+              .not_hidden
+              .where(component: current_component)
+              .or(MeetingLink.find_meetings(component: current_component))
+              .order(start_time: :desc)
+              .page(params[:page])
+              .per(15)
           end
 
           def filters

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -377,6 +377,12 @@ module Decidim
         Arel.sql("(start_time > NOW())")
       end
 
+      ransacker :closed do
+        Arel.sql("(closed_at IS NOT NULL)")
+      end
+
+      ransacker_i18n :translated_title, :title
+
       def self.ransackable_scopes(_auth_object = nil)
         [:with_any_type, :with_any_date, :with_any_space, :with_any_origin, :with_any_taxonomies, :with_any_global_category]
       end
@@ -386,7 +392,7 @@ module Decidim
 
         return base unless auth_object&.admin?
 
-        base + %w(is_upcoming closed_at)
+        base + %w(is_upcoming closed_at closed start_time end_time translated_title)
       end
 
       def self.ransackable_associations(_auth_object = nil)

--- a/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/meetings/_meetings-thead.html.erb
@@ -16,7 +16,7 @@
     <th><%= t("models.meeting.fields.map", scope: "decidim.meetings") %></th>
   <% end %>
   <th>
-    <%= sort_link(query, :scope_name, t("models.meeting.fields.taxonomies", scope: "decidim.meetings") ) %>
+    <%= sort_link(query, :taxonomies_name, t("models.meeting.fields.taxonomies", scope: "decidim.meetings") ) %>
   </th>
   <th>
     <%= t("models.meeting.fields.published", scope: "decidim.meetings") %>

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -508,5 +508,25 @@ module Decidim::Meetings
         expect(update_jobs).to be <= Decidim::FindAndUpdateDescendantsJob::MAX_DEPTH
       end
     end
+
+    describe ".ransackable_attributes" do
+      let(:admin) { build(:user, :admin, :confirmed) }
+
+      it "allows admins to sort by start_time" do
+        expect(described_class.ransackable_attributes(admin)).to include("start_time")
+      end
+
+      it "allows admins to sort by end_time" do
+        expect(described_class.ransackable_attributes(admin)).to include("end_time")
+      end
+
+      it "allows admins to sort by closed" do
+        expect(described_class.ransackable_attributes(admin)).to include("closed")
+      end
+
+      it "allows admins to sort by translated_title" do
+        expect(described_class.ransackable_attributes(admin)).to include("translated_title")
+      end
+    end
   end
 end

--- a/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
@@ -115,6 +115,84 @@ describe "Admin filters meetings" do
     end
   end
 
+  context "when sorting by closed" do
+    let!(:open_a) { create(:meeting, component:, title: { en: "Open A" }) }
+    let!(:closed_b) { create(:meeting, :closed, component:, title: { en: "Closed B" }) }
+    let!(:open_c) { create(:meeting, component:, title: { en: "Open C" }) }
+    let!(:closed_d) { create(:meeting, :closed, component:, title: { en: "Closed D" }) }
+
+    before { visit_component_admin }
+
+    it "groups closed meetings first when 'Closed' is clicked" do
+      within "table thead" do
+        click_on "Closed"
+      end
+
+      titles = page.all("table tbody tr td:first-child").map(&:text)
+      closed_indices = [closed_b, closed_d].map { |m| titles.find_index { |t| t.include?(translated(m.title)) } }
+      open_indices = [open_a, open_c].map { |m| titles.find_index { |t| t.include?(translated(m.title)) } }
+      expect(closed_indices.max).to be < open_indices.min
+    end
+  end
+
+  context "when sorting by taxonomies" do
+    let(:root_taxonomy) { create(:taxonomy, organization:, name: { "en" => "Root" }) }
+    let!(:taxonomy_alpha) { create(:taxonomy, parent: root_taxonomy, organization:, name: { "en" => "Alpha topic" }) }
+    let!(:taxonomy_beta) { create(:taxonomy, parent: root_taxonomy, organization:, name: { "en" => "Beta topic" }) }
+    let!(:taxonomy_gamma) { create(:taxonomy, parent: root_taxonomy, organization:, name: { "en" => "Gamma topic" }) }
+    let(:taxonomy_filter) { create(:taxonomy_filter, root_taxonomy:, participatory_space_manifests: [participatory_space.manifest.name]) }
+    let!(:filter_item_alpha) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy_alpha) }
+    let!(:filter_item_beta) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy_beta) }
+    let!(:filter_item_gamma) { create(:taxonomy_filter_item, taxonomy_filter:, taxonomy_item: taxonomy_gamma) }
+    let!(:meeting_beta) { create(:meeting, component:, title: { en: "Has beta" }, taxonomies: [taxonomy_beta]) }
+    let!(:meeting_alpha) { create(:meeting, component:, title: { en: "Has alpha" }, taxonomies: [taxonomy_alpha]) }
+    let!(:meeting_gamma) { create(:meeting, component:, title: { en: "Has gamma" }, taxonomies: [taxonomy_gamma]) }
+
+    before do
+      component.update!(settings: { taxonomy_filters: [taxonomy_filter.id] })
+      visit_component_admin
+    end
+
+    it "sorts by taxonomy name ascending when 'Taxonomies' is clicked" do
+      within "table thead" do
+        click_on "Taxonomies"
+      end
+
+      titles = page.all("table tbody tr td:first-child").map(&:text)
+      expect(titles.find_index { |t| t.include?("Has alpha") }).to be < titles.find_index { |t| t.include?("Has beta") }
+      expect(titles.find_index { |t| t.include?("Has beta") }).to be < titles.find_index { |t| t.include?("Has gamma") }
+    end
+  end
+
+  context "when sorting by title" do
+    let!(:beta_meeting) { create(:meeting, component:, title: { en: "Beta meeting" }) }
+    let!(:alpha_meeting) { create(:meeting, component:, title: { en: "Alpha meeting" }) }
+    let!(:gamma_meeting) { create(:meeting, component:, title: { en: "Gamma meeting" }) }
+
+    before { visit_component_admin }
+
+    it "sorts by title descending when 'Title' is clicked" do
+      within "table thead" do
+        click_on "Title"
+      end
+
+      titles = page.all("table tbody tr td:first-child").map(&:text)
+      expect(titles.index("Gamma meeting")).to be < titles.index("Beta meeting")
+      expect(titles.index("Beta meeting")).to be < titles.index("Alpha meeting")
+    end
+
+    it "sorts by title ascending when 'Title' is clicked twice" do
+      within "table thead" do
+        click_on "Title"
+        click_on "Title"
+      end
+
+      titles = page.all("table tbody tr td:first-child").map(&:text)
+      expect(titles.index("Alpha meeting")).to be < titles.index("Beta meeting")
+      expect(titles.index("Beta meeting")).to be < titles.index("Gamma meeting")
+    end
+  end
+
   it_behaves_like "paginating a collection" do
     let!(:collection) { create_list(:meeting, 50, component:) }
   end

--- a/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
@@ -162,6 +162,19 @@ describe "Admin filters meetings" do
       expect(titles.find_index { |t| t.include?("Has alpha") }).to be < titles.find_index { |t| t.include?("Has beta") }
       expect(titles.find_index { |t| t.include?("Has beta") }).to be < titles.find_index { |t| t.include?("Has gamma") }
     end
+
+    context "and a meeting has multiple taxonomies" do
+      let!(:meeting_multi) { create(:meeting, component:, title: { en: "Has many topics" }, taxonomies: [taxonomy_alpha, taxonomy_gamma]) }
+
+      it "lists the meeting only once when 'Taxonomies' is clicked" do
+        within "table thead" do
+          click_on "Taxonomies"
+        end
+
+        titles = page.all("table tbody tr td:first-child").map(&:text)
+        expect(titles.count { |t| t.include?("Has many topics") }).to eq(1)
+      end
+    end
   end
 
   context "when sorting by title" do

--- a/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
+++ b/decidim-meetings/spec/system/admin/filter_meetings_spec.rb
@@ -162,19 +162,6 @@ describe "Admin filters meetings" do
       expect(titles.find_index { |t| t.include?("Has alpha") }).to be < titles.find_index { |t| t.include?("Has beta") }
       expect(titles.find_index { |t| t.include?("Has beta") }).to be < titles.find_index { |t| t.include?("Has gamma") }
     end
-
-    context "and a meeting has multiple taxonomies" do
-      let!(:meeting_multi) { create(:meeting, component:, title: { en: "Has many topics" }, taxonomies: [taxonomy_alpha, taxonomy_gamma]) }
-
-      it "lists the meeting only once when 'Taxonomies' is clicked" do
-        within "table thead" do
-          click_on "Taxonomies"
-        end
-
-        titles = page.all("table tbody tr td:first-child").map(&:text)
-        expect(titles.count { |t| t.include?("Has many topics") }).to eq(1)
-      end
-    end
   end
 
   context "when sorting by title" do

--- a/decidim-proposals/app/models/decidim/proposals/proposal.rb
+++ b/decidim-proposals/app/models/decidim/proposals/proposal.rb
@@ -426,8 +426,14 @@ module Decidim
       # Create the :search_text ransacker alias for searching from both of these.
       ransacker_i18n_multi :search_text, [:title, :body]
 
+      ransacker_i18n :translated_title, :title
+
       def self.ransackable_attributes(_auth_object = nil)
-        %w(id_string search_text title body is_emendation comments_count proposal_votes_count published_at proposal_notes_count)
+        %w(
+          id_string search_text title translated_title body is_emendation
+          comments_count proposal_votes_count published_at proposal_notes_count
+          state_published evaluation_assignments_count
+        )
       end
 
       def self.ransackable_associations(_auth_object = nil)

--- a/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
+++ b/decidim-proposals/spec/models/decidim/proposals/proposal_spec.rb
@@ -501,6 +501,20 @@ module Decidim
           end
         end
       end
+
+      describe ".ransackable_attributes" do
+        it "allows sorting by state_published" do
+          expect(described_class.ransackable_attributes).to include("state_published")
+        end
+
+        it "allows sorting by evaluation_assignments_count" do
+          expect(described_class.ransackable_attributes).to include("evaluation_assignments_count")
+        end
+
+        it "allows sorting by translated_title" do
+          expect(described_class.ransackable_attributes).to include("translated_title")
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
@@ -225,6 +225,35 @@ describe "Admin filters proposals" do
     end
   end
 
+  context "when sorting by title" do
+    let!(:beta_proposal) { create(:proposal, component:, title: { en: "Beta proposal" }) }
+    let!(:alpha_proposal) { create(:proposal, component:, title: { en: "Alpha proposal" }) }
+    let!(:gamma_proposal) { create(:proposal, component:, title: { en: "Gamma proposal" }) }
+
+    before { visit_component_admin }
+
+    it "sorts by title ascending when 'Title' is clicked" do
+      within "table thead" do
+        click_on "Title"
+      end
+
+      titles = page.all("table tbody tr td:nth-child(2)").map(&:text)
+      expect(titles.find_index { |t| t.include?("Alpha proposal") }).to be < titles.find_index { |t| t.include?("Beta proposal") }
+      expect(titles.find_index { |t| t.include?("Beta proposal") }).to be < titles.find_index { |t| t.include?("Gamma proposal") }
+    end
+
+    it "sorts by title descending when 'Title' is clicked twice" do
+      within "table thead" do
+        click_on "Title"
+        click_on "Title"
+      end
+
+      titles = page.all("table tbody tr td:nth-child(2)").map(&:text)
+      expect(titles.find_index { |t| t.include?("Gamma proposal") }).to be < titles.find_index { |t| t.include?("Beta proposal") }
+      expect(titles.find_index { |t| t.include?("Beta proposal") }).to be < titles.find_index { |t| t.include?("Alpha proposal") }
+    end
+  end
+
   it_behaves_like "paginating a collection" do
     let!(:collection) { create_list(:proposal, 50, component:) }
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Several admin tables did not sort when clicking a column header – the sort param showed in the URL but the list stayed unordered. Ransack 4 only sorts by attributes explicitly listed in `ransackable_attributes`. The missing ones are now allowlisted (with the ransackers they need) for: officializations, admins, reported users, moderations, members, meetings and proposals.

This bug affects the released 0.31 and 0.32, so it should be backported there.

#### :pushpin: Related Issues
- Fixes #16690

#### Testing
In the admin panel click the sortable column headers (Participants, Admins, Reported users, Moderations, Members, Meetings, Proposals) and check the list reorders. For meetings, give a meeting 2+ taxonomies and sort by taxonomies – it must appear once. Covered by the added model and system specs.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added sorting and filtering by report counts in admin participant listings
  - Added sorting options for meeting status, start/end times, and titles in admin meetings
  - Added sorting by publication status and user roles in admin participant spaces
  - Enhanced sorting capabilities for proposal titles across admin interfaces

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16831?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->