### PR TITLE
Fix blogs `:comments_count` stat returning post count

### DIFF
--- a/decidim-blogs/lib/decidim/blogs/component.rb
+++ b/decidim-blogs/lib/decidim/blogs/component.rb
@@ -34,7 +34,7 @@ Decidim.register_component(:blogs) do |component|
                           icon_name: "chat-1-line",
                           tooltip_key: "comments_count",
                           tag: :comments do |components, _start_at, _end_at|
-    Decidim::Blogs::Post.where(component: components).count
+    Decidim::Blogs::Post.where(component: components).sum(:comments_count)
   end
 
   component.actions = %w(create update destroy)

--- a/decidim-blogs/spec/lib/decidim/blogs/component_spec.rb
+++ b/decidim-blogs/spec/lib/decidim/blogs/component_spec.rb
@@ -7,6 +7,48 @@ describe "Blogs component" do # rubocop:disable RSpec/DescribeClass
   let(:organization) { component.organization }
   let!(:current_user) { create(:user, :confirmed, :admin, organization:) }
 
+  describe "stats" do
+    subject { current_stat[1][:data] }
+
+    let(:raw_stats) do
+      Decidim.component_manifests.map do |component_manifest|
+        component_manifest.stats.filter(name: stats_name).with_context(component).flat_map { |name, data| [component_manifest.name, name, data] }
+      end
+    end
+
+    let(:stats) do
+      raw_stats.select { |stat| stat[0] == :blogs }
+    end
+
+    let!(:post) { create(:post, component:) }
+    let!(:another_post) { create(:post, component:) }
+
+    let(:current_stat) { stats.find { |stat| stat[1][:name] == stats_name } }
+
+    describe "posts_count" do
+      let(:stats_name) { :posts_count }
+
+      it "counts posts in the component" do
+        expect(Decidim::Blogs::Post.where(component:).count).to eq 2
+        expect(subject).to eq 2
+      end
+    end
+
+    describe "comments_count" do
+      let(:stats_name) { :comments_count }
+
+      before do
+        create_list(:comment, 3, commentable: post)
+        create_list(:comment, 5, commentable: another_post)
+      end
+
+      it "counts the comments across all posts in the component" do
+        expect(Decidim::Comments::Comment.count).to eq 8
+        expect(subject).to eq 8
+      end
+    end
+  end
+
   describe "on edit", type: :system do
     let(:edit_component_path) do
       Decidim::EngineRouter.admin_proxy(component.participatory_space).edit_component_path(component.id)


### PR DESCRIPTION
#### :tophat: What? Why?

`decidim-blogs/lib/decidim/blogs/component.rb` registers `:comments_count` with the same query body as `:posts_count`.

As a result, the blogs component reports the number of posts under the "Comments" stat instead of the actual number of comments.
Any consumer that relies on `blogs_component.stats[:comments_count]` (such as dashboards, exports, or analytics) receives the post count instead of the comment count.

This PR:

1. Replaces the query body with `Decidim::Blogs::Post.where(component: components).sum(:comments_count)`.
2. Adds the missing `describe "stats"` block to `component_spec.rb`, asserting `:posts_count` and `:comments_count` independently.

#### :pushpin: Related Issues

- N/A

#### Testing

```
cd decidim-blogs
bundle exec rspec spec/lib/decidim/blogs/component_spec.rb
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the comments count statistic to now accurately sum all comments across posts in the blog component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->