### PR TITLE
Do not show the status select in the result form if no statuses

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_form.html.erb
@@ -48,9 +48,11 @@
       <% end %>
 
       <div class="row">
-        <div class="columns">
-          <%= form.select :decidim_accountability_status_id, statuses.map { |status| [translated_attribute(status.name), status.id, { "data-progress" => status.progress }] }, include_blank: true %>
-        </div>
+        <% if statuses.any? %>
+          <div class="columns">
+            <%= form.select :decidim_accountability_status_id, statuses.map { |status| [translated_attribute(status.name), status.id, { "data-progress" => status.progress }] }, include_blank: true %>
+          </div>
+        <% end %>
 
         <div class="columns">
           <%= form.number_field :progress %>

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/bulk_actions/_dropdown.html.erb
@@ -27,10 +27,12 @@
         <%= t(".change_dates") %>
       </button>
     </li>
-    <li class="dropdown__item">
-      <button type="button" class="dropdown__button" data-action="change-status">
-        <%= t(".change_status") %>
-      </button>
-    </li>
+    <% if statuses.any? %>
+      <li class="dropdown__item">
+        <button type="button" class="dropdown__button" data-action="change-status">
+          <%= t(".change_status") %>
+        </button>
+      </li>
+    <% end %>
   </ul>
 </div>

--- a/decidim-accountability/spec/shared/manage_results_bulk_actions_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_bulk_actions_examples.rb
@@ -37,6 +37,21 @@ shared_examples "when managing results bulk actions as an admin" do
           expect(page).to have_selector(:link_or_button, "Change status")
           expect(page).to have_selector(:link_or_button, "Change dates")
         end
+
+        context "when there are no statuses" do
+          before do
+            Decidim::Accountability::Status.where(component: current_component).destroy_all
+            visit current_path
+            page.find_by_id("results_bulk").set(true)
+            click_on "Actions"
+          end
+
+          it "does not show the change status option" do
+            expect(page).to have_selector(:link_or_button, "Change taxonomies")
+            expect(page).to have_no_selector(:link_or_button, "Change status")
+            expect(page).to have_selector(:link_or_button, "Change dates")
+          end
+        end
       end
 
       context "when change taxonomies is selected from actions dropdown" do

--- a/decidim-accountability/spec/shared/manage_results_examples.rb
+++ b/decidim-accountability/spec/shared/manage_results_examples.rb
@@ -9,6 +9,27 @@ shared_examples "manage results" do
     it_behaves_like "having a rich text editor", "new_result", "full"
   end
 
+  context "when there are statuses" do
+    before do
+      click_on "New result"
+    end
+
+    it "displays the status select" do
+      expect(page).to have_select "result_decidim_accountability_status_id"
+    end
+  end
+
+  context "when there are no statuses" do
+    before do
+      Decidim::Accountability::Status.where(component: current_component).destroy_all
+      click_on "New result"
+    end
+
+    it "does not display the status select" do
+      expect(page).to have_no_select "result_decidim_accountability_status_id"
+    end
+  end
+
   context "when the proposal module is not installed" do
     before do
       allow(Decidim).to receive(:module_installed?).and_return(false)


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the an Association internal QA session for the v0.32.0 release, we found an issue:

> **Accountability: status select is shown with empty values**
ID: IRRP032-13
>
> Describe the bug
> 
> When I create a new Accountability component and create a new Result inside of it, I see a select dropdown with Status that it is empty
> 
> To Reproduce
>
> 1. Log in as administrator
> 2. Create a new Accountability component
> 3. Create a new Result
> 4. See the form
Expected behavior
To not have this option if there isn’t any Status
Screenshot 

Reported by:  @andreslucena 

#### Testing

1. Log in as administrator
2. Create a new Accountability component
3. Create a new Result
4. See the form
5. Go to the index/manage page 
6. Click in any budget checkbox
7. Click in the Actions menu
8. See the options

### :camera: Screenshots

On both cases, this is the Statuses page:

<img width="1640" height="700" alt="image" src="https://github.com/user-attachments/assets/8d0bffcb-e62a-43e3-aa9a-ef44cfcfe31d" />

#### Before

<img width="1721" height="1061" alt="image" src="https://github.com/user-attachments/assets/83ccc289-3ef4-4a0c-84d7-7f390ab096f4" />
<img width="1529" height="674" alt="image" src="https://github.com/user-attachments/assets/598bae76-0ec9-412f-9589-bc4e5f1c19a1" />

#### After

<img width="1445" height="1336" alt="image" src="https://github.com/user-attachments/assets/d58038f6-5e16-4a43-baeb-aa724971947e" />
<img width="1541" height="573" alt="image" src="https://github.com/user-attachments/assets/c70b318d-3574-46a3-bbb8-f936e548fa94" />

On this case, once there's a new status:

<img width="1592" height="721" alt="image" src="https://github.com/user-attachments/assets/9993714b-8118-477f-89ab-ebec738dae9b" />
<img width="1721" height="1061" alt="image" src="https://github.com/user-attachments/assets/47313677-4f9f-42dc-bf4b-bd8617f1d5fc" />
<img width="1389" height="552" alt="image" src="https://github.com/user-attachments/assets/0631207a-0601-4aa0-848e-78041fd8c2fc" />


:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Results form now displays the status selection field only when statuses are configured for the project.
  * Bulk actions dropdown conditionally shows the "change status" option only when statuses are available.

* **Tests**
  * Added test coverage for form and bulk actions behavior when no statuses are configured.
  * Verified status-related fields are properly hidden in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->