### PR TITLE
Fix role menu/presentation on action buttons

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/_menu_actions.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_menu_actions.html.erb
@@ -1,7 +1,7 @@
 
 <% if allowed_to?(:update, :blogpost, blogpost: post) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= link_to edit_post_path(post), class: "dropdown__button" do %>
+  <li role="presentation" class="dropdown__item">
+    <%= link_to edit_post_path(post), class: "dropdown__button", role: "menuitem" do %>
       <span><%= t("button_edit", scope: "decidim.blogs.posts.menu_actions") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -9,10 +9,11 @@
 <% end %>
 
 <% if allowed_to?(:destroy, :blogpost, blogpost: post) %>
-  <li role="menuitem" class="dropdown__item">
+  <li role="presentation" class="dropdown__item">
     <%= link_to post_path(post),
                 method: :delete,
                 class: "dropdown__button",
+                role: "menuitem",
                 data: { confirm: t("button_destroy_confirm", scope: "decidim.blogs.posts.menu_actions") } do %>
       <span><%= t("button_destroy", scope: "decidim.blogs.posts.menu_actions") %></span>
       <%= icon "delete-bin-line" %>

--- a/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_item_template.html.erb
+++ b/decidim-collaborative_texts/app/views/decidim/collaborative_texts/documents/_suggestions_box_item_template.html.erb
@@ -15,12 +15,12 @@
 
     <div class="collaborative-texts-suggestions-box-header-menu" id="dropdown-menu-{{ID}}" role="menu" aria-labelledby="dropdown-trigger-{{ID}}" tabindex="-1" aria-hidden="true">
       <ul class="dropdown dropdown__bottom divide-y divide-gray-3 pt-1 pb-0" role="menu">
-        <li role="menuitem" class="dropdown__item">
-          <button class="button-apply dropdown__button">
+        <li role="presentation" class="dropdown__item">
+          <button class="button-apply dropdown__button" role="menuitem">
             <%= icon "checkbox-circle-line" %>
             <%= t("decidim.collaborative_texts.document.apply") %>
           </button>
-          <button class="button-restore dropdown__button">
+          <button class="button-restore dropdown__button" role="menuitem">
             <%= icon "arrow-go-back-line" %>
             <%= t("decidim.collaborative_texts.document.restore") %>
           </button>

--- a/decidim-core/app/cells/decidim/amendable/amend_button_card/show.erb
+++ b/decidim-core/app/cells/decidim/amendable/amend_button_card/show.erb
@@ -1,5 +1,5 @@
-<li role="menuitem" class="dropdown__item">
-  <%= action_authorized_link_to :amend, new_amend_path, resource: model, data: { "redirect_url" => new_amend_path }, id: "amend-button", class: "dropdown__button" do %>
+<li role="presentation" class="dropdown__item">
+  <%= action_authorized_link_to :amend, new_amend_path, resource: model, data: { "redirect_url" => new_amend_path }, id: "amend-button", class: "dropdown__button", role: "menuitem" do %>
     <span><%= t("button", scope: "decidim.amendments.amendable", model_name: nil) %></span>
     <%= icon "pencil-line" %>
   <% end %>

--- a/decidim-core/app/cells/decidim/resource_types_filter/show.erb
+++ b/decidim-core/app/cells/decidim/resource_types_filter/show.erb
@@ -10,8 +10,8 @@
   </button>
   <ul id="dropdown-menu-resource">
     <% resource_types.each do |resource_type| %>
-      <li role="menuitem">
-        <%= link_to filter_url(resource_type[0]), class: "filter#{" is-active" if filter_param == resource_type[0]}" do %>
+      <li role="presentation">
+        <%= link_to filter_url(resource_type[0]), class: "filter#{" is-active" if filter_param == resource_type[0]}", role: "menuitem" do %>
           <span class="sr-only"><%= resource_type[1] %></span>
           <%= text_with_resource_icon(*resource_type) %>
         <% end %>

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -29,11 +29,11 @@ module Decidim
     delegate :content_tag, :safe_join, :link_to, :active_link_to_class, :is_active_link?, :icon, to: :@view
 
     def render
-      content_tag :li, role: menuitem_role, class: link_wrapper_classes do
+      content_tag :li, role: wrapper_role, class: link_wrapper_classes do
         output = if url == "#"
-                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled")]
+                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled", role: menuitem_role)]
                  else
-                   [link_to(composed_label, url, link_options)]
+                    [link_to(composed_label, url, link_options)]
                  end
         output.push(@view.send(:simple_menu, **@menu_item.submenu).render) if @menu_item.submenu
 
@@ -52,7 +52,7 @@ module Decidim
         { aria: { current: "page" } }
       else
         {}
-      end.merge({ class: link_classes })
+      end.merge({ class: link_classes, role: menuitem_role })
     end
 
     def composed_label
@@ -73,6 +73,12 @@ module Decidim
       return if @options.role == false
 
       @options.role || :menuitem
+    end
+
+    def wrapper_role
+      return if menuitem_role.blank?
+
+      :presentation
     end
 
     def active_class

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -33,7 +33,7 @@ module Decidim
         output = if url == "#"
                    [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled", role: menuitem_role)]
                  else
-                    [link_to(composed_label, url, link_options)]
+                   [link_to(composed_label, url, link_options)]
                  end
         output.push(@view.send(:simple_menu, **@menu_item.submenu).render) if @menu_item.submenu
 

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -42,7 +42,7 @@ edit_link(
                 <div id="accordion-panel-<%= ix %>" class="page__accordion-panel" aria-hidden="true">
                   <ul role="menu">
                     <% topic.pages.each do |page| %>
-                      <li role="menuitem"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary" %></li>
+                      <li role="presentation"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary", role: "menuitem" %></li>
                     <% end %>
                   </ul>
                 </div>

--- a/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
+++ b/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
@@ -12,12 +12,12 @@
     <ul class="dropdown dropdown__bottom divide-y divide-gray-3" role="menu">
       <%= yield %>
       <% unless defined?(skip_report) && skip_report %>
-        <li role="menuitem" class="dropdown__item">
-          <%= cell "decidim/report_button", resource, button_classes: "dropdown__button" %>
+        <li role="presentation" class="dropdown__item">
+          <%= cell "decidim/report_button", resource, button_classes: "dropdown__button", html_options: { role: "menuitem" } %>
         </li>
       <% end %>
-      <li role="menuitem" class="dropdown__item">
-        <%= cell "decidim/follow_button", resource, large: false, button_classes: "dropdown__button" %>
+      <li role="presentation" class="dropdown__item">
+        <%= cell "decidim/follow_button", resource, large: false, button_classes: "dropdown__button", html_options: { role: "menuitem" } %>
       </li>
     </ul>
   </div>

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -16,8 +16,9 @@ module Decidim
       expect(subject.render).to have_link("Foo", href: "/boo")
     end
 
-    it "adds the menuitem role by default" do
-      expect(subject.render).to have_css("li[role='menuitem']")
+    it "adds the menuitem role to the interactive element by default" do
+      expect(subject.render).to have_css("li[role='presentation']")
+      expect(subject.render).to have_css("a[role='menuitem']")
     end
 
     it "does not add the aria-current attribute for non-active page" do
@@ -51,7 +52,7 @@ module Decidim
 
       it "adds a span instead of a link" do
         expect(subject.render).to have_no_link("Foo", href: "#")
-        expect(subject.render).to have_css("span.sidebar-menu__item-disabled")
+        expect(subject.render).to have_css("li[role='presentation'] span.sidebar-menu__item-disabled[role='menuitem']")
       end
     end
   end

--- a/decidim-debates/app/views/decidim/debates/debates/_debate_actions.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_debate_actions.html.erb
@@ -1,14 +1,14 @@
 
 <% if allowed_to?(:edit, :debate, debate: debate) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= link_to edit_debate_path(debate), class: "dropdown__button" do %>
+  <li role="presentation" class="dropdown__item">
+    <%= link_to edit_debate_path(debate), class: "dropdown__button", role: "menuitem" do %>
       <span><%= t("edit_debate", scope: "decidim.debates.debates.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
   </li>
 <% elsif admin_allowed_to?(:update, :debate, debate: debate) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= link_to resource_locator(debate).edit, class: "dropdown__button" do %>
+  <li role="presentation" class="dropdown__item">
+    <%= link_to resource_locator(debate).edit, class: "dropdown__button", role: "menuitem" do %>
       <span><%= t("edit_debate", scope: "decidim.debates.debates.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -17,15 +17,15 @@
 
 <% close_debate_action_text = (debate.closed? ? "decidim.debates.debates.show.edit_conclusions" : "decidim.debates.debates.show.close_debate" ) %>
 <% if allowed_to?(:close, :debate, debate: debate) %>
-  <li role="menuitem" class="dropdown__item">
-    <button type="button" data-dialog-open="close-debate" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="dropdown__button">
+  <li role="presentation" class="dropdown__item">
+    <button type="button" data-dialog-open="close-debate" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="dropdown__button" role="menuitem">
       <span><%= t(close_debate_action_text) %></span>
       <%= icon "lock-line" %>
     </button>
   </li>
 <% elsif admin_allowed_to?(:close, :debate, debate: debate) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= link_to Decidim::EngineRouter.admin_proxy(debate.component).edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), class: "dropdown__button" do %>
+  <li role="presentation" class="dropdown__item">
+    <%= link_to Decidim::EngineRouter.admin_proxy(debate.component).edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), class: "dropdown__button", role: "menuitem" do %>
       <span><%= t(close_debate_action_text) %></span>
       <%= icon "lock-line" %>
     <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
@@ -1,6 +1,6 @@
 <% if allowed_to?(:update, :meeting, meeting: meeting) %>
-  <li class="dropdown__item" role="menuitem">
-    <%= link_to edit_meeting_path(meeting), class: "dropdown__button"  do %>
+  <li class="dropdown__item" role="presentation">
+    <%= link_to edit_meeting_path(meeting), class: "dropdown__button", role: "menuitem"  do %>
       <span><%= t("edit_meeting", scope: "decidim.meetings.meetings.meeting") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -9,8 +9,8 @@
 
 <% if allowed_to?(:close, :meeting, meeting: meeting) %>
   <% caption = meeting.closed? ? t("edit_close_meeting", scope: "decidim.meetings.meetings.meeting") : t("close_meeting", scope: "decidim.meetings.meetings.meeting") %>
-  <li class="dropdown__item" role="menuitem">
-    <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "dropdown__button"  do %>
+  <li class="dropdown__item" role="presentation">
+    <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "dropdown__button", role: "menuitem"  do %>
       <span><%= caption %></span>
       <%= icon "lock-line" %>
     <% end %>
@@ -18,12 +18,13 @@
 <% end %>
 
 <% if meeting.withdrawable_by?(current_user) %>
-  <li class="dropdown__item" role="menuitem">
+  <li class="dropdown__item" role="presentation">
     <%= action_authorized_link_to(
           :withdraw,
           withdraw_meeting_path(meeting),
           method: :put,
           class: "dropdown__button" ,
+          role: "menuitem",
           title: t("withdraw_btn_hint", scope: "decidim.meetings.meetings.show"),
           data: { confirm: t("withdraw_confirmation_html", scope: "decidim.meetings.meetings.show") }
         ) do %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_actions.html.erb
@@ -1,6 +1,6 @@
 <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= link_to edit_proposal_path(@proposal), class: "dropdown__button" do %>
+  <li role="presentation" class="dropdown__item">
+    <%= link_to edit_proposal_path(@proposal), class: "dropdown__button", role: "menuitem" do %>
       <span><%= t("edit_proposal", scope: "decidim.proposals.proposals.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -10,8 +10,8 @@
 <% end %>
 
 <% if @proposal.withdrawable_by?(current_user) %>
-  <li role="menuitem" class="dropdown__item">
-    <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), resource: @proposal, method: :put, class: "dropdown__button", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
+  <li role="presentation" class="dropdown__item">
+    <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), resource: @proposal, method: :put, class: "dropdown__button", role: "menuitem", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
       <span><%= t("withdraw_proposal", scope: "decidim.proposals.proposals.show") %></span>
       <%= icon "arrow-go-back-line" %>
     <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

After the validator updated on their side and changed the rules, we have some failures in the CI.

This PR fixes them. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/16873 

#### Testing

As the public validator service that we use by default locally isn't yet updated, you need to run the latest docker image as we do in CI

```bash
docker run --rm -p 8888:8888 ghcr.io/validator/validator:latest
VALIDATOR_HTML_URI=http://localhost:8888/ CI=true bin/rspec decidim-proposals/spec/system/proposals_spec.rb:45
``` 

NOTE: on my case as I'm running with devcontainers I needed to also adjust the Webmock configuration: 

```diff
diff --git a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
index 6cd298fd503..f243dda4a20 100644
--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -6,6 +6,7 @@ WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: [
     %r{https://validator\.w3\.org/},
+    %r{172\.19\.0\.1},
     Decidim::Dev::Test::MapServer.host
   ]
 )
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility of dropdowns and menus across the platform by changing markup so list wrappers are non-semantic and interactive elements carry menuitem semantics, improving screen reader behavior and keyboard navigation.
* **Tests**
  * Updated test expectations to reflect the revised markup and accessibility semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->