### PR TITLE
Fix flaky spec at admin adds display condition on template

### DIFF
--- a/decidim-templates/spec/system/admin/admin_adds_display_condition_on_questionnaire_templates_spec.rb
+++ b/decidim-templates/spec/system/admin/admin_adds_display_condition_on_questionnaire_templates_spec.rb
@@ -16,8 +16,8 @@ describe "Admin adds display condition to template's questionnaire question" do
 
   it "adds display condition to questionnaire question" do
     questionnaire = template.templatable
-    question_one = create(:questionnaire_question, mandatory: true, question_type: "matrix_single", rows: matrix_rows, options: response_options, questionnaire:)
-    question_two = create(:questionnaire_question, :with_response_options, questionnaire:)
+    question_one = create(:questionnaire_question, position: 0, mandatory: true, question_type: "matrix_single", rows: matrix_rows, options: response_options, questionnaire:)
+    question_two = create(:questionnaire_question, :with_response_options, position: 1, questionnaire:)
 
     visit decidim_admin_templates.edit_questions_questionnaire_template_path(template.id)
     # expand question two


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/27329017271/job/80736605015?pr=16847

Relevant test output:

```
Failures:

  1) Admin adds display condition to template's questionnaire question adds display condition to questionnaire question
     Failure/Error: find(".add-display-condition").click

     Capybara::ElementNotFound:
       Unable to find visible css ".add-display-condition"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_adds_display_condition_to_template_s_questionnaire_question_adds_display_condition_to_questionnaire_question_921.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_adds_display_condition_to_template_s_questionnaire_question_adds_display_condition_to_questionnaire_question_921.html


     # ./spec/system/admin/admin_adds_display_condition_on_questionnaire_templates_spec.rb:26:in 'block (2 levels) in <top (required)>'
```

#### :pushpin: Related Issues
- Related to #16847

#### Testing
Run the related spec several times:

```bash
cd decidim-templates
for i in {1..100}; do bundle exec rspec ./spec/system/admin/admin_adds_display_condition_on_questionnaire_templates_spec.rb || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test setup for questionnaire template display condition verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->