### PR TITLE
Fix flaky on generators bundler (multijson)

### DIFF
--- a/decidim-generators/lib/decidim/generators/app_generator.rb
+++ b/decidim-generators/lib/decidim/generators/app_generator.rb
@@ -218,7 +218,10 @@ module Decidim
 
         add_production_gems do
           gem "aws-sdk-s3", require: false if providers.include?("s3")
-          gem "google-cloud-storage", "~> 1.11", require: false if providers.include?("gcs")
+          if providers.include?("gcs")
+            gem "google-cloud-storage", "~> 1.11", require: false
+            gem "multi_json"
+          end
         end
       end
 

--- a/decidim-generators/lib/decidim/generators/install_generator.rb
+++ b/decidim-generators/lib/decidim/generators/install_generator.rb
@@ -165,7 +165,7 @@ module Decidim
       end
 
       def bundle_install
-        run "bundle install"
+        Bundler.with_original_env { run "bundle install" }
       end
 
       def copy_migrations


### PR DESCRIPTION
#### :tophat: What? Why?

While working with https://github.com/decidim/decidim/pull/16983 and https://github.com/decidim/decidim/pull/17024 I noticed a new flaky, with Generators pipeline. See it at https://github.com/decidim/decidim/actions/runs/26998006705/job/79675790172?pr=17024 

This PR fix it. 
 
#### Testing

Pipeline should be green. As I can't reproduce it locally, I'll run the pipeline 10 times (for StorageFlag on `decidim-generators`)

### :camera: Stacktrace

```

Run bundle exec parallel_test --type rspec --pattern spec/runtime/storage_flag_spec.rb
1 process for 1 spec, ~ 1 spec per process
/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/configurator.rb:39:in 'ActiveStorage::Service::Configurator#resolve': Missing service adapter for "GCS" (RuntimeError)
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/configurator.rb:17:in 'ActiveStorage::Service::Configurator#build'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:13:in 'block in ActiveStorage::Service::Registry#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:11:in 'Hash#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:11:in 'ActiveStorage::Service::Registry#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/engine.rb:184:in 'block (2 levels) in <class:Engine>'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:97:in 'Module#class_eval'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:97:in 'block in ActiveSupport::LazyLoadHooks#execute_hook'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:87:in 'ActiveSupport::LazyLoadHooks#with_execution_control'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:92:in 'ActiveSupport::LazyLoadHooks#execute_hook'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:78:in 'block in ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:77:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:77:in 'ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/app/models/active_storage/blob.rb:401:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:26:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:179:in 'Module#const_get'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:179:in 'block in Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:51:in 'block in Zeitwerk::Loader::FileSystem#ls'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:40:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:40:in 'Zeitwerk::Loader::FileSystem#ls'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:170:in 'Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:18:in 'block (2 levels) in Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:17:in 'Hash#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:17:in 'block in Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:11:in 'Thread::Mutex#synchronize'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:11:in 'Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader.rb:454:in 'block in Zeitwerk::Loader.eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/registry/loaders.rb:10:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/registry/loaders.rb:10:in 'Zeitwerk::Registry::Loaders#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader.rb:452:in 'Zeitwerk::Loader.eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application/finisher.rb:79:in 'block in <module:Finisher>'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:231:in 'block in TSort.tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:350:in 'Method#call'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:350:in 'TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:229:in 'TSort.tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:208:in 'TSort#tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
	from /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/environment.rb:5:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application.rb:418:in 'Rails::Application#require_environment!'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/actions.rb:20:in 'Rails::Command::Actions#boot_application!'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/commands/runner/runner_command.rb:30:in 'Rails::Command::RunnerCommand#perform'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor.rb:538:in 'Thor.dispatch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:63:in 'Rails::Command.invoke'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/commands.rb:18:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from bin/rails:5:in '<main>'
/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bundler-2.4.20/lib/bundler/rubygems_integration.rb:280:in 'block (2 levels) in Kernel#replace_gem': multi_json is not part of the bundle. Add it to your Gemfile. (Gem::LoadError)
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/representable-3.2.0/lib/representable/json.rb:1:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/google-apis-core-1.1.0/lib/google/apis/core/json_representation.rb:15:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/google-apis-iamcredentials_v1-0.27.0/lib/google/apis/iamcredentials_v1/service.rb:16:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/google-apis-iamcredentials_v1-0.27.0/lib/google/apis/iamcredentials_v1.rb:15:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/gcs_service.rb:4:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/configurator.rb:36:in 'ActiveStorage::Service::Configurator#resolve'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/configurator.rb:17:in 'ActiveStorage::Service::Configurator#build'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:13:in 'block in ActiveStorage::Service::Registry#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:11:in 'Hash#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/service/registry.rb:11:in 'ActiveStorage::Service::Registry#fetch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/lib/active_storage/engine.rb:184:in 'block (2 levels) in <class:Engine>'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:97:in 'Module#class_eval'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:97:in 'block in ActiveSupport::LazyLoadHooks#execute_hook'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:87:in 'ActiveSupport::LazyLoadHooks#with_execution_control'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:92:in 'ActiveSupport::LazyLoadHooks#execute_hook'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:78:in 'block in ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:77:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activesupport-8.1.3/lib/active_support/lazy_load_hooks.rb:77:in 'ActiveSupport::LazyLoadHooks#run_load_hooks'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/activestorage-8.1.3/app/models/active_storage/blob.rb:401:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:26:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:179:in 'Module#const_get'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:179:in 'block in Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:51:in 'block in Zeitwerk::Loader::FileSystem#ls'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:40:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/file_system.rb:40:in 'Zeitwerk::Loader::FileSystem#ls'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:170:in 'Zeitwerk::Loader::EagerLoad#actual_eager_load_dir'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:18:in 'block (2 levels) in Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:17:in 'Hash#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:17:in 'block in Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:11:in 'Thread::Mutex#synchronize'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader/eager_load.rb:11:in 'Zeitwerk::Loader::EagerLoad#eager_load'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader.rb:454:in 'block in Zeitwerk::Loader.eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/registry/loaders.rb:10:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/registry/loaders.rb:10:in 'Zeitwerk::Registry::Loaders#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/loader.rb:452:in 'Zeitwerk::Loader.eager_load_all'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application/finisher.rb:79:in 'block in <module:Finisher>'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'BasicObject#instance_exec'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:24:in 'Rails::Initializable::Initializer#run'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:103:in 'block in Rails::Initializable#run_initializers'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:231:in 'block in TSort.tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:353:in 'block (2 levels) in TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:434:in 'TSort.each_strongly_connected_component_from'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:352:in 'block in TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Array#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:59:in 'Rails::Initializable::Collection#each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:350:in 'Method#call'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:350:in 'TSort.each_strongly_connected_component'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:229:in 'TSort.tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/tsort.rb:208:in 'TSort#tsort_each'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/initializable.rb:102:in 'Rails::Initializable#run_initializers'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application.rb:442:in 'Rails::Application#initialize!'
	from /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/environment.rb:5:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/zeitwerk-2.8.1/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/application.rb:418:in 'Rails::Application#require_environment!'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/actions.rb:20:in 'Rails::Command::Actions#boot_application!'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/commands/runner/runner_command.rb:30:in 'Rails::Command::RunnerCommand#perform'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor/command.rb:28:in 'Thor::Command#run'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor/invocation.rb:127:in 'Thor::Invocation#invoke_command'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/base.rb:176:in 'Rails::Command::Base#invoke_command'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/thor-1.5.0/lib/thor.rb:538:in 'Thor.dispatch'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command/base.rb:71:in 'Rails::Command::Base.perform'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:65:in 'block in Rails::Command.invoke'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:143:in 'Rails::Command.with_argv'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/command.rb:63:in 'Rails::Command.invoke'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/railties-8.1.3/lib/rails/commands.rb:18:in '<top (required)>'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from <internal:/opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/3.4.0/rubygems/core_ext/kernel_require.rb>:37:in 'Kernel#require'
	from /opt/hostedtoolcache/Ruby/3.4.7/x64/lib/ruby/gems/3.4.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in 'Kernel#require'
	from bin/rails:5:in '<main>'
.F

Failures:

  1) Decidim::Generators with an application with --storage providers behaves like an application with cloud storage gems includes cloud storage gems in the Gemfile
     Failure/Error: JSON.parse cmd_capture(path, "bin/rails runner 'puts #{value}.to_json'", env:)

     JSON::ParserError:
       unexpected end of input at line 1 column 1
     Shared Example Group: "an application with cloud storage gems" called from ./spec/runtime/storage_flag_spec.rb:24
     # ./lib/decidim/generators/test/generator_examples.rb:880:in 'Object#rails_value'
     # ./lib/decidim/generators/test/generator_examples.rb:835:in 'block (3 levels) in <top (required)>'
     # ./lib/decidim/generators/test/generator_examples.rb:834:in 'Array#each'
     # ./lib/decidim/generators/test/generator_examples.rb:834:in 'block (2 levels) in <top (required)>'

Finished in 4 minutes 55.3 seconds (files took 0.22569 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/runtime/storage_flag_spec.rb:24 # Decidim::Generators with an application with --storage providers behaves like an application with cloud storage gems includes cloud storage gems in the Gemfile

Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
Coverage report generated for (1/4) to /home/runner/work/decidim/decidim/coverage/coverage.xml.
Line Coverage: 0.0% (0 / 107759)
Tests Failed

2 examples, 1 failure
``` 


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation so bundle commands run reliably across different environment configurations.

* **Chores**
  * Updated production setup for Google Cloud Storage to include an additional JSON parsing dependency for more reliable storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->