### PR TITLE
Move the 'add comment' textarea below the blocked comments warning

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comments/inline.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/inline.erb
@@ -1,10 +1,5 @@
 <div id="comments">
   <div class="comments">
-    <% if user_signed_in? %>
-      <button class="button button__lg button__secondary flex md:hidden w-full h-9 text-sm add-comment-mobile">
-        <%= t("add_comment", scope: "decidim.components.add_comment_form") %>
-      </button>
-    <% end %>
     <%= user_comments_blocked_warning %>
     <div class="comments__header mt-8">
       <h2 class="h4">
@@ -26,6 +21,11 @@
     <%= single_comment_warning %>
     <%= blocked_comments_warning %>
     <%= add_comment %>
+    <% if user_signed_in? %>
+      <button class="button button__lg button__secondary flex md:hidden w-full h-9 text-sm add-comment-mobile">
+        <%= t("add_comment", scope: "decidim.components.add_comment_form") %>
+      </button>
+    <% end %>
     <%= render_comments %>
   </div>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comments/inline.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/inline.erb
@@ -5,7 +5,6 @@
         <%= t("add_comment", scope: "decidim.components.add_comment_form") %>
       </button>
     <% end %>
-    <%= add_comment %>
     <%= user_comments_blocked_warning %>
     <div class="comments__header mt-8">
       <h2 class="h4">
@@ -26,6 +25,7 @@
     </div>
     <%= single_comment_warning %>
     <%= blocked_comments_warning %>
+    <%= add_comment %>
     <%= render_comments %>
   </div>
 </div>

--- a/decidim-comments/app/packs/src/decidim/comments/comments_mobile_modal.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments_mobile_modal.js
@@ -2,7 +2,6 @@
 // 2. Handles dropdown menus: Dynamically updates button content based on user selection, hides selected items, and manages dropdown visibility.
 // This creates a responsive, interactive comment interface with mobile-friendly design and dynamic user group selection.
 
-import { screens } from "tailwindcss/defaultTheme"
 import { initializeCommentsDropdown } from "../../decidim/comments/comments_dropdown";
 
 // Add comment card for mobile

--- a/decidim-comments/app/packs/src/decidim/comments/comments_mobile_modal.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments_mobile_modal.js
@@ -7,11 +7,8 @@ import { initializeCommentsDropdown } from "../../decidim/comments/comments_drop
 
 // Add comment card for mobile
 const addCommentMobile = function (addCommentCard) {
-  const smBreakpoint = parseInt(screens.sm.replace("px", ""), 10);
-  if (window.matchMedia(`(max-width: ${smBreakpoint}px)`).matches) {
-    addCommentCard.classList.remove("hidden");
-    addCommentCard.classList.add("fullscreen");
-  }
+  addCommentCard.classList.remove("hidden");
+  addCommentCard.classList.add("fullscreen");
 };
 
 const closeAddComment = function (addCommentCard) {

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -73,7 +73,7 @@
 }
 
 .comment {
-  @apply rounded-lg border-2 border-background-5 p-3 pl-6;
+  @apply rounded-lg border-2 border-background-5 p-3 pl-6 mt-4 md:mt-0;
 
   &.top-comment {
     @apply border-gray-2;

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -140,7 +140,7 @@
   }
 
   &-thread {
-    @apply mb-8;
+    @apply mb-4;
 
     .button[aria-expanded="false"] {
       svg:first-of-type {

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -6,7 +6,7 @@
   }
 
   .add-comment {
-    @apply mt-2 md:bg-gray-5 p-0 md:px-4 md:pb-6 md:pt-1 rounded-lg w-full;
+    @apply mt-2 mb-4 md:bg-gray-5 p-0 md:px-4 md:pb-6 md:pt-1 rounded-lg w-full;
 
     .new_comment {
       @apply w-full;


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session:  

> **Describe the bug**
> 1. As an administrator, I create an official meeting
> 1. I define the permission to comment to “Ephemeral”
> 1. I go on the meeting
> Error: I can comment, I see no success callouts to confirm the submission of the comment. 
>
> **Expected behavior**
> I should not be able to comment if I’ve not the permission I’ve defined. IF this was intended result (as I am an admin), the the warning should be before the form.
> Once published, I should be notified the comment has been saved AND the text field should be empty

Reported by:  @froger 

Apart from this, I've also added some margins to make it work better.

#### :pushpin: Related Issues
 
- Related to #16073 (I think this is when we moved the textarea at the top, but I'm not 100% sure)

#### Testing

1. As an administrator, I create a meeting component
2. I create an official meeting with comments enabled, and permission to comment “ephemeral example”
3. THEN as an admin, I can create a comment without having the authorization
4. THEN as a participant, I do not see the comment form, nor any way of getting the authorization

As this is intentional (the callout say "Comments are currently disabled, only administrators can reply or post new ones.") I'm applying the "callout should be before the form" part: 

<img width="726" height="340" alt="image" src="https://github.com/user-attachments/assets/88c598a8-4ef3-4a9f-b35f-8c557ee97023" />


About the other bugs:

1. "The comment field is still with the value I published" -> I could not reproduce it locally
2. " I should be notified the comment has been saved " -> as this is an dynamic (i.e. AJAX/XHR post) we don't have an UX pattern for this, only the reload :/ I can talk with @julietapasetti to see if we can come-up with something here (if she thinks is necessary). Update: we talked about it and we don't consider necessary to add a callout here (specially if the textarea clears after sending the comment, as it should)

### :camera: Screenshots

#### Before

<img width="1598" height="1446" alt="2026-05-19-110423_hyprshot" src="https://github.com/user-attachments/assets/19fd8901-3b4c-415d-b230-9373715eaed3" />

#### After

<img width="1650" height="1524" alt="2026-05-19-110723_hyprshot" src="https://github.com/user-attachments/assets/1d704ee2-a20c-43f3-91c1-6c5f90cb4e07" />

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The comment input form now appears after warning/blocking notices so users see important messages before composing a comment.
  * The mobile add-comment dialog always opens fullscreen for consistent behavior across devices.

* **Style**
  * Updated spacing around the add-comment form and comment threads for a cleaner, more consistent layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->