### PR TITLE
Implement new design for meetings registrations invitations

### DIFF
--- a/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/invite_user_to_join_meeting.rb
@@ -78,15 +78,16 @@ module Decidim
               InviteJoinMeetingMailer.invite(user, meeting, invited_by).deliver_later
             end
           else
-            user.name = form.name
-            user.nickname = User.nicknamize(user.name, user.decidim_organization_id)
+            email_local_part = form.email.split("@").first
+            user.name = email_local_part
+            user.nickname = User.nicknamize(email_local_part, user.decidim_organization_id)
             invite_user_to_sign_up
             create_invitation!
           end
         end
 
         def user
-          @user ||= if form.existing_user
+          @user ||= if form.attendee_type == "name"
                       form.user
                     else
                       Decidim::User.find_or_initialize_by(

--- a/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registration_invite_form.rb
+++ b/decidim-meetings/app/forms/decidim/meetings/admin/meeting_registration_invite_form.rb
@@ -6,14 +6,13 @@ module Decidim
       # A form object used to invite users to join a meeting.
       #
       class MeetingRegistrationInviteForm < Form
-        attribute :name, String
         attribute :email, String
         attribute :user_id, Integer
-        attribute :existing_user, Boolean, default: false
+        attribute :attendee_type, String, default: "name"
 
-        validates :name, presence: true, unless: proc { |object| object.existing_user }
-        validates :email, presence: true, "valid_email_2/email": { disposable: true }, unless: proc { |object| object.existing_user }
-        validates :user, presence: true, if: proc { |object| object.existing_user }
+        validates :attendee_type, presence: true, inclusion: { in: %w(name email) }
+        validates :user, presence: true, if: proc { |object| object.attendee_type == "name" }
+        validates :email, presence: true, "valid_email_2/email": { disposable: true }, if: proc { |object| object.attendee_type == "email" }
 
         def user
           @user ||= current_organization.users.find_by(id: user_id)

--- a/decidim-meetings/app/packs/src/decidim/meetings/admin/registrations_invite_form.js
+++ b/decidim-meetings/app/packs/src/decidim/meetings/admin/registrations_invite_form.js
@@ -1,25 +1,25 @@
 import createFieldDependentInputs from "src/decidim/admin/field_dependent_inputs.component"
 
 document.addEventListener("turbo:load", () => {
-  const $attendeeType = $('[name="meeting_registration_invite[existing_user]"');
+  const $attendeeType = $('[name="meeting_registration_invite[attendee_type]"]');
 
   createFieldDependentInputs({
     controllerField: $attendeeType,
     wrapperSelector: ".attendee-fields",
-    dependentFieldsSelector: ".attendee-fields--new-user",
-    dependentInputSelector: "input",
+    dependentFieldsSelector: ".attendee-fields--name",
+    dependentInputSelector: "input, select",
     enablingCondition: () => {
-      return $("#meeting_registration_invite_existing_user_false").is(":checked")
+      return $("#meeting_registration_invite_attendee_type_name").is(":checked")
     }
   });
 
   createFieldDependentInputs({
     controllerField: $attendeeType,
     wrapperSelector: ".attendee-fields",
-    dependentFieldsSelector: ".attendee-fields--user-picker",
+    dependentFieldsSelector: ".attendee-fields--email",
     dependentInputSelector: "input",
     enablingCondition: () => {
-      return $("#meeting_registration_invite_existing_user_true").is(":checked")
+      return $("#meeting_registration_invite_attendee_type_email").is(":checked")
     }
   });
 })

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
@@ -31,7 +31,7 @@
       <div class="mt-4">
         <div class="attendee-fields--name hidden">
           <% prompt_options = { placeholder: t(".select_user") } %>
-          <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, class: "autocomplete-field--results-inline" }, prompt_options) do |user|
+          <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, label: t(".name_or_nickname"), class: "autocomplete-field--results-inline" }, prompt_options) do |user|
             { value: user.id, label: "#{user.name} (@#{user.nickname})" }
           end %>
         </div>

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
@@ -14,14 +14,14 @@
 
       <div class="grid grid-cols-2 gap-4">
         <%= label_tag :meeting_registration_invite_attendee_type_name, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
-          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "name", form.object.attendee_type == "name", id: "meeting_registration_invite_attendee_type_name", class: "hidden peer", disabled: %>
+          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "name", form.object.attendee_type == "name", id: "meeting_registration_invite_attendee_type_name", class: "hidden peer !m-0", disabled: %>
           <span class="text-lg font-normal">
             <%= t(".name_or_nickname") %>
           </span>
         <% end %>
 
         <%= label_tag :meeting_registration_invite_attendee_type_email, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
-          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "email", form.object.attendee_type == "email", id: "meeting_registration_invite_attendee_type_email", class: "hidden peer", disabled: %>
+          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "email", form.object.attendee_type == "email", id: "meeting_registration_invite_attendee_type_email", class: "hidden peer !m-0", disabled: %>
           <span class="text-lg font-normal">
             <%= t(".email") %>
           </span>

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
@@ -9,35 +9,39 @@
       </button>
     </div>
 
-    <div id="panel-attendee" class="card-section">
+    <div id="panel-attendee" class="card-section m-4">
+      <p class="mb-4"><%= t(".invite_explanation") %></p>
 
-      <div class="row column">
-        <fieldset>
-          <%= form.collection_radio_buttons(:existing_user, [[t(".non_user"), false], [t(".existing_user"), true]], :last, :first) %>
-        </fieldset>
+      <div class="grid grid-cols-2 gap-4">
+        <%= label_tag :meeting_registration_invite_attendee_type_name, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
+          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "name", form.object.attendee_type == "name", id: "meeting_registration_invite_attendee_type_name", class: "hidden peer", disabled: %>
+          <span class="text-lg font-normal">
+            <%= t(".name_or_nickname") %>
+          </span>
+        <% end %>
+
+        <%= label_tag :meeting_registration_invite_attendee_type_email, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
+          <%= radio_button_tag "meeting_registration_invite[attendee_type]", "email", form.object.attendee_type == "email", id: "meeting_registration_invite_attendee_type_email", class: "hidden peer", disabled: %>
+          <span class="text-lg font-normal">
+            <%= t(".email") %>
+          </span>
+        <% end %>
       </div>
 
-      <div class="row column">
-        <p><%= t(".invite_explanation") %></p>
-      </div>
-
-      <div class="row column">
-        <div class="cell attendee-fields--new-user">
-          <%= form.text_field :name, disabled: %>
-        </div>
-        <div class="cell attendee-fields--new-user">
-          <%= form.text_field :email, disabled: %>
-        </div>
-
-        <div class="cell attendee-fields--user-picker">
+      <div class="mt-4">
+        <div class="attendee-fields--name hidden">
           <% prompt_options = { placeholder: t(".select_user") } %>
           <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, class: "autocomplete-field--results-inline" }, prompt_options) do |user|
             { value: user.id, label: "#{user.name} (@#{user.nickname})" }
           end %>
         </div>
 
+        <div class="attendee-fields--email hidden">
+          <%= form.text_field :email, disabled: %>
+        </div>
       </div>
-      <div class="row column">
+
+      <div class="mt-4">
         <%= form.submit t(".invite"), class: "button button__sm button__secondary", disabled: %>
       </div>
     </div>

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -348,10 +348,10 @@ en:
             success: Participant successfully invited to join the meeting.
           form:
             attendee_type: Attendee type
-            existing_user: Existing participant
+            email: Email
             invite: Invite
             invite_explanation: The participant will be invited to join the meeting and to the organization as well.
-            non_user: Non existing participant
+            name_or_nickname: Name or nickname
             select_user: Select participant
           index:
             invites: Invites

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -147,6 +147,18 @@ module Decidim::Meetings
           expect(Decidim::User.last.nickname).to eq("john_doe")
         end
       end
+
+      context "when a user does not exist for the given email with plus sign" do
+        let(:email) { "john.doe+richard@example.org" }
+        let(:attendee_name) { "john.doe" }
+
+        it "sets name and nickname from email local part" do
+          subject.call
+
+          expect(Decidim::User.last.name).to eq("john.doe+richard")
+          expect(Decidim::User.last.nickname).to eq("john_doe_richard")
+        end
+      end
     end
 
     context "when the form is not valid" do

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -157,6 +157,22 @@ module Decidim::Meetings
           expect(Decidim::User.last.nickname).to eq("john_doe_richard")
         end
       end
+
+      context "when a user does not exist for the given email with leading dots" do
+        let(:email) { ".john.doe@example.org" }
+
+        it "broadcasts invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
+
+      context "when a user does not exist for the given email with trailing dots" do
+        let(:email) { "john.doe.@example.org" }
+
+        it "broadcasts invalid" do
+          expect { subject.call }.to broadcast(:invalid)
+        end
+      end
     end
 
     context "when the form is not valid" do

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -138,7 +138,6 @@ module Decidim::Meetings
 
       context "when a user does not exist for the given email with dots" do
         let(:email) { "john.doe@example.org" }
-        let(:attendee_name) { "john.doe" }
 
         it "sets name and nickname from email local part" do
           subject.call
@@ -150,7 +149,6 @@ module Decidim::Meetings
 
       context "when a user does not exist for the given email with plus sign" do
         let(:email) { "john.doe+richard@example.org" }
-        let(:attendee_name) { "john.doe" }
 
         it "sets name and nickname from email local part" do
           subject.call

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -8,15 +8,13 @@ module Decidim::Meetings
 
     let(:organization) { create(:organization) }
     let!(:current_user) { create(:user, :admin, organization:) }
-    let(:name) { "name" }
     let(:email) { "foo@example.org" }
-    let(:existing_user) { false }
+    let(:attendee_type) { "email" }
     let(:user_id) { nil }
     let(:form_params) do
       {
-        name:,
         email:,
-        existing_user:,
+        attendee_type:,
         user_id:
       }
     end
@@ -64,10 +62,10 @@ module Decidim::Meetings
         expect { subject.call }.to broadcast(:ok)
       end
 
-      context "when the form provides an existing user" do
+      context "when the form provides an existing user by name" do
         let!(:user) { create(:user, :confirmed, organization:) }
         let(:attendee_name) { user.name }
-        let(:existing_user) { true }
+        let(:attendee_type) { "name" }
         let(:user_id) { user.id }
 
         it "does not create another user" do
@@ -86,7 +84,7 @@ module Decidim::Meetings
         end
       end
 
-      context "when a user already exists" do
+      context "when a user already exists for the given email" do
         let!(:user) { create(:user, :confirmed, email: form.email, organization:) }
         let(:attendee_name) { user.name }
 
@@ -107,7 +105,7 @@ module Decidim::Meetings
       end
 
       context "when a user does not exist for the given email" do
-        let(:attendee_name) { "name" }
+        let(:attendee_name) { "foo" }
 
         it "creates it" do
           expect do
@@ -115,6 +113,13 @@ module Decidim::Meetings
           end.to change(Decidim::User, :count).by(1)
 
           expect(Decidim::User.last.email).to eq(form.email)
+        end
+
+        it "sets name and nickname from email local part" do
+          subject.call
+
+          expect(Decidim::User.last.name).to eq("foo")
+          expect(Decidim::User.last.nickname).to eq("foo")
         end
 
         it "sends an invitation email with the given instructions" do
@@ -128,6 +133,18 @@ module Decidim::Meetings
 
         it_behaves_like "creates the invitation and traces the action" do
           let(:attendee) { Decidim::User.last }
+        end
+      end
+
+      context "when a user does not exist for the given email with dots" do
+        let(:email) { "john.doe@example.org" }
+        let(:attendee_name) { "john.doe" }
+
+        it "sets name and nickname from email local part" do
+          subject.call
+
+          expect(Decidim::User.last.name).to eq("john.doe")
+          expect(Decidim::User.last.nickname).to eq("john.doe")
         end
       end
     end

--- a/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
+++ b/decidim-meetings/spec/commands/admin/invite_user_to_join_meeting_spec.rb
@@ -144,7 +144,7 @@ module Decidim::Meetings
           subject.call
 
           expect(Decidim::User.last.name).to eq("john.doe")
-          expect(Decidim::User.last.nickname).to eq("john.doe")
+          expect(Decidim::User.last.nickname).to eq("john_doe")
         end
       end
     end

--- a/decidim-meetings/spec/forms/admin/meeting_registration_invite_form_spec.rb
+++ b/decidim-meetings/spec/forms/admin/meeting_registration_invite_form_spec.rb
@@ -13,37 +13,37 @@ module Decidim::Meetings
       }
     end
 
-    let(:name) { "Foo" }
     let(:email) { "foo@example.org" }
-    let(:existing_user) { false }
+    let(:attendee_type) { "email" }
     let(:user_id) { nil }
     let(:attributes) do
       {
-        name:,
         email:,
-        existing_user:,
+        attendee_type:,
         user_id:
       }
     end
 
-    context "when everything is OK" do
-      it { is_expected.to be_valid }
+    context "when attendee_type is email" do
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when email is missing" do
+        let(:email) { nil }
+
+        it { is_expected.to be_invalid }
+      end
+
+      context "when email is invalid" do
+        let(:email) { "not-an-email" }
+
+        it { is_expected.to be_invalid }
+      end
     end
 
-    context "when name is missing" do
-      let(:name) { nil }
-
-      it { is_expected.to be_invalid }
-    end
-
-    context "when email is missing" do
-      let(:email) { nil }
-
-      it { is_expected.to be_invalid }
-    end
-
-    context "when existing user is present" do
-      let(:existing_user) { true }
+    context "when attendee_type is name" do
+      let(:attendee_type) { "name" }
 
       context "and no user is provided" do
         it { is_expected.to be_invalid }
@@ -82,6 +82,18 @@ module Decidim::Meetings
           it { is_expected.to be_nil }
         end
       end
+    end
+
+    context "when attendee_type is missing" do
+      let(:attendee_type) { nil }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "when attendee_type is invalid" do
+      let(:attendee_type) { "invalid" }
+
+      it { is_expected.to be_invalid }
     end
   end
 end

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -13,8 +13,7 @@ def invite_unregistered_user(name:, email:)
   visit_meeting_invites_page
 
   within "form.new_meeting_registration_invite" do
-    choose "Non existing participant", name: "meeting_registration_invite[existing_user]"
-    fill_in :meeting_registration_invite_name, with: name
+    choose "Email", name: "meeting_registration_invite[attendee_type]"
     fill_in :meeting_registration_invite_email, with: email
 
     perform_enqueued_jobs do
@@ -34,7 +33,7 @@ def invite_existing_user(user)
   visit_meeting_invites_page
 
   within "form.new_meeting_registration_invite" do
-    choose "Existing participant", name: "meeting_registration_invite[existing_user]"
+    choose "Name or nickname", name: "meeting_registration_invite[attendee_type]"
     autocomplete_select "#{user.name} (@#{user.nickname})", from: :user_id
 
     perform_enqueued_jobs do

--- a/decidim-meetings/spec/shared/manage_invites_examples.rb
+++ b/decidim-meetings/spec/shared/manage_invites_examples.rb
@@ -9,7 +9,7 @@ def visit_meeting_invites_page
   click_on "Invitations"
 end
 
-def invite_unregistered_user(name:, email:)
+def invite_unregistered_user(email:)
   visit_meeting_invites_page
 
   within "form.new_meeting_registration_invite" do
@@ -24,7 +24,6 @@ def invite_unregistered_user(name:, email:)
   expect(page).to have_callout("Participant successfully invited to join the meeting.")
 
   within "#meeting-invites table" do
-    expect(page).to have_text(name)
     expect(page).to have_text(email)
   end
 end
@@ -72,7 +71,7 @@ shared_examples "manage invites" do
 
       context "when inviting a unregistered user" do
         it "the invited user sign up into the application and joins the meeting" do
-          invite_unregistered_user name: "Foo", email: "foo@example.org"
+          invite_unregistered_user email: "foo@example.org"
 
           logout :user
           perform_enqueued_jobs
@@ -91,7 +90,7 @@ shared_examples "manage invites" do
         end
 
         it "the invited user sign up into the application and declines the invitation" do
-          invite_unregistered_user name: "Foo", email: "foo@example.org"
+          invite_unregistered_user email: "foo@example.org"
 
           logout :user
           perform_enqueued_jobs
@@ -140,7 +139,7 @@ shared_examples "manage invites" do
         let!(:registered_user) { create(:user, :confirmed, organization:) }
 
         it "the invited user joins the meeting" do
-          invite_unregistered_user name: registered_user.name, email: registered_user.email
+          invite_unregistered_user email: registered_user.email
 
           relogin_as registered_user
           perform_enqueued_jobs
@@ -151,7 +150,7 @@ shared_examples "manage invites" do
         end
 
         it "the invited user declines the invitation" do
-          invite_unregistered_user name: registered_user.name, email: registered_user.email
+          invite_unregistered_user email: registered_user.email
 
           relogin_as registered_user
 

--- a/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
+++ b/decidim-meetings/spec/system/admin/admin_filters_meeting_invites_spec.rb
@@ -50,7 +50,7 @@ describe "Admin filters invites" do
 
     it "successfully handles the error" do
       within "#new_meeting_registration_invite" do
-        fill_in :meeting_registration_invite_name, with: user1.name
+        choose "Email", name: "meeting_registration_invite[attendee_type]"
         fill_in :meeting_registration_invite_email, with: user1.email
         click_on "Invite"
       end
@@ -66,7 +66,7 @@ describe "Admin filters invites" do
       invited = build(:user, organization:)
 
       within "#new_meeting_registration_invite" do
-        fill_in :meeting_registration_invite_name, with: invited.name
+        choose "Email", name: "meeting_registration_invite[attendee_type]"
         fill_in :meeting_registration_invite_email, with: invited.email
         click_on "Invite"
       end


### PR DESCRIPTION
#### :tophat: What? Why?

While working on fixes for Members, we wanted to change how to invite non/existing participants (see #16992). As on @decidim/product weren't happy with that UX pattern, we are changing it to something (hopefully) clear and more consistent with other parts of the app. 

To not have one pattern at Members and another on Meetings Registrations Invitations, I'm doing first the change in Invitations, and I'll do the change in Members after this is merged.

#### :pushpin: Related Issues
 
- Related to #16992 
 - See Figma mockups: https://www.figma.com/design/rQ1b27LTcc02wd8b6TInLx/Internal-Decidim--2026-?node-id=7021-21521&t=JxmQp7QV2sfBqlbr-0 

#### Testing

1. Sign in as admin
2. Edit a meeting with "Registration type" -> "On this platform"
<img width="529" height="181" alt="image" src="https://github.com/user-attachments/assets/b9865b02-2b22-4614-95b4-135b4618fa09" />
3. Go to the Registrations page
<img width="564" height="412" alt="image" src="https://github.com/user-attachments/assets/58455255-3818-4279-8cdf-1db321cf94bb" />
4. Click on the Invitations button
<img width="878" height="297" alt="image" src="https://github.com/user-attachments/assets/44c469b7-6ce2-4ac9-aaef-5730da9c25a2" />
5. See the page

### :camera: Screenshots

#### Before 

<img width="1575" height="673" alt="image" src="https://github.com/user-attachments/assets/4c908c14-a2c8-475b-9bf2-3bd4c9478f15" />

#### After

<img width="1480" height="620" alt="image" src="https://github.com/user-attachments/assets/7deb75ee-ddd6-4f80-9d65-afc4ad3b6c89" />
<img width="1480" height="524" alt="image" src="https://github.com/user-attachments/assets/a6217195-41af-4445-8308-0dbf4bc51a45" />





:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Meeting invite form now allows choosing between inviting attendees by email address or existing name.
  * When inviting by email, attendee names and nicknames are automatically generated from the email address.
  * Form interface updated with radio card selection for clearer workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->