### PR TITLE
Fix conversations multiple mentions UI

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
@@ -91,18 +91,18 @@ export default class extends Controller {
         });
       },
       render: {
-        option: (data) => {
+        option: (data, escape) => {
           const isDisabled = data.directMessagesEnabled === "false";
           const className = isDisabled
             ? "disabled"
             : "";
           const disabledMsg = isDisabled
-            ? `<small>${this.searchInput.dataset.directMessagesDisabled}</small>`
+            ? `<small>${escape(this.searchInput.dataset.directMessagesDisabled)}</small>`
             : "";
           return `<div class="${className}">
-            <img src="${data.avatarUrl}" alt="${data.name}">
-            <span>${data.nickname}</span>
-            <small>${data.name}</small>
+            <img src="${escape(data.avatarUrl)}" alt="${escape(data.name)}">
+            <span>${escape(data.nickname)}</span>
+            <small>${escape(data.name)}</small>
             ${disabledMsg}
           </div>`;
         },

--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
@@ -206,16 +206,22 @@ export default class extends Controller {
    * @param {string} id - The user ID
    * @returns {void}
    */
+  htmlEscape(str) {
+    const div = document.createElement("div");
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
   addSelectedUser(selection, id) {
     const label = this.removeLabel.replace("%name%", selection.value.name);
 
     const listItem = document.createElement("li");
     listItem.tabIndex = "-1";
     listItem.innerHTML = `
-      <input type="hidden" name="${this.options.name}" value="${id}">
-      <img src="${selection.value.avatarUrl}" alt="${selection.value.name}">
-      <span>${selection.value.name}</span>
-      <button type="button" data-remove="${id}" tabindex="0" aria-controls="0" aria-label="${label}">${icon("delete-bin-line")}</button>
+      <input type="hidden" name="${this.htmlEscape(this.options.name)}" value="${this.htmlEscape(id)}">
+      <img src="${this.htmlEscape(selection.value.avatarUrl)}" alt="${this.htmlEscape(selection.value.name)}">
+      <span>${this.htmlEscape(selection.value.name)}</span>
+      <button type="button" data-remove="${this.htmlEscape(id)}" tabindex="0" aria-controls="0" aria-label="${this.htmlEscape(label)}">${icon("delete-bin-line")}</button>
     `;
 
     this.selectedItems.appendChild(listItem);

--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import AutoComplete from "src/decidim/refactor/moved/autocomplete";
+import TomSelect from "tom-select/dist/cjs/tom-select.popular";
 import icon from "src/decidim/refactor/moved/icon";
 
 export default class extends Controller {
@@ -16,20 +16,6 @@ export default class extends Controller {
 
     this.initializeEmptyFocusElement();
     this.initializeAutoComplete();
-    this.setupSelectionListener();
-  }
-
-  /**
-   * Setup the selection event listener
-   * @returns {void}
-   */
-  setupSelectionListener() {
-    this.selectionHandler = (event) => {
-      const feedback = event.detail;
-      const selection = feedback.selection;
-      this.handleSelection(selection);
-    };
-    this.searchInput.addEventListener("selection", this.selectionHandler);
   }
 
   /*
@@ -37,8 +23,8 @@ export default class extends Controller {
    * @returns {void}
    */
   disconnect() {
-    if (this.searchInput && this.selectionHandler) {
-      this.searchInput.removeEventListener("selection", this.selectionHandler);
+    if (this.tomSelect) {
+      this.tomSelect.destroy();
     }
   }
 
@@ -80,11 +66,56 @@ export default class extends Controller {
    * @returns {void}
    */
   initializeAutoComplete() {
-    this.autoComplete = new AutoComplete(this.searchInput, {
-      dataMatchKeys: ["name", "nickname"],
-      dataSource: this.getDataSource.bind(this),
-      dataFilter: this.filterResults.bind(this),
-      modifyResult: this.modifyResult.bind(this)
+    this.tomSelect = new TomSelect(this.searchInput, {
+      maxItems: 1,
+      valueField: "id",
+      labelField: "name",
+      searchField: ["name", "nickname"],
+      loadThrottle: 200,
+      loadingClass: "loading",
+      preload: false,
+      highlight: true,
+      load: (query, callback) => {
+        if (!query || query.length < 2) {
+          callback();
+          return;
+        }
+        this.getDataSource(query, (results) => {
+          const filtered = this.filterResults(results);
+          filtered.forEach((item) => {
+            if (item.directMessagesEnabled === "false") {
+              item.disabled = true;
+            }
+          });
+          callback(filtered);
+        });
+      },
+      render: {
+        option: (data) => {
+          const isDisabled = data.directMessagesEnabled === "false";
+          const className = isDisabled
+            ? "disabled"
+            : "";
+          const disabledMsg = isDisabled
+            ? `<small>${this.searchInput.dataset.directMessagesDisabled}</small>`
+            : "";
+          return `<div class="${className}">
+            <img src="${data.avatarUrl}" alt="${data.name}">
+            <span>${data.nickname}</span>
+            <small>${data.name}</small>
+            ${disabledMsg}
+          </div>`;
+        },
+        "no_results": () => `<div class="no-results">${this.searchInput.dataset.noresults || ""}</div>`
+      },
+      onChange: (value) => {
+        if (value) {
+          const option = this.tomSelect.options[value];
+          this.handleSelection({ value: option });
+          this.tomSelect.clear();
+          this.tomSelect.clearOptions();
+        }
+      }
     });
   }
 
@@ -129,7 +160,7 @@ export default class extends Controller {
    */
   filterResults(list) {
     return list.filter(
-      (item) => !this.selected.includes(item.value.id)
+      (item) => !this.selected.includes(item.id)
     );
   }
 
@@ -161,18 +192,12 @@ export default class extends Controller {
    */
   handleSelection(selection) {
     const id = selection.value.id;
-    // Check if we have reached the maximum limit or if direct messages are disabled
     if (this.isMaxLimitReached() || selection.value.directMessagesEnabled === "false") {
       return;
     }
 
     this.addSelectedUser(selection, id);
-    this.autoComplete.setInput("");
     this.selected.push(id);
-
-    if (this.autoComplete && this.autoComplete.autocomplete) {
-      this.autoComplete.autocomplete.close();
-    }
   }
 
   /**

--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/controller.js
@@ -201,10 +201,9 @@ export default class extends Controller {
   }
 
   /**
-   * Add a selected user to the display list
-   * @param {Object} selection - The selected user object
-   * @param {string} id - The user ID
-   * @returns {void}
+   * Escape HTML characters in a string
+   * @param {string} str - The string to escape
+   * @returns {string} The escaped HTML string
    */
   htmlEscape(str) {
     const div = document.createElement("div");
@@ -212,6 +211,12 @@ export default class extends Controller {
     return div.innerHTML;
   }
 
+  /**
+   * Add a selected user to the display list
+   * @param {Object} selection - The selected user object
+   * @param {string} id - The user ID
+   * @returns {void}
+   */
   addSelectedUser(selection, id) {
     const label = this.removeLabel.replace("%name%", selection.value.name);
 

--- a/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/input_multiple_mentions.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/multiple_mentions/input_multiple_mentions.test.js
@@ -7,13 +7,14 @@
 import { Application } from "@hotwired/stimulus"
 import MultipleMentionsController from "src/decidim/controllers/multiple_mentions/controller"
 
-const AutoComplete = require("src/decidim/refactor/moved/autocomplete");
+const TomSelect = require("tom-select/dist/cjs/tom-select.popular");
 const iconMock = require("src/decidim/refactor/moved/icon");
 
 // Mock the dependencies
-jest.mock("src/decidim/refactor/moved/autocomplete", () => {
+jest.mock("tom-select/dist/cjs/tom-select.popular", () => {
   return jest.fn().mockImplementation(() => ({
-    setInput: jest.fn()
+    destroy: jest.fn(),
+    clearOptions: jest.fn()
   }));
 });
 
@@ -114,12 +115,22 @@ describe("MultipleMentionsManager", () => {
       expect(controller.emptyFocusElement).toBe(existingElement);
     });
 
-    it("should initialize AutoComplete with correct configuration", () => {
-      expect(AutoComplete).toHaveBeenCalledWith(searchInput, {
-        dataMatchKeys: ["name", "nickname"],
-        dataSource: expect.any(Function),
-        dataFilter: expect.any(Function),
-        modifyResult: expect.any(Function)
+    it("should initialize TomSelect with correct configuration", () => {
+      expect(TomSelect).toHaveBeenCalledWith(searchInput, {
+        maxItems: 1,
+        valueField: "id",
+        labelField: "name",
+        searchField: ["name", "nickname"],
+        loadThrottle: 200,
+        loadingClass: "loading",
+        preload: false,
+        highlight: true,
+        load: expect.any(Function),
+        render: {
+          option: expect.any(Function),
+          "no_results": expect.any(Function)
+        },
+        onChange: expect.any(Function)
       });
     });
   });
@@ -226,24 +237,24 @@ describe("MultipleMentionsManager", () => {
       controller.selected = ["1", "3"];
 
       const list = [
-        { value: { id: "1" } },
-        { value: { id: "2" } },
-        { value: { id: "3" } },
-        { value: { id: "4" } }
+        { id: "1" },
+        { id: "2" },
+        { id: "3" },
+        { id: "4" }
       ];
 
       const filtered = controller.filterResults(list);
 
       expect(filtered).toEqual([
-        { value: { id: "2" } },
-        { value: { id: "4" } }
+        { id: "2" },
+        { id: "4" }
       ]);
     });
 
     it("should return all users when none are selected", () => {
       const list = [
-        { value: { id: "1" } },
-        { value: { id: "2" } }
+        { id: "1" },
+        { id: "2" }
       ];
 
       const filtered = controller.filterResults(list);
@@ -255,8 +266,8 @@ describe("MultipleMentionsManager", () => {
       controller.selected = ["1", "2"];
 
       const list = [
-        { value: { id: "1" } },
-        { value: { id: "2" } }
+        { id: "1" },
+        { id: "2" }
       ];
 
       const filtered = controller.filterResults(list);
@@ -330,7 +341,6 @@ describe("MultipleMentionsManager", () => {
 
       expect(controller.selected).toContain("1");
       expect(selectedItems.children.length).toBe(1);
-      expect(controller.autoComplete.setInput).toHaveBeenCalledWith("");
     });
 
     it("should not add user when max limit is reached", () => {
@@ -350,7 +360,6 @@ describe("MultipleMentionsManager", () => {
 
       expect(controller.selected).not.toContain("10");
       expect(selectedItems.children.length).toBe(0);
-      expect(controller.autoComplete.setInput).not.toHaveBeenCalled();
     });
 
     it("should not add user when direct messages are disabled", () => {
@@ -368,7 +377,6 @@ describe("MultipleMentionsManager", () => {
 
       expect(controller.selected).not.toContain("1");
       expect(selectedItems.children.length).toBe(0);
-      expect(controller.autoComplete.setInput).not.toHaveBeenCalled();
     });
 
     it("should handle multiple valid selections", () => {
@@ -383,7 +391,6 @@ describe("MultipleMentionsManager", () => {
 
       expect(controller.selected).toEqual(["1", "2"]);
       expect(selectedItems.children.length).toBe(2);
-      expect(controller.autoComplete.setInput).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/decidim-core/app/packs/stylesheets/decidim/_tom_select.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_tom_select.scss
@@ -12,8 +12,12 @@
   &-dropdown {
     @apply text-md text-gray-2 font-normal;
 
+    .option img {
+      @apply inline;
+    }
+
     .active {
-      @apply text-white bg-secondary;
+      @apply bg-gray-3;
     }
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/_tom_select.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_tom_select.scss
@@ -1,0 +1,19 @@
+@use "tom-select/dist/scss/tom-select";
+
+.ts {
+  &-control {
+    @apply border-gray text-md min-h-[40px];
+
+    input {
+      @apply font-normal text-black text-md;
+    }
+  }
+
+  &-dropdown {
+    @apply text-md text-gray-2 font-normal;
+
+    .active {
+      @apply text-white bg-secondary;
+    }
+  }
+}

--- a/decidim-core/app/packs/stylesheets/decidim/application.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/application.scss
@@ -6,6 +6,8 @@
 // Datepicker
 @use "stylesheets/decidim/vendor/datepicker_light";
 @use "stylesheets/decidim/datepicker";
+// TomSelect
+@use "stylesheets/decidim/tom_select";
 // On the other hand, the following styles match with specific routes
 @use "stylesheets/decidim/header";
 @use "stylesheets/decidim/footer";

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -313,7 +313,7 @@ describe "Conversations" do
           expect(page).to have_css(".conversation__modal-results li", count: 1)
           expect(page).to have_text("Maria")
           expect(page).to have_no_css(".ts-dropdown .option", visible: :visible)
-          expect(find("#add_conversation_users", visible: false).value).to eq("")
+          expect(find_by_id("add_conversation_users", visible: false).value).to eq("")
         end
       end
     end

--- a/decidim-core/spec/system/messaging/conversations_spec.rb
+++ b/decidim-core/spec/system/messaging/conversations_spec.rb
@@ -287,11 +287,10 @@ describe "Conversations" do
           visit_inbox
           expect(page).to have_text("New conversation")
           click_on "New conversation"
-          expect(page).to have_css("#add_conversation_users")
-          field = find_by_id("add_conversation_users")
-          field.set ""
+          expect(page).to have_css(".ts-control input")
+          field = find(".ts-control input")
           field.native.send_keys "@#{interlocutor2.nickname.slice(0, 3)}"
-          expect(page).to have_css("#autoComplete_list_1 li.disabled", wait: 5)
+          expect(page).to have_css(".ts-dropdown .option.disabled", wait: 5)
         end
       end
 
@@ -302,19 +301,19 @@ describe "Conversations" do
         it "does not insert element twice and closes dropdown", :slow do
           visit_inbox
           click_on "New conversation"
-          expect(page).to have_css("#add_conversation_users")
+          expect(page).to have_css(".ts-control input")
 
-          field = find_by_id("add_conversation_users")
+          field = find(".ts-control input")
           field.native.send_keys "Mar"
 
-          expect(page).to have_css("#autoComplete_list_1 li", wait: 5)
+          expect(page).to have_css(".ts-dropdown .option", wait: 5)
 
-          find("#autoComplete_list_1 li").click
+          find(".ts-dropdown .option", match: :first).click
 
           expect(page).to have_css(".conversation__modal-results li", count: 1)
           expect(page).to have_text("Maria")
-          expect(page).to have_no_css("#autoComplete_list_1 li", wait: 2)
-          expect(field.value).to eq("")
+          expect(page).to have_no_css(".ts-dropdown .option", visible: :visible)
+          expect(find("#add_conversation_users", visible: false).value).to eq("")
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #16912, I noticed a bug with the UI:

<img width="1814" height="1232" alt="image" src="https://github.com/user-attachments/assets/f426e880-d0f9-4d85-b58b-1b215aa6478c" />

Basically:

1. the design is broken
2. the list appears two times
3. with the correct behavior in Metadecidim, it doesn't show any feedback when searching or when results aren't found
4. with the correct behavior in Metadecidim, when it is open and you press Escape key, the modal is closed (it should only close the autocomplete list, and with another Escape key it should close the modal)
5. While reviewing the code, I noticed that it is using autocomplete.js

So, instead of trying to patch something that is already deprecated, I prefer to migrate to Tom Select, as we already started the process to migrating these usages to it. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/pull/11076 
- Related to #16912

#### Testing

1. Log in
2. Go to http://localhost:3000/en/conversations
3. Click on the "New conversation" button
4. Start writing something
5. See that you have feedback on search
6. If any participant with that name or nickname is found, click it. See that it works correctly.
7. Write anything really wrong. See that you have a "No results" message.
8. Write again another name. Close with Escape key. See that the autocomplete list is closed. Close again with Escape key. See that the modal is closed.

As the correct behavior is broken in `develop` and also in https://nightly.decidim.org/en/conversations, the best place to check the happy path is Metadecidim: https://meta.decidim.org/conversations 

### :camera: Screenshots

#### Before

<img width="2046" height="1224" alt="image" src="https://github.com/user-attachments/assets/87ae0178-5477-479d-b685-bf96f1aa4787" />

#### After

<img width="1622" height="838" alt="image" src="https://github.com/user-attachments/assets/9bcab910-dce8-4058-b110-7c97c268f853" />
<img width="1760" height="808" alt="image" src="https://github.com/user-attachments/assets/a0cd8675-7f90-4a0f-9074-3721cc9c4254" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Replaced autocomplete with a token-style selection (TomSelect): throttled search, single-item selection, avatar/name/nickname rendering, proper teardown, and cleared control state after selection.

* **Bug Fixes**
  * Suggestions exclude already-selected users, prevent selecting users with direct messages disabled, and enforce max selection limits.

* **Style**
  * Added and integrated TomSelect styles.

* **Tests**
  * Updated unit and system tests to match the new control and result shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->