### PR TITLE
Change setting "comments max length" for "max characters per comment"

### DIFF
--- a/decidim-accountability/config/locales/en.yml
+++ b/decidim-accountability/config/locales/en.yml
@@ -303,7 +303,7 @@ en:
           global:
             clear_all: Clear all
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             default_taxonomy: Default taxonomy
             default_taxonomy_help: Select which taxonomy you want to show by default. If no taxonomy is selected, the results will be shown in a list format.
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -50,7 +50,7 @@ en:
         alert_color: Alert
         available_authorizations: Available authorizations
         badges_enabled: Enable badges
-        comments_max_length: Comments max length (Leave 0 for default value)
+        comments_max_length: Max characters per comment (Leave 0 for default value)
         customize_welcome_notification: Customize welcome notification
         default_locale: Default locale
         description: Description

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -115,7 +115,7 @@ en:
             announcement: Announcement
             attachments_allowed: Allow attachments
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             creation_enabled_for_participants: Participants can create posts
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             no_taxonomy_filters_found: No taxonomy filters found.

--- a/decidim-budgets/config/locales/en.yml
+++ b/decidim-budgets/config/locales/en.yml
@@ -347,7 +347,7 @@ en:
             announcement: Announcement
             clear_all: Clear all
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             form:
               errors:

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -556,7 +556,7 @@ en:
           global:
             amendments_enabled: Amendments enabled
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length
+            comments_max_length: Max characters per comment
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             dummy_global_attribute1: Dummy Attribute 1
             dummy_global_attribute2: Dummy Attribute 2

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
             attachments_allowed: Allow attachments
             clear_all: Clear all
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.
             no_taxonomy_filters_found: No taxonomy filters found.
             taxonomy_filters: Select filters for the component

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -169,7 +169,7 @@ en:
             announcement: Announcement
             clear_all: Clear all
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             creation_enabled_for_participants: Participants can create meetings
             default_registration_terms: Default registration terms
             define_taxonomy_filters: Please define some filters for this participatory space before using this setting.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -177,7 +177,7 @@ en:
             collaborative_drafts_enabled: Collaborative drafts enabled
             collaborative_drafts_enabled_help: The Collaborative Drafts feature will be removed in Decidim v0.32. Organizations using it can switch to the new proposal co-authorship feature.
             comments_enabled: Comments enabled
-            comments_max_length: Comments max length (Leave 0 for default value)
+            comments_max_length: Max characters per comment (Leave 0 for default value)
             default_sort_order: Default proposal sorting
             default_sort_order_help: Automatic means that if the votes are enabled, the proposals will be shown sorted by random, and if the votes are blocked, then they will be sorted by the most voted.
             default_sort_order_options:


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the a Association internal QA session for the v0.32.0 release, we found an issue:

> **Copy for “max comments” setting within budgeting should be changed **
>
>
> A particular setting within the budgets component leads to confusing context: 
> “Comments max length (Leave 0 for default value)*Required field” 
> This could lead a user to assume this is in reference to the max number of comments within the budget, not the max number of characters a user can use in a comment. This also makes it extra confusing due to the structure of the form. Before this setting the user is asked if they wish to have comments enabled or disabled, leading to the possible assumption this was a setting was due to the no. of comments active or not.
>
> To Reproduce
> 
> 1. Login
> 2. Configure a budget
> 3. With the settings find the setting called: “Comments max length (Leave 0 for default value)*Required field”
> 4. Configure it if you wish with 5 then save 
> 5. Head to budget and add a comment and see you’re limited by 5 characters not 5 comments.
>
> Expected behavior
> 
> Use a different copy for example: “Max number of character within a comment (Leave 0 for default value) ”

Reported by: @greenwoodt   

My counter-proposal is to make it a bit less verbose and say "Max characters per comment" 
 

#### Testing

1. Log in as administrator
2. Go to a component with this setting

### :camera: Screenshots
 
<img width="635" height="572" alt="image" src="https://github.com/user-attachments/assets/28c2191a-173e-485c-8b16-758571afe2bf" />

:hearts: Thank you!
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English localization labels for comment maximum character settings across multiple platform components including accountability, blogs, budgets, core, debates, meetings, and proposals. Changed label wording to provide clearer guidance and improve consistency across all component configuration screens visible to administrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->