### PR TITLE
Fix image upload HTML validation errors

### DIFF
--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -78,7 +78,7 @@ const updateActiveUploads = (modal) => {
 
     const template = `
       <div ${attachmentIdOrHiddenField} data-filename="${escapeHtml(file.name)}" data-title="${escapeHtml(title)}">
-        ${(/image/).test(file.type) && "<div><img src=\"data:,\" role=\"presentation\" /></div>" || ""}
+        ${(/image/).test(file.type) && "<div><img src=\"data:,\" alt=\"\" /></div>" || ""}
         <p>${escapeHtml(title)}</p>
         ${hidden}
       </div>

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_field.js
@@ -1,5 +1,5 @@
 import UploadModal from "src/decidim/direct_uploads/upload_modal";
-import { escapeHtml, escapeQuotes } from "src/decidim/utilities/text";
+import { escapeHtml } from "src/decidim/utilities/text";
 
 const updateModalTitle = (modal) => {
   if (modal.uploadItems.children.length === 0) {
@@ -67,7 +67,7 @@ const updateActiveUploads = (modal) => {
       const titleField = isMultiple
         ? `${modal.options.resourceName}[${modal.options.addAttribute}][${ix}][title]`
         : `${modal.options.resourceName}[${modal.options.addAttribute}][title]`
-      hidden += `<input type="hidden" name="${titleField}" value="${escapeQuotes(titleValue)}" />`
+      hidden += `<input type="hidden" name="${titleField}" value="${escapeHtml(titleValue)}" />`
 
       title = titleValue
     }
@@ -77,7 +77,7 @@ const updateActiveUploads = (modal) => {
       : `data-hidden-field="${file.hiddenField}"`
 
     const template = `
-      <div ${attachmentIdOrHiddenField} data-filename="${escapeQuotes(file.name)}" data-title="${escapeQuotes(title)}">
+      <div ${attachmentIdOrHiddenField} data-filename="${escapeHtml(file.name)}" data-title="${escapeHtml(title)}">
         ${(/image/).test(file.type) && "<div><img src=\"data:,\" role=\"presentation\" /></div>" || ""}
         <p>${escapeHtml(title)}</p>
         ${hidden}

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -1,6 +1,6 @@
 import { Uploader } from "src/decidim/direct_uploads/uploader";
 import icon from "src/decidim/refactor/moved/icon";
-import { escapeHtml, escapeQuotes } from "src/decidim/utilities/text";
+import { escapeHtml } from "src/decidim/utilities/text";
 
 const STATUS = {
   VALIDATED: "validated",
@@ -170,7 +170,7 @@ export default class UploadModal {
 
   createUploadItem(file, errors, opts = {}) {
     const okTemplate = `
-      <img src="data:,", role="presentation" />
+      <img src="data:," alt="" />
       <span class="upload-modal__span">${escapeHtml(file.name)}</span>
     `
 
@@ -184,7 +184,7 @@ export default class UploadModal {
     `
 
     const titleTemplate = `
-      <img src="data:," role="presentation" />
+      <img src="data:," alt="" />
       <div>
         <div>
           <label>${this.locales.filename}</label>
@@ -192,7 +192,7 @@ export default class UploadModal {
         </div>
         <div>
           <label for="${file.name}">${this.locales.title}</label>
-          <input class="sm" type="text" value="${escapeQuotes(opts.title || file.name)}" id="${file.name}" />
+          <input class="sm" type="text" value="${escapeHtml(opts.title || file.name)}" id="${file.name}" />
         </div>
       </div>
     `
@@ -216,7 +216,7 @@ export default class UploadModal {
       ? `data-attachment-id="${opts.attachmentId}"`
       : ""
     const fullTemplate = `
-      <li ${attachmentId} data-filename="${escapeQuotes(file.name)}" data-state="${state}">
+      <li ${attachmentId} data-filename="${escapeHtml(file.name)}" data-state="${state}">
         <div data-template="${template}">
           ${content.trim()}
           <button>${this.locales.remove}</button>
@@ -252,7 +252,7 @@ export default class UploadModal {
   }
 
   setProgressBar(name, value) {
-    this.uploadItems.querySelector(`[data-filename="${escapeQuotes(name)}"] progress`).value = value
+    this.uploadItems.querySelector(`[data-filename="${escapeHtml(name)}"] progress`).value = value
   }
 
   updateAddAttachmentsButton() {

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -183,6 +183,7 @@ export default class UploadModal {
       </div>
     `
 
+    const titleInputId = `upload-title-${this.getOrdinalNumber()}`
     const titleTemplate = `
       <img src="data:," alt="" />
       <div>
@@ -191,8 +192,8 @@ export default class UploadModal {
           <span class="upload-modal__span">${escapeHtml(file.name)}</span>
         </div>
         <div>
-          <label for="${file.name}">${this.locales.title}</label>
-          <input class="sm" type="text" value="${escapeHtml(opts.title || file.name)}" id="${file.name}" />
+          <label for="${titleInputId}">${this.locales.title}</label>
+          <input class="sm" type="text" value="${escapeHtml(opts.title || file.name)}" id="${titleInputId}" />
         </div>
       </div>
     `
@@ -252,7 +253,10 @@ export default class UploadModal {
   }
 
   setProgressBar(name, value) {
-    this.uploadItems.querySelector(`[data-filename="${escapeHtml(name)}"] progress`).value = value
+    const item = Array.from(this.uploadItems.querySelectorAll("[data-filename]")).find((el) => el.dataset.filename === name);
+    if (item) {
+      item.querySelector("progress").value = value;
+    }
   }
 
   updateAddAttachmentsButton() {

--- a/decidim-core/app/packs/src/decidim/utilities/text.js
+++ b/decidim-core/app/packs/src/decidim/utilities/text.js
@@ -1,3 +1,11 @@
+const escapeQuotes = (text) => {
+  if (!text) {
+    return "";
+  }
+
+  return text.replace(/"/g, "&quot;");
+}
+
 export const escapeHtml = (text) => {
   if (!text) {
     return "";
@@ -5,13 +13,5 @@ export const escapeHtml = (text) => {
 
   const el = document.createElement("div");
   el.appendChild(document.createTextNode(text));
-  return el.innerHTML;
-}
-
-export const escapeQuotes = (text) => {
-  if (!text) {
-    return "";
-  }
-
-  return text.replace(/"/g, "&quot;");
+  return escapeQuotes(el.innerHTML);
 }


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed some tests failing due to validation errors on the image upload modal.

Validation errors:
- Extra comma inside the `<img>` tag originating from #14788
- The `role="presentation"` attribute not allowed on the `<img>` tag (see e.g. [this article](https://rocketvalidator.com/html-validation/bad-value-presentation-for-attribute-role-on-element-img))

At the same time, I also fixed the cases where `escapeQuotes` was used instead of `escapeHtml`. This could lead to some issues if the file name contains unexpected characters (rare but technically possible). I also made the `escapeQuotes` an internal method in the text utility not to endorse its usage, as `escapeHtml` is better and should be used instead.

Example failed test run:
https://github.com/decidim/decidim/actions/runs/26085623791/job/76697871917?pr=11036

Relevant output:

```
  1) Account when on the account page behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       ######
       line 909: Attribute “,” not allowed on element “img” at this point.

             <ul class="upload-modal__dropzone" data-dropzone-items="" data-locales="{&quot;error&quot;:&quot;Error!&quot;,&quot;title_required&quot;:&quot;Title is required!&quot;,&quot;filename&quot;:&quot;Filename&quot;,&quot;file_size_too_large&quot;:&quot;File size is too large! Maximun file size: 5MB&quot;,&quot;remove&quot;:&quot;Remove&quot;,&quot;title&quot;:&quot;Title&quot;,&quot;uploaded&quot;:&quot;Uploaded&quot;,&quot;validating&quot;:&quot;Validating...&quot;,&quot;validation_error&quot;:&quot;Validation error! Check that the file has an allowed extension or size.&quot;}"><li data-filename="avatar.jpg" data-state="validated">
               <div data-template="ok">
       >>          <img src="data:image/*;base64,..." ,="" role="presentation">
             <span class="upload-modal__span">avatar.jpg</span>
                 <button>Remove</button>
               </div>

       ######
       line 909: An “img” element with a “role” attribute must also have an accessible name (e.g., an “alt” attribute).

             <ul class="upload-modal__dropzone" data-dropzone-items="" data-locales="{&quot;error&quot;:&quot;Error!&quot;,&quot;title_required&quot;:&quot;Title is required!&quot;,&quot;filename&quot;:&quot;Filename&quot;,&quot;file_size_too_large&quot;:&quot;File size is too large! Maximun file size: 5MB&quot;,&quot;remove&quot;:&quot;Remove&quot;,&quot;title&quot;:&quot;Title&quot;,&quot;uploaded&quot;:&quot;Uploaded&quot;,&quot;validating&quot;:&quot;Validating...&quot;,&quot;validation_error&quot;:&quot;Validation error! Check that the file has an allowed extension or size.&quot;}"><li data-filename="avatar.jpg" data-state="validated">
               <div data-template="ok">
       >>          <img src="data:image/*;base64,..." ,="" role="presentation">


     Shared Example Group: "accessible page" called from ./spec/system/account_spec.rb:32
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:132:in 'block (2 levels) in <top (required)>'

Finished in 11 minutes 18 seconds (files took 18.38 seconds to load)
176 examples, 1 failure

Failed examples:

rspec ./spec/system/account_spec.rb[1:2:1:2] # Account when on the account page behaves like accessible page passes HTML validation
```

#### :pushpin: Related Issues
- Related to #14788

#### Testing
```bash
for i in {1..100}; do bundle exec rspec spec/system/account_spec.rb[1:2:1:2] || break; done
```

(you shouldn't need 100 runs, the failure should happen rather quickly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Strengthened handling of uploaded file names and titles to prevent unsafe characters and ensure consistent display
* Improved upload dialog image markup for better accessibility (clearer image semantics)
* Fixed upload progress matching so progress indicators reliably update the correct file/item

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->