### PR TITLE
Backport 'Fix role menu/presentation on action buttons' to v0.30

### DIFF
--- a/decidim-blogs/app/views/decidim/blogs/posts/_menu_actions.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_menu_actions.html.erb
@@ -1,7 +1,7 @@
 
 <% if allowed_to?(:update, :blogpost, blogpost: post) %>
-  <li role="menuitem">
-    <%= link_to edit_post_path(post), class: "button button__sm button__text button__text-secondary" do %>
+  <li role="presentation">
+    <%= link_to edit_post_path(post), class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= t("button_edit", scope: "decidim.blogs.posts.menu_actions") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -9,10 +9,11 @@
 <% end %>
 
 <% if allowed_to?(:destroy, :blogpost, blogpost: post) %>
-  <li role="menuitem">
+  <li role="presentation">
     <%= link_to post_path(post),
                 method: :delete,
                 class: "button button__sm button__text button__text-secondary",
+                role: "menuitem",
                 data: { confirm: t("button_destroy_confirm", scope: "decidim.blogs.posts.menu_actions") } do %>
       <span><%= t("button_destroy", scope: "decidim.blogs.posts.menu_actions") %></span>
       <%= icon "delete-bin-line" %>

--- a/decidim-core/app/cells/decidim/amendable/amend_button_card/show.erb
+++ b/decidim-core/app/cells/decidim/amendable/amend_button_card/show.erb
@@ -1,5 +1,5 @@
-<li role="menuitem">
-  <%= action_authorized_link_to :amend, new_amend_path, resource: model, data: { "redirect_url" => new_amend_path }, id: "amend-button", class: "button button__sm button__text button__text-secondary" do %>
+<li role="presentation">
+  <%= action_authorized_link_to :amend, new_amend_path, resource: model, data: { "redirect_url" => new_amend_path }, id: "amend-button", class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
     <span><%= t("button", scope: "decidim.amendments.amendable", model_name: nil) %></span>
     <%= icon "pencil-line" %>
   <% end %>

--- a/decidim-core/app/cells/decidim/resource_types_filter/show.erb
+++ b/decidim-core/app/cells/decidim/resource_types_filter/show.erb
@@ -10,8 +10,8 @@
   </button>
   <ul id="dropdown-menu-resource">
     <% resource_types.each do |resource_type| %>
-      <li role="menuitem">
-        <%= link_to filter_url(resource_type[0]), class: "filter#{" is-active" if filter_param == resource_type[0]}" do %>
+      <li role="presentation">
+        <%= link_to filter_url(resource_type[0]), class: "filter#{" is-active" if filter_param == resource_type[0]}", role: "menuitem" do %>
           <span class="sr-only"><%= resource_type[1] %></span>
           <%= text_with_resource_icon(*resource_type) %>
         <% end %>

--- a/decidim-core/app/packs/src/decidim/a11y.js
+++ b/decidim-core/app/packs/src/decidim/a11y.js
@@ -60,6 +60,7 @@ const createDropdown = (component) => {
   dropdownOptions.dropdown = component.dataset.target;
   dropdownOptions.hover = component.dataset.hover === "true";
   dropdownOptions.autoClose = component.dataset.autoClose === "true";
+  const addAriaRoles = component.dataset.addAriaRoles !== "false";
 
   // This snippet allows to disable the dropdown based on the current viewport
   // Just include the breakpoint where the different value will be applied from.
@@ -115,6 +116,18 @@ const createDropdown = (component) => {
   }
 
   Dropdowns.render(component.id, dropdownOptions);
+
+  if (!addAriaRoles) {
+    const dropdown = document.getElementById(dropdownOptions.dropdown);
+
+    if (dropdown) {
+      dropdown.removeAttribute("role");
+      dropdown.removeAttribute("aria-labelledby");
+      dropdown.querySelectorAll("[role='menuitem'], [role='none']").forEach((item) => {
+        item.removeAttribute("role");
+      });
+    }
+  }
 }
 
 /**

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -26,9 +26,9 @@ module Decidim
     delegate :content_tag, :safe_join, :link_to, :active_link_to_class, :is_active_link?, :icon, to: :@view
 
     def render
-      content_tag :li, role: menuitem_role, class: link_wrapper_classes do
+      content_tag :li, role: wrapper_role, class: link_wrapper_classes do
         output = if url == "#"
-                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled")]
+                   [content_tag(:span, composed_label, class: "sidebar-menu__item-disabled", role: menuitem_role)]
                  else
                    [link_to(composed_label, url, link_options)]
                  end
@@ -49,7 +49,7 @@ module Decidim
         { aria: { current: "page" } }
       else
         {}
-      end
+      end.merge({ role: menuitem_role })
     end
 
     def composed_label
@@ -66,6 +66,12 @@ module Decidim
       return if @options.role == false
 
       @options.role || :menuitem
+    end
+
+    def wrapper_role
+      return if menuitem_role.blank?
+
+      :presentation
     end
 
     def active_class

--- a/decidim-core/app/views/decidim/pages/index.html.erb
+++ b/decidim-core/app/views/decidim/pages/index.html.erb
@@ -42,7 +42,7 @@ edit_link(
                 <div id="accordion-panel-<%= ix %>" class="page__accordion-panel" aria-hidden="true">
                   <ul role="menu">
                     <% topic.pages.each do |page| %>
-                      <li role="menuitem"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary" %></li>
+                      <li role="presentation"><%= link_to translated_attribute(page.title), page_path(page), class: "text-secondary", role: "menuitem" %></li>
                     <% end %>
                   </ul>
                 </div>

--- a/decidim-core/app/views/decidim/shared/_filters.html.erb
+++ b/decidim-core/app/views/decidim/shared/_filters.html.erb
@@ -4,7 +4,7 @@
 <% if filter_sections.present? || local_assigns.has_key?(:search_variable) %>
   <%= filter_form_for filter, url_for, class: "new_filter self-stretch", data: { filters: "", component: "accordion" } do |form| %>
 
-    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters" data-open-md="true">
+    <button id="dropdown-trigger-filters" data-component="dropdown" data-target="dropdown-menu-filters" data-open-md="true" data-add-aria-roles="false">
       <%= icon "arrow-down-s-line" %>
       <%= icon "arrow-up-s-line" %>
       <span>
@@ -14,13 +14,13 @@
 
     <div id="dropdown-menu-filters">
       <% if local_assigns.has_key?(:skip_to_id) %>
-        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", role: "menuitem", "data-skip-to-content": true %>
+        <%= link_to t("skip", scope: "decidim.shared.filter_form_help"), "##{skip_to_id}", class: "filter-skip", "data-skip-to-content": true %>
       <% end %>
 
-      <p id="filter-help-text" class="filter-help" role="menuitem" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
+      <p id="filter-help-text" class="filter-help" aria-disabled="true"><%= t("help", scope: "decidim.shared.filter_form_help") %></p>
 
       <% if local_assigns.has_key?(:search_variable) %>
-        <div class="filter-search filter-container" role="menuitem">
+        <div class="filter-search filter-container">
           <%= form.search_field search_variable,
                                 label: false,
                                 placeholder: search_label,

--- a/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
+++ b/decidim-core/app/views/decidim/shared/_resource_actions.html.erb
@@ -12,10 +12,9 @@
     <ul class="dropdown dropdown__bottom divide-y divide-gray-3 px-4" role="menu">
       <%= yield %>
       <% unless defined?(skip_report) && skip_report %>
-        <li role="menuitem"><%= cell "decidim/report_button", resource %></li>
+        <li role="presentation"><%= cell "decidim/report_button", resource, html_options: { role: "menuitem" } %></li>
       <% end %>
-      <li role="menuitem">
-        <%= cell "decidim/follow_button", resource, large: false %></li>
+      <li role="presentation"><%= cell "decidim/follow_button", resource, large: false, html_options: { role: "menuitem" } %></li>
     </ul>
   </div>
 </div>

--- a/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_check_boxes_tree.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
+++ b/decidim-core/app/views/decidim/shared/filters/_collection.html.erb
@@ -1,4 +1,4 @@
-<div class="filter-container" role="menuitem">
+<div class="filter-container">
   <button id="trigger-menu-<%= id %>" data-controls="panel-dropdown-menu-<%= id %>" data-open="false" data-open-md="true">
     <%= icon "arrow-down-s-line" %>
     <%= icon "arrow-up-s-line" %>

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -16,8 +16,9 @@ module Decidim
       expect(subject.render).to have_link("Foo", href: "/boo")
     end
 
-    it "adds the menuitem role by default" do
-      expect(subject.render).to have_css("li[role='menuitem']")
+    it "adds the menuitem role to the interactive element by default" do
+      expect(subject.render).to have_css("li[role='presentation']")
+      expect(subject.render).to have_css("a[role='menuitem']")
     end
 
     it "does not add the aria-current attribute for non-active page" do
@@ -51,7 +52,7 @@ module Decidim
 
       it "adds a span instead of a link" do
         expect(subject.render).to have_no_link("Foo", href: "#")
-        expect(subject.render).to have_css("span.sidebar-menu__item-disabled")
+        expect(subject.render).to have_css("li[role='presentation'] span.sidebar-menu__item-disabled[role='menuitem']")
       end
     end
   end

--- a/decidim-debates/app/views/decidim/debates/debates/_debate_actions.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_debate_actions.html.erb
@@ -1,14 +1,14 @@
 
 <% if allowed_to?(:edit, :debate, debate: debate) %>
-  <li role="menuitem">
-    <%= link_to edit_debate_path(debate), class: "button button__sm button__text button__text-secondary" do %>
+  <li role="presentation">
+    <%= link_to edit_debate_path(debate), class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= t("edit_debate", scope: "decidim.debates.debates.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
   </li>
 <% elsif admin_allowed_to?(:update, :debate, debate: debate) %>
-  <li role="menuitem">
-    <%= link_to resource_locator(debate).edit, class: "button button__sm button__text button__text-secondary" do %>
+  <li role="presentation">
+    <%= link_to resource_locator(debate).edit, class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= t("edit_debate", scope: "decidim.debates.debates.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -17,15 +17,15 @@
 
 <% close_debate_action_text = (debate.closed? ? "decidim.debates.debates.show.edit_conclusions" : "decidim.debates.debates.show.close_debate" ) %>
 <% if allowed_to?(:close, :debate, debate: debate) %>
-  <li role="menuitem">
-    <button type="button" data-dialog-open="close-debate" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="button button__sm button__text button__text-secondary">
+  <li role="presentation">
+    <button type="button" data-dialog-open="close-debate" title="<%= t(close_debate_action_text) %>" aria-controls="closeDebateModal" aria-haspopup="dialog" tabindex="0" class="button button__sm button__text button__text-secondary" role="menuitem">
       <span><%= t(close_debate_action_text) %></span>
       <%= icon "lock-line" %>
     </button>
   </li>
 <% elsif admin_allowed_to?(:close, :debate, debate: debate) %>
-  <li role="menuitem">
-    <%= link_to Decidim::EngineRouter.admin_proxy(debate.component).edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), class: "button button__sm button__text button__text-secondary" do %>
+  <li role="presentation">
+    <%= link_to Decidim::EngineRouter.admin_proxy(debate.component).edit_debate_debate_close_path(debate_id: debate.id, id: debate.id), class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= t(close_debate_action_text) %></span>
       <%= icon "lock-line" %>
     <% end %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
@@ -1,6 +1,6 @@
 <% if allowed_to?(:update, :meeting, meeting: meeting) %>
-  <li role="menuitem">
-    <%= link_to edit_meeting_path(meeting), class: "button button__sm button__text button__text-secondary"  do %>
+  <li role="presentatino">
+    <%= link_to edit_meeting_path(meeting), class: "button button__sm button__text button__text-secondary", role: "menuitem"  do %>
       <span><%= t("edit_meeting", scope: "decidim.meetings.meetings.meeting") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -9,8 +9,8 @@
 
 <% if allowed_to?(:close, :meeting, meeting: meeting) %>
   <% caption = meeting.closed? ? t("edit_close_meeting", scope: "decidim.meetings.meetings.meeting") : t("close_meeting", scope: "decidim.meetings.meetings.meeting") %>
-  <li role="menuitem">
-    <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "button button__sm button__text button__text-secondary"  do %>
+  <li role="presentation">
+    <%= link_to edit_meeting_meeting_close_path(meeting_id: meeting.id, id: meeting.id), class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= caption %></span>
       <%= icon "lock-line" %>
     <% end %>
@@ -18,12 +18,13 @@
 <% end %>
 
 <% if meeting.withdrawable_by?(current_user) %>
-  <li role="menuitem">
+  <li role="presentation">
     <%= action_authorized_link_to(
           :withdraw,
           withdraw_meeting_path(meeting),
           method: :put,
           class: "button button__sm button__text button__text-secondary" ,
+          role: "menuitem",
           title: t("withdraw_btn_hint", scope: "decidim.meetings.meetings.show"),
           data: { confirm: t("withdraw_confirmation_html", scope: "decidim.meetings.meetings.show") }
         ) do %>

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_meeting_actions.html.erb
@@ -1,5 +1,5 @@
 <% if allowed_to?(:update, :meeting, meeting: meeting) %>
-  <li role="presentatino">
+  <li role="presentation">
     <%= link_to edit_meeting_path(meeting), class: "button button__sm button__text button__text-secondary", role: "menuitem"  do %>
       <span><%= t("edit_meeting", scope: "decidim.meetings.meetings.meeting") %></span>
       <%= icon "pencil-line" %>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_actions.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_proposal_actions.html.erb
@@ -1,6 +1,6 @@
 <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
-  <li role="menuitem">
-    <%= link_to edit_proposal_path(@proposal), class: "button button__sm button__text button__text-secondary" do %>
+  <li role="presentation">
+    <%= link_to edit_proposal_path(@proposal), class: "button button__sm button__text button__text-secondary", role: "menuitem" do %>
       <span><%= t("edit_proposal", scope: "decidim.proposals.proposals.show") %></span>
       <%= icon "pencil-line" %>
     <% end %>
@@ -10,8 +10,8 @@
 <% end %>
 
 <% if @proposal.withdrawable_by?(current_user) %>
-  <li role="menuitem">
-    <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), resource: @proposal, method: :put, class: "button button__sm button__text button__text-secondary", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
+  <li role="presentation">
+    <%= action_authorized_link_to :withdraw, withdraw_proposal_path(@proposal), resource: @proposal, method: :put, class: "button button__sm button__text button__text-secondary", role: "menuitem", title: t("withdraw_btn_hint", scope: "decidim.proposals.proposals.show" ), data: { confirm: t("withdraw_confirmation_html", scope: "decidim.proposals.proposals.show" ) } do %>
       <span><%= t("withdraw_proposal", scope: "decidim.proposals.proposals.show") %></span>
       <%= icon "arrow-go-back-line" %>
     <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #16875 to v0.30\


NOTE: 

I had to also add some fixes from https://github.com/decidim/decidim/pull/16489 adapted to this version, as the CI was failing (see https://github.com/decidim/decidim/actions/runs/26282759999/job/77383721330?pr=16879): 

```
Run sudo Xvfb -ac $DISPLAY -screen 0 1920x1084x24 > /dev/null 2>&1 & # optional
3 processes for 128 specs, ~ 42 specs per process

Randomized with seed 10418
......
Randomized with seed 10890

Randomized with seed 7189
...........................................................W, [2026-05-22T12:57:29.774967 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
W, [2026-05-22T12:57:29.781338 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.........................................................................................................................................................................W, [2026-05-22T12:59:02.984575 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
....W, [2026-05-22T12:59:03.347301 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.....W, [2026-05-22T12:59:03.721128 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:04.074041 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:04.458657 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:05.255636 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:05.627792 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:05.957019 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:06.239313 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:06.518503 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:06.818996 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
...W, [2026-05-22T12:59:07.171464 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
...W, [2026-05-22T12:59:07.517509 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
...W, [2026-05-22T12:59:08.348531 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:08.662264 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:08.945362 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:09.227142 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T12:59:09.522730 #7200]  WARN -- : Scoped order is ignored, it's forced to be batch order.
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:71
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:72
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:71
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:72
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:71
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:72
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:71
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:72
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:71
/opt/hostedtoolcache/Ruby/3.3.4/x64/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:55: warning: 'find' does not support count options ({:count=>1}) ignoring. Called from: /home/runner/work/decidim/decidim/decidim-participatory_processes/spec/system/participatory_process_all_metrics_spec.rb:72
2026-05-22 12:59:47 +0000 SEVERE: http://135.lvh.me:6485/processes/seller-transfer-90 821:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 12:59:47 +0000 SEVERE: http://135.lvh.me:6485/processes/seller-transfer-90 821:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 12:59:50 +0000 SEVERE: http://136.lvh.me:6485/processes/relationship-patience-91 809:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
............................................................................................................................................
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126:
######
line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


        <div class="filter-container" role="menuitem">
>>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
    <span>Date</span>

######
line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <span>Date</span>
  </button>
>>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><span>All</span><span></span></label>

######
line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

######
line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_1903585a-6649-4447-b676-e179eec5be53_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>


RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
.
2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126:
######
line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


        <div class="filter-container" role="menuitem">
>>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
    <span>Date</span>

######
line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <span>Date</span>
  </button>
>>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><span>All</span><span></span></label>

######
line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

######
line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_ef217e72-6ba3-44e7-b64c-24e092f48a88_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
F......
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126:
######
line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


        <div class="filter-container" role="menuitem">
>>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
    <span>Date</span>

######
line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <span>Date</span>
  </button>
>>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><span>All</span><span></span></label>

######
line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

######
line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_3c4652fd-e613-4071-be7d-dc73d8057515_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>


RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
2026-05-22 13:01:34 +0000 SEVERE: http://190.lvh.me:6454/packs-test/js/decidim_core.js 26:12320 Uncaught Error: Syntax error, unrecognized expression: #
.
2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126:
######
line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


        <div class="filter-container" role="menuitem">
>>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
    <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
    <span>Date</span>

######
line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <span>Date</span>
  </button>
>>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><span>All</span><span></span></label>

######
line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

    <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_all"><span>All</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_past"><span>Past</span><span></span></label>
      </div>

      <div class="filter">

######
line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

######
line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


      <div class="filter">
>>        <label for="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_e49d761a-f28d-4546-8400-73c561bb305d_filter_with_date_active"><span>Active</span><span></span></label>
      </div>
  </div>
</div>

RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
2026-05-22 13:02:11 +0000 SEVERE: http://203.lvh.me:5609/processes/wear-capital-360 685:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:29 +0000 SEVERE: http://220.lvh.me:5609/processes/seller-condition-386 685:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:31 +0000 SEVERE: http://221.lvh.me:5609/processes/compete-message-387 685:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:32 +0000 SEVERE: http://222.lvh.me:5609/processes/plain-distant-388 685:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:40 +0000 SEVERE: http://213.lvh.me:6454/processes - Failed to load resource: the server responded with a status of 404 (Not Found)
2026-05-22 13:02:39 +0000 SEVERE: http://225.lvh.me:5609/processes/dictate-corn-393 701:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:41 +0000 SEVERE: http://226.lvh.me:5609/processes/judge-whole-394 719:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:44 +0000 SEVERE: http://227.lvh.me:5609/processes/strikebreaker-academy-395 719:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:46 +0000 SEVERE: http://228.lvh.me:5609/processes/branch-onion-396 707:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:02:48 +0000 SEVERE: http://229.lvh.me:5609/processes/curriculum-hope-397 707:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:03:18 +0000 SEVERE: http://231.lvh.me:6454/processes/thank-figure-296?locale=en 872:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:03:21 +0000 SEVERE: http://231.lvh.me:6454/processes/thank-figure-296?locale=en 856:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
.F................................................................................................................................................................W, [2026-05-22T13:04:44.264209 #7202]  WARN -- : Scoped order is ignored, it's forced to be batch order.
........W, [2026-05-22T13:04:58.463153 #7202]  WARN -- : Scoped order is ignored, it's forced to be batch order.
2026-05-22 13:05:07 +0000 SEVERE: http://199.lvh.me:6485/processes/twilight-copy-752 823:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
2026-05-22 13:05:14 +0000 SEVERE: http://200.lvh.me:6485/processes/arena-theorist-753 834:9 Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
............................................................................................................................................................................................................................W, [2026-05-22T13:06:17.721258 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T13:06:18.242507 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T13:06:18.572085 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
.W, [2026-05-22T13:06:19.109721 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
..W, [2026-05-22T13:06:19.730384 #7201]  WARN -- : Scoped order is ignored, it's forced to be batch order.
...................................................................................

Failures:

  1) Participatory Processes when there are some published processes when requesting the processes path behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       ######
       line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


               <div class="filter-container" role="menuitem">
       >>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
           <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
           <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
           <span>Date</span>

       ######
       line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <span>Date</span>
         </button>
       >>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
               <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><span>All</span><span></span></label>

       ######
       line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><span>All</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_all"><span>All</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_past"><span>Past</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_past"><span>Past</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_active"><span>Active</span><span></span></label>
             </div>
         </div>
       </div>

       ######
       line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_e4a2a250-e43b-4ddd-b213-22ce424b9c5a_filter_with_date_active"><span>Active</span><span></span></label>
             </div>
         </div>
       </div>

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_participatory_processes_when_there_are_some_published_processes_when_requesting_the_processes_path_behaves_like_accessible_page_passes_html_validation_607.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_participatory_processes_when_there_are_some_published_processes_when_requesting_the_processes_path_behaves_like_accessible_page_passes_html_validation_607.html


     Shared Example Group: "accessible page" called from ./spec/system/participatory_processes_spec.rb:98
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:132:in `block (2 levels) in <top (required)>'

  2) Participatory Processes when there are some published processes when requesting the processes path with highlighted processes behaves like accessible page passes HTML validation
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }

       ######
       line 388: The element “button” must not appear as a descendant of an element with the attribute “role=menuitem”.


               <div class="filter-container" role="menuitem">
       >>  <button id="trigger-menu-date" data-controls="panel-dropdown-menu-date" data-open="true" data-open-md="true" role="button" tabindex="0" aria-controls="panel-dropdown-menu-date" aria-expanded="true" aria-disabled="false">
           <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-down-s-line"></use></svg>
           <svg width="1em" height="1em" role="img" aria-hidden="true"><use href="/packs-test/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-arrow-up-s-line"></use></svg>
           <span>Date</span>

       ######
       line 393: An element with the attribute “tabindex” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <span>Date</span>
         </button>
       >>  <div id="panel-dropdown-menu-date" role="region" tabindex="-1" aria-labelledby="trigger-menu-date" aria-hidden="false">
           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
               <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><span>All</span><span></span></label>

       ######
       line 396: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><span>All</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 396: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.

           <input type="hidden" name="filter[with_date]" value="" autocomplete="off">
             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><input class="reset-defaults" type="radio" value="all" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_all"><span>All</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 400: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 400: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_upcoming"><input class="reset-defaults" type="radio" value="upcoming" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_upcoming"><span>Upcoming</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 404: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_past"><span>Past</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 404: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_past"><input class="reset-defaults" type="radio" value="past" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_past"><span>Past</span><span></span></label>
             </div>

             <div class="filter">

       ######
       line 408: The element “label” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_active"><span>Active</span><span></span></label>
             </div>
         </div>
       </div>

       ######
       line 408: The element “input” must not appear as a descendant of an element with the attribute “role=menuitem”.


             <div class="filter">
       >>        <label for="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_active"><input class="reset-defaults" type="radio" value="active" checked="checked" name="filter[with_date]" id="filters_2059fe25-8079-44db-b308-f9f111f425a2_filter_with_date_active"><span>Active</span><span></span></label>
             </div>
         </div>
       </div>

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_participatory_processes_when_there_are_some_published_processes_when_requesting_the_processes_path_with_highlighted_processes_behaves_like_accessible_page_passes_html_validation_957.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_participatory_processes_when_there_are_some_published_processes_when_requesting_the_processes_path_with_highlighted_processes_behaves_like_accessible_page_passes_html_validation_957.html


     Shared Example Group: "accessible page" called from ./spec/system/participatory_processes_spec.rb:121
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:132:in `block (2 levels) in <top (required)>'

Top 10 slowest examples (83.07 seconds, 12.3% of total time):
  Admin manages participatory process share tokens when the user is a process admin behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens when ordering can be ordered by token and other attributes
    10.88 seconds /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:92
  Admin manages participatory process steps behaves like manage process steps examples creates a new participatory_process
    10.21 seconds ./spec/shared/manage_process_steps_examples.rb:27
  Admin manages participatory process steps behaves like manage process steps examples updates a participatory_process_step
    8.97 seconds ./spec/shared/manage_process_steps_examples.rb:64
  Admin manages participatory process share tokens behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens when ordering can be ordered by token and other attributes
    8.62 seconds /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:92
  Admin manages participatory process groups with existing groups can edit them
    8.48 seconds ./spec/system/admin/admin_manages_participatory_process_groups_spec.rb:75
  Participatory Processes when there are some published processes when requesting the processes path with highlighted processes behaves like accessible page passes HTML validation
    7.66 seconds /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
  Participatory Processes when there are some published processes when requesting the processes path behaves like accessible page passes HTML validation
    7.5 seconds /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/accessibility_examples.rb:126
  Admin manages participatory process share tokens when the user is a process admin behaves like manage participatory space share tokens behaves like manage resource share tokens when there are tokens can edit a share token
    7.2 seconds /home/runner/work/decidim/decidim/decidim-core/lib/decidim/core/test/shared_examples/manage_share_tokens_examples.rb:114
  Admin manages participatory process groups creates a new participatory process group
    7.11 seconds ./spec/system/admin/admin_manages_participatory_process_groups_spec.rb:29
  Admin manages participatory process admins behaves like manage process admins examples when managing different users updates a process admin
    6.44 seconds ./spec/shared/manage_process_admins_examples.rb:57

Top 10 slowest example groups:
  Admin manages participatory process steps
    7.31 seconds average (36.54 seconds / 5 examples) ./spec/system/admin/admin_manages_participatory_process_steps_spec.rb:5
  Admin manages participatory process private users
    5.87 seconds average (29.37 seconds / 5 examples) ./spec/system/admin/admin_manages_participatory_process_private_users_spec.rb:5
  Admin manages participatory process admins
    5.43 seconds average (32.61 seconds / 6 examples) ./spec/system/admin/admin_manages_participatory_process_admins_spec.rb:5
  Admin manages participatory process groups
    4.94 seconds average (39.49 seconds / 8 examples) ./spec/system/admin/admin_manages_participatory_process_groups_spec.rb:5
  Admin filters participatory processes private space users
    4.7 seconds average (32.92 seconds / 7 examples) ./spec/system/admin/admin_filters_participatory_processes_private_space_users_spec.rb:5
  Admin manages participatory process share tokens
    4.59 seconds average (110.1 seconds / 24 examples) ./spec/system/admin/admin_manages_participatory_process_share_tokens_spec.rb:5
  Admin manages participatory process landing page
    4.55 seconds average (18.21 seconds / 4 examples) ./spec/system/admin/admin_manages_participatory_process_landing_page_spec.rb:5
  ParticipatoryProcess Participatory Space
    4.16 seconds average (4.16 seconds / 1 example) ./spec/lib/decidim/participatory_processes/participatory_space_spec.rb:6
  Participatory Process Steps
    3.72 seconds average (14.87 seconds / 4 examples) ./spec/system/participatory_process_steps_spec.rb:5
  Decidim::ParticipatoryProcesses::AdminLog::ParticipatoryProcessTypePresenter
    3.33 seconds average (3.33 seconds / 1 example) ./spec/presenters/decidim/participatory_processes/admin_log/participatory_process_type_presenter_spec.rb:5

Finished in 11 minutes 16 seconds (files took 14.84 seconds to load)
446 examples, 2 failures

Failed examples:

rspec ./spec/system/participatory_processes_spec.rb[1:5:3:1:2] # Participatory Processes when there are some published processes when requesting the processes path behaves like accessible page passes HTML validation
rspec ./spec/system/participatory_processes_spec.rb[1:5:3:3:1:2] # Participatory Processes when there are some published processes when requesting the processes path with highlighted processes behaves like accessible page passes HTML validation

Randomized with seed 10890

.......................................................................................................................................................................................................................................................

Top 10 slowest examples (121.44 seconds, 13.4% of total time):
  Download Open Data files participatory processes when there is none returns an empty file
    25.5 seconds ./spec/system/download_open_data_files_spec.rb:25
  Participatory process admin manages participatory processes behaves like manage processes examples when updating a participatory process updates a participatory_process
    14.1 seconds ./spec/shared/manage_processes_examples.rb:100
  Participatory process admin manages participatory processes behaves like manage processes examples when viewing the processes list when processes are filtered by process_group listing processes filtered by group behaves like filtering collection by published/unpublished behaves like paginating a collection behaves like a paginated collection Number of results per page changes the number of results per page
    12.13 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_paginated_collection_examples.rb:19
  Participatory process admin manages participatory processes behaves like manage processes examples when viewing the processes list when processes are filtered by process_group listing processes filtered by group behaves like filtering collection by private/public behaves like paginating a collection behaves like a paginated collection Number of results per page changes the number of results per page
    11.16 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_paginated_collection_examples.rb:19
  Admin filters user_roles behaves like paginating a collection behaves like a paginated collection Number of results per page changes the number of results per page
    10.13 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_paginated_collection_examples.rb:19
  Admin filters user_roles when sorting when sorting by last_sign_in_at when desc displays the result
    9.87 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb:44
  Admin filters user_roles when sorting when sorting by email when asc displays the result
    9.81 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb:34
  Admin filters user_roles when sorting when sorting by name when desc displays the result
    9.79 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb:8
  Admin filters user_roles when sorting when sorting by last_sign_in_at when asc displays the result
    9.49 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb:52
  Admin filters user_roles when sorting when sorting by invitation_accepted_at when asc displays the result
    9.48 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/filters_participatory_space_user_roles_examples.rb:70

Top 10 slowest example groups:
  Admin copies participatory process
    7.71 seconds average (23.12 seconds / 3 examples) ./spec/system/admin/admin_copy_participatory_process_spec.rb:5
  Admin filters user_roles
    7.22 seconds average (129.88 seconds / 18 examples) ./spec/system/admin/admin_filters_participatory_process_user_roles_spec.rb:5
  Download Open Data files
    6.47 seconds average (38.82 seconds / 6 examples) ./spec/system/download_open_data_files_spec.rb:7
  Invite process collaborator
    5.69 seconds average (17.07 seconds / 3 examples) ./spec/system/admin/invite_process_collaborator_spec.rb:7
  Valuator checks components
    5.43 seconds average (10.86 seconds / 2 examples) ./spec/system/admin/valuator_checks_components_spec.rb:5
  Participatory process admin manages participatory processes
    5.17 seconds average (351.49 seconds / 68 examples) ./spec/system/admin/participatory_process_admin_manages_participatory_processes_spec.rb:5
  Admin imports participatory process
    4.3 seconds average (21.52 seconds / 5 examples) ./spec/system/admin/admin_import_participatory_process_spec.rb:5
  Admin sorting participatory processes
    4.26 seconds average (8.51 seconds / 2 examples) ./spec/system/admin/admin_filters_participatory_process_spec.rb:5
  Admin manages participatory process component permissions
    4.18 seconds average (58.56 seconds / 14 examples) ./spec/system/admin/admin_manages_participatory_process_component_permissions_spec.rb:5
  Admin manages participatory process component share tokens
    3.92 seconds average (47.07 seconds / 12 examples) ./spec/system/admin/admin_manages_participatory_process_component_share_tokens_spec.rb:5

Finished in 15 minutes 5 seconds (files took 15.54 seconds to load)
409 examples, 0 failures

Randomized with seed 10418

....Coverage report generated for (2/3) to /home/runner/work/decidim/decidim/coverage/coverage.xml. 37368 / 67440 LOC (55.41%) covered
................................................................................................

Top 10 slowest examples (128.57 seconds, 12.6% of total time):
  Participatory Processes when metrics are enabled downloads CSV data from link
    27.58 seconds ./spec/system/participatory_process_all_metrics_spec.rb:50
  Admin manages participatory processes when creating a participatory process creates a new participatory process
    14.07 seconds ./spec/system/admin/admin_manages_participatory_processes_spec.rb:73
  Invite process administrator behaves like inviting participatory space admins when the user does not exist when the user does not exist and is a private space behaves like sees private space menu can access all sections
    12.36 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb:26
  Invite process administrator behaves like inviting participatory space admins when the user does not exist when the user does not exist and is a public space behaves like sees public space menu can access all sections
    11.64 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb:11
  Admin manages participatory process attachments behaves like manage process attachments examples when checking notifications successfully displays the notification
    11.56 seconds ./spec/system/admin/admin_manages_participatory_process_attachments_spec.rb:10
  Admin manages participatory processes behaves like manage processes examples when updating a participatory process updates a participatory_process
    10.64 seconds ./spec/shared/manage_processes_examples.rb:100
  Invite process administrator behaves like inviting participatory space admins when the user already exists when user exists in the organization and is a private space behaves like sees private space menu can access all sections
    10.51 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb:26
  Invite process administrator behaves like inviting participatory space admins when the user already exists when user exists in the organization and is a public space behaves like sees public space menu can access all sections
    10.5 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/invite_participatory_space_admins_shared_examples.rb:11
  Admin manages participatory processes behaves like manage processes examples when viewing the processes list listing processes behaves like filtering collection by published/unpublished behaves like paginating a collection behaves like a paginated collection Number of results per page changes the number of results per page
    10.02 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_paginated_collection_examples.rb:19
  Admin manages participatory processes behaves like manage processes examples when viewing the processes list when processes are filtered by process_group listing processes filtered by group behaves like filtering collection by published/unpublished behaves like paginating a collection behaves like a paginated collection Number of results per page changes the number of results per page
    9.67 seconds /home/runner/work/decidim/decidim/decidim-admin/lib/decidim/admin/test/manage_paginated_collection_examples.rb:19

Top 10 slowest example groups:
  Participatory Processes
    12.87 seconds average (38.62 seconds / 3 examples) ./spec/system/participatory_process_all_metrics_spec.rb:6
  Invite process administrator
    10.61 seconds average (74.29 seconds / 7 examples) ./spec/system/admin/invite_process_admin_spec.rb:7
  Admin manages participatory process attachments
    7.18 seconds average (71.82 seconds / 10 examples) ./spec/system/admin/admin_manages_participatory_process_attachments_spec.rb:5
  Admin manages participatory process attachment collections
    6.9 seconds average (41.37 seconds / 6 examples) ./spec/system/admin/admin_manages_participatory_process_attachment_collections_spec.rb:5
  Admin manages participatory process publication
    5.97 seconds average (17.92 seconds / 3 examples) ./spec/system/admin/admin_manages_participatory_process_publication_spec.rb:5
  Invite process moderator
    5.28 seconds average (15.84 seconds / 3 examples) ./spec/system/admin/invite_process_moderator_spec.rb:7
  Admin manages participatory process components
    5 seconds average (99.99 seconds / 20 examples) ./spec/system/admin/admin_manages_participatory_process_components_spec.rb:5
  Admin manages participatory processes
    4.75 seconds average (351.33 seconds / 74 examples) ./spec/system/admin/admin_manages_participatory_processes_spec.rb:5
  Decidim::StatisticsCell
    3.47 seconds average (3.47 seconds / 1 example) ./spec/cells/decidim/participatory_processes/statistics_cell_spec.rb:6
  Filter Participatory Processes
    3.19 seconds average (19.17 seconds / 6 examples) ./spec/system/filter_participatory_processes_spec.rb:5

Finished in 17 minutes 4 seconds (files took 15.33 seconds to load)
383 examples, 0 failures

Randomized with seed 7189

Coverage report generated for (1/3), (2/3) to /home/runner/work/decidim/decidim/coverage/coverage.xml. 39035 / 67344 LOC (57.96%) covered
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
Coverage report generated for (1/3), (2/3), (3/3) to /home/runner/work/decidim/decidim/coverage/coverage.xml. 39719 / 67344 LOC (58.98%) covered
Tests Failed
```

:hearts: Thank you!