### PR TITLE
Fix search indexing for unexisting locales

### DIFF
--- a/decidim-core/lib/decidim/searchable.rb
+++ b/decidim-core/lib/decidim/searchable.rb
@@ -117,6 +117,11 @@ module Decidim
             searchables_in_org.find_each do |sr|
               next if sr.blank?
 
+              unless sr.locale.in?(org.available_locales)
+                sr.destroy
+                next
+              end
+
               sr.update(contents_to_searchable_resource_attributes(fields, sr.locale))
             end
           end

--- a/decidim-core/spec/lib/searchable_spec.rb
+++ b/decidim-core/spec/lib/searchable_spec.rb
@@ -98,6 +98,26 @@ module Decidim
           participatory_process.update!(published_at: nil)
         end
       end
+
+      context "when the resource locale is not an available locale" do
+        let!(:searchable_resource) do
+          create(
+            :searchable_resource,
+            resource: participatory_process,
+            organization: participatory_process.organization,
+            decidim_participatory_space: participatory_process,
+            locale: "tlh"
+          )
+        end
+
+        it "deletes the searchable resource for unexisting locale" do
+          expect do
+            participatory_process.update!(title: { en: "Updated" })
+          end.to change(Decidim::SearchableResource, :count).by(-1)
+
+          expect(Decidim::SearchableResource.count).to eq(0)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When the organization locales are changed, the search index updates will fail the search indexing because it is trying to update content for locales that are no longer available in the organization.

This fixes the issue.

Relevant stack trace:

```
NoMethodError (undefined method `[]' for nil):
  
decidim-core (0.31.5) lib/decidim/searchable.rb:138:in `contents_to_searchable_resource_attributes'
decidim-core (0.31.5) lib/decidim/searchable.rb:120:in `block in try_update_index_for_search_resource'
```

Workaround for this issue through the rails console:
```irb
> Decidim::SearchableResource.where.not(locale: org.available_locales).destroy_all
```

#### Testing
- Create the development app and seed it with multiple locales
- After this, change the organization's `available_locales` to only `en` (`org.update!(available_locales: %w(en))`)
- Browse the site for a while and you will see the shown errors appear (depending on your queue handler, you might see them at the queue handler logs, in this case I was using the async handler)

The added spec also tests this situation and can be run with and without the fix to see the effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search resources are now automatically cleaned up when their locale is removed from the organization's available languages.

* **Tests**
  * Added test case for search resource removal when locales become unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/decidim/decidim/pull/16931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->