### PR TITLE
Fix crash on login/logout with unsupported image file extensions

### DIFF
--- a/decidim-core/app/uploaders/decidim/image_uploader.rb
+++ b/decidim-core/app/uploaders/decidim/image_uploader.rb
@@ -8,7 +8,7 @@ module Decidim
     end
 
     def content_type_allowlist
-      extension_allowlist.map { |ext| MiniMime.lookup_by_extension(ext).content_type }.uniq
+      extension_allowlist.filter_map { |ext| MiniMime.lookup_by_extension(ext)&.content_type }.uniq
     end
 
     # Fetches info about different variants, their processors and dimensions

--- a/decidim-core/spec/uploaders/image_uploader_spec.rb
+++ b/decidim-core/spec/uploaders/image_uploader_spec.rb
@@ -30,6 +30,18 @@ module Decidim
       it "returns the correct MIME types" do
         expect(subject).to eq(%w(image/jpeg image/gif image/png))
       end
+
+      context "when the allowlist contains unsupported extensions" do
+        let(:extensions) { %w(jpg asdf silly png) }
+
+        it "does not raise" do
+          expect { subject }.not_to raise_error
+        end
+
+        it "returns only the MIME types for known extensions" do
+          expect(subject).to eq(%w(image/jpeg image/png))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If you have file extensions added in your organization settings in /system that Decidim does not support, the system crashes on login/logouts. With this PR, invalid file extensions are ignored.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16832

#### Testing

1. Go to /system
2. Edit your organization, click "Advanced settings."
3. Add a silly extension in the "Image file extensions" (i.e., asdf).
4. Log in to your Decidim
5. Log out, see the system crashing, and you are not logged out.


### :camera: Screenshots
<img width="1458" height="184" alt="image" src="https://github.com/user-attachments/assets/9b75b88d-e41e-48ce-9375-9c125dde1b7f" />
image file extensions

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image upload validation by gracefully handling unsupported file extensions in organization allowlists. The system now properly filters out unrecognized image formats instead of raising validation errors, ensuring more reliable upload processing and preventing disruptions when administrators configure allowlists with unsupported file types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16850?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->