### PR TITLE
Docs: fix two broken cross-references (system.adoc / machine_translations.adoc)

### DIFF
--- a/docs/modules/configure/pages/system.adoc
+++ b/docs/modules/configure/pages/system.adoc
@@ -127,7 +127,7 @@ in multi tenant mode. To learn more, check this https://developer.mozilla.org/en
 ==== Allow participants to register and login
 
 Most of the installations use this setting. Means that everyone can register a participant account and login, without restrictions, only with an email account confirmation.
-You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc.adoc[Decidim's environment variables], although we do not recommend doing that,
+You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc[Decidim's environment variables], although we do not recommend doing that,
 as it is a measure for stopping spam accounts. For additional details, read about `DECIDIM_UNCONFIRMED_ACCESS_FOR` environment variable.
 
 ==== Do not allow participants to register, but allow existing participants to login

--- a/docs/modules/develop/pages/machine_translations.adoc
+++ b/docs/modules/develop/pages/machine_translations.adoc
@@ -42,7 +42,7 @@ config.machine_translation_service = "MyApp::MyOwnTranslationService"
 config.machine_translation_delay = 0.seconds
 ----
 
-The class will need to be implemented, or reuse one from the community. Check the docs on xref:services:machine_translations.adoc[how to implement a machine translation service].
+The class will need to be implemented, or reuse one from the community. Check the docs on xref:services:machine_translation.adoc[how to implement a machine translation service].
 
 == Enabling the integration, organization-wise
 


### PR DESCRIPTION
> **Dear maintainer** — this PR has a permanent home with methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good). A one-line "no thanks" → auto-close + blacklist. Sorry for the notification this edit caused.
>
> ---

## What

Fix two broken AsciiDoc `xref` links in the docs that currently render
as plain (unlinked) text on the published documentation site:

1. **`docs/modules/configure/pages/system.adoc`** referenced
   `xref:configure:environment_variables.adoc.adoc[…]` — a duplicated
   `.adoc` extension. The correct page name is
   `environment_variables.adoc`.

2. **`docs/modules/develop/pages/machine_translations.adoc`**
   referenced `xref:services:machine_translations.adoc[…]` (plural),
   while the actual page in the `services` module is
   `machine_translation.adoc` (singular).

## Why

Both were broken xrefs visible in the published docs. The first showed
up as raw text inside a section users are sent to from the System
Panel; the second is on the developer page describing how to plug in
a machine translation service.

## Verification

- Re-rendered both pages with `asciidoctor` locally with no warnings.
- `git diff` is two single-line changes:

```diff
-You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc.adoc[Decidim's environment variables],
+You can disable that confirmation also if you want to through xref:configure:environment_variables.adoc[Decidim's environment variables],
```

```diff
-The class will need to be implemented, or reuse one from the community. Check the docs on xref:services:machine_translations.adoc[how to implement a machine translation service].
+The class will need to be implemented, or reuse one from the community. Check the docs on xref:services:machine_translation.adoc[how to implement a machine translation service].
```

## AI disclosure

Per AGENTS.md / CONTRIBUTING — this is a small AI-generated, unattended
contribution made by a Cursor Anthropic Claude Opus 4.7 agent under
@adv0r as a short personal token-burn initiative before my Cursor
subscription billing cycle ends. Happy to iterate on review.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected broken cross-reference link in system configuration documentation to properly direct users to the environment variables documentation.
  * Fixed incorrect cross-reference path in machine translation documentation to align with the correct file naming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
