### PR TITLE
Fix exception when user is already invited in meetings

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -20,9 +20,9 @@ module Decidim
         def create
           enforce_permission_to(:invite_attendee, :meeting, meeting:)
 
+          @invites = filtered_collection
           @form = form(MeetingRegistrationInviteForm).from_params(params)
 
-          @invites = filtered_collection
           InviteUserToJoinMeeting.call(@form, meeting, current_user) do
             on(:ok) do
               flash[:notice] = I18n.t("invites.create.success", scope: "decidim.meetings.admin")

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -22,13 +22,16 @@ module Decidim
 
           @form = form(MeetingRegistrationInviteForm).from_params(params)
 
+          @invites = filtered_collection
           InviteUserToJoinMeeting.call(@form, meeting, current_user) do
             on(:ok) do
-              redirect_to meeting_registrations_invites_path(meeting), notice: I18n.t("invites.create.success", scope: "decidim.meetings.admin")
+              flash[:notice] = I18n.t("invites.create.success", scope: "decidim.meetings.admin")
+              redirect_to meeting_registrations_invites_path(meeting)
             end
 
             on(:invalid) do
-              redirect_to meeting_registrations_invites_path(meeting), alert: I18n.t("invites.create.error", scope: "decidim.meetings.admin")
+              flash.now[:alert] = I18n.t("invites.create.error", scope: "decidim.meetings.admin")
+              render :index, status: :unprocessable_content
             end
           end
         end

--- a/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/admin/invites_controller.rb
@@ -24,13 +24,11 @@ module Decidim
 
           InviteUserToJoinMeeting.call(@form, meeting, current_user) do
             on(:ok) do
-              flash[:notice] = I18n.t("invites.create.success", scope: "decidim.meetings.admin")
-              redirect_to meeting_registrations_invites_path(meeting)
+              redirect_to meeting_registrations_invites_path(meeting), notice: I18n.t("invites.create.success", scope: "decidim.meetings.admin")
             end
 
             on(:invalid) do
-              flash.now[:alert] = I18n.t("invites.create.error", scope: "decidim.meetings.admin")
-              render :index, status: :unprocessable_content
+              redirect_to meeting_registrations_invites_path(meeting), alert: I18n.t("invites.create.error", scope: "decidim.meetings.admin")
             end
           end
         end

--- a/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
@@ -62,7 +62,7 @@ describe "Admin filters invites" do
   context "when user does not exist in database" do
     let(:meeting) { create(:meeting, :with_registrations_enabled) }
 
-    it "successfully handles the error" do
+    it "successfully handles the invite" do
       invited = build(:user, organization:)
 
       within "#new_meeting_registration_invite" do

--- a/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
@@ -44,4 +44,34 @@ describe "Admin filters invites" do
   it_behaves_like "paginating a collection" do
     let!(:collection) { create_list(:invite, 50, meeting:) }
   end
+
+  context "when user exists in database" do
+    let(:meeting) { create(:meeting, :with_registrations_enabled) }
+
+    it "successfully handles the error" do
+      within "#new_meeting_registration_invite" do
+        fill_in :meeting_registration_invite_name, with: user1.name
+        fill_in :meeting_registration_invite_email, with: user1.email
+        click_on "Invite"
+      end
+
+      expect(page).to have_callout("There was a problem inviting the participant to join the meeting.")
+    end
+  end
+
+  context "when user does not exist in database" do
+    let(:meeting) { create(:meeting, :with_registrations_enabled) }
+
+    it "successfully handles the error" do
+      invited = build(:user, organization:)
+
+      within "#new_meeting_registration_invite" do
+        fill_in :meeting_registration_invite_name, with: invited.name
+        fill_in :meeting_registration_invite_email, with: invited.email
+        click_on "Invite"
+      end
+
+      expect(page).to have_callout("Participant successfully invited to join the meeting.")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am trying to fix an issue related to the user invites. When the user is already invited, a 500 error page is being displayed. This is caused because the we are rendering the invite object inside the index object, and is not responding to `.each`

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16898

#### Testing
1. Login as admin, navigate to admin, processes, components , meetings 
2. Create a new meeting with registration enabled save it 
3. Viusit the registration menu .
4. Invite an user ( user@example.org ) 
5. See it works fine
6. Invite again the user ( user@example.org ) 
7. See exception 
8. Apply patch 
9. Repeat steps 4,5,6 
10. See there is no error

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1867" height="673" alt="image" src="https://github.com/user-attachments/assets/6f94e0a2-5f1c-45ca-bc69-7e68eda89b38" />

<img width="2035" height="635" alt="image" src="https://github.com/user-attachments/assets/0a718f58-1ceb-4732-8a4e-6453795cd986" />

<img width="1964" height="626" alt="image" src="https://github.com/user-attachments/assets/370620b5-6f97-492c-9ce4-163de1deb14c" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the invite list is available and the page renders correctly when an invite submission fails, showing consistent feedback alongside successful invites.

* **Tests**
  * Added system tests for the admin invite flow with registrations enabled, covering existing-user error and new-user success scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->