### PR TITLE
Use GHCR.io postgres image in pipelines

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 90
     services:
       postgres:
-        image: ghcr.io/decidim/postgres:14
+        image: ghcr.io/cloudnative-pg/postgresql:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 90
     services:
       postgres:
-        image: postgres:14
+        image: postgresghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 90
     services:
       postgres:
-        image: ghcr.io/cloudnative-pg/postgresql:14
+        image: ghcr.io/devcontainers/features/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 90
     services:
       postgres:
-        image: postgresghcr.io/decidim/postgres:14
+        image: ghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: postgresghcr.io/decidim/postgres:14
+        image: ghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: ghcr.io/cloudnative-pg/postgresql:14
+        image: ghcr.io/devcontainers/features/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: ghcr.io/decidim/postgres:14
+        image: ghcr.io/cloudnative-pg/postgresql:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: postgres:14
+        image: postgresghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: postgres:14
+        image: ghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: ghcr.io/decidim/postgres:14
+        image: ghcr.io/cloudnative-pg/postgresql:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -35,7 +35,7 @@ jobs:
     timeout-minutes: 60
     services:
       postgres:
-        image: ghcr.io/cloudnative-pg/postgresql:14
+        image: ghcr.io/devcontainers/features/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -74,7 +74,7 @@ jobs:
         image: ${{ vars.ACTION_ACCESSIBILITY_VALIDATOR_VERSION || 'ghcr.io/validator/validator:latest' }}
         ports: ["8888:8888"]
       postgres:
-        image: ghcr.io/decidim/postgres:14
+        image: ghcr.io/cloudnative-pg/postgresql:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -75,14 +75,22 @@ jobs:
         ports: ["8888:8888"]
       postgres:
         image: ghcr.io/cloudnative-pg/postgresql:14
-        ports: ["5432:5432"]
+        ports:
+          - 5432:5432
         options: >-
-          --health-cmd pg_isready
+          --entrypoint bash
+          --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         env:
           POSTGRES_PASSWORD: postgres
+          PGDATA: /tmp/pgdata
+        run: |
+          mkdir -p /tmp/pgdata
+          initdb -D /tmp/pgdata --username=postgres
+          echo "host all all all trust" >> /tmp/pgdata/pg_hba.conf
+          postgres -D /tmp/pgdata
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -74,7 +74,7 @@ jobs:
         image: ${{ vars.ACTION_ACCESSIBILITY_VALIDATOR_VERSION || 'ghcr.io/validator/validator:latest' }}
         ports: ["8888:8888"]
       postgres:
-        image: postgres:14
+        image: ghcr.io/decidim/postgres:14
         ports: ["5432:5432"]
         options: >-
           --health-cmd pg_isready


### PR DESCRIPTION
#### :tophat: What? Why?
While reviewing some of the PRs i have noticed there are some pipeline failing with the following: 

```
  /usr/bin/docker pull postgres:14
  Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
  Warning: Docker pull failed with exit code 1, back off 6.585 seconds before retry.
  /usr/bin/docker pull postgres:14
  Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
  Warning: Docker pull failed with exit code 1, back off 5.752 seconds before retry.
  /usr/bin/docker pull postgres:14
  Error response from daemon: Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
  Error: Docker pull failed with exit code 1
```

After a short discussion with Andres, we are starting to use the ghcr.io for pipeline related actions. Since postgres does not not have (or i could not find) any published image in ghcr, i have pushed a new image, that i am using in this PR. 

#### Testing
The pipeline should be green without any retries.

### :camera: Screenshots
<img width="1337" height="340" alt="image" src="https://github.com/user-attachments/assets/01d40307-379e-40b8-a5bd-cf893e779eb2" />
:hearts: Thank you!
