### PR TITLE
Make import of assemblies/processes attachments more robust

### DIFF
--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -105,8 +105,8 @@ module Decidim
           end
         end
 
-        unless attachments["attachment_collections"].empty?
-          attachments["attachment_collections"].map do |collection|
+        unless attachments["attachment_collections"].blank?
+          attachments["attachment_collections"]&.map do |collection|
             Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
               create_attachment_collection(collection)
             end

--- a/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
+++ b/decidim-assemblies/app/serializers/decidim/assemblies/assembly_importer.rb
@@ -105,7 +105,7 @@ module Decidim
           end
         end
 
-        unless attachments["attachment_collections"].blank?
+        if attachments["attachment_collections"].present?
           attachments["attachment_collections"]&.map do |collection|
             Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
               create_attachment_collection(collection)

--- a/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
+++ b/decidim-assemblies/spec/serializers/decidim/assemblies/assembly_importer_spec.rb
@@ -410,6 +410,109 @@ module Decidim::Assemblies
               .not_to change(Decidim::Attachment, :count)
           end
         end
+
+        context "when attachment collection is not defined" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url
+                }
+              ]
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "does not create any attachments collections" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::AttachmentCollection, :count)
+          end
+        end
+
+        context "when attachment collection is nil" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url
+                }
+              ],
+              "attachment_collections" => nil
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "does not create any attachments collections" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::AttachmentCollection, :count)
+          end
+        end
+
+        context "when attachment collection is defined" do
+          let(:attachment_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url,
+                  "attachment_collections" => {
+                    "name" => {
+                      "en" => "Collection name"
+                    },
+                    "weight" => 0,
+                    "description" => {
+                      "en" => "Collection description"
+                    }
+                  }
+                }
+              ],
+              "attachment_collections" => [
+                {
+                  "name" => {
+                    "en" => "Collection name"
+                  },
+                  "weight" => 0,
+                  "description" => {
+                    "en" => "Collection description"
+                  }
+                }
+              ]
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "creates the attachment and the collection" do
+            expect { importer.import_folders_and_attachments(attachment_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+              .and change(Decidim::AttachmentCollection, :count).by(1)
+          end
+        end
       end
     end
   end

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -130,7 +130,7 @@ module Decidim
           end
         end
 
-        unless attachments["attachment_collections"].blank?
+        if attachments["attachment_collections"].present?
           attachments["attachment_collections"]&.map do |collection|
             Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
               create_attachment_collection(collection)

--- a/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
+++ b/decidim-participatory_processes/app/serializers/decidim/participatory_processes/participatory_process_importer.rb
@@ -130,8 +130,8 @@ module Decidim
           end
         end
 
-        unless attachments["attachment_collections"].empty?
-          attachments["attachment_collections"].map do |collection|
+        unless attachments["attachment_collections"].blank?
+          attachments["attachment_collections"]&.map do |collection|
             Decidim.traceability.perform_action!("create", AttachmentCollection, @user) do
               create_attachment_collection(collection)
             end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -530,6 +530,109 @@ module Decidim::ParticipatoryProcesses
               .not_to change(Decidim::Attachment, :count)
           end
         end
+
+        context "when the attachment collection is not defined" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url
+                }
+              ]
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "does not create any attachments collections" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::AttachmentCollection, :count)
+          end
+        end
+
+        context "when the attachment collection is nil" do
+          let(:attachments_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url
+                }
+              ],
+              "attachment_collections" => nil
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "does not create any attachments collections" do
+            expect { importer.import_folders_and_attachments(attachments_data) }
+              .not_to change(Decidim::AttachmentCollection, :count)
+          end
+        end
+
+                context "when attachment collection is defined" do
+          let(:attachment_data) do
+            {
+              "files" => [
+                {
+                  "title" => { "en" => "Test File" },
+                  "description" => { "en" => "Test Description" },
+                  "weight" => 1,
+                  "remote_file_url" => remote_file_url,
+                  "attachment_collections" => {
+                    "name" => {
+                      "en" => "Collection name"
+                    },
+                    "weight" => 0,
+                    "description" => {
+                      "en" => "Collection description"
+                    }
+                  }
+                }
+              ],
+              "attachment_collections" => [
+                {
+                  "name" => {
+                    "en" => "Collection name"
+                  },
+                  "weight" => 0,
+                  "description" => {
+                    "en" => "Collection description"
+                  }
+                }
+              ]
+            }
+          end
+
+          before do
+            stub_request(:head, remote_file_url)
+              .to_return(status: 200, headers: { "Content-Type" => "application/pdf" })
+            stub_request(:get, remote_file_url)
+              .to_return(status: 200, body: File.read(Decidim::Dev.asset("Exampledocument.pdf")))
+          end
+
+          it "creates the attachment and the collection" do
+            expect { importer.import_folders_and_attachments(attachment_data) }
+              .to change(Decidim::Attachment, :count).by(1)
+              .and change(Decidim::AttachmentCollection, :count).by(1)
+          end
+        end
       end
     end
   end

--- a/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
+++ b/decidim-participatory_processes/spec/serializers/decidim/participatory_processes/participatory_process_importer_spec.rb
@@ -586,7 +586,7 @@ module Decidim::ParticipatoryProcesses
           end
         end
 
-                context "when attachment collection is defined" do
+        context "when attachment collection is defined" do
           let(:attachment_data) do
             {
               "files" => [


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

In #14880 we fixed the import of processes and assemblies when the attachment_collection field was empty, since it was doing `#map` on a nil object.

Even though that solution was correct for some cases, it was not for all of them, and we faced this error again during some imports with the new code.

Using `#blank?` is a better approach, since `#empty?` fails on `nil` objects

In case the code continues, and the object is not an array, the validation of `attachments["attachment_collections"]&.map` will prevent using `#map` on an object that's not valid.

#### Testing
*Describe the best way to test or validate your PR.*

1. Export a process or assembly that has no attachment collections
2. Import it.
3. See that it does not work.

Repeat with the patch and see it working.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

<img width="1822" height="1412" alt="imatge" src="https://github.com/user-attachments/assets/c0365a38-cfb8-4598-9425-c9457aec632e" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import processes now tolerate missing or nil attachment collections, preventing failures and improving reliability when attachment data is absent and ensuring imports proceed smoothly in those cases.
* **Tests**
  * Added test coverage for import behavior with absent, nil, and present attachment collection scenarios to validate correct creation (or non-creation) of attachments and collections and to guard against regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->