### PR TITLE
System docs: document how to delete an Organization through a script (#15825)

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -27,6 +27,7 @@ adjunt
 admins
 adoc
 AFFERO
+affordance
 AGPL
 aitools
 Ajuntament
@@ -34,6 +35,7 @@ Ajuntamentde
 alabs
 alecslupu
 Alexandru
+alexrlpz
 amagat
 amd
 amendables

--- a/docs/modules/configure/pages/system.adoc
+++ b/docs/modules/configure/pages/system.adoc
@@ -127,7 +127,7 @@ in multi tenant mode. To learn more, check this https://developer.mozilla.org/en
 ==== Allow participants to register and login
 
 Most of the installations use this setting. Means that everyone can register a participant account and login, without restrictions, only with an email account confirmation.
-You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc.adoc[Decidim's environment variables], although we do not recommend doing that,
+You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc[Decidim's environment variables], although we do not recommend doing that,
 as it is a measure for stopping spam accounts. For additional details, read about `DECIDIM_UNCONFIRMED_ACCESS_FOR` environment variable.
 
 ==== Do not allow participants to register, but allow existing participants to login
@@ -175,13 +175,25 @@ of the `Host` field in the System panel (for example `decidim.example.org`).
 This is what uniquely identifies the organization in the database.
 . Take a fresh database backup.
 . Download the script to your Decidim application root (the directory that
-contains `bin/rails`):
+contains `bin/rails`). The URL below is *pinned to an immutable gist
+revision* so the content you download is exactly what is documented here, not
+whatever the gist's owner has on `HEAD` at the time you run the command:
 +
 [source, console]
 ....
 curl -L -o destroy_organization.rb \
-  https://gist.githubusercontent.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7/raw/destroy_organization.rb
+  https://gist.githubusercontent.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7/raw/abba116b844672635e3735a07f6add9171ace798/destroy_organization.rb
 ....
+. Verify the integrity of the downloaded file against the known
+`sha256` of the pinned revision above before doing anything else with it:
++
+[source, console]
+....
+echo "05a348d38f0070377a56b791ecc89b950c9eb4bde962ede061190ab1bfb9c3e4  destroy_organization.rb" | shasum -a 256 -c -
+....
++
+If the check fails, *stop*: the file you downloaded does not match the
+revision this guide was written against, and you should not run it.
 . Review the script's contents. It deletes data from many tables — including
 users, participatory spaces, components, moderations, action logs, and
 `PaperTrail` versions — for the organization matching the given host. If you

--- a/docs/modules/configure/pages/system.adoc
+++ b/docs/modules/configure/pages/system.adoc
@@ -143,3 +143,90 @@ In the case where you have an external provider configured (like the `Omniauth s
 Finally, you can also Edit an organization, although some fields cannot be changed as some contents in the database depends on them.
 
 For accessing your newly created Organization, you can do it by going to the domain or subdomain that you have configured in `Host`.
+
+== Delete an organization
+
+The System Panel intentionally **does not** expose a button to delete an organization.
+A Decidim organization is the root of a large tree of records — users, participatory
+spaces (processes, assemblies, conferences, initiatives, consultations), components,
+attachments, taxonomies, moderation traces, audit logs, etc. Deleting all of those
+records correctly requires running a database-level script that walks the entire
+tree and handles a number of validation, search-index, and `PaperTrail` callbacks
+along the way. There is no way to undo this operation; once an organization is
+deleted, all of its data is gone.
+
+If you really need to delete an organization (for example to remove a stale demo
+instance from a multi-tenant install, or after migrating its data elsewhere),
+the community currently maintains a Ruby script that does the deletion in the
+right order: link:https://gist.github.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7[gist.github.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7].
+The script is run with `rails runner` and takes the organization's host as a
+single argument.
+
+WARNING: **This is a destructive, irreversible operation.** Always take a full
+database backup before running the script (`pg_dump`, snapshot, or whatever
+backup tooling your platform offers), and run it first against a copy of your
+database — never directly on production. Read the script before running it so
+you understand exactly which tables it will touch on your installation.
+
+=== Steps
+
+. Identify the `host` of the organization you want to delete. This is the value
+of the `Host` field in the System panel (for example `decidim.example.org`).
+This is what uniquely identifies the organization in the database.
+. Take a fresh database backup.
+. Download the script to your Decidim application root (the directory that
+contains `bin/rails`):
++
+[source, console]
+....
+curl -L -o destroy_organization.rb \
+  https://gist.githubusercontent.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7/raw/destroy_organization.rb
+....
+. Review the script's contents. It deletes data from many tables — including
+users, participatory spaces, components, moderations, action logs, and
+`PaperTrail` versions — for the organization matching the given host. If you
+maintain custom modules with their own organization-scoped tables, you may
+need to extend the script to clean those up too.
+. Run the script with `rails runner` against your **production-like backup
+database** first, passing the host as the argument. The script asks for an
+interactive `YES` confirmation before deleting anything:
++
+[source, console]
+....
+bin/rails runner destroy_organization.rb decidim.example.org
+....
+. If the dry-run on the backup succeeds and the resulting database looks
+correct, only then run the same command against the real database.
+
+=== What the script does, at a high level
+
+The script is intentionally long because Decidim is a large platform; at a
+high level it:
+
+* monkey-patches a handful of models (e.g. `Decidim::StaticPage`,
+`Decidim::ActionLog`, `Decidim::Comments::Comment`,
+`Decidim::Meetings::Meeting`, `Decidim::ConferenceMeeting`,
+`Decidim::Initiative`) so default static pages, action logs, and
+searchable resources do not block deletion;
+* disables `PaperTrail` for the duration of the run so deleting traceable
+entities does not create yet more rows in `PaperTrail::Version`;
+* finds the target organization by `host` and walks every participatory
+space it owns (processes, assemblies, conferences, initiatives,
+consultations), destroying each space's components, attachments,
+categorizations, moderations, and `PaperTrail` versions;
+* deletes per-user data (amendments, coauthorships, badges, impersonation
+logs, reports, blocks, authorizations, moderations, comments, …) for
+every user that belongs to the organization, then the users themselves;
+* deletes the organization-scoped “system” tables that are not cleaned up by
+ActiveRecord callbacks (areas, scopes, OAuth applications, content blocks,
+identities, metrics, share tokens, short links, static pages, user groups,
+…);
+* finally destroys the `Decidim::Organization` record itself.
+
+NOTE: There is an open discussion to surface a clearer "this cannot be deleted
+from the UI on purpose, here is how to do it from the console" affordance in
+the System Panel (see https://github.com/decidim/decidim/issues/15825[issue #15825])
+and previous related issues
+https://github.com/decidim/decidim/issues/9291[#9291] and
+https://github.com/decidim/decidim/issues/15610[#15610]. Once those land, this
+page will be updated accordingly.


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Closes #15825.

## What changed

Adds a new "Delete an organization" section to
\`docs/modules/configure/pages/system.adoc\`, immediately after
"Edit an organization", that fills the gap reported in #15825:
the System Panel deliberately does not expose a delete button,
and there is currently no place in the docs that tells operators
what to do instead.

The new section:

- explains *why* no UI deletion exists (organization is the root of
  a large tree of records and the deletion needs to walk it correctly,
  handle PaperTrail / search-index callbacks, etc.);
- points at the community-maintained
  [\`destroy_organization.rb\` gist](https://gist.github.com/alexrlpz/90bcdb6304d68d21360d1ffa9c9bd1c7)
  referenced from the issue itself, with a \`curl\` snippet to fetch
  it next to \`bin/rails\`;
- gives a numbered procedure: identify the organization's \`host\`,
  take a backup, dry-run against a copy of the database, then run
  the real deletion;
- adds a \`WARNING\` admonition that this is destructive and
  irreversible;
- includes a high-level summary of what the script actually does so
  operators have an understandable mental model before running it
  (model monkey-patches to permit deletion, PaperTrail disable, walk
  every participatory space and per-user data, clean up
  organization-scoped "system" tables, destroy the
  \`Decidim::Organization\` record last);
- and cross-references #15825, #9291 and #15610 so readers can
  follow the longer-term plan of surfacing this in the System Panel.

## Why this PR

The issue (#15825) explicitly asks for a docs entry pointing operators
to the deletion script. It has been open with 0 comments and no PR.
This is a docs-only change that does not block or pre-empt the
follow-on UI work tracked in #15825 / #9291 / #15610.

## Verification

Rendered the page locally with:

\`\`\`
asciidoctor --safe-mode unsafe -o /tmp/system.html docs/modules/configure/pages/system.adoc
\`\`\`

Page builds cleanly with no warnings; the new "Delete an
organization" section, the \`curl\` snippet, and the issue
cross-references all render correctly.

No application code touched.

---

AI-assisted via Cursor (Claude Opus 4.7).
Personal token-burn initiative by @adv0r: contributing OSS work using
leftover Cursor credits before subscription renewal.
Authored and verified by an AI agent operating **unattended**.
**Not human-reviewed before submission** — please review carefully.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for deleting organizations: step‑by‑step procedure, mandatory backups, verification of the deletion artifact, running against a backup first, safety precautions, and a high‑level summary of the deletion workflow (recursive cleanup, per‑user data removal, organization‑scoped table cleanup, final organization removal). Corrected a broken cross‑reference in the users registration mode section.
* **Chores**
  * Updated spelling dictionary with two new entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
