### PR TITLE
Make the fields at the "highlighted content banner" content block required

### DIFF
--- a/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_organization_homepage_spec.rb
@@ -115,12 +115,24 @@ describe "Admin manages organization homepage" do
       it "displays the 'Resolution is too large' error message when image is invalid" do
         visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
 
+        fill_in(:content_block_settings_title_en, with: "Custom title text!")
+        fill_in(:content_block_settings_action_button_title_en, with: "Custom action title!")
+        fill_in(:content_block_settings_action_button_subtitle_en, with: "Custom action subtitle!")
+        fill_in(:content_block_settings_action_button_url, with: "http://example.org")
+
         dynamically_attach_file(:content_block_images_background_image, Decidim::Dev.asset("8001x4000.png"))
 
         click_on "Update"
-        sleep 1
 
         expect(page).to have_text("File resolution is too large")
+      end
+
+      it "displays validation errors when required fields are empty" do
+        visit decidim_admin.edit_organization_homepage_content_block_path(content_block)
+
+        click_on "Update"
+
+        expect(page).to have_text("There is an error in this field.")
       end
     end
 

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_content_banner_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_content_banner_cell.rb
@@ -32,7 +32,7 @@ module Decidim
       private
 
       def render?
-        required_keys = [:title, :short_description, :action_button_title, :action_button_subtitle, :action_button_url]
+        required_keys = [:title, :action_button_title, :action_button_subtitle, :action_button_url]
         required_keys.all? { |key| model.settings.public_send(key).present? }
       end
     end

--- a/decidim-core/lib/decidim/core/content_blocks/registry_manager.rb
+++ b/decidim-core/lib/decidim/core/content_blocks/registry_manager.rb
@@ -45,11 +45,11 @@ module Decidim
             ]
 
             content_block.settings do |settings|
-              settings.attribute :title, type: :text, translated: true
+              settings.attribute :title, type: :text, translated: true, required: true
               settings.attribute :short_description, type: :text, translated: true
-              settings.attribute :action_button_title, type: :text, translated: true
-              settings.attribute :action_button_subtitle, type: :text, translated: true
-              settings.attribute :action_button_url, type: :text
+              settings.attribute :action_button_title, type: :text, translated: true, required: true
+              settings.attribute :action_button_subtitle, type: :text, translated: true, required: true
+              settings.attribute :action_button_url, type: :text, required: true
             end
 
             content_block.default!


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the a Association internal QA session for the v0.32.0 release, we found an issue:

> **“Highlighted content banner” is not seen on the frontend and does not respond to changes**
>
> When you add content to highlighted content banner, it is not reflected on the frontend. Also, if you make changes, they are not reflected either.
>
> To Reproduce
>
> 1. Settings > Homepage layout
> 2. Configuring the “Highlighted content banner”
>
> Expected behavior
>
> Highlighted content banner should be seen on the frontend and should reflect the changes you make when configuring it.
>
> Screenshot 
> 
> <img width="542" height="299" alt="image" src="https://github.com/user-attachments/assets/3a222b6d-d6d3-4104-b1dc-bd8d6dd8fa39" />

Reported by Maite

By checking out the code of the cell, I noticed that the problem is that we aren't doing validations here, so I added them.

Mind that the `short_description` as it is a rich text localized attribute, it isn't actually necessary, so I prefer to update the `render` condition (and not add the validation).

#### :pushpin: Related Issues
 
- Related to #14797 
 

#### Testing

0. Log in as admin
1. Settings > Homepage layout
2. Configure the “Highlighted content banner”

### :camera: Screenshots

<img width="1771" height="982" alt="image" src="https://github.com/user-attachments/assets/a5c67623-2e98-4327-9f02-f173313fdf43" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation feedback for the highlighted content banner editor. Required fields (title, action button title, subtitle, and URL) now display appropriate error messages when submitted empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->