### PR TITLE
Fix flaky spec on accountability

### DIFF
--- a/decidim-accountability/spec/services/decidim/accountability/searchable_result_resource_spec.rb
+++ b/decidim-accountability/spec/services/decidim/accountability/searchable_result_resource_spec.rb
@@ -20,19 +20,6 @@ module Decidim
       )
     end
 
-    # rubocop:disable RSpec/BeforeAfterAll
-    # to be removed when results will have a card-m and are declared searchable in its component
-    before(:all) do
-      manifest = Decidim.find_resource_manifest(Decidim::Accountability::Result)
-      manifest.searchable = true
-    end
-
-    after(:all) do
-      manifest = Decidim.find_resource_manifest(Decidim::Accountability::Result)
-      manifest.searchable = false
-    end
-    # rubocop:enable  RSpec/BeforeAfterAll
-
     describe "Indexing of results" do
       context "when implementing Searchable" do
         context "when on create" do


### PR DESCRIPTION
#### :tophat: What? Why?

There's a flaky spec on Accountability search, where on CI it fails a lot.

With a little help of my good old friend GPT-5.3-Codex, I found that we have this hack in one spec that may introduce a leak when running the specs on parallel. It can be removed as the spec works without it, and it'll fix the problem with the other specs, as we're not globally mutating the state.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to  https://github.com/decidim/decidim/actions/runs/26496820468/job/78056477318?pr=16854 
- Related to https://github.com/decidim/decidim/pull/5469

#### Testing

Preparing the parallel spec, and running the suite for decidim-accountability with and without this patch: 

```
cd spec/decidim_dummy_app/
bundle exec rake parallel:create
bundle exec rake parallel:prepare
cd -
cd decidim-accountability/
bundle exec parallel_test --type rspec --pattern spec/
```

### :camera: Stacktrace

``` 

................................................
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156:
expected `0.positive?` to be truthy, got false

RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156

2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156:
expected `0.positive?` to be truthy, got false
RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156
F
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128:
expected `0.positive?` to be truthy, got false

RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128

2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128:
expected `0.positive?` to be truthy, got false
RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128
F.
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156:
expected `0.positive?` to be truthy, got false

RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156

2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156:
expected `0.positive?` to be truthy, got false
RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:156
F.
1st Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128:
expected `0.positive?` to be truthy, got false

RSpec::Retry: 2nd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128

2nd Try error in /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128:
expected `0.positive?` to be truthy, got false
RSpec::Retry: 3rd try /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:128
F..............................................................

Failures:

  1) Admin manages component publication when there are children when component is published, and admin unpublishes removes records from index
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected `0.positive?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_children_when_component_is_published_and_admin_unpublishes_removes_records_from_index_816.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_children_when_component_is_published_and_admin_unpublishes_removes_records_from_index_816.html


     Shared Example Group: "removes component resources from search index" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:48
     Shared Example Group: "when managing a component as an admin" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:6
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:162:in 'block (2 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:153:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:153:in 'block (2 levels) in <top (required)>'

  2) Admin manages component publication when there are children when component is unpublished, and admin publishes adds records to index
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected `0.positive?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_children_when_component_is_unpublished_and_admin_publishes_adds_records_to_index_832.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_children_when_component_is_unpublished_and_admin_publishes_adds_records_to_index_832.html


     Shared Example Group: "add component resources to search index" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:42
     Shared Example Group: "when managing a component as an admin" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:6
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:142:in 'block (2 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:125:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:125:in 'block (2 levels) in <top (required)>'

  3) Admin manages component publication when there are no children when component is published, and admin unpublishes removes records from index
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected `0.positive?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_no_children_when_component_is_published_and_admin_unpublishes_removes_records_from_index_442.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_no_children_when_component_is_published_and_admin_unpublishes_removes_records_from_index_442.html


     Shared Example Group: "removes component resources from search index" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:25
     Shared Example Group: "when managing a component as an admin" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:6
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:162:in 'block (2 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:153:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:153:in 'block (2 levels) in <top (required)>'

  4) Admin manages component publication when there are no children when component is unpublished, and admin publishes adds records to index
     Failure/Error: DEFAULT_FAILURE_NOTIFIER = lambda { |failure, _opts| raise failure }
       expected `0.positive?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_no_children_when_component_is_unpublished_and_admin_publishes_adds_records_to_index_565.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_component_publication_when_there_are_no_children_when_component_is_unpublished_and_admin_publishes_adds_records_to_index_565.html


     Shared Example Group: "add component resources to search index" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:19
     Shared Example Group: "when managing a component as an admin" called from ./spec/system/admin/admin_manages_component_publication_spec.rb:6
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:142:in 'block (2 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:125:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb:125:in 'block (2 levels) in <top (required)>'

Finished in 12 minutes 22 seconds (files took 19.32 seconds to load)
311 examples, 4 failures

Failed examples:

rspec ./spec/system/admin/admin_manages_component_publication_spec.rb:45 # Admin manages component publication when there are children when component is published, and admin unpublishes removes records from index
rspec ./spec/system/admin/admin_manages_component_publication_spec.rb:39 # Admin manages component publication when there are children when component is unpublished, and admin publishes adds records to index
rspec ./spec/system/admin/admin_manages_component_publication_spec.rb:22 # Admin manages component publication when there are no children when component is published, and admin unpublishes removes records from index
rspec ./spec/system/admin/admin_manages_component_publication_spec.rb:16 # Admin manages component publication when there are no children when component is unpublished, and admin publishes adds records to index



``` 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test setup and teardown logic in the accountability search test suite, removing unnecessary resource manifest configuration and cleanup routines for improved test maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->