### PR TITLE
Install docs: document AI/spam-detection rake tasks in Scheduled tasks (#14202)

### DIFF
--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -144,6 +144,55 @@ If you have installed the `decidim-initiatives` module, you may want to add to y
 0 8 * * * cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim_initiatives:notify_progress
 ----
 
+==== Spam-detection (AI) module
+
+The `decidim-ai` module ships a spam-detection engine that classifies user
+profiles and resources. The Rake tasks that drive it are *training and
+maintenance commands rather than cron jobs* — they are run once on install
+and then whenever you want to re-train the classifier. There is currently
+no scheduled task that you should add to `crontab` for spam detection; the
+classifier learns from reports made through the platform's
+"report as spam" affordances in real time.
+
+The relevant tasks, all under the `decidim:ai:spam` namespace, are:
+
+[source,console]
+----
+# Create the system user that owns the spam reports the classifier produces.
+# Run this once after installing the module.
+bundle exec rake decidim:ai:spam:create_reporting_user
+
+# Load a baseline training dataset from a file into both the user
+# classifier and the resource classifier.
+# `<file>` is a path to a dataset file shipped with `decidim-ai` (see the
+# module's docs for the exact path).
+bundle exec rake decidim:ai:spam:load_application_dataset[<file>]
+
+# Re-train the classifier from the current application database.
+# Useful periodically (e.g. weekly or monthly) after you have accumulated
+# moderation decisions — schedule this only if you want a regular
+# retrain.
+bundle exec rake decidim:ai:spam:train_application_database
+
+# Reset both classifiers (user and resource). Destructive — use with
+# care.
+bundle exec rake decidim:ai:spam:reset
+----
+
+If — and only if — you want a periodic retrain on top of live moderation
+data, you can add a single entry to your crontab, for example weekly on
+Sundays at 03:00 UTC:
+
+[source,console]
+----
+# Re-train the spam classifier from accumulated application data
+0 3 * * 0 cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim:ai:spam:train_application_database
+----
+
+NOTE: Refer to xref:services:aitools.adoc[AI tools] for the full
+configuration of the AI/spam module before scheduling any of these
+commands.
+
 === Further configuration
 
 We also have other guides on how to configure some extra mandatory components:

--- a/docs/modules/install/pages/index.adoc
+++ b/docs/modules/install/pages/index.adoc
@@ -166,7 +166,9 @@ bundle exec rake decidim:ai:spam:create_reporting_user
 # classifier and the resource classifier.
 # `<file>` is a path to a dataset file shipped with `decidim-ai` (see the
 # module's docs for the exact path).
-bundle exec rake decidim:ai:spam:load_application_dataset[<file>]
+# NOTE: keep the brackets quoted — zsh and some other shells try to glob
+# inside `[…]` and will fail otherwise.
+bundle exec rake "decidim:ai:spam:load_application_dataset[<file>]"
 
 # Re-train the classifier from the current application database.
 # Useful periodically (e.g. weekly or monthly) after you have accumulated
@@ -181,11 +183,14 @@ bundle exec rake decidim:ai:spam:reset
 
 If — and only if — you want a periodic retrain on top of live moderation
 data, you can add a single entry to your crontab, for example weekly on
-Sundays at 03:00 UTC:
+Sundays at 03:00 UTC. By default `cron` runs in the system's local
+timezone, so the `CRON_TZ=UTC` line below pins the schedule to UTC
+regardless of where the server lives:
 
 [source,console]
 ----
 # Re-train the spam classifier from accumulated application data
+CRON_TZ=UTC
 0 3 * * 0 cd /home/user/decidim_application && RAILS_ENV=production bundle exec rake decidim:ai:spam:train_application_database
 ----
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

Refs #14202.

## What changed

Adds a new \"Spam-detection (AI) module\" subsection under
\"Scheduled tasks from modules\" in
\`docs/modules/install/pages/index.adoc\` that documents the
\`decidim:ai:spam:*\` Rake tasks shipped with \`decidim-ai\`. The
section explains why these are training/maintenance commands
(not unconditional cron jobs), lists all four tasks with their
canonical descriptions, and shows an *optional* crontab snippet
for a periodic retrain.

## Why this PR

#14202 notes that the install docs' \"Scheduled tasks\" section
makes no mention of the spam engine. Reading
[\`decidim-ai/lib/tasks/decidim_ai.rake\`](https://github.com/decidim/decidim/blob/develop/decidim-ai/lib/tasks/decidim_ai.rake),
the four tasks are:

- \`decidim:ai:spam:create_reporting_user\` — one-off install task.
- \`decidim:ai:spam:load_application_dataset[<file>]\` — load a
  baseline dataset.
- \`decidim:ai:spam:train_application_database\` — re-train from
  application data; this is the one worth scheduling for operators
  who want a periodic retrain.
- \`decidim:ai:spam:reset\` — destructive, manual.

Treating them as a blanket cron block would be misleading, so the
new subsection makes the distinction explicit, while still giving
operators an example schedule for the *one* task that benefits from
recurrence.

Also cross-references \`services:aitools.adoc\` so operators read the
full AI/spam-engine configuration before scheduling anything.

This PR is scoped to the spam-engine gap explicitly called out in
#14202. A broader top-to-bottom audit of every rake task vs. the
docs is out of scope here.

## Verification

Rendered the page locally with:

\`\`\`
asciidoctor --safe-mode unsafe -o /tmp/install_index.html docs/modules/install/pages/index.adoc
\`\`\`

Page builds cleanly with no warnings; the new \"Spam-detection (AI)
module\" subsection, the rake-task code block, the optional cron
snippet, and the \`xref:services:aitools.adoc\` cross-reference all
render correctly.

No application code touched.

---

AI-assisted via Cursor (Claude Opus 4.7).
Personal token-burn initiative by @adv0r: contributing OSS work using
leftover Cursor credits before subscription renewal.
Authored and verified by an AI agent operating **unattended**.
**Not human-reviewed before submission** — please review carefully.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user-facing documentation for the spam-detection (AI) module.
  * Explained available scheduled tasks for training and resetting spam classification.
  * Provided setup guidance for optional periodic retraining and links to AI/spam configuration docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
