### PR TITLE
Fix flaky on `admin_manages_organization_spec.rb`

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/extensions/indent/index.js
+++ b/decidim-core/app/packs/src/decidim/editor/extensions/indent/index.js
@@ -170,6 +170,15 @@ export default Extension.create({
       "Shift-Tab": outdent,
       Backspace: () => {
         if (this.editor.isActive("listItem")) {
+          // When at the start of a list item, join the list items
+          // together using joinItemBackward which properly merges
+          // inline content. This ensures the items are merged
+          // correctly regardless of how the browser handles the
+          // event.
+          if (this.editor.state.selection.$head.parentOffset === 0) {
+            return this.editor.commands.joinItemBackward();
+          }
+
           return false;
         }
 


### PR DESCRIPTION
#### :tophat: What? Why?

We have a new flaky in the specs, for instance at https://github.com/decidim/decidim/actions/runs/26926911631/job/79452425803?pr=17020

~~According to GPT-5.3 Codex, the problem might be in a race condition related to Capybara and Selenium, where sending all the keys at the same time using the `native.send_keys` might not send them deterministically at the same order. This PR solves it by sending it separately.~~ After further try outs, I think the problem is related to the update to TipTap 3 (https://github.com/decidim/decidim/pull/15823), as there's a change in the behavior of the Backspace and Lists. By introducing this change in the Backspace key event we maintain the behavior of v2 for this spec.

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/26926911631/job/79452425803?pr=17020
- Related to https://github.com/decidim/decidim/pull/15823 

#### Testing

I **could not reproduce** the error locally with the typical for loop

```
$ for i in $(seq 1 50) ; do echo "TEST ${i}" ; bin/rspec decidim-admin/spec/system/admin_manages_organization_spec.rb -e "keeps right" ; done
```

So I'll re run the  "[CI] Admin / Tests with system specs / Test (pull_request)" workflow 10 times to see if it actually solves it 

### Stacktrace

``` 

Failures:

  1) Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right format when using the backspace
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
       )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item abc</p></li></ul>".to_s.gsub("\n", ""))

       expected: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item abc</p></li></ul>"
            got: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3abc</p></li></ul>"

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_format_when_using_the_backspace_669.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_format_when_using_the_backspace_669.html


     # ./spec/system/admin_manages_organization_spec.rb:494:in 'block (5 levels) in <top (required)>'

  2) Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using backspace after empty list item
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
       )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List itemabcd</p></li></ul>".to_s.gsub("\n", ""))

       expected: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List itemabcd</p></li></ul>"
            got: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abcd</p></li></ul>"

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_backspace_after_empty_list_item_755.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_backspace_after_empty_list_item_755.html


     # ./spec/system/admin_manages_organization_spec.rb:502:in 'block (5 levels) in <top (required)>'

  3) Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using backspace after list item with text
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
       )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item bcd</p></li></ul>".to_s.gsub("\n", ""))

       expected: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item bcd</p></li></ul>"
            got: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abcd</p></li></ul>"

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_backspace_after_list_item_with_t_171.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_backspace_after_list_item_with_t_171.html


     # ./spec/system/admin_manages_organization_spec.rb:510:in 'block (5 levels) in <top (required)>'

  4) Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using the backspace
     Failure/Error:
       expect(find(
         "#organization-admin_terms_of_service_body-tabs-admin_terms_of_service_body-panel-0 .editor .ProseMirror"
       )["innerHTML"]).to eq("<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3abc</p></li></ul>".to_s.gsub("\n", ""))

       expected: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3abc</p></li></ul>"
            got: "<p>Paragraph</p><ul><li><p>List item 1</p></li><li><p>List item 2</p></li><li><p>List item 3</p></li><li><p>abc</p></li></ul>"

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_the_backspace_423.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_organization_edit_when_using_the_rich_text_editor_when_modifying_list_using_rich_text_editor_keeps_right_cursor_position_when_using_the_backspace_423.html


     # ./spec/system/admin_manages_organization_spec.rb:487:in 'block (5 levels) in <top (required)>'

Finished in 14 minutes 58 seconds (files took 19.07 seconds to load)
169 examples, 4 failures

Failed examples:

rspec ./spec/system/admin_manages_organization_spec.rb:490 # Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right format when using the backspace
rspec ./spec/system/admin_manages_organization_spec.rb:497 # Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using backspace after empty list item
rspec ./spec/system/admin_manages_organization_spec.rb:505 # Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using backspace after list item with text
rspec ./spec/system/admin_manages_organization_spec.rb:482 # Admin manages organization edit when using the rich text editor when modifying list using rich text editor keeps right cursor position when using the backspace

``` 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backspace behavior in list editing to properly merge list items when backspace is pressed at the start of an item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->