### PR TITLE
Document how to troubleshoot issues with the W3C A11y Validator

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -53,7 +53,7 @@ jobs:
       DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
       PARALLEL_TEST_PROCESSORS: 3
     services:
-      # If you see any inconsistency between CI and local testing environment related to the accessibiliity validator, the best way of troubleshooting is:
+      # If you see any inconsistency between CI and local testing environment related to the accessibility validator, the best way of troubleshooting is:
       # 1. Go to the "Raw log" of the failing action
       # 2. Search for the version of the validator in the line
       # > Status: Downloaded newer image for ghcr.io/validator/validator@XXX

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -53,6 +53,23 @@ jobs:
       DECIDIM_SPAM_DETECTION_BACKEND_USER: "memory"
       PARALLEL_TEST_PROCESSORS: 3
     services:
+      # If you see any inconsistency between CI and local testing environment related to the accessibiliity validator, the best way of troubleshooting is:
+      # 1. Go to the "Raw log" of the failing action
+      # 2. Search for the version of the validator in the line
+      # > Status: Downloaded newer image for ghcr.io/validator/validator@XXX
+      # Example:
+      # > Status: Downloaded newer image for ghcr.io/validator/validator@sha256:238afea6aed5f057e90c4c3ed2b40fa1e3646d16773cdddfb2f069dc265b111b
+      # 3. Copy the version
+      # 4. Run it with docker locally
+      # ```
+      # docker run --rm -p 8888:8888 ghcr.io/validator/validator@sha256:238afea6aed5f057e90c4c3ed2b40fa1e3646d16773cdddfb2f069dc265b111b
+      # ```
+      # 5. Run the failing spec with the VALIDATOR_HTML_URI environment variable
+      # ```
+      # VALIDATOR_HTML_URI=http://127.0.0.1:8888/ CI=true bin/rspec decidim-proposals/spec/system/proposals_spec.rb -e "accessible page"
+      # ```
+      #
+      # Mind that we could not be using the latest version because there was some problem upstream (new rules, or just a bad release).
       validator:
         image: ${{ vars.ACTION_ACCESSIBILITY_VALIDATOR_VERSION || 'ghcr.io/validator/validator:latest' }}
         ports: ["8888:8888"]

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -4,7 +4,7 @@ require "webmock/rspec"
 
 class CleanUpValidatorHtmlUri
   def self.host
-    validator_html_uri = ENV["VALIDATOR_HTML_URI"]
+    validator_html_uri = ENV.fetch("VALIDATOR_HTML_URI", nil)
     return if validator_html_uri.to_s.empty?
 
     URI.parse(validator_html_uri).host

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/webmock.rb
@@ -2,10 +2,22 @@
 
 require "webmock/rspec"
 
+class CleanUpValidatorHtmlUri
+  def self.host
+    validator_html_uri = ENV["VALIDATOR_HTML_URI"]
+    return if validator_html_uri.to_s.empty?
+
+    URI.parse(validator_html_uri).host
+  rescue URI::InvalidURIError
+    nil
+  end
+end
+
 WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: [
     %r{https://validator\.w3\.org/},
+    CleanUpValidatorHtmlUri.host,
     Decidim::Dev::Test::MapServer.host
-  ]
+  ].compact
 )


### PR DESCRIPTION
#### :tophat: What? Why?

As I mentioned at #16873, I think that by letting ourselves workaround issues with the W3C validator, we could actually make it much more difficult to troubleshoot for contributors. This is an scenario that I can come-up with: 

1. There's a problem upstream introduced by an update
2. As a workaround we introduce this change in the Env Vars (only visible for Maintainers in this organization)
3. We forgot that we introduced this change
4. An external contributor start to see a11y issues locally - but they're almost impossible to check out locally, as the version of the two services is different.

I think we should troubleshoot how to reproduce the environment locally (for ourselves and for the AI 😄)

#### :pushpin: Related Issues
 
- Related to #16873 

#### Testing

1. Follow the instructions from `.github/workflows/test_app.yml`
2. On my case, I also needed to add the value from `VALIDATOR_HTML_URI` to the WebMock configuration, as I'm using devcontainers, so the docker image is actually running in my host and I need to point to that IP address for this to work 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for accessibility validator inconsistencies in the CI workflow.

* **Tests**
  * Updated test support to respect the accessibility validator URL from environment and allow connections to the validator host during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->