### PR TITLE
Second attempt to fix flakyness of the show replies spec

### DIFF
--- a/decidim-comments/spec/system/show_replies_spec.rb
+++ b/decidim-comments/spec/system/show_replies_spec.rb
@@ -58,7 +58,8 @@ describe "Show replies" do
 
       click_button "Load more comments"
 
-      expect(page).to have_css(".comment")
+      expect(page).to have_css(".comment", minimum: 25)
+      expect(page).to have_no_button("Load more comments")
     end
 
     it "can reply to a loaded comment", :slow do

--- a/decidim-comments/spec/system/show_replies_spec.rb
+++ b/decidim-comments/spec/system/show_replies_spec.rb
@@ -15,6 +15,7 @@ describe "Show replies" do
     switch_to_host(organization.host)
     visit resource_path
     expect(page).to have_text(translated_attribute(commentable.title))
+    wait_comments_to_load
   end
 
   after do
@@ -94,6 +95,7 @@ describe "Show replies" do
       end
 
       expect(page).to have_css(%(html[lang="es"]))
+      wait_comments_to_load("es")
     end
 
     it "shows the replies button in the correct locale" do
@@ -105,5 +107,10 @@ describe "Show replies" do
 
       expect(page).to have_css(".comment-thread .comment", count: 4)
     end
+  end
+
+  # Waits for the comments section to be loaded initially.
+  def wait_comments_to_load(locale = "en")
+    expect(page).to have_no_text(I18n.with_locale(locale) { I18n.t("decidim.components.comments.loading") })
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
I was previously attempting to fix the flaky show replies spec at #16932. But there is still one branch of the spec that seems to fail fairly consistently with the following error:

```
Failures:

  1) Show replies when replying to a loaded comment shows comments after loading more
     Failure/Error: expect_no_js_errors

       http://59.lvh.me:5100/packs-test/js/decidim_comments.js 3296:12 "Error loading more comments:" TypeError: Failed to fetch
           at extended.<anonymous> (http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3231:14)
           at Generator.next (<anonymous>)
           at http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3151:61
           at new Promise (<anonymous>)
           at __async (http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3135:10)
           at extended.makeRequest (http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3229:12)
           at extended.<anonymous> (http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3187:37)
           at Generator.next (<anonymous>)
           at http://59.lvh.me:5100/packs-test/js/decidim_comments.js:3151:61
           at new Promise (<anonymous>)

Failed examples:

rspec ./spec/system/show_replies_spec.rb:56 # Show replies when replying to a loaded comment shows comments after loading more
```

Example failed run:
https://github.com/decidim/decidim/actions/runs/27329017225/job/80736607759?pr=16847

This branch only tests that there is a comment on the page but comments already exist on the page before loading more. Therefore, the ongoing requests can be aborted after the test finishes and therefore this error appears in the error console logs.

This adds more strict expectations after clicking the button in order to ensure the request has finished before finishing the test.

#### :pushpin: Related Issues
- Related to
  * #16932
  * #16847

#### Testing
Still have not been able to replicate this error locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened test coverage for comment loading: verifies a minimum number of comments and that the "Load more comments" control is removed after loading.
  * Added a wait helper to ensure loading completes before assertions and applied checks for both default and Spanish locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->