### PR TITLE
Fix flaky spec at `authorizations_spec.rb`

### DIFF
--- a/decidim-verifications/spec/system/authorizations_spec.rb
+++ b/decidim-verifications/spec/system/authorizations_spec.rb
@@ -441,5 +441,6 @@ describe "Authorizations", with_authorization_workflows: %w(dummy_authorization_
       fill_in :session_user_password, with: "decidim123456789"
       find("*[type=submit]").click
     end
+    expect(page).to have_button(id: "trigger-dropdown-account")
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/27342459989/job/80782537190

Relevant test output:

```
Failures:

  1) Authorizations when there is onboarding action data and the user signs in and there are authorizations defined for the resource and the user is verified with the authorization and the authorization is granted with metadata which does not meet the conditions to allow the action the user onboarding extended data is removed
     Failure/Error: expect(user.reload.extended_data["onboarding"]).to be_blank
       expected `{"action" => "comment", "model" => "gid://decidim-test-app/Decidim::Dev::DummyResource/4"}.blank?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authorizations_when_there_is_onboarding_action_data_and_the_user_signs_in_and_there_are_authorizations_defined_for_the_resource_and_the_user_is_verified_with_the_authorization_an_497.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authorizations_when_there_is_onboarding_action_data_and_the_user_signs_in_and_there_are_authorizations_defined_for_the_resource_and_the_user_is_verified_with_the_authorization_an_497.html


     # ./spec/system/authorizations_spec.rb:411:in 'block (6 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb:42:in 'block (2 levels) in <top (required)>'

  2) Authorizations when there is onboarding action data and the user signs in and there are authorizations defined for the resource and the user is verified with the authorization and the authorization is granted with metadata which meets the conditions to allow the action the user onboarding extended data is removed
     Failure/Error: expect(user.reload.extended_data["onboarding"]).to be_blank
       expected `{"action" => "comment", "model" => "gid://decidim-test-app/Decidim::Dev::DummyResource/9"}.blank?` to be truthy, got false

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authorizations_when_there_is_onboarding_action_data_and_the_user_signs_in_and_there_are_authorizations_defined_for_the_resource_and_the_user_is_verified_with_the_authorization_an_948.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authorizations_when_there_is_onboarding_action_data_and_the_user_signs_in_and_there_are_authorizations_defined_for_the_resource_and_the_user_is_verified_with_the_authorization_an_948.html


     # ./spec/system/authorizations_spec.rb:393:in 'block (6 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/authorization.rb:42:in 'block (2 levels) in <top (required)>'

Finished in 5 minutes 34 seconds (files took 18.64 seconds to load)
143 examples, 2 failures

Failed examples:

rspec ./spec/system/authorizations_spec.rb:410 # Authorizations when there is onboarding action data and the user signs in and there are authorizations defined for the resource and the user is verified with the authorization and the authorization is granted with metadata which does not meet the conditions to allow the action the user onboarding extended data is removed
rspec ./spec/system/authorizations_spec.rb:392 # Authorizations when there is onboarding action data and the user signs in and there are authorizations defined for the resource and the user is verified with the authorization and the authorization is granted with metadata which meets the conditions to allow the action the user onboarding extended data is removed
```

#### :pushpin: Related Issues

- Related to #17094

#### Testing
Run the spec several times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced authorization system test verification for account functionality.

*Note: This release contains internal improvements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->