### PR TITLE
Update ActiveStorage S3 section with the ACL configuration

### DIFF
--- a/docs/modules/services/pages/activestorage.adoc
+++ b/docs/modules/services/pages/activestorage.adoc
@@ -66,6 +66,9 @@ To have public assets in your application, so that you do not rely on the Active
 8. Add a bucket policy similar to the example below.
    - If you are unsure of your bucket’s ARN, you can find it in the Properties tab. For this example, we use  `arn:aws:s3:::your-bucket-name`
 9. Click *Save changes*
+10. Still in the *Permissions tab*, locate the *Object Ownership* section and click *Edit*
+11. Select the options "ACLs enabled" and "Object writer"
+12. Click *Save changes*
 [source,json]
 ----
 {


### PR DESCRIPTION
#### :tophat: What? Why?
Update ActiveStorage S3 section with the missing ACL object ownership configuration

### :camera: Screenshots
<img width="1682" height="548" alt="Screenshot 2026-06-09 at 12 26 58" src="https://github.com/user-attachments/assets/df46700d-d818-40e8-b397-7b88f31585a2" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Amazon S3 configuration instructions to include Object Ownership settings in the S3 bucket Permissions tab, requiring users to enable ACLs and select "Object writer" as the object owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->