### PR TITLE
Fix cache invalidation bug in highlighted spaces content blocks

### DIFF
--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -32,7 +32,7 @@ module Decidim
     end
 
     def perform_caching?
-      true
+      ActionController::Base.perform_caching
     end
 
     def raw_model

--- a/decidim-core/app/cells/decidim/author_cell.rb
+++ b/decidim-core/app/cells/decidim/author_cell.rb
@@ -31,10 +31,6 @@ module Decidim
       render unless current_user == model
     end
 
-    def perform_caching?
-      ActionController::Base.perform_caching
-    end
-
     def raw_model
       model.try(:__getobj__) || model
     end

--- a/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
+++ b/decidim-core/app/cells/decidim/content_blocks/highlighted_participatory_spaces_cell.rb
@@ -28,7 +28,7 @@ module Decidim
       private
 
       def cache_hash
-        [I18n.locale, highlighted_spaces.map(&:cache_key_with_version)].join(Decidim.cache_key_separator)
+        [I18n.locale, model.cache_key_with_version, highlighted_spaces.map(&:cache_key_with_version)].join(Decidim.cache_key_separator)
       end
 
       def section_class

--- a/decidim-core/lib/decidim/view_model.rb
+++ b/decidim-core/lib/decidim/view_model.rb
@@ -83,7 +83,7 @@ module Decidim
     end
 
     def perform_caching?
-      cache_hash.present?
+      super && cache_hash.present?
     end
 
     def cache_hash


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the an Association internal QA session for the v0.32.0 release, we found an issue:

> **Maximum number of items set for assemblies and conferences are not reflected in the frontend**
> 
> Describe the bug
> 
> The frontend does not reflect the maximum number of items to be displayed for highlighted assemblies and conferences. It’s fixed on 6 on the frontend, and when you change it in the layout configuration, it’s not reflected in the frontend.
> 
> To Reproduce
> 
> 1. Settings > Homepage layout
> 2. Edit Highlighted Assemblies and Highlighted Conferences
> 
> Expected behavior
> 
> If you set a maximum number of highlighted assemblies and/or conferences in the configuration, it should be reflected in the frontend.
> 
> Screenshot 
>
> <img width="314" height="383" alt="image" src="https://github.com/user-attachments/assets/9156882d-b405-4aa1-92c1-f9edcdf83e03" />

Reported by:  Maite

This one was funny, as the actual problem was in the cache invalidation for this cell.

The thing is that I was also seeing this bug without the cache enabled in development rails environment, so digging a bit more I found that we were overriding the `rails-cell` method without actually taking into account if it should be caching or not:

https://github.com/trailblazer/cells-rails/blob/77ff22ae8f94472cf477672ca2f0c86757d627d8/lib/cell/rails.rb#L65

I noticed that we had a similar problem with the AuthorCell, where we are always caching it. 

This PR fixes these 3 issues.  

#### Testing

1. Create multiple assemblies
```
bin/rails runner 'require "decidim/assemblies/seeds"  ;  20.times { Decidim::Assemblies::Seeds.new.call }'
```
2. Change the Content Block in the Homepage layout to only show 3 
3. Go to the frontend
4. (Before) see that it wasn't updated and it was showing the default (6)
5. (After) see that it is updated

### :camera: Screenshots

#### Before

<img width="2040" height="996" alt="image" src="https://github.com/user-attachments/assets/e59e5784-4988-4c67-9b02-796fe4992c5d" />

#### After

<img width="1977" height="922" alt="image" src="https://github.com/user-attachments/assets/5e4b40ff-b349-486a-833d-56b970f47e6d" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache invalidation so highlighted content refreshes correctly when the underlying model changes (including model version changes).
  * Refined caching decisions to follow the base caching rules in addition to requiring cache data, preventing unintended stale rendering.
  * Updated author-related cell caching behavior to rely on the default caching mechanism rather than a hardcoded override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->