### PR TITLE
Fix `ActiveStorage::FileNotFoundError` in specs

### DIFF
--- a/decidim-assemblies/spec/commands/duplicate_assembly_spec.rb
+++ b/decidim-assemblies/spec/commands/duplicate_assembly_spec.rb
@@ -101,10 +101,7 @@ module Decidim::Assemblies
     context "when duplicate_landing_page_blocks exists" do
       let(:duplicate_landing_page_blocks) { true }
       let(:original_image) do
-        Rack::Test::UploadedFile.new(
-          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-          "image/jpeg"
-        )
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg")
       end
 
       before do

--- a/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_imports_assembly_spec.rb
@@ -101,7 +101,7 @@ describe "Admin imports assembly" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
 
     before do
@@ -150,7 +150,7 @@ describe "Admin imports assembly" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
     let(:hero_image_url) { "http://example.com/#{"a" * 5000}.jpg" }
 
@@ -200,7 +200,7 @@ describe "Admin imports assembly" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
 
     before do

--- a/decidim-conferences/spec/controllers/admin/imports_controller_spec.rb
+++ b/decidim-conferences/spec/controllers/admin/imports_controller_spec.rb
@@ -13,10 +13,7 @@ module Decidim
           let(:extra_params) { { conference_slug: participatory_space.slug } }
 
           let(:file) do
-            Rack::Test::UploadedFile.new(
-              Decidim::Dev.test_file("import_proposals.csv", "text/csv"),
-              "text/csv"
-            )
+            Decidim::Dev.test_file("import_proposals.csv", "text/csv")
           end
         end
       end

--- a/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/newsletter_templates/basic_only_text_cell_spec.rb
@@ -31,10 +31,7 @@ describe Decidim::NewsletterTemplates::BasicOnlyTextCell, type: :cell do
 
   context "when the organization has a logo set" do
     let(:logo) do
-      Rack::Test::UploadedFile.new(
-        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-        "image/jpeg"
-      )
+      Decidim::Dev.test_file("city.jpeg", "image/jpeg")
     end
 
     before do

--- a/decidim-core/spec/models/decidim/content_block_spec.rb
+++ b/decidim-core/spec/models/decidim/content_block_spec.rb
@@ -31,10 +31,7 @@ module Decidim
 
       context "when the related attachment exists" do
         let(:original_image) do
-          Rack::Test::UploadedFile.new(
-            Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-            "image/jpeg"
-          )
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg")
         end
 
         before do
@@ -52,10 +49,7 @@ module Decidim
 
       context "when the image is larger in size than the organization allows" do
         let(:original_image) do
-          Rack::Test::UploadedFile.new(
-            Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-            "image/jpeg"
-          )
+          Decidim::Dev.test_file("city.jpeg", "image/jpeg")
         end
 
         before do

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -55,8 +55,9 @@ module Decidim
     # @return [Rack::Test::UploadedFile] A new uploaded test file instance
     def self.uploaded_file(path, content_type, binary: false)
       original_filename = File.basename(path)
+      extension = File.extname(original_filename)
 
-      tempfile = Tempfile.open([original_filename, File.extname(original_filename)])
+      tempfile = Tempfile.open([File.basename(original_filename, extension), extension])
       tempfile.binmode if binary
       tempfile.write(binary ? File.binread(path) : File.read(path))
       tempfile.rewind

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -33,7 +33,35 @@ module Decidim
 
     # Public: Returns a file for testing, just like file fields expect it
     def self.test_file(filename, content_type)
-      Rack::Test::UploadedFile.new(asset(filename), content_type)
+      uploaded_file(asset(filename), content_type)
+    end
+
+    # Public: Creates a safe uploaded file for tests.
+    #
+    # Creating instances of Rack::Test::UploadedFile directly from file paths
+    # may lead to 0-byte files created in the storage under specific
+    # configurations/kernels and specifically with Docker containers. This
+    # method creates a safe uploaded file that does not have this problem.
+    #
+    # See:
+    # https://github.com/rails/rails/issues/41991
+    # https://github.com/docker/for-mac/issues/5570
+    # https://github.com/docker/for-linux/issues/1015
+    #
+    # @param path [String] The path to the original file
+    # @param content_type [String] The MIME type for the file
+    # @param binary [Boolean] Boolean indicating whether the uploaded file's
+    #   tempfile should be in binary mode
+    # @return [Rack::Test::UploadedFile] A new uploaded test file instance
+    def self.uploaded_file(path, content_type, binary: false)
+      original_filename = File.basename(path)
+
+      content = File.read(path)
+      tempfile = Tempfile.open([original_filename, File.extname(original_filename)])
+      tempfile.write(content)
+      tempfile.rewind
+
+      Rack::Test::UploadedFile.new(tempfile, content_type, binary, original_filename:)
     end
 
     # Public: add rake tasks

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -56,12 +56,14 @@ module Decidim
     def self.uploaded_file(path, content_type, binary: false)
       original_filename = File.basename(path)
 
-      content = File.read(path)
       tempfile = Tempfile.open([original_filename, File.extname(original_filename)])
-      tempfile.write(content)
+      tempfile.binmode if binary
+      tempfile.write(binary ? File.binread(path) : File.read(path))
       tempfile.rewind
 
       Rack::Test::UploadedFile.new(tempfile, content_type, binary, original_filename:)
+    ensure
+      tempfile&.close!
     end
 
     # Public: add rake tasks

--- a/decidim-participatory_processes/spec/commands/duplicate_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/commands/duplicate_participatory_process_spec.rb
@@ -124,10 +124,7 @@ module Decidim::ParticipatoryProcesses
     context "when duplicate_landing_page_blocks exists" do
       let(:duplicate_landing_page_blocks) { true }
       let(:original_image) do
-        Rack::Test::UploadedFile.new(
-          Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-          "image/jpeg"
-        )
+        Decidim::Dev.test_file("city.jpeg", "image/jpeg")
       end
 
       before do

--- a/decidim-participatory_processes/spec/controllers/admin/imports_controller_spec.rb
+++ b/decidim-participatory_processes/spec/controllers/admin/imports_controller_spec.rb
@@ -13,10 +13,7 @@ module Decidim
           let(:extra_params) { { participatory_process_slug: participatory_space.slug } }
 
           let(:file) do
-            Rack::Test::UploadedFile.new(
-              Decidim::Dev.test_file("import_proposals.csv", "text/csv"),
-              "text/csv"
-            )
+            Decidim::Dev.test_file("import_proposals.csv", "text/csv")
           end
         end
       end

--- a/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
+++ b/decidim-participatory_processes/spec/system/admin/admin_import_participatory_process_spec.rb
@@ -107,7 +107,7 @@ describe "Admin imports participatory process" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
 
     before do
@@ -160,7 +160,7 @@ describe "Admin imports participatory process" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
 
     before do
@@ -213,7 +213,7 @@ describe "Admin imports participatory process" do
       end
     end
     let(:uploaded_file) do
-      Rack::Test::UploadedFile.new(json_file.path, "application/json")
+      Decidim::Dev.uploaded_file(json_file.path, "application/json")
     end
 
     before do

--- a/decidim-system/spec/commands/decidim/system/create_oauth_application_spec.rb
+++ b/decidim-system/spec/commands/decidim/system/create_oauth_application_spec.rb
@@ -21,10 +21,7 @@ module Decidim::System
       }
     end
     let(:file) do
-      Rack::Test::UploadedFile.new(
-        Decidim::Dev.test_file("city.jpeg", "image/jpeg"),
-        "image/jpeg"
-      )
+      Decidim::Dev.test_file("city.jpeg", "image/jpeg")
     end
     let(:context) do
       {


### PR DESCRIPTION
#### :tophat: What? Why?
Creating instances of Rack::Test::UploadedFile directly from file paths may lead to 0-byte files created in the storage under specific configurations/kernels and specifically with Docker containers (i.e. GitHub runners). 

This fixes the issue by creating a safe uploaded file that does not have this problem.

The problem is related to the `FileUtils.copy_file` method [used by `rack-test`](https://github.com/rack/rack-test/blob/1fc57f3d26275c51ba6ecea860182b94c9c242fa/lib/rack/test/uploaded_file.rb#L95)

The underlying issue is better described by the related issues. The fix also originates from the combined work at those issues.

Example test failure output:

```
Failures:

  1) Show replies when replying to a loaded comment shows comments after loading more
     Got 1 failure and 1 other error:

     1.1) Failure/Error: expect_no_js_errors
            http://1.lvh.me:5000/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MTI1MDUsInB1ciI6ImJsb2JfaWQifX0=--e08a94d969ebe534de130b4eb0211d7f57cb05f7/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJqcGciLCJyZXNpemVfdG9fZml0IjpbNDAsNDBdfSwicHVyIjoidmFyaWF0aW9uIn19--76a4b3fbfc2aa1dba028a53370530de752ea4420/avatar.jpg - Failed to load resource: the server responded with a status of 500 (Internal Server Error)
          
          [Screenshot Image]: file:///.../dev/rails/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_show_replies_when_replying_to_a_loaded_comment_shows_comments_after_loading_more_887.png

          [Screenshot HTML]: file:///.../dev/rails/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_show_replies_when_replying_to_a_loaded_comment_shows_comments_after_loading_more_887.html

          
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/frontend.rb:12:in 'block (2 levels) in FrontendHelpers#expect_no_js_errors'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/frontend.rb:11:in 'Array#each'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/frontend.rb:11:in 'block in FrontendHelpers#expect_no_js_errors'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/frontend.rb:10:in 'FrontendHelpers#expect_no_js_errors'
          # ./spec/system/show_replies_spec.rb:51:in 'block (3 levels) in <top (required)>'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <main>'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in 'block (2 levels) in <main>'

     1.2) Failure/Error: raise ActiveStorage::FileNotFoundError
          
          ActiveStorage::FileNotFoundError:
            ActiveStorage::FileNotFoundError
          
          [Screenshot Image]: file:///.../dev/rails/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_show_replies_when_replying_to_a_loaded_comment_shows_comments_after_loading_more_887.png

          [Screenshot HTML]: file:///.../dev/rails/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_show_replies_when_replying_to_a_loaded_comment_shows_comments_after_loading_more_887.html

          
          # /.../dev/rails/decidim/decidim-core/lib/decidim/middleware/strip_x_forwarded_host.rb:12:in 'Decidim::Middleware::StripXForwardedHost#call'
          # /.../dev/rails/decidim/decidim-core/lib/decidim/middleware/current_organization.rb:22:in 'Decidim::Middleware::CurrentOrganization#call'
          # /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/map_server.rb:36:in 'Decidim::Dev::Test::MapServer#call'
          # ------------------
          # --- Caused by: ---
          # Capybara::CapybaraError:
          #   Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true
          #   /.../dev/rails/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <main>'

Top 1 slowest examples (10.62 seconds, 81.4% of total time):
  Show replies when replying to a loaded comment shows comments after loading more
    10.62 seconds ./spec/system/show_replies_spec.rb:54

Finished in 13.05 seconds (files took 4.31 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/system/show_replies_spec.rb:54 # Show replies when replying to a loaded comment shows comments after loading more

```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to
  * rails/rails#41991
  * docker/for-mac#5570
  * docker/for-linux#1015

#### Testing
Hard to replicate exact situation, kernel, OS and configuration that would replicate this issue but at least I got the bug replicating by running the following spec several times (typically it failed after 20-30 runs):

```bash
for i in {1..100}; do bundle exec rspec spec/system/show_replies_spec.rb:54 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test file handling to avoid zero-byte uploads and ensure consistent behavior across environments.

* **Chores**
  * Simplified uploaded-file fixtures across multiple test suites for more reliable and maintainable test setups.
* **Tests**
  * Added a safer helper for building temporary uploaded files to make media-related tests more robust.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16859?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->