### PR TITLE
Fix exception in intiatives when `has_authorship?` receives a nil argument for user

### DIFF
--- a/.github/workflows/ci_initiatives.yml
+++ b/.github/workflows/ci_initiatives.yml
@@ -16,6 +16,7 @@ on:
       - "decidim-core/**"
       - "decidim-dev/**"
       - "decidim-initiatives/**"
+      - "decidim-meetings/**"
       - "decidim-verifications/**"
 
 permissions:

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -380,6 +380,7 @@ module Decidim
     #
     # Returns a Boolean.
     def has_authorship?(user)
+      return false unless user
       return true if author.id == user.id
 
       committee_members.approved.where(decidim_users_id: user.id).any?

--- a/decidim-initiatives/spec/models/decidim/initiative_spec.rb
+++ b/decidim-initiatives/spec/models/decidim/initiative_spec.rb
@@ -173,6 +173,10 @@ module Decidim
       it "returns false for any other user" do
         expect(initiative).not_to have_authorship(user)
       end
+
+      it "returns false for any inexistent user" do
+        expect(initiative).not_to have_authorship(nil)
+      end
     end
 
     describe "signatures calculations" do


### PR DESCRIPTION
#### :tophat: What? Why?
After we merged #17026, i noticed the pipeline started to fail with the following error: 
<img width="1766" height="246" alt="image" src="https://github.com/user-attachments/assets/3619e914-b176-4f72-afea-84430a597c6c" />

This is caused by the fact that is user is not checked anymore in meetings permissions. We did not not caught this one before, because we did not instruct GH actions to trigger the initiatives pipeline if the meetings  module is being changed.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #17026
- Fixes #?

#### Testing
Green pipeline on initiatives

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
<img width="1766" height="246" alt="image" src="https://github.com/user-attachments/assets/76cbe542-a31a-4e4e-b605-41f7c70fc0b1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run for changes in additional directories.

* **Bug Fixes**
  * Authorship check now safely returns false when user information is missing, preventing errors.

* **Tests**
  * Added test coverage asserting authorship check behavior with a missing user.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->