### PR TITLE
Fix OAuth forgetting data on registration

### DIFF
--- a/decidim-core/app/commands/decidim/create_omniauth_registration.rb
+++ b/decidim-core/app/commands/decidim/create_omniauth_registration.rb
@@ -29,6 +29,7 @@ module Decidim
           return broadcast(:ok, @user)
         end
         return broadcast(:invalid) if form.invalid?
+        return broadcast(:add_tos_errors) if requires_tos_acceptance?
 
         transaction do
           create_or_find_user
@@ -37,8 +38,6 @@ module Decidim
         trigger_omniauth_event
 
         broadcast(:ok, @user)
-      rescue NeedTosAcceptance
-        broadcast(:add_tos_errors, @user)
       rescue ActiveRecord::RecordInvalid => e
         broadcast(:error, e.record)
       end
@@ -75,12 +74,17 @@ module Decidim
         attach_avatar(form.avatar_url) if form.avatar_url.present?
         @user.tos_agreement = form.tos_agreement
         @user.accepted_tos_version = Time.current
-        raise NeedTosAcceptance if @user.tos_agreement.blank?
 
         @user.skip_confirmation! if verified_email
         @user.save!
         @user.after_confirmation if verified_email
       end
+    end
+
+    def requires_tos_acceptance?
+      return false if form.tos_agreement.present?
+
+      verified_email.blank? || User.find_by(email: verified_email, organization:).blank?
     end
 
     def attach_avatar(avatar_url)
@@ -146,9 +150,6 @@ module Decidim
         accepted_tos_version: form.current_organization.tos_version
       )
     end
-  end
-
-  class NeedTosAcceptance < StandardError
   end
 
   class InvalidOauthSignature < StandardError

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -14,13 +14,15 @@ module Decidim
       end
 
       def create
-        form_params = user_params_from_oauth_hash || params[:user]
+        form_params = form_params_from_pending_oauth
 
         @form = form(OmniauthRegistrationForm).from_params(form_params)
         @form.email ||= verified_email
 
         CreateOmniauthRegistration.call(@form, verified_email) do
           on(:ok) do |user|
+            clear_pending_oauth_data!
+
             if user.active_for_authentication?
               sign_in_and_redirect user, event: :authentication
               set_flash_message :notice, :success, kind: @form.provider.capitalize
@@ -39,7 +41,6 @@ module Decidim
 
           on(:add_tos_errors) do
             set_flash_message :alert, :add_tos_errors if @form.valid_tos?
-            session[:verified_email] = verified_email
             render :new_tos_fields
           end
 
@@ -61,28 +62,89 @@ module Decidim
 
       private
 
+      def form_params_from_pending_oauth
+        submitted_params = params.fetch(:user, {}).permit(:name, :nickname, :email, :tos_agreement, :newsletter).to_h.symbolize_keys
+        oauth_params = pending_oauth_form_params
+
+        oauth_params.merge(
+          submitted_params
+        )
+      end
+
       def oauth_data
         @oauth_data ||= oauth_hash.slice(:provider, :uid, :info)
       end
 
-      # Private: Create form params from omniauth hash
-      # Since we are using trusted omniauth data we are generating a valid signature.
-      def user_params_from_oauth_hash
-        return nil if oauth_data.empty?
+      # Private: Create trusted form params from oauth data stored server-side.
+      # Since we are using trusted oauth data we are generating a valid signature.
+      def pending_oauth_form_params
+        return {} if pending_oauth_data.blank?
 
         {
-          provider: oauth_data[:provider],
-          uid: oauth_data[:uid],
-          name: oauth_data[:info][:name],
-          nickname: oauth_data[:info][:nickname],
-          oauth_signature: OmniauthRegistrationForm.create_signature(oauth_data[:provider], oauth_data[:uid]),
-          avatar_url: oauth_data[:info][:image],
-          raw_data: oauth_hash
+          provider: pending_oauth_data[:provider],
+          uid: pending_oauth_data[:uid],
+          name: pending_oauth_data[:name],
+          nickname: pending_oauth_data[:nickname],
+          oauth_signature: OmniauthRegistrationForm.create_signature(pending_oauth_data[:provider], pending_oauth_data[:uid]),
+          avatar_url: pending_oauth_data[:avatar_url],
+          raw_data: pending_oauth_data[:raw_data],
+          pending_oauth_token:
         }
       end
 
       def verified_email
-        @verified_email ||= oauth_data.dig(:info, :email).presence || session[:verified_email]
+        @verified_email ||= pending_oauth_data&.dig(:verified_email)
+      end
+
+      def pending_oauth_data
+        @pending_oauth_data ||= if oauth_hash.present?
+                                  store_pending_oauth_data!
+                                else
+                                  restore_pending_oauth_data
+                                end
+      end
+
+      def pending_oauth_token
+        @pending_oauth_token ||= params.dig(:user, :pending_oauth_token).presence || session.dig(:omniauth_registration, :token)
+      end
+
+      def store_pending_oauth_data!
+        data = {
+          provider: oauth_data[:provider],
+          uid: oauth_data[:uid],
+          name: oauth_data.dig(:info, :name),
+          nickname: oauth_data.dig(:info, :nickname),
+          avatar_url: oauth_data.dig(:info, :image),
+          verified_email: oauth_data.dig(:info, :email).presence,
+          raw_data: oauth_hash
+        }
+
+        session[:omniauth_registration] = {
+          token: SecureRandom.hex(16),
+          data:
+        }
+
+        @pending_oauth_token = session[:omniauth_registration][:token]
+        data
+      end
+
+      def restore_pending_oauth_data
+        token = params.dig(:user, :pending_oauth_token)
+        return {} if token.blank?
+
+        state = session[:omniauth_registration]
+        return {} if state.blank?
+
+        stored_token = state[:token].to_s
+        return {} unless stored_token.bytesize == token.to_s.bytesize
+        return {} unless ActiveSupport::SecurityUtils.secure_compare(stored_token, token.to_s)
+
+        @pending_oauth_token = stored_token
+        state[:data] || {}
+      end
+
+      def clear_pending_oauth_data!
+        session.delete(:omniauth_registration)
       end
 
       def oauth_hash

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -137,7 +137,11 @@ module Decidim
       def restore_raw_data_from_cache
         return {} if pending_oauth_token.blank?
 
-        Rails.cache.read(raw_data_cache_key(pending_oauth_token)) || {}
+        raw_data = Rails.cache.read(raw_data_cache_key(pending_oauth_token))
+        return raw_data if raw_data.present?
+
+        Rails.logger.warn("[Decidim::OmniauthRegistrationsController] Missing raw_data in cache for pending_oauth_token=#{pending_oauth_token}")
+        {}
       end
 
       def restore_pending_oauth_data

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -19,7 +19,6 @@ module Decidim
         form_params = form_params_from_pending_oauth
 
         @form = form(OmniauthRegistrationForm).from_params(form_params)
-
         CreateOmniauthRegistration.call(@form, verified_email) do
           on(:ok) do |user|
             clear_pending_oauth_data!
@@ -134,7 +133,7 @@ module Decidim
         token = params.dig(:user, :pending_oauth_token)
         return {} if token.blank?
 
-        state = session[:omniauth_registration]
+        state = session[:omniauth_registration]&.with_indifferent_access
         return {} if state.blank?
 
         stored_token = state[:token].to_s

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -14,10 +14,11 @@ module Decidim
       end
 
       def create
+        return handle_missing_oauth_data! if pending_oauth_data.blank?
+
         form_params = form_params_from_pending_oauth
 
         @form = form(OmniauthRegistrationForm).from_params(form_params)
-        @form.email ||= verified_email
 
         CreateOmniauthRegistration.call(@form, verified_email) do
           on(:ok) do |user|
@@ -83,6 +84,7 @@ module Decidim
         {
           provider: pending_oauth_data[:provider],
           uid: pending_oauth_data[:uid],
+          email: pending_oauth_data[:verified_email],
           name: pending_oauth_data[:name],
           nickname: pending_oauth_data[:nickname],
           oauth_signature: OmniauthRegistrationForm.create_signature(pending_oauth_data[:provider], pending_oauth_data[:uid]),
@@ -152,6 +154,11 @@ module Decidim
         return {} unless raw_hash
 
         raw_hash.deep_symbolize_keys
+      end
+
+      def handle_missing_oauth_data!
+        flash[:alert] = t("devise.failure.timeout")
+        redirect_to decidim.root_path
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -157,7 +157,7 @@ module Decidim
 
       def handle_missing_oauth_data!
         flash[:alert] = t("devise.failure.timeout")
-        redirect_to decidim.root_path
+        redirect_back_or_to(decidim.root_path)
       end
     end
   end

--- a/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
+++ b/decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb
@@ -77,6 +77,9 @@ module Decidim
 
       # Private: Create trusted form params from oauth data stored server-side.
       # Since we are using trusted oauth data we are generating a valid signature.
+      # Note: raw_data is stored in Rails.cache (not session) to avoid cookie size issues.
+      # If cache is not shared across nodes, raw_data may not be available on retry —
+      # the registration flow will still succeed but raw_data will be empty.
       def pending_oauth_form_params
         return {} if pending_oauth_data.blank?
 
@@ -88,7 +91,7 @@ module Decidim
           nickname: pending_oauth_data[:nickname],
           oauth_signature: OmniauthRegistrationForm.create_signature(pending_oauth_data[:provider], pending_oauth_data[:uid]),
           avatar_url: pending_oauth_data[:avatar_url],
-          raw_data: pending_oauth_data[:raw_data],
+          raw_data: restore_raw_data_from_cache,
           pending_oauth_token:
         }
       end
@@ -116,17 +119,25 @@ module Decidim
           name: oauth_data.dig(:info, :name),
           nickname: oauth_data.dig(:info, :nickname),
           avatar_url: oauth_data.dig(:info, :image),
-          verified_email: oauth_data.dig(:info, :email).presence,
-          raw_data: oauth_hash
+          verified_email: oauth_data.dig(:info, :email).presence
         }
 
-        session[:omniauth_registration] = {
-          token: SecureRandom.hex(16),
-          data:
-        }
+        token = SecureRandom.hex(16)
+        session[:omniauth_registration] = { token:, data: }
+        Rails.cache.write(raw_data_cache_key(token), oauth_hash, expires_in: 30.minutes)
 
-        @pending_oauth_token = session[:omniauth_registration][:token]
+        @pending_oauth_token = token
         data
+      end
+
+      def raw_data_cache_key(token)
+        "decidim/omniauth_registration/raw_data/#{token}"
+      end
+
+      def restore_raw_data_from_cache
+        return {} if pending_oauth_token.blank?
+
+        Rails.cache.read(raw_data_cache_key(pending_oauth_token)) || {}
       end
 
       def restore_pending_oauth_data
@@ -145,6 +156,7 @@ module Decidim
       end
 
       def clear_pending_oauth_data!
+        Rails.cache.delete(raw_data_cache_key(pending_oauth_token)) if pending_oauth_token.present?
         session.delete(:omniauth_registration)
       end
 

--- a/decidim-core/app/forms/decidim/omniauth_registration_form.rb
+++ b/decidim-core/app/forms/decidim/omniauth_registration_form.rb
@@ -15,6 +15,7 @@ module Decidim
     attribute :oauth_signature, String
     attribute :avatar_url, String
     attribute :raw_data, Hash
+    attribute :pending_oauth_token, String
 
     validates :email, presence: true
     validates :name, presence: true

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -24,9 +24,7 @@
 
       <%= render partial: "decidim/devise/shared/tos_fields", locals: { form: f, user: :user } %>
 
-      <%= f.hidden_field :uid %>
-      <%= f.hidden_field :provider %>
-      <%= f.hidden_field :oauth_signature %>
+      <%= f.hidden_field :pending_oauth_token %>
     </div>
 
     <div class="form__wrapper-block">

--- a/decidim-core/app/views/decidim/devise/omniauth_registrations/new_tos_fields.html.erb
+++ b/decidim-core/app/views/decidim/devise/omniauth_registrations/new_tos_fields.html.erb
@@ -12,9 +12,7 @@
 
       <%= render partial: "decidim/devise/shared/tos_fields", locals: { form: f, user: :user } %>
 
-      <%= f.hidden_field :uid %>
-      <%= f.hidden_field :provider %>
-      <%= f.hidden_field :oauth_signature %>
+      <%= f.hidden_field :pending_oauth_token %>
     </div>
 
     <div class="form__wrapper-block">

--- a/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_omniauth_registration_spec.rb
@@ -107,6 +107,38 @@ module Decidim
           end
         end
 
+        context "when tos agreement is missing for a new user" do
+          let(:tos_agreement) { nil }
+
+          it "broadcasts add_tos_errors" do
+            expect { command.call }.to broadcast(:add_tos_errors)
+          end
+
+          it "does not create a new user" do
+            expect do
+              command.call
+            end.not_to change(User, :count)
+          end
+        end
+
+        context "when tos agreement is missing for an existing verified user" do
+          let(:tos_agreement) { nil }
+
+          before do
+            create(:user, email:, organization:)
+          end
+
+          it "broadcasts ok" do
+            expect { command.call }.to broadcast(:ok)
+          end
+
+          it "does not create a new user" do
+            expect do
+              command.call
+            end.not_to change(User, :count)
+          end
+        end
+
         context "when the form is valid" do
           it "broadcasts ok" do
             expect { command.call }.to broadcast(:ok)

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -293,6 +293,46 @@ module Decidim
           expect(flash[:alert]).to eq(I18n.t("devise.failure.timeout"))
         end
       end
+
+      context "when pending oauth state session keys are strings" do
+        let(:pending_token) { SecureRandom.hex(16) }
+        let(:pending_raw_data) do
+          {
+            provider: provider,
+            uid: uid,
+            info: {
+              name: "Facebook User",
+              nickname: "facebook_user",
+              email: email
+            }
+          }
+        end
+
+        before do
+          request.env["omniauth.auth"] = nil
+          session[:omniauth_registration] = {
+            "token" => pending_token,
+            "data" => {
+              "provider" => provider,
+              "uid" => uid,
+              "name" => "Facebook User",
+              "nickname" => "facebook_user",
+              "avatar_url" => nil,
+              "verified_email" => email,
+              "raw_data" => pending_raw_data
+            }
+          }
+        end
+
+        it "restores the pending state and signs in" do
+          expect do
+            post :create, params: { locale: I18n.locale, user: { pending_oauth_token: pending_token, tos_agreement: "1" } }
+          end.to change(Identity, :count).by(1)
+
+          expect(controller).to be_user_signed_in
+          expect(User.find_by(email:)).to be_present
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -221,6 +221,62 @@ module Decidim
           end
         end
       end
+
+      context "when ToS is missing and user retries without omniauth.auth" do
+        let!(:user) { create(:user, organization:, email: "other@example.org") }
+        let(:raw_data) do
+          {
+            "provider" => provider,
+            "uid" => uid,
+            "info" => {
+              "name" => "Facebook User",
+              "nickname" => "facebook_user",
+              "email" => email
+            },
+            "extra" => {
+              "raw_info" => {
+                "id" => uid,
+                "name" => "Facebook User"
+              }
+            }
+          }
+        end
+
+        before do
+          request.env["omniauth.auth"] = raw_data
+        end
+
+        it "preserves oauth data in pending state and creates the account on retry" do
+          expect do
+            post :create, params: { locale: I18n.locale, user: { tos_agreement: nil } }
+          end.not_to change(User, :count)
+
+          expect(response).to render_template(:new_tos_fields)
+
+          token = session.dig(:omniauth_registration, :token)
+          expect(token).to be_present
+          expect(session.dig(:omniauth_registration, :data, :raw_data)).to eq(raw_data.deep_symbolize_keys)
+
+          request.env["omniauth.auth"] = nil
+          allow(ActiveSupport::Notifications).to receive(:publish).and_call_original
+
+          expect do
+            post :create, params: { locale: I18n.locale, user: { pending_oauth_token: token, tos_agreement: "1" } }
+          end.to change(User, :count).by(1)
+
+          expect(controller).to be_user_signed_in
+          expect(User.find_by(email:)).to be_present
+          expect(ActiveSupport::Notifications).to have_received(:publish).with(
+            "decidim.user.omniauth_registration",
+            hash_including(
+              provider:,
+              uid:,
+              email:,
+              raw_data: raw_data.deep_symbolize_keys
+            )
+          )
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -277,6 +277,22 @@ module Decidim
           )
         end
       end
+
+      context "when oauth data is missing and there is no pending state" do
+        before do
+          request.env["omniauth.auth"] = nil
+        end
+
+        it "redirects to root with a timeout alert" do
+          expect do
+            post :create, params: { locale: I18n.locale }
+          end.not_to raise_error
+
+          expect(controller).not_to be_user_signed_in
+          expect(controller).to redirect_to(root_path)
+          expect(flash[:alert]).to eq(I18n.t("devise.failure.timeout"))
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -335,6 +335,23 @@ module Decidim
           expect(controller).to be_user_signed_in
           expect(User.find_by(email:)).to be_present
         end
+
+        context "when raw_data is missing in cache" do
+          before do
+            Rails.cache.delete("decidim/omniauth_registration/raw_data/#{pending_token}")
+          end
+
+          it "logs a warning and signs in" do
+            expect(Rails.logger).to receive(:warn).with(/Missing raw_data in cache for pending_oauth_token=/)
+
+            expect do
+              post :create, params: { locale: I18n.locale, user: { pending_oauth_token: pending_token, tos_agreement: "1" } }
+            end.to change(Identity, :count).by(1)
+
+            expect(controller).to be_user_signed_in
+            expect(User.find_by(email:)).to be_present
+          end
+        end
       end
     end
   end

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -298,12 +298,12 @@ module Decidim
         let(:pending_token) { SecureRandom.hex(16) }
         let(:pending_raw_data) do
           {
-            provider: provider,
-            uid: uid,
+            provider:,
+            uid:,
             info: {
               name: "Facebook User",
               nickname: "facebook_user",
-              email: email
+              email:
             }
           }
         end

--- a/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
+++ b/decidim-core/spec/controllers/omniauth_registrations_controller_spec.rb
@@ -247,34 +247,37 @@ module Decidim
         end
 
         it "preserves oauth data in pending state and creates the account on retry" do
-          expect do
-            post :create, params: { locale: I18n.locale, user: { tos_agreement: nil } }
-          end.not_to change(User, :count)
+          Rails.cache.with_local_cache do
+            expect do
+              post :create, params: { locale: I18n.locale, user: { tos_agreement: nil } }
+            end.not_to change(User, :count)
 
-          expect(response).to render_template(:new_tos_fields)
+            expect(response).to render_template(:new_tos_fields)
 
-          token = session.dig(:omniauth_registration, :token)
-          expect(token).to be_present
-          expect(session.dig(:omniauth_registration, :data, :raw_data)).to eq(raw_data.deep_symbolize_keys)
+            token = session.dig(:omniauth_registration, :token)
+            expect(token).to be_present
+            expect(session.dig(:omniauth_registration, :data)).not_to have_key(:raw_data)
+            expect(Rails.cache.read("decidim/omniauth_registration/raw_data/#{token}")).to eq(raw_data.deep_symbolize_keys)
 
-          request.env["omniauth.auth"] = nil
-          allow(ActiveSupport::Notifications).to receive(:publish).and_call_original
+            request.env["omniauth.auth"] = nil
+            allow(ActiveSupport::Notifications).to receive(:publish).and_call_original
 
-          expect do
-            post :create, params: { locale: I18n.locale, user: { pending_oauth_token: token, tos_agreement: "1" } }
-          end.to change(User, :count).by(1)
+            expect do
+              post :create, params: { locale: I18n.locale, user: { pending_oauth_token: token, tos_agreement: "1" } }
+            end.to change(User, :count).by(1)
 
-          expect(controller).to be_user_signed_in
-          expect(User.find_by(email:)).to be_present
-          expect(ActiveSupport::Notifications).to have_received(:publish).with(
-            "decidim.user.omniauth_registration",
-            hash_including(
-              provider:,
-              uid:,
-              email:,
-              raw_data: raw_data.deep_symbolize_keys
+            expect(controller).to be_user_signed_in
+            expect(User.find_by(email:)).to be_present
+            expect(ActiveSupport::Notifications).to have_received(:publish).with(
+              "decidim.user.omniauth_registration",
+              hash_including(
+                provider:,
+                uid:,
+                email:,
+                raw_data: raw_data.deep_symbolize_keys
+              )
             )
-          )
+          end
         end
       end
 
@@ -318,10 +321,10 @@ module Decidim
               "name" => "Facebook User",
               "nickname" => "facebook_user",
               "avatar_url" => nil,
-              "verified_email" => email,
-              "raw_data" => pending_raw_data
+              "verified_email" => email
             }
           }
+          Rails.cache.write("decidim/omniauth_registration/raw_data/#{pending_token}", pending_raw_data)
         end
 
         it "restores the pending state and signs in" do

--- a/docs/modules/customize/pages/oauth.adoc
+++ b/docs/modules/customize/pages/oauth.adoc
@@ -18,7 +18,7 @@ This event comes with the following payload:
 * name: User's name.
 * nickname: User's nickname after being normalized.
 * avatar_url: Avatar's url, if any.
-* raw_data: The raw hash received directly from the Omniauth gem.
+* raw_data: The raw hash received directly from the Omniauth gem. In multi-step registration flows (e.g. when users must accept Terms of Service before completing signup), this value is restored from temporary cache. To keep `raw_data` reliably available across retries in production, use a shared cache backend.
 
 To be notified after a registration one should subscribe to the event, in the passed block the after registration code should be implemented:
 
@@ -29,6 +29,10 @@ ActiveSupport::Notifications.subscribe "decidim.user.omniauth_registration" do |
   IdCatMobilVerificationJob.perform_later(data[:raw_data])
 end
 ----
+
+If your integration depends on `data[:raw_data]`, make sure your cache is properly configured so this payload can be restored during multi-step OAuth registration retries.
+
+When testing this behavior in development, enable caching first (for example with `bin/rails dev:cache`) so `raw_data` can be persisted across retries.
 
 Note that, if the user is already registered, the `CreateOmniauthRegistration` command will not trigger the "decidim.user.omniauth_registration" event by instead it will trigger the "decidim.user.omniauth_login" event, which has the same payload as the registration event.
 


### PR DESCRIPTION
#### :tophat: What? Why?

We've found that some data comming from an oauth registration is not maintained after having to check the mandatory ToS field.

This PR simplifies the omniauth registration flow so oauth data is kept in a server-side pending state instead of being round-tripped through hidden fields. This keeps `raw_data` and the rest of the oauth payload intact when the user has to come back and accept the ToS.

Note that this should make this type of registration a bit more secure as it does not relies on using "hidden" fields anymore.

In addition, this PR also removes the exception "NeedsTosAcceptance" as I think this simplifies intent: ToS is a validation state, not an exceptional state. It also simplifies the workflow (IMO).

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
It's a bit difficult to test this without having custom implementation for the "decidim.user.omniauth_registration" event that needs to use the data coming from the Omniauth registration.

asically:

1. Start an omniauth sign-up.
2. Fill the profile form but leave the ToS unchecked.
3. Submit once, which takes you to the ToS-only screen.
4. Submit again from that screen.

In the old flow, that second submit could lose oauth data like `raw_data` because it was being carried through hidden fields/session instead of a trusted server-side state.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
Screens involved:

<img width="1918" height="1643" alt="Captura de pantalla de 2026-06-01 13-20-59" src="https://github.com/user-attachments/assets/84a63b19-452f-40f4-b25b-09f6e2a7dfb1" />
<img width="1884" height="1374" alt="imatge" src="https://github.com/user-attachments/assets/efba544c-34da-4b4f-beab-69cb109e43a8" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a token-based pending OAuth signup flow; forms and views include a pending token to support secure multi-step retries.

* **Bug Fixes**
  * Enforced clearer ToS acceptance during OAuth signup and prevented account creation without acceptance.
  * Improved handling and timeout messaging when OAuth data is missing or cannot be restored.

* **Documentation**
  * Clarified OAuth registration payload and cache requirements for multi-step retries.

* **Tests**
  * Expanded tests for ToS, missing OAuth data, retry, and signup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->