### PR TITLE
Fix system organization form (short name update and only one locale)

### DIFF
--- a/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -45,6 +45,7 @@ module Decidim
 
       def save_organization
         organization.name = form.name
+        organization.short_name = form.short_name
         organization.host = form.host
         organization.secondary_hosts = form.clean_secondary_hosts
         organization.force_users_to_authenticate_before_access_organization = form.force_users_to_authenticate_before_access_organization

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -82,7 +82,7 @@ module Decidim
           host: request.host,
           organization_admin_name: current_admin.email.split("@")[0],
           organization_admin_email: current_admin.email,
-          available_locales: [Decidim.default_locale.to_s],
+          available_locales: [Decidim.default_locale],
           default_locale: Decidim.default_locale,
           users_registration_mode: "enabled"
         }

--- a/decidim-system/app/controllers/decidim/system/organizations_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/organizations_controller.rb
@@ -82,7 +82,7 @@ module Decidim
           host: request.host,
           organization_admin_name: current_admin.email.split("@")[0],
           organization_admin_email: current_admin.email,
-          available_locales: Decidim.available_locales.map(&:to_s),
+          available_locales: [Decidim.default_locale.to_s],
           default_locale: Decidim.default_locale,
           users_registration_mode: "enabled"
         }

--- a/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/update_organization_spec.rb
@@ -58,6 +58,7 @@ module Decidim
             organization = Organization.last
 
             expect(translated(organization.name)).to eq("Gotham City")
+            expect(translated(organization.short_name)).to eq("GothamCity")
             expect(organization.host).to eq("decide.example.org")
             expect(organization.secondary_hosts).to contain_exactly("foo.example.org", "bar.example.org")
             expect(organization.users_registration_mode).to eq("existing")

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -33,6 +33,7 @@ describe "Organizations" do
         expect(find(:xpath, "//input[@id='organization_organization_admin_name']").value).to eq(admin.email.split("@")[0])
         expect(find(:xpath, "//input[@id='organization_organization_admin_email']").value).to eq(admin.email)
         within "table" do
+          expect(page).to have_field("input[type='checkbox']:checked", count: 1)
           expect(find(:xpath, "//input[@id='organization_available_locales_#{Decidim.default_locale}']")).to be_checked
           expect(find(:xpath, "//input[@name='organization[default_locale]']", match: :first)).to be_checked
         end

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -33,7 +33,7 @@ describe "Organizations" do
         expect(find(:xpath, "//input[@id='organization_organization_admin_name']").value).to eq(admin.email.split("@")[0])
         expect(find(:xpath, "//input[@id='organization_organization_admin_email']").value).to eq(admin.email)
         within "table" do
-          expect(all("input[type=checkbox]")).to all(be_checked)
+          expect(find(:xpath, "//input[@id='organization_available_locales_#{Decidim.default_locale}']")).to be_checked
           expect(find(:xpath, "//input[@name='organization[default_locale]']", match: :first)).to be_checked
         end
         expect(find(:xpath, "//input[@name='organization[users_registration_mode]']", match: :first).value).to eq("enabled")

--- a/decidim-system/spec/system/organizations_spec.rb
+++ b/decidim-system/spec/system/organizations_spec.rb
@@ -33,7 +33,7 @@ describe "Organizations" do
         expect(find(:xpath, "//input[@id='organization_organization_admin_name']").value).to eq(admin.email.split("@")[0])
         expect(find(:xpath, "//input[@id='organization_organization_admin_email']").value).to eq(admin.email)
         within "table" do
-          expect(page).to have_field("input[type='checkbox']:checked", count: 1)
+          expect(page).to have_field(type: "checkbox", checked: true, count: 1)
           expect(find(:xpath, "//input[@id='organization_available_locales_#{Decidim.default_locale}']")).to be_checked
           expect(find(:xpath, "//input[@name='organization[default_locale]']", match: :first)).to be_checked
         end


### PR DESCRIPTION
#### :tophat: What? Why?
##### First fix
When a system administrator edited an organization and filled in the "short name" field, the value appeared to be saved, but after refreshing the page, the field was empty again. This happened every time, making the field impossible to update. This PR adds the missing step so that the short name is now saved to the database along with all other organization fields.

##### Second fix
When creating a new organization, the language selection form used to have every available language pre-checked, sometimes dozens of them, forcing administrators to uncheck each unwanted language one by one manually. Now, only the default language is pre-selected, so administrators only need to add the extra languages they actually want.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16828 

#### Testing
First:
1. Go to /system
2. Edit an organization, press "save".
3. See the error as the short name field is not filled.

Second:
1. Go to /system
2. Create a new organization.
3. Go patiently through over 50 checkboxes to disable languages you don't want.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Organization short names are now saved and persisted when updating organization details.
  * Default locale selection for new organizations now defaults exclusively to the system default locale.

* **Tests**
  * Specs tightened to assert short name persistence and to verify only the system default locale is preselected during organization creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->