### PR TITLE
Make possible to add members by nickname or name

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
+++ b/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
@@ -63,14 +63,14 @@ module Decidim
         def existing_user
           return @existing_user if defined?(@existing_user)
 
-          if form.existing_user
-            @existing_user = form.user
-          else
-            @existing_user = User.find_by(
-              email: form.email.downcase,
-              organization: member_to.organization
-            )
-          end
+          @existing_user = if form.existing_user
+                             form.user
+                           else
+                             User.find_by(
+                               email: form.email.downcase,
+                               organization: member_to.organization
+                             )
+                           end
 
           InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user&.invitation_pending?
 

--- a/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
+++ b/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
@@ -63,10 +63,14 @@ module Decidim
         def existing_user
           return @existing_user if defined?(@existing_user)
 
-          @existing_user = User.find_by(
-            email: form.email.downcase,
-            organization: member_to.organization
-          )
+          if form.existing_user
+            @existing_user = form.user
+          else
+            @existing_user = User.find_by(
+              email: form.email.downcase,
+              organization: member_to.organization
+            )
+          end
 
           InviteUserAgain.call(@existing_user, invitation_instructions) if @existing_user&.invitation_pending?
 

--- a/decidim-admin/app/forms/decidim/admin/participatory_space/member_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space/member_form.rb
@@ -13,13 +13,21 @@ module Decidim
 
         attribute :name, String
         attribute :email, String
+        attribute :user_id, Integer
+        attribute :existing_user, Boolean, default: false
         attribute :published, Boolean
 
         translatable_attribute :role, String
 
-        validates :name, :email, presence: true
+        validates :name, presence: true, unless: proc { |object| object.existing_user }
+        validates :email, presence: true, "valid_email_2/email": { disposable: true }, unless: proc { |object| object.existing_user }
+        validates :user, presence: true, if: proc { |object| object.existing_user }
 
-        validates :name, format: { with: UserBaseEntity::REGEXP_NAME }
+        validates :name, format: { with: UserBaseEntity::REGEXP_NAME }, unless: proc { |object| object.existing_user }
+
+        def user
+          @user ||= current_organization.users.find_by(id: user_id)
+        end
       end
     end
   end

--- a/decidim-admin/app/packs/entrypoints/decidim_admin.js
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin.js
@@ -21,6 +21,7 @@ import "src/decidim/admin/css_preview"
 import "src/decidim/admin/sync_radio_buttons"
 import "src/decidim/admin/text_copy"
 import "src/decidim/admin/taxonomy_filters"
+import "src/decidim/admin/members_form"
 
 // CSS
 import "entrypoints/decidim_admin.scss";

--- a/decidim-admin/app/packs/src/decidim/admin/members_form.js
+++ b/decidim-admin/app/packs/src/decidim/admin/members_form.js
@@ -9,8 +9,8 @@ document.addEventListener("turbo:load", () => {
 
   createFieldDependentInputs({
     controllerField: $memberType,
-    wrapperSelector: ".member-fields",
-    dependentFieldsSelector: ".member-fields--new-participant",
+    wrapperSelector: "[data-member-fields]",
+    dependentFieldsSelector: "[data-member-type='new-participant']",
     dependentInputSelector: "input",
     enablingCondition: () => {
       return $("#member_existing_user_false").is(":checked")
@@ -19,8 +19,8 @@ document.addEventListener("turbo:load", () => {
 
   createFieldDependentInputs({
     controllerField: $memberType,
-    wrapperSelector: ".member-fields",
-    dependentFieldsSelector: ".member-fields--existing-participant",
+    wrapperSelector: "[data-member-fields]",
+    dependentFieldsSelector: "[data-member-type='existing-participant']",
     dependentInputSelector: "input",
     enablingCondition: () => {
       return $("#member_existing_user_true").is(":checked")

--- a/decidim-admin/app/packs/src/decidim/admin/members_form.js
+++ b/decidim-admin/app/packs/src/decidim/admin/members_form.js
@@ -1,0 +1,29 @@
+import createFieldDependentInputs from "src/decidim/admin/field_dependent_inputs.component"
+
+document.addEventListener("turbo:load", () => {
+  const $memberType = $('[name="member[existing_user]"]')
+
+  if ($memberType.length === 0) {
+    return
+  }
+
+  createFieldDependentInputs({
+    controllerField: $memberType,
+    wrapperSelector: ".member-fields",
+    dependentFieldsSelector: ".member-fields--new-participant",
+    dependentInputSelector: "input",
+    enablingCondition: () => {
+      return $("#member_existing_user_false").is(":checked")
+    }
+  })
+
+  createFieldDependentInputs({
+    controllerField: $memberType,
+    wrapperSelector: ".member-fields",
+    dependentFieldsSelector: ".member-fields--existing-participant",
+    dependentInputSelector: "input",
+    enablingCondition: () => {
+      return $("#member_existing_user_true").is(":checked")
+    }
+  })
+})

--- a/decidim-admin/app/views/decidim/admin/members/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/members/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="form__wrapper member-fields">
+<div class="form__wrapper" data-member-fields>
   <div class="card pt-4">
     <div id="panel-title" class="card-section">
       <% unless @form.persisted? %>
@@ -20,15 +20,15 @@
             <%= form.email_field :email, readonly: true %>
           </div>
         <% else %>
-          <div class="columns member-fields--new-participant">
+          <div class="columns" data-member-type="new-participant">
             <p><%= t(".invite_explanation") %></p>
             <%= form.text_field :name %>
           </div>
-          <div class="columns member-fields--new-participant">
+          <div class="columns" data-member-type="new-participant">
             <%= form.email_field :email %>
           </div>
 
-          <div class="columns member-fields--existing-participant">
+          <div class="columns" data-member-type="existing-participant">
             <% prompt_options = { placeholder: t(".select_user") } %>
             <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, class: "autocomplete-field--results-inline" }, prompt_options) do |user|
               { value: user.id, label: "#{user.name} (@#{user.nickname})" }

--- a/decidim-admin/app/views/decidim/admin/members/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/members/_form.html.erb
@@ -7,10 +7,6 @@
             <%= form.collection_radio_buttons(:existing_user, [[t(".non_existing_participant"), false], [t(".existing_participant"), true]], :last, :first) %>
           </fieldset>
         </div>
-
-        <div class="row column">
-          <p><%= t(".invite_explanation") %></p>
-        </div>
       <% end %>
 
       <div class="row">
@@ -23,6 +19,7 @@
           </div>
         <% else %>
           <div class="columns member-fields--new-participant">
+            <p><%= t(".invite_explanation") %></p>
             <%= form.text_field :name %>
           </div>
           <div class="columns member-fields--new-participant">

--- a/decidim-admin/app/views/decidim/admin/members/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/members/_form.html.erb
@@ -1,13 +1,41 @@
-<div class="form__wrapper">
+<div class="form__wrapper member-fields">
   <div class="card pt-4">
     <div id="panel-title" class="card-section">
+      <% unless @form.persisted? %>
+        <div class="row column">
+          <fieldset>
+            <%= form.collection_radio_buttons(:existing_user, [[t(".non_existing_participant"), false], [t(".existing_participant"), true]], :last, :first) %>
+          </fieldset>
+        </div>
+
+        <div class="row column">
+          <p><%= t(".invite_explanation") %></p>
+        </div>
+      <% end %>
+
       <div class="row">
-        <div class="columns">
-          <%= form.text_field :name, readonly: @form.persisted? %>
-        </div>
-        <div class="columns">
-          <%= form.email_field :email, readonly: @form.persisted? %>
-        </div>
+        <% if @form.persisted? %>
+          <div class="columns">
+            <%= form.text_field :name, readonly: true %>
+          </div>
+          <div class="columns">
+            <%= form.email_field :email, readonly: true %>
+          </div>
+        <% else %>
+          <div class="columns member-fields--new-participant">
+            <%= form.text_field :name %>
+          </div>
+          <div class="columns member-fields--new-participant">
+            <%= form.email_field :email %>
+          </div>
+
+          <div class="columns member-fields--existing-participant">
+            <% prompt_options = { placeholder: t(".select_user") } %>
+            <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, class: "autocomplete-field--results-inline" }, prompt_options) do |user|
+              { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+            end %>
+          </div>
+        <% end %>
         <div class="columns">
           <%= form.translated :text_field, :role %>
         </div>

--- a/decidim-admin/app/views/decidim/admin/members/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/members/_form.html.erb
@@ -4,7 +4,9 @@
       <% unless @form.persisted? %>
         <div class="row column">
           <fieldset>
-            <%= form.collection_radio_buttons(:existing_user, [[t(".non_existing_participant"), false], [t(".existing_participant"), true]], :last, :first) %>
+            <%= form.collection_radio_buttons(:existing_user, [[t(".non_existing_participant"), false], [t(".existing_participant"), true]], :last, :first) do |builder|
+              builder.label(class: "inline-block mr-4") { builder.radio_button + builder.text }
+            end %>
           </fieldset>
         </div>
       <% end %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -607,6 +607,11 @@ en:
         edit:
           title: Edit member
           update: Update
+        form:
+          existing_participant: Existing participant
+          invite_explanation: This participant will be invited to join the space and to the organization as well.
+          non_existing_participant: Non existing participant
+          select_user: Select participant
         index:
           import_via_csv: Import via CSV
           publish_all: Publish all

--- a/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_examples "manage admin members examples" do
-  let(:other_user) { create(:user, organization:, email: "my_email@example.org") }
+  let(:other_user) { create(:user, :confirmed, organization:, email: "my_email@example.org") }
 
   let!(:member) { create(:member, user:, participatory_space:) }
 
@@ -46,19 +46,7 @@ shared_examples "manage admin members examples" do
 
     within ".new_member" do
       choose "Existing participant", name: "member[existing_user]"
-      page.execute_script(<<~JS)
-        const wrapper = document.querySelector("div[data-autocomplete-for='user_id']");
-        if (wrapper) {
-          const hiddenInput = wrapper.querySelector("input[type='hidden']");
-          if (hiddenInput) { hiddenInput.value = "#{other_user.id}"; }
-          const selectedSpan = wrapper.querySelector(".autocomplete__selected-item.sticky");
-          if (selectedSpan) {
-            selectedSpan.textContent = "#{other_user.name} (@#{other_user.nickname})";
-            selectedSpan.style.display = "block";
-          }
-        }
-      JS
-      expect(page).to have_css(".autocomplete__selected-item", text: "#{other_user.name} (@#{other_user.nickname})")
+      autocomplete_select "#{other_user.name} (@#{other_user.nickname})", from: :user_id
 
       find("*[type=submit]").click
     end

--- a/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
@@ -24,6 +24,7 @@ shared_examples "manage admin members examples" do
     click_on "New member"
 
     within ".new_member" do
+      choose "Non existing participant", name: "member[existing_user]"
       fill_in :member_name, with: "John Doe"
       fill_in :member_email, with: other_user.email
 
@@ -38,6 +39,35 @@ shared_examples "manage admin members examples" do
 
     visit decidim_admin.root_path
     expect(page).to have_text("invited #{other_user.name} to be a member")
+  end
+
+  it "adds an existing participant as a member" do
+    click_on "New member"
+
+    within ".new_member" do
+      choose "Existing participant", name: "member[existing_user]"
+      page.execute_script(<<~JS)
+        const wrapper = document.querySelector("div[data-autocomplete-for='user_id']");
+        if (wrapper) {
+          const hiddenInput = wrapper.querySelector("input[type='hidden']");
+          if (hiddenInput) { hiddenInput.value = "#{other_user.id}"; }
+          const selectedSpan = wrapper.querySelector(".autocomplete__selected-item.sticky");
+          if (selectedSpan) {
+            selectedSpan.textContent = "#{other_user.name} (@#{other_user.nickname})";
+            selectedSpan.style.display = "block";
+          }
+        }
+      JS
+      expect(page).to have_css(".autocomplete__selected-item", text: "#{other_user.name} (@#{other_user.nickname})")
+
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_callout("Member access successfully created.")
+
+    within "#members table" do
+      expect(page).to have_text(other_user.email)
+    end
   end
 
   describe "when import a batch of members from csv" do

--- a/decidim-admin/spec/commands/decidim/admin/participatory_space/create_member_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/participatory_space/create_member_spec.rb
@@ -13,6 +13,8 @@ module Decidim::Admin::ParticipatorySpace
     let!(:user) { create(:user, email: "my_email@example.org", organization: participatory_space.organization) }
     let!(:current_user) { create(:user, email: "some_email@example.org", organization: participatory_space.organization) }
     let(:role) { generate_localized_title(:role) }
+    let(:existing_user) { false }
+    let(:user_id) { nil }
     let(:form) do
       double(
         invalid?: invalid,
@@ -21,7 +23,10 @@ module Decidim::Admin::ParticipatorySpace
         current_user:,
         name:,
         role:,
-        published:
+        published:,
+        existing_user:,
+        user_id:,
+        user: existing_user ? user : nil
       )
     end
     let(:delete) { false }
@@ -52,10 +57,29 @@ module Decidim::Admin::ParticipatorySpace
 
         expect(Decidim::ParticipatorySpace::Member.where(user:).count).to eq 1
 
-        form = double(invalid?: false, email:, current_user:, name:, role:, published: false)
+        form = double(invalid?: false, email:, current_user:, name:, role:, published: false, existing_user: false, user_id: nil, user: nil)
         described_class.new(form, participatory_space, via_csv:).call
 
         expect(Decidim::ParticipatorySpace::Member.where(user:).count).to eq 1
+      end
+
+      context "when inviting an existing user by user_id" do
+        let(:existing_user) { true }
+        let(:email) { nil }
+        let(:name) { nil }
+        let(:user_id) { user.id }
+
+        it "creates the member" do
+          expect { subject.call }.to broadcast(:ok)
+
+          members = Decidim::ParticipatorySpace::Member.where(user:)
+
+          expect(members.count).to eq 1
+        end
+
+        it "does not create a new user" do
+          expect { subject.call }.not_to change(Decidim::User, :count)
+        end
       end
 
       it "creates a new user with no application admin privileges" do

--- a/decidim-admin/spec/forms/decidim/admin/participatory_space/member_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/participatory_space/member_form_spec.rb
@@ -6,15 +6,21 @@ module Decidim
   module Admin
     module ParticipatorySpace
       describe MemberForm do
-        subject { described_class.from_params(attributes) }
+        subject { described_class.from_params(attributes).with_context(context) }
 
+        let(:organization) { create(:organization) }
+        let(:context) { { current_organization: organization } }
         let(:email) { "my_email@example.org" }
         let(:name) { "John Wayne" }
+        let(:existing_user) { false }
+        let(:user_id) { nil }
         let(:attributes) do
           {
             "member" => {
               "email" => email,
-              "name" => name
+              "name" => name,
+              "existing_user" => existing_user,
+              "user_id" => user_id
             }
           }
         end
@@ -27,6 +33,22 @@ module Decidim
           let(:email) { nil }
 
           it { is_expected.to be_invalid }
+        end
+
+        context "when inviting an existing user" do
+          let(:existing_user) { true }
+          let(:email) { nil }
+          let(:name) { nil }
+          let(:user) { create(:user, organization:) }
+          let(:user_id) { user.id }
+
+          it { is_expected.to be_valid }
+
+          context "when user_id is missing" do
+            let(:user_id) { nil }
+
+            it { is_expected.to be_invalid }
+          end
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the [Release Party for v0.32](https://meta.decidim.org/assemblies/eix-comunitat/f/149/meetings/2163), we detected this bug in the QA session:  

> As an administrator of participatory space (not general administrator), I do not know the emails of the participants, and can not add a participant as member without knowing the email.-
>
> *To Reproduce*
>
> As a participatory process administrator, I access private member list, and create member
> 
> Error: I do not know the email of the existing participants. 
>
> *Expected behavior*
>
> As an administrator of a participatory space, I should not need emails adress of existing participant to add them to a private space.

Reported by:  @froger   

As we have a similar pattern for this in Meetings invitations (found at the Meetings -> Registrations -> Invitations form), I'm copying the implementation from there. If we want to introduce improvements in the UI/UX, we should implement it in both places.  

<img width="1599" height="739" alt="image" src="https://github.com/user-attachments/assets/5c454dd9-25ee-49f5-b5ad-41dbdf1ef69f" />


#### Testing

1. Edit a process
2. Enable " This space has members"
3. Go to the Members page in the sidebar -> New member
4. See the form before and after
5. Invite a member by searching its name or nickname

### :camera: Screenshots

#### Before

<img width="1603" height="707" alt="image" src="https://github.com/user-attachments/assets/8dc4d910-af34-4289-904e-187e10de7d4e" />

#### After

<img width="1748" height="914" alt="image" src="https://github.com/user-attachments/assets/ed8be517-241a-484f-92da-222951969947" />
<img width="1750" height="921" alt="image" src="https://github.com/user-attachments/assets/7fbf14db-e899-4ebe-a703-21647947fe48" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Members can be added either by inviting a new participant or by selecting an existing participant via a radio toggle; persisted members show read-only name/email.
  * Autocomplete-backed user picker for selecting existing participants; form fields toggle based on choice.

* **Bug Fixes**
  * Selecting "existing participant" now reliably associates the chosen user when creating a member.

* **Tests**
  * Added/expanded tests for both invite and existing-participant flows.

* **Localization**
  * Added English strings for the member selection UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->