### PR TITLE
Add visual feedback for the "Use my current location" feature

### DIFF
--- a/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
@@ -13,9 +13,16 @@ export const initializeReverseGeocoding = function() {
 
   const setLocating = (button, enable) => {
     if (enable) {
+      button.dataset.originalContent = button.innerHTML;
+      button.innerHTML = `<span class="geocoding-spinner"></span> ${button.dataset.locatingText || "Locating..."}`;
       button.setAttribute("disabled", true);
+      button.classList.add("is-locating");
     } else {
+      if (button.dataset.originalContent) {
+        button.innerHTML = button.dataset.originalContent;
+      }
       button.removeAttribute("disabled");
+      button.classList.remove("is-locating");
     }
   };
 
@@ -36,19 +43,18 @@ export const initializeReverseGeocoding = function() {
         navigator.geolocation.getCurrentPosition((position) => {
           const coordinates = [position.coords.latitude, position.coords.longitude];
 
-          // reverse geolocation
           $.post(url, { latitude: coordinates[0], longitude: coordinates[1] }, (data) => {
             input.value = data.address;
             $(input).trigger("geocoder-suggest-coordinates.decidim", [coordinates]);
+            setLocating(target, false);
           }).fail((xhr, status, error) => {
             info(input, `${errorNoLocation} ${error}`);
+            setLocating(target, false);
           });
-
-          setLocating(target, false);
 
         }, (evt) => {
           info(input, `${errorNoLocation} ${evt.message}`);
-          target.removeAttribute("disabled");
+          setLocating(target, false);
         }, {
           enableHighAccuracy: true
         });

--- a/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
@@ -16,21 +16,21 @@ export const initializeReverseGeocoding = function() {
       button.dataset.originalContent = button.innerHTML;
       button.textContent = "";
       const spinner = document.createElement("span");
-      spinner.className = "geocoding-spinner";
+      spinner.className = "geocoding__spinner";
       button.appendChild(spinner);
       button.append(` ${button.dataset.locatingText || "Locating..."}`);
       button.setAttribute("disabled", true);
-      button.classList.add("is-locating");
+      button.classList.add("geocoding__button--locating");
     } else {
       if (button.dataset.originalContent) {
         button.innerHTML = button.dataset.originalContent;
       }
       button.removeAttribute("disabled");
-      button.classList.remove("is-locating");
+      button.classList.remove("geocoding__button--locating");
     }
   };
 
-  document.querySelectorAll(".user-device-location button").forEach((button) => {
+  document.querySelectorAll(".geocoding__button").forEach((button) => {
     button.addEventListener("click", (event) => {
       const target = event.target;
       if (target.disabled) {

--- a/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.js
@@ -14,7 +14,11 @@ export const initializeReverseGeocoding = function() {
   const setLocating = (button, enable) => {
     if (enable) {
       button.dataset.originalContent = button.innerHTML;
-      button.innerHTML = `<span class="geocoding-spinner"></span> ${button.dataset.locatingText || "Locating..."}`;
+      button.textContent = "";
+      const spinner = document.createElement("span");
+      spinner.className = "geocoding-spinner";
+      button.appendChild(spinner);
+      button.append(` ${button.dataset.locatingText || "Locating..."}`);
       button.setAttribute("disabled", true);
       button.classList.add("is-locating");
     } else {

--- a/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.test.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.test.js
@@ -1,0 +1,196 @@
+/* global global, jest */
+
+import { initializeReverseGeocoding } from "src/decidim/geocoding/reverse_geocoding";
+
+describe("reverseGeocoding", () => {
+  let container = null;
+  let button = null;
+  let input = null;
+  let label = null;
+  let mockGeolocation = null;
+  let mockPost = null;
+  let originalGeolocation = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+
+    container = document.createElement("div");
+    container.innerHTML = `
+      <label>
+        <input id="test_address" type="text" />
+        <div class="user-device-location">
+          <button
+            type="button"
+            data-input="test_address"
+            data-error-no-location="Could not detect location."
+            data-error-unsupported="Device not supported."
+            data-locating-text="Locating..."
+            data-url="/locate">
+            Use my location
+          </button>
+        </div>
+      </label>
+    `;
+    document.body.appendChild(container);
+
+    button = container.querySelector(".user-device-location button");
+    input = container.querySelector("#test_address");
+    label = container.querySelector("label");
+
+    originalGeolocation = navigator.geolocation;
+    mockGeolocation = {
+      getCurrentPosition: jest.fn()
+    };
+    Reflect.defineProperty(global.navigator, "geolocation", {
+      value: mockGeolocation,
+      configurable: true
+    });
+
+    mockPost = jest.fn();
+    global.jQuery = jest.fn(() => ({ trigger: jest.fn() }));
+    global.jQuery.post = mockPost;
+    // eslint-disable-next-line id-length
+    global.$ = global.jQuery;
+
+    initializeReverseGeocoding();
+  });
+
+  afterEach(() => {
+    Reflect.defineProperty(global.navigator, "geolocation", {
+      value: originalGeolocation,
+      configurable: true
+    });
+    jest.restoreAllMocks();
+  });
+
+  describe("when clicking the button", () => {
+    it("shows the spinner and disables the button", () => {
+      mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+
+      button.click();
+
+      expect(button.disabled).toBe(true);
+      expect(button.classList.contains("is-locating")).toBe(true);
+      expect(button.querySelector(".geocoding-spinner")).not.toBeNull();
+      expect(button.textContent).toContain("Locating...");
+    });
+
+    it("uses custom locating text from data attribute", () => {
+      button.dataset.locatingText = "Finding you...";
+      mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+
+      button.click();
+
+      expect(button.textContent).toContain("Finding you...");
+    });
+
+    it("stores original content for restoration", () => {
+      mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+
+      button.click();
+
+      expect(button.dataset.originalContent).toContain("Use my location");
+    });
+  });
+
+  describe("when geolocation succeeds", () => {
+    it("restores the button after successful reverse geocoding", () => {
+      const mockPosition = {
+        coords: { latitude: 40.7128, longitude: -74.006 }
+      };
+      mockGeolocation.getCurrentPosition.mockImplementation((success) => {
+        success(mockPosition);
+      });
+
+      const mockDeferred = { fail: jest.fn() };
+      mockPost.mockImplementation((url, data, callback) => {
+        callback({ address: "New York, NY, USA" });
+        return mockDeferred;
+      });
+
+      button.click();
+
+      expect(button.disabled).toBe(false);
+      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.querySelector(".geocoding-spinner")).toBeNull();
+      expect(button.textContent).toContain("Use my location");
+      expect(input.value).toBe("New York, NY, USA");
+    });
+
+    it("restores the button when reverse geocoding fails", () => {
+      const mockPosition = {
+        coords: { latitude: 40.7128, longitude: -74.006 }
+      };
+      mockGeolocation.getCurrentPosition.mockImplementation((success) => {
+        success(mockPosition);
+      });
+
+      const mockDeferred = { fail: jest.fn((callback) => {
+        callback({}, "error", "Not Found");
+      }) };
+      mockPost.mockReturnValue(mockDeferred);
+
+      button.click();
+
+      expect(button.disabled).toBe(false);
+      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.textContent).toContain("Use my location");
+    });
+  });
+
+  describe("when geolocation fails", () => {
+    it("restores the button when user denies permission", () => {
+      const mockError = { message: "User denied geolocation" };
+      mockGeolocation.getCurrentPosition.mockImplementation((success, error) => {
+        error(mockError);
+      });
+
+      button.click();
+
+      expect(button.disabled).toBe(false);
+      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.textContent).toContain("Use my location");
+    });
+
+    it("shows an error message", () => {
+      const mockError = { message: "User denied geolocation" };
+      mockGeolocation.getCurrentPosition.mockImplementation((success, error) => {
+        error(mockError);
+      });
+
+      button.click();
+
+      const errorElement = label.querySelector(".form-error");
+      expect(errorElement).not.toBeNull();
+      expect(errorElement.textContent).toContain("Could not detect location.");
+    });
+  });
+
+  describe("when geolocation is not supported", () => {
+    it("shows an unsupported error and does not show spinner", () => {
+      Reflect.defineProperty(global.navigator, "geolocation", {
+        value: null,
+        configurable: true
+      });
+
+      button.click();
+
+      expect(button.disabled).toBe(false);
+      expect(button.classList.contains("is-locating")).toBe(false);
+      const errorElement = label.querySelector(".form-error");
+      expect(errorElement).not.toBeNull();
+      expect(errorElement.textContent).toContain("Device not supported.");
+    });
+  });
+
+  describe("when button is already disabled", () => {
+    it("does not trigger geolocation again", () => {
+      button.disabled = true;
+      mockGeolocation.getCurrentPosition.mockImplementation(() => {});
+
+      button.click();
+
+      expect(mockGeolocation.getCurrentPosition).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.test.js
+++ b/decidim-core/app/packs/src/decidim/geocoding/reverse_geocoding.test.js
@@ -18,8 +18,9 @@ describe("reverseGeocoding", () => {
     container.innerHTML = `
       <label>
         <input id="test_address" type="text" />
-        <div class="user-device-location">
+        <div class="geocoding__locate">
           <button
+            class="geocoding__button"
             type="button"
             data-input="test_address"
             data-error-no-location="Could not detect location."
@@ -33,7 +34,7 @@ describe("reverseGeocoding", () => {
     `;
     document.body.appendChild(container);
 
-    button = container.querySelector(".user-device-location button");
+    button = container.querySelector(".geocoding__button");
     input = container.querySelector("#test_address");
     label = container.querySelector("label");
 
@@ -70,8 +71,8 @@ describe("reverseGeocoding", () => {
       button.click();
 
       expect(button.disabled).toBe(true);
-      expect(button.classList.contains("is-locating")).toBe(true);
-      expect(button.querySelector(".geocoding-spinner")).not.toBeNull();
+      expect(button.classList.contains("geocoding__button--locating")).toBe(true);
+      expect(button.querySelector(".geocoding__spinner")).not.toBeNull();
       expect(button.textContent).toContain("Locating...");
     });
 
@@ -111,8 +112,8 @@ describe("reverseGeocoding", () => {
       button.click();
 
       expect(button.disabled).toBe(false);
-      expect(button.classList.contains("is-locating")).toBe(false);
-      expect(button.querySelector(".geocoding-spinner")).toBeNull();
+      expect(button.classList.contains("geocoding__button--locating")).toBe(false);
+      expect(button.querySelector(".geocoding__spinner")).toBeNull();
       expect(button.textContent).toContain("Use my location");
       expect(input.value).toBe("New York, NY, USA");
     });
@@ -133,7 +134,7 @@ describe("reverseGeocoding", () => {
       button.click();
 
       expect(button.disabled).toBe(false);
-      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.classList.contains("geocoding__button--locating")).toBe(false);
       expect(button.textContent).toContain("Use my location");
     });
   });
@@ -148,7 +149,7 @@ describe("reverseGeocoding", () => {
       button.click();
 
       expect(button.disabled).toBe(false);
-      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.classList.contains("geocoding__button--locating")).toBe(false);
       expect(button.textContent).toContain("Use my location");
     });
 
@@ -176,7 +177,7 @@ describe("reverseGeocoding", () => {
       button.click();
 
       expect(button.disabled).toBe(false);
-      expect(button.classList.contains("is-locating")).toBe(false);
+      expect(button.classList.contains("geocoding__button--locating")).toBe(false);
       const errorElement = label.querySelector(".form-error");
       expect(errorElement).not.toBeNull();
       expect(errorElement.textContent).toContain("Device not supported.");

--- a/decidim-core/app/packs/stylesheets/decidim/geocoding_addons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/geocoding_addons.scss
@@ -1,5 +1,13 @@
 .geocoding-container {
   .user-device-location button {
     @apply mt-4;
+
+    &.is-locating {
+      @apply opacity-70 cursor-wait;
+    }
+
+    .geocoding-spinner {
+      @apply inline-block w-4 h-4 rounded-full animate-spin border-2 border-l-transparent border-y-transparent border-r-secondary align-middle;
+    }
   }
 }

--- a/decidim-core/app/packs/stylesheets/decidim/geocoding_addons.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/geocoding_addons.scss
@@ -1,12 +1,12 @@
-.geocoding-container {
-  .user-device-location button {
+.geocoding {
+  &__locate .geocoding__button {
     @apply mt-4;
 
-    &.is-locating {
+    &--locating {
       @apply opacity-70 cursor-wait;
     }
 
-    .geocoding-spinner {
+    .geocoding__spinner {
       @apply inline-block w-4 h-4 rounded-full animate-spin border-2 border-l-transparent border-y-transparent border-r-secondary align-middle;
     }
   }

--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -50,6 +50,7 @@ module Decidim
                                        longitude: "#{object_name}_longitude",
                                        error_no_location: I18n.t("errors.no_device_location", scope: "decidim.proposals.forms"),
                                        error_unsupported: I18n.t("errors.device_not_supported", scope: "decidim.proposals.forms"),
+                                       locating_text: I18n.t("locating", scope: "decidim.proposals.forms"),
                                        url: Decidim::Core::Engine.routes.url_helpers.locate_path
                                      }) do
                   icon("map-pin-line", role: "img", "aria-hidden": true) + " #{I18n.t("use_my_location", scope: "decidim.proposals.forms")}"

--- a/decidim-core/lib/decidim/map/autocomplete.rb
+++ b/decidim-core/lib/decidim/map/autocomplete.rb
@@ -37,14 +37,14 @@ module Decidim
           template.snippets.add(:decidim_geocoding_scripts, template.append_javascript_pack_tag("decidim_geocoding"))
           template.snippets.add(:decidim_geocoding_styles, template.append_stylesheet_pack_tag("decidim_geocoding"))
 
-          template.content_tag(:div, class: "geocoding-container") do
+          template.content_tag(:div, class: "geocoding") do
             template.text_field(
               object_name,
               method,
               options.merge("data-decidim-geocoding" => view_options.to_json)
             ) +
-              template.content_tag(:div, class: "input-group-button user-device-location") do
-                template.content_tag(:button, class: "button button__sm md:button__sm button__text-secondary", type: "button", data: {
+              template.content_tag(:div, class: "input-group-button geocoding__locate") do
+                template.content_tag(:button, class: "button button__sm md:button__sm button__text-secondary geocoding__button", type: "button", data: {
                                        input: "#{object_name}_#{method}",
                                        latitude: "#{object_name}_latitude",
                                        longitude: "#{object_name}_longitude",

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -93,6 +93,19 @@ module Decidim
 
         it_behaves_like "having a help text"
       end
+
+      context "when showing the location button" do
+        let(:component) { double(manifest_name: "proposals") }
+
+        before do
+          allow(template).to receive(:current_component).and_return(component)
+        end
+
+        it "renders the button with data-locating-text attribute" do
+          expect(form_markup).to include("data-locating-text")
+          expect(form_markup).to include("user-device-location")
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/lib/map/autocomplete_spec.rb
+++ b/decidim-core/spec/lib/map/autocomplete_spec.rb
@@ -103,7 +103,7 @@ module Decidim
 
         it "renders the button with data-locating-text attribute" do
           expect(form_markup).to include("data-locating-text")
-          expect(form_markup).to include("user-device-location")
+          expect(form_markup).to include("geocoding__locate")
         end
       end
     end

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -767,6 +767,7 @@ en:
           device_not_supported: Your device does not support location services. Please enter the address manually.
           no_device_location: Sorry, we could not detect your location. Please enter the address manually.
         use_my_location: Use my current location
+        locating: Locating...
       invite_coauthors:
         cancel:
           error: There was a problem canceling the co-author invitation.

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -766,8 +766,8 @@ en:
         errors:
           device_not_supported: Your device does not support location services. Please enter the address manually.
           no_device_location: Sorry, we could not detect your location. Please enter the address manually.
-        use_my_location: Use my current location
         locating: Locating...
+        use_my_location: Use my current location
       invite_coauthors:
         cancel:
           error: There was a problem canceling the co-author invitation.


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the a Association internal QA session for the v0.32.0 release, we found an issue:

I was checking a bug report on the geolocation feature, and I thought that the "Use my current location" feature was broken, but it actually didn't have any kind of visual feedback, so a participant might think that it isn't working (when actually is fetching the location).

This PR adds it. 

#### :pushpin: Related Issues

- Related to #13423

#### Testing

1. If you don't have it locally, enable the geolocation by adding the env vars. Do not forget to restart spring 😅 - restart the server too
```
MAPS_PROVIDER
MAPS_API_KEY
```
2. Log in as admin
3. Go to a proposals component
4. Check the setting "Maps enabled" 
5. Go to a proposals creation page (both in Admin and in the Frontend)
6. (Before) click in the button "Use my current location". See that you don't have feedback
7. (After) click in the button "Use my current location". See that you have feedback

### :camera: Screenshots

#### Before

https://github.com/user-attachments/assets/12d97560-bc15-4cfb-9027-5643d86076c1

#### After

https://github.com/user-attachments/assets/9e08e879-be40-44f4-8e64-5e025491981f

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When using location, the button now shows a spinner and updates its label to a localized “Locating...” message.

* **Bug Fixes**
  * Improved reverse-geocoding state handling so the button consistently restores its original content after success, failure, or geolocation errors.

* **Tests**
  * Added Jest coverage for UI transitions, success/failure outcomes, unsupported geolocation messaging, and preventing repeat clicks while disabled.

* **Chores**
  * Updated location button markup and added the new locating localization string.

* **Style**
  * Refreshed geocoding button/spinner styling with scoped BEM classes and a locating state indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->