### PR TITLE
Fix create meeting display button

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -21,6 +21,7 @@ module Decidim
       helper_method :meetings, :meeting, :registration, :registration_qr_code_image, :search, :tab_panel_items, :withdrawn_meetings?
 
       before_action :add_additional_csp_directives, only: [:show]
+      before_action :authenticate_user!, only: [:new, :create, :edit, :update, :withdraw]
 
       def new
         enforce_permission_to :create, :meeting

--- a/decidim-meetings/app/permissions/decidim/meetings/meeting_permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/meeting_permissions.rb
@@ -39,8 +39,6 @@ module Decidim
       end
 
       def can_create?
-        return false unless user
-
         (component_settings&.creation_enabled_for_participants? && can_participate?) || initiative_authorship?
       end
 

--- a/decidim-meetings/lib/decidim/api/mutations/create_meeting_type.rb
+++ b/decidim-meetings/lib/decidim/api/mutations/create_meeting_type.rb
@@ -52,7 +52,7 @@ module Decidim
       end
 
       def authorized?(attributes:, locale:, toggle_translations:)
-        unless super && allowed_to?(:create, :meeting, Meeting.new(component: current_component), { current_user:, current_component: })
+        unless super && current_user.present? && allowed_to?(:create, :meeting, Meeting.new(component: current_component), { current_user:, current_component: })
           raise Decidim::Api::Errors::MutationNotAuthorizedError, I18n.t("decidim.api.errors.unauthorized_mutation")
         end
 

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -187,7 +187,7 @@ describe Decidim::Meetings::MeetingsController do
 
     context "when user is not authenticated" do
       it "redirects to login page" do
-        put(:create, params:)
+        post(:create, params:)
         expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
         expect(response).to redirect_to(new_user_session_path)
       end

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -51,15 +51,15 @@ describe Decidim::Meetings::MeetingsController do
         component_id: meeting_component.id
       }
     end
-    let(:params) { { meeting: meeting_params } }
-
-    before { sign_in user }
+    let(:params) { { meeting: meeting_params, id: meeting.id } }
 
     context "when an authorized user is withdrawing a meeting" do
       let(:meeting) { create(:meeting, component: meeting_component, author: user) }
 
+      before { sign_in user }
+
       it "withdraws the meeting" do
-        put :withdraw, params: params.merge(id: meeting.id)
+        put(:withdraw, params:)
 
         expect(flash[:notice]).to eq("The meeting has been withdrawn successfully.")
         expect(response).to have_http_status(:found)
@@ -72,11 +72,25 @@ describe Decidim::Meetings::MeetingsController do
       let(:current_user) { create(:user, organization: meeting_component.organization) }
       let(:meeting) { create(:meeting, component: meeting_component, author: current_user) }
 
+      before { sign_in user }
+
       it "is not able to withdraw the meeting" do
-        put :withdraw, params: params.merge(id: meeting.id)
+        put(:withdraw, params:)
 
         expect(flash[:alert]).to eq("You are not authorized to perform this action.")
         expect(response).to have_http_status(:found)
+        meeting.reload
+        expect(meeting.withdrawn?).to be false
+      end
+    end
+
+    context "when user is not authenticated" do
+      let(:user) { nil }
+
+      it "redirects to login page" do
+        put(:withdraw, params:)
+        expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+        expect(response).to redirect_to(new_user_session_path)
         meeting.reload
         expect(meeting.withdrawn?).to be false
       end
@@ -158,6 +172,57 @@ describe Decidim::Meetings::MeetingsController do
       it "redirects to the login page" do
         get(:new)
         expect(response).to have_http_status(:found)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "#create" do
+    let(:meeting_params) do
+      {
+        component_id: meeting_component.id
+      }
+    end
+    let(:params) { { meeting: meeting_params } }
+
+    context "when user is not authenticated" do
+      it "redirects to login page" do
+        put(:create, params:)
+        expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "#edit" do
+    let(:meeting_params) do
+      {
+        component_id: meeting_component.id
+      }
+    end
+    let(:params) { { meeting: meeting_params, id: meeting.id } }
+
+    context "when user is not authenticated" do
+      it "redirects to login page" do
+        get(:edit, params:)
+        expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:meeting_params) do
+      {
+        component_id: meeting_component.id
+      }
+    end
+    let(:params) { { meeting: meeting_params, id: meeting.id } }
+
+    context "when user is not authenticated" do
+      it "redirects to login page" do
+        put(:update, params:)
+        expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -33,6 +33,72 @@ describe "User creates meeting" do
     switch_to_host(organization.host)
   end
 
+  context "when the user is not logged in" do
+    context "when creation is enabled" do
+      let!(:component) do
+        create(:meeting_component,
+               participatory_space: participatory_process,
+               settings: { creation_enabled_for_participants: true, taxonomy_filters: [taxonomy_filter.id] })
+      end
+
+      it "displays the new post button" do
+        visit_component
+        expect(page).to have_text("New meeting")
+      end
+
+      it "redirects to login page when visiting new page" do
+        visit Decidim::EngineRouter.main_proxy(component).new_meeting_path
+        expect(page).to have_text("You need to log in or create an account before continuing.")
+        expect(page).to have_current_path(decidim.new_user_session_path)
+      end
+    end
+
+    context "when creation is disabled" do
+      let!(:component) do
+        create(:meeting_component,
+               participatory_space: participatory_process,
+               settings: { taxonomy_filters: [taxonomy_filter.id] })
+      end
+
+      it "hides the new meeting button" do
+        visit_component
+        expect(page).to have_no_text("New meeting")
+      end
+    end
+  end
+
+  context "when the user is logged in" do
+    before do
+      login_as user, scope: :user
+    end
+
+    context "when creation is enabled" do
+      let!(:component) do
+        create(:meeting_component,
+               participatory_space: participatory_process,
+               settings: { creation_enabled_for_participants: true, taxonomy_filters: [taxonomy_filter.id] })
+      end
+
+      it "displays the new post button" do
+        visit_component
+        expect(page).to have_text("New meeting")
+      end
+    end
+
+    context "when creation is disabled" do
+      let!(:component) do
+        create(:meeting_component,
+               participatory_space: participatory_process,
+               settings: { taxonomy_filters: [taxonomy_filter.id] })
+      end
+
+      it "hides the new meeting button" do
+        visit_component
+        expect(page).to have_no_text("New meeting")
+      end
+    end
+  end
+
   context "when creating a new meeting" do
     let(:user) { create(:user, :confirmed, organization:) }
 

--- a/decidim-meetings/spec/system/user_creates_meeting_spec.rb
+++ b/decidim-meetings/spec/system/user_creates_meeting_spec.rb
@@ -41,7 +41,7 @@ describe "User creates meeting" do
                settings: { creation_enabled_for_participants: true, taxonomy_filters: [taxonomy_filter.id] })
       end
 
-      it "displays the new post button" do
+      it "displays the new meeting button" do
         visit_component
         expect(page).to have_text("New meeting")
       end


### PR DESCRIPTION
#### :tophat: What? Why?
It has been found on my deployment that the create button displayed on the meeting index page is not properly working on meetings. 

#### :pushpin: Related Issues
*Link your PR to an issue*


#### Testing
1. Login as admin on nightly 
2. Edit the configuration of any meeting component
3. Choose to enable "Participants can create meetings"
4. In a private window, open that meeting component's index page 
5. See the button is not displayed 
6. Apply this patch 
7. See the "New meeting" button is visible. Clicking it, launches the Login modal.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Require authentication for withdrawing a meeting.
  * Require a signed-in user for API meeting creation.

* **Tests**
  * Added system tests for "New meeting" button visibility and access for logged-out and logged-in users.
  * Expanded controller tests to cover withdraw authorization and authentication redirects for create/edit/update actions.

* **Refactor**
  * Simplified internal logic for displaying the "New meeting" button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->