### PR TITLE
Fix exception on post new page as a visitor

### DIFF
--- a/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/posts_controller.rb
@@ -12,6 +12,7 @@ module Decidim
       include Decidim::FormFactory
 
       helper_method :posts, :post, :post_presenter, :paginate_posts, :posts_most_commented, :tabs, :panels
+      before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
 
       def index; end
 

--- a/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
+++ b/decidim-blogs/spec/controllers/decidim/blogs/posts_controller_spec.rb
@@ -5,21 +5,24 @@ require "spec_helper"
 module Decidim
   module Blogs
     describe PostsController do
+      include Decidim::Core::Engine.routes.url_helpers
+
+      let(:organization) { create(:organization) }
+      let(:participatory_process) { create(:participatory_process, organization:) }
+      let!(:post_component) { create(:post_component, participatory_space: participatory_process) }
+      let!(:published) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.ago) }
+
+      before do
+        request.env["decidim.current_organization"] = organization
+        request.env["decidim.current_component"] = post_component
+        request.env["decidim.current_participatory_space"] = participatory_process
+      end
+
       describe "show" do
         context "when the post has not published yet" do
-          let(:organization) { create(:organization) }
-          let(:participatory_process) { create(:participatory_process, organization:) }
-          let!(:post_component) { create(:post_component, participatory_space: participatory_process) }
           let!(:unpublished) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.from_now) }
-          let!(:published) { create(:post, component: post_component, created_at: 2.days.ago, published_at: 2.days.ago) }
           let!(:another_published) { create(:post, component: post_component, created_at: 3.days.ago, published_at: 1.day.ago) }
           let!(:current_user) { create(:user, :admin, :confirmed, organization:) }
-
-          before do
-            request.env["decidim.current_organization"] = organization
-            request.env["decidim.current_component"] = post_component
-            request.env["decidim.current_participatory_space"] = participatory_process
-          end
 
           it "lists only published posts" do
             get :index
@@ -60,6 +63,57 @@ module Decidim
               get :show, params: { id: unpublished.id }
               expect(response).to have_http_status(:ok)
             end
+          end
+        end
+      end
+
+      describe "#destroy" do
+        context "when user is not authenticated" do
+          it "redirects to login page" do
+            delete(:destroy, params: { id: published.id })
+            expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+            expect(response).to redirect_to(new_user_session_path)
+            expect(published.reload).to be_present
+          end
+        end
+      end
+
+      describe "#new" do
+        context "when user is not authenticated" do
+          it "redirects to login page" do
+            get :new
+            expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+            expect(response).to redirect_to(new_user_session_path)
+          end
+        end
+      end
+
+      describe "#create" do
+        context "when user is not authenticated" do
+          it "redirects to login page" do
+            post(:create, params: { component_id: post_component.id })
+            expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+            expect(response).to redirect_to(new_user_session_path)
+          end
+        end
+      end
+
+      describe "#edit" do
+        context "when user is not authenticated" do
+          it "redirects to login page" do
+            get :edit, params: { component_id: post_component.id, id: published.id }
+            expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+            expect(response).to redirect_to(new_user_session_path)
+          end
+        end
+      end
+
+      describe "#update" do
+        context "when user is not authenticated" do
+          it "redirects to login page" do
+            put :update, params: { component_id: post_component.id, id: published.id }
+            expect(flash[:alert]).to eq("You need to log in or create an account before continuing.")
+            expect(response).to redirect_to(new_user_session_path)
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?
A while back, i have found out that a visitor navigating the website, or clicking a link to a new post page , could raise a 500 error. 
This PR fixes it. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #16592

#### Testing

1. As an admin visit admin area
2. Identify the a space, enable / install a blog component . Publish it
3. Configure the component to allow users to create posts
4. As admin, visit the newly created component on public site. Click on Create post
5. When the blog form is being visible, copy the url
6. Open an incognito window and paste.
7. You will see a 500 error
8. Apply patch 
9. As a visitor visit again the URL. See there is no error generated

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added user authentication requirement for creating, editing, and deleting blog posts, ensuring only logged-in users can modify content. Unauthenticated users are now redirected to the login page.

* **Tests**
  * Expanded test coverage to verify authentication protection on blog post management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->