### PR TITLE
Fix flaky spec at `admin_manages_participatory_process_components_spec.rb`

### DIFF
--- a/decidim-accountability/spec/types/integration_schema_spec.rb
+++ b/decidim-accountability/spec/types/integration_schema_spec.rb
@@ -156,7 +156,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
   let!(:current_component) { create(:accountability_component, participatory_space: participatory_process) }

--- a/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/update_component_spec.rb
@@ -6,7 +6,7 @@ module Decidim::Admin
   describe UpdateComponent do
     let!(:participatory_process) { create(:participatory_process, :with_steps) }
     let(:step) { participatory_process.steps.first }
-    let!(:component) { create(:component, :with_one_step, participatory_space: participatory_process) }
+    let!(:component) { create(:component, :with_one_step, participatory_space: participatory_process, weight: 0) }
     let(:manifest) { component.manifest }
     let(:user) { create(:user) }
 

--- a/decidim-blogs/spec/types/integration_schema_spec.rb
+++ b/decidim-blogs/spec/types/integration_schema_spec.rb
@@ -124,7 +124,7 @@ describe "Decidim::Api::QueryType" do
         }
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-budgets/spec/types/integration_schema_spec.rb
+++ b/decidim-budgets/spec/types/integration_schema_spec.rb
@@ -119,7 +119,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-collaborative_texts/spec/types/integration_schema_spec.rb
+++ b/decidim-collaborative_texts/spec/types/integration_schema_spec.rb
@@ -71,7 +71,7 @@ describe "Decidim::Api::QueryType" do
         }
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -85,6 +85,8 @@ FactoryBot.define do
     "#{Faker::Lorem.sentence(word_count: 1, supplemental: true, random_words_to_add: 3)} #{n}"
   end
 
+  sequence(:component_position)
+
   factory :category, class: "Decidim::Category" do
     transient do
       skip_injection { false }
@@ -469,6 +471,7 @@ FactoryBot.define do
     manifest_name { "dummy" }
     published_at { Time.current }
     deleted_at { nil }
+    weight { generate(:component_position) }
     settings do
       {
         dummy_global_translatable_text: generate_localized_title(:dummy_global_translatable_text, skip_injection:),

--- a/decidim-debates/spec/types/integration_schema_spec.rb
+++ b/decidim-debates/spec/types/integration_schema_spec.rb
@@ -122,7 +122,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-meetings/spec/types/integration_schema_spec.rb
+++ b/decidim-meetings/spec/types/integration_schema_spec.rb
@@ -196,7 +196,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-pages/spec/types/integration_schema_spec.rb
+++ b/decidim-pages/spec/types/integration_schema_spec.rb
@@ -52,7 +52,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-proposals/spec/types/integration_schema_spec.rb
+++ b/decidim-proposals/spec/types/integration_schema_spec.rb
@@ -224,7 +224,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 

--- a/decidim-surveys/spec/types/integration_schema_spec.rb
+++ b/decidim-surveys/spec/types/integration_schema_spec.rb
@@ -124,7 +124,7 @@ describe "Decidim::Api::QueryType" do
         ]
       },
       "url" => Decidim::EngineRouter.main_proxy(current_component).root_url,
-      "weight" => 0
+      "weight" => current_component.weight
     }
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/27342459684/job/80782541654

Relevant test output:

```
Failures:

  1) Admin manages participatory process components behaves like manage process components does not reorder components after edit does not reorder when component updates
     Failure/Error: expect(page.text.index(translated(attributes[:name]))).to be < page.text.index("Component 2")

       expected: < 414
            got:   444

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_participatory_process_components_behaves_like_manage_process_components_does_not_reorder_components_after_edit_does_not_reorder_when_component_updates_193.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_participatory_process_components_behaves_like_manage_process_components_does_not_reorder_components_after_edit_does_not_reorder_when_component_updates_193.html


     Shared Example Group: "manage process components" called from ./spec/system/admin/admin_manages_participatory_process_components_spec.rb:8
     # ./spec/shared/manage_process_components_examples.rb:424:in 'block (3 levels) in <top (required)>'

Finished in 7 minutes 31 seconds (files took 14.77 seconds to load)
63 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_participatory_process_components_spec.rb[1:1:5:1] # Admin manages participatory process components behaves like manage process components does not reorder components after edit does not reorder when component updates

```

#### :pushpin: Related Issues
- Related to #17094

#### Testing
Run the spec several times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test data generation for component positions to produce consistent positional values across specs.
  * Updated integration schema tests to assert actual component weights (instead of hard-coded values), and adjusted update tests to use a deterministic initial weight so weight-related behavior is reliably verified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->