### PR TITLE
Add validation in status' progress field

### DIFF
--- a/decidim-accountability/app/forms/decidim/accountability/admin/status_form.rb
+++ b/decidim-accountability/app/forms/decidim/accountability/admin/status_form.rb
@@ -15,6 +15,7 @@ module Decidim
 
         validates :key, presence: true
         validates :name, translatable_presence: true
+        validates :progress, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }, if: ->(form) { form.progress.present? }
       end
     end
   end

--- a/decidim-accountability/spec/forms/admin/status_form_spec.rb
+++ b/decidim-accountability/spec/forms/admin/status_form_spec.rb
@@ -46,5 +46,29 @@ module Decidim::Accountability
 
       it { is_expected.not_to be_valid }
     end
+
+    describe "when progress is negative" do
+      let(:progress) { -12 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when progress is greater than 100" do
+      let(:progress) { 999 }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    describe "when progress is between 0 and 100" do
+      let(:progress) { (0..100).to_a.sample }
+
+      it { is_expected.to be_valid }
+    end
+
+    describe "when progress is empty" do
+      let(:progress) { nil }
+
+      it { is_expected.to be_valid }
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

While doing the an Association internal QA session for the v0.32.0 release, we found an issue:

> **Accountability: progress isn’t validated in Status form**
>
> Describe the bug
> 
> When I create a new status in Accountability, I can add numbers that doesn’t make much sense (-33, 1000).
> 
> To Reproduce
> 
> 1. Log in as administrator
> 2. Create a new Accountability component
> 3. Create a new Status
> 4. Add -33 or 10000 in Progress
> 5. See that the form can be saved
> 
> Expected behavior
> 
> It should be validated to 0..100 (numbers between 0 and 100), as we already do for Results
> 
> Screenshot 
> 
> <img width="960" height="306" alt="image" src="https://github.com/user-attachments/assets/80091854-8ac0-4021-b808-f73b568220ad" />

Reported by:  @andreslucena 
 
#### Testing

1. Log in as administrator
2. Create a new Accountability component
3. Create a new Status
4. Add -33 or 10000 in Progress
5. See that the form isn't saved

### :camera: Screenshots

<img width="893" height="775" alt="image" src="https://github.com/user-attachments/assets/f1fc5c14-b2a6-4e4f-a554-86c71a7ee347" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Progress values in status updates are now validated to ensure they fall between 0 and 100 inclusive.

* **Tests**
  * Added test coverage for progress value validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->