### PR TITLE
Fix rendering mentions for Proposals' answer page

### DIFF
--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -47,7 +47,7 @@
         <div class="card-section">
           <div class="row column">
             <span class="component__show-title"><%= t ".body" %></span>
-            <div class="component__show-text">
+            <div class="component__show-text editor-content">
               <%= render_proposal_body(proposal) %>
             </div>
           </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: "decidim/admin/shared/adjacent_navigation", locals: { adjacent_paths: filtered_adjacent_paths(proposal, :proposal_path) } %>
     <div class="component__show_header">
       <h2 class="component__show_header-title">
-        <%= decidim_html_escape(present(proposal).title).html_safe %>
+        <%= decidim_escape_translated(proposal.title) %>
       </h2>
     </div>
 
@@ -20,7 +20,7 @@
             <li class="component__show_nav-author-title">
               <%= link_to_if(
                     presented_author.profile_path.present?,
-                    presented_author.name,
+                    decidim_html_escape(presented_author.name),
                     presented_author.profile_path,
                     target: :blank
                   ) %>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -48,7 +48,7 @@
           <div class="row column">
             <span class="component__show-title"><%= t ".body" %></span>
             <p class="component__show-text">
-              <%= simple_format(present(proposal).body(strip_tags: true)) %>
+              <%= render_proposal_body(proposal) %>
             </p>
           </div>
         </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -6,7 +6,7 @@
     <%= render partial: "decidim/admin/shared/adjacent_navigation", locals: { adjacent_paths: filtered_adjacent_paths(proposal, :proposal_path) } %>
     <div class="component__show_header">
       <h2 class="component__show_header-title">
-        <%= decidim_escape_translated(proposal.title) %>
+        <%= present(proposal).title(html_escape: true) %>
       </h2>
     </div>
 

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/show.html.erb
@@ -47,9 +47,9 @@
         <div class="card-section">
           <div class="row column">
             <span class="component__show-title"><%= t ".body" %></span>
-            <p class="component__show-text">
+            <div class="component__show-text">
               <%= render_proposal_body(proposal) %>
-            </p>
+            </div>
           </div>
         </div>
 

--- a/decidim-proposals/spec/shared/merge_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/merge_proposals_examples.rb
@@ -80,10 +80,6 @@ shared_examples "merge proposals" do
           context "when merging to another component" do
             before do
               click_on "My result merge proposal"
-              wait = Selenium::WebDriver::Wait.new(timeout: 10)
-              wait.until { page.driver.browser.switch_to.alert }
-              alert = page.driver.browser.switch_to.alert
-              alert.accept
               new_proposal_url = find("a", text: "See proposal")[:href]
               visit new_proposal_url
             end

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -120,6 +120,7 @@ describe "Admin views proposal details from admin" do
       let!(:proposal) { create(:proposal, body: content, component: current_component) }
 
       before do
+        current_component.organization.update(rich_text_editor_in_public_views: false)
         go_to_admin_proposal_page(proposal)
       end
 

--- a/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
+++ b/decidim-proposals/spec/system/admin/view_proposal_details_from_admin_spec.rb
@@ -82,6 +82,51 @@ describe "Admin views proposal details from admin" do
     expect(page).to have_text(strip_tags(translated(proposal.body)).strip)
   end
 
+  describe "with rich text proposal body" do
+    include_context "with rich text editor content"
+
+    context "when it is an official proposal" do
+      let!(:proposal) { create(:proposal, :official, body: content, component: current_component) }
+
+      before do
+        go_to_admin_proposal_page(proposal)
+      end
+
+      it_behaves_like "rendering safe content", ".editor-content"
+    end
+
+    context "when it is an official meeting proposal" do
+      let!(:proposal) { create(:proposal, :official_meeting, body: content, component: current_component) }
+
+      before do
+        go_to_admin_proposal_page(proposal)
+      end
+
+      it_behaves_like "rendering safe content", ".editor-content"
+    end
+
+    context "when rich text editor is enabled for participants" do
+      let!(:proposal) { create(:proposal, body: content, component: current_component) }
+
+      before do
+        current_component.organization.update(rich_text_editor_in_public_views: true)
+        go_to_admin_proposal_page(proposal)
+      end
+
+      it_behaves_like "rendering safe content", ".editor-content"
+    end
+
+    context "when rich text editor is NOT enabled for participants" do
+      let!(:proposal) { create(:proposal, body: content, component: current_component) }
+
+      before do
+        go_to_admin_proposal_page(proposal)
+      end
+
+      it_behaves_like "rendering unsafe content", ".editor-content"
+    end
+  end
+
   describe "with an specific creation date" do
     let!(:proposal) { create(:proposal, component: current_component, created_at: Time.zone.parse("2020-01-29 15:00")) }
 


### PR DESCRIPTION
#### :tophat: What? Why?

If you create a proposal with some RIch Text features, like :

- link 
- resource mention
- image

Then this is not visible in the Answer page

This PR fixes it

#### :pushpin: Related Issues

- Related to https://github.com/decidim/decidim/issues/16405 (as that was the starting of this rabbit hole)

#### Testing

1. Create a proposal with links, resource mentions, and images
2. Click in its title in the Admin to go to the Answer proposal page
3. See the error

### :camera: Screenshots

<img width="828" height="850" alt="image" src="https://github.com/user-attachments/assets/24420d27-0bf6-4719-955f-0dd88a03db76" />

##### Before

<img width="882" height="639" alt="image" src="https://github.com/user-attachments/assets/ee094ec3-68a7-4d4c-befb-366401f0a113" />

##### After
<img width="1901" height="1859" alt="image" src="https://github.com/user-attachments/assets/00293662-f221-47c4-b585-58ba728e951d" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Admin proposal detail view now uses safer, dedicated rendering for titles, co-author names, and the proposal body, improving HTML-escaping and applying editor-content styling for rich text.

* **Tests**
  * Added system tests for rich-text proposal body rendering in the admin view and updated shared merge flow tests to navigate directly to the resulting proposal page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->