### PR TITLE
Fix reply expansion for  comment links within a thread

### DIFF
--- a/decidim-comments/app/cells/decidim/comments/comment/chain_reply.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/chain_reply.erb
@@ -1,0 +1,5 @@
+<div id="comment-<%= model.id %>-replies" class="comment-reply">
+  <% chain_reply.each do |reply| %>
+    <%= cell("decidim/comments/comment", reply, root_depth:, order:, target_chain_ids:) %>
+  <% end %>
+</div>

--- a/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/deletion_data.erb
@@ -1,5 +1,7 @@
 <%= render partial: "decidim/comments/comments/delete", formats: [:html], locals: { comment: model } %>
 
-<% if has_replies_in_children? %>
+<% if render_chain_reply? %>
+  <%= render :chain_reply %>
+<% elsif has_replies_in_children? %>
   <%= render :replies %>
 <% end %>

--- a/decidim-comments/app/cells/decidim/comments/comment/replies.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/replies.erb
@@ -20,8 +20,8 @@
        data-show-replies-target="container"
        class="comment-reply <%= "hidden" unless expand_replies? %>">
     <% if expand_replies? %>
-      <% server_rendered_replies.each do |reply| %>
-        <%= cell("decidim/comments/comment", reply, root_depth:, order:, target_chain_ids:) %>
+      <% next_chain_reply.each do |reply| %>
+        <%= cell("decidim/comments/comment", reply, root_depth: root_depth, order: order, target_chain_ids: target_chain_ids) %>
       <% end %>
     <% end %>
   </div>

--- a/decidim-comments/app/cells/decidim/comments/comment/replies.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/replies.erb
@@ -2,12 +2,12 @@
      data-show-replies-url-value="<%= decidim_comments.comments_path %>"
      data-show-replies-comment-gid-value="<%= model.to_signed_global_id.to_s %>"
      data-show-replies-order-value="<%= order %>"
-     data-show-replies-loaded-value="<%= expand_replies? %>">
+     data-show-replies-loaded-value="false">
   <div class="show-replies-button">
     <button class="button button__xs button__text-secondary"
             data-action="click->show-replies#toggle"
             data-show-replies-target="button"
-            aria-expanded="<%= expand_replies? %>"
+            aria-expanded="false"
             aria-controls="comment-<%= model.id %>-replies"
             id="comment-<%= model.id %>-replies-trigger">
       <span class="font-normal"><%= t("decidim.components.comment.replies_count", count: replies_count) %></span>
@@ -18,11 +18,6 @@
   </div>
   <div id="comment-<%= model.id %>-replies"
        data-show-replies-target="container"
-       class="comment-reply <%= "hidden" unless expand_replies? %>">
-    <% if expand_replies? %>
-      <% next_chain_reply.each do |reply| %>
-        <%= cell("decidim/comments/comment", reply, root_depth: root_depth, order: order, target_chain_ids: target_chain_ids) %>
-      <% end %>
-    <% end %>
+       class="comment-reply hidden">
   </div>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comment/replies.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/replies.erb
@@ -2,12 +2,12 @@
      data-show-replies-url-value="<%= decidim_comments.comments_path %>"
      data-show-replies-comment-gid-value="<%= model.to_signed_global_id.to_s %>"
      data-show-replies-order-value="<%= order %>"
-     data-show-replies-loaded-value="false">
+     data-show-replies-loaded-value="<%= expand_replies? %>">
   <div class="show-replies-button">
     <button class="button button__xs button__text-secondary"
             data-action="click->show-replies#toggle"
             data-show-replies-target="button"
-            aria-expanded="false"
+            aria-expanded="<%= expand_replies? %>"
             aria-controls="comment-<%= model.id %>-replies"
             id="comment-<%= model.id %>-replies-trigger">
       <span class="font-normal"><%= t("decidim.components.comment.replies_count", count: replies_count) %></span>
@@ -18,6 +18,11 @@
   </div>
   <div id="comment-<%= model.id %>-replies"
        data-show-replies-target="container"
-       class="comment-reply hidden">
+       class="comment-reply <%= "hidden" unless expand_replies? %>">
+    <% if expand_replies? %>
+      <% server_rendered_replies.each do |reply| %>
+        <%= cell("decidim/comments/comment", reply, root_depth:, order:, target_chain_ids:) %>
+      <% end %>
+    <% end %>
   </div>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -1,10 +1,11 @@
 <%= content_tag :div,
                 id: "comment_#{model.id}",
-                class: ["comment", "relative", ("top-comment" if top_comment_label.present?)].compact,
+                class: ["comment", "relative", ("top-comment" if top_comment_label.present?), ("comment--highlighted" if target_self?)].compact,
                 role: "comment",
                 data: { comment_id: model.id, parent: parent_element_id } do %>
   <% if model.hidden? %>
     <%= render :moderation_data %>
+    <%= render :chain_reply if render_chain_reply? %>
   <% elsif model.deleted? %>
     <%= render :deletion_data %>
   <% else %>
@@ -96,7 +97,9 @@
         </div>
       <% end %>
     </div>
-    <% if has_replies_in_children? %>
+    <% if render_chain_reply? %>
+      <%= render :chain_reply %>
+    <% elsif has_replies_in_children? %>
       <%= render :replies %>
     <% elsif can_reply? %>
       <div id="comment-<%= model.id %>-replies" class="comment-reply"></div>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
                 id: "comment_#{model.id}",
-                class: ["comment", "relative", ("top-comment" if top_comment_label.present?)].compact,
+                class: ["comment", "relative", ("top-comment" if top_comment_label.present?), ("comment--highlighted" if target_self?)].compact,
                 role: "comment",
                 data: { comment_id: model.id, parent: parent_element_id } do %>
   <% if model.hidden? %>

--- a/decidim-comments/app/cells/decidim/comments/comment/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment/show.erb
@@ -1,6 +1,6 @@
 <%= content_tag :div,
                 id: "comment_#{model.id}",
-                class: ["comment", "relative", ("top-comment" if top_comment_label.present?), ("comment--highlighted" if target_self?)].compact,
+                class: ["comment", "relative", ("top-comment" if top_comment_label.present?)].compact,
                 role: "comment",
                 data: { comment_id: model.id, parent: parent_element_id } do %>
   <% if model.hidden? %>

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -75,7 +75,6 @@ module Decidim
         hash.push(model.cache_key_with_version)
         hash.push(model.author.cache_key_with_version)
         hash.push(extra_actions.to_s)
-        hash.push(target_self? ? 1 : 0)
         hash.push(expand_replies? ? 1 : 0)
         @hash = hash.join(Decidim.cache_key_separator)
       end
@@ -251,20 +250,20 @@ module Decidim
         target_chain_ids.include?(model.id)
       end
 
-      def target_self?
-        on_target_chain? && target_chain_ids.last == model.id
-      end
-
       def expand_replies?
-        on_target_chain? && !target_self?
+        on_target_chain? && target_chain_ids.last != model.id
       end
 
-      def server_rendered_replies
-        @server_rendered_replies ||= model.comment_threads
-                                          .not_hidden
-                                          .not_deleted
-                                          .includes(:author, :up_votes, :down_votes)
-                                          .order(created_at: :asc)
+      # Returns only the direct child that continues the target chain (an
+      # array of zero or one Comments). Sibling replies under this ancestor
+      # keep their lazy-load behaviour.
+      def next_chain_reply
+        return [] unless on_target_chain?
+
+        next_id = target_chain_ids[target_chain_ids.index(model.id) + 1]
+        return [] unless next_id
+
+        model.comment_threads.not_hidden.not_deleted.where(id: next_id).includes(:author, :up_votes, :down_votes).to_a
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -75,6 +75,7 @@ module Decidim
         hash.push(model.cache_key_with_version)
         hash.push(model.author.cache_key_with_version)
         hash.push(extra_actions.to_s)
+        hash.push(target_self? ? 1 : 0)
         @hash = hash.join(Decidim.cache_key_separator)
       end
 
@@ -239,6 +240,28 @@ module Decidim
 
       def replies_count
         @replies_count ||= model.replies.count
+      end
+
+      def target_chain_ids
+        @target_chain_ids ||= options[:target_chain_ids] || []
+      end
+
+      def expand_replies?
+        return false if target_chain_ids.blank?
+
+        target_chain_ids.include?(model.id)
+      end
+
+      def target_self?
+        target_chain_ids.present? && target_chain_ids.last == model.id
+      end
+
+      def server_rendered_replies
+        @server_rendered_replies ||= model.comment_threads
+                                          .not_hidden
+                                          .not_deleted
+                                          .includes(:author, :up_votes, :down_votes)
+                                          .order(created_at: :asc)
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -76,6 +76,7 @@ module Decidim
         hash.push(model.author.cache_key_with_version)
         hash.push(extra_actions.to_s)
         hash.push(target_self? ? 1 : 0)
+        hash.push(expand_replies? ? 1 : 0)
         @hash = hash.join(Decidim.cache_key_separator)
       end
 
@@ -246,14 +247,16 @@ module Decidim
         @target_chain_ids ||= options[:target_chain_ids] || []
       end
 
-      def expand_replies?
-        return false if target_chain_ids.blank?
-
+      def on_target_chain?
         target_chain_ids.include?(model.id)
       end
 
       def target_self?
-        target_chain_ids.present? && target_chain_ids.last == model.id
+        on_target_chain? && target_chain_ids.last == model.id
+      end
+
+      def expand_replies?
+        on_target_chain? && !target_self?
       end
 
       def server_rendered_replies

--- a/decidim-comments/app/cells/decidim/comments/comment_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comment_cell.rb
@@ -33,7 +33,7 @@ module Decidim
       end
 
       def perform_caching?
-        super && has_replies_in_children? == false && current_user.blank?
+        super && has_replies_in_children? == false && current_user.blank? && !render_chain_reply?
       end
 
       private
@@ -75,7 +75,8 @@ module Decidim
         hash.push(model.cache_key_with_version)
         hash.push(model.author.cache_key_with_version)
         hash.push(extra_actions.to_s)
-        hash.push(expand_replies? ? 1 : 0)
+        hash.push(next_chain_id.to_s)
+        hash.push(target_self? ? 1 : 0)
         @hash = hash.join(Decidim.cache_key_separator)
       end
 
@@ -246,24 +247,26 @@ module Decidim
         @target_chain_ids ||= options[:target_chain_ids] || []
       end
 
-      def on_target_chain?
-        target_chain_ids.include?(model.id)
+      def next_chain_id
+        return @next_chain_id if defined?(@next_chain_id)
+
+        index = target_chain_ids.index(model.id)
+        @next_chain_id = index ? target_chain_ids[index + 1] : nil
       end
 
-      def expand_replies?
-        on_target_chain? && target_chain_ids.last != model.id
+      def render_chain_reply?
+        next_chain_id.present?
       end
 
-      # Returns only the direct child that continues the target chain (an
-      # array of zero or one Comments). Sibling replies under this ancestor
-      # keep their lazy-load behaviour.
-      def next_chain_reply
-        return [] unless on_target_chain?
+      def target_self?
+        target_chain_ids.last == model.id
+      end
 
-        next_id = target_chain_ids[target_chain_ids.index(model.id) + 1]
-        return [] unless next_id
+      # Deleted and hidden comments are kept so a moderated ancestor does not break the chain
+      def chain_reply
+        return [] unless next_chain_id
 
-        model.comment_threads.not_hidden.not_deleted.where(id: next_id).includes(:author, :up_votes, :down_votes).to_a
+        model.comment_threads.where(id: next_chain_id).includes(:author, :up_votes, :down_votes).to_a
       end
 
       # action_authorization_button expects current_component to be available

--- a/decidim-comments/app/cells/decidim/comments/comment_thread/show.erb
+++ b/decidim-comments/app/cells/decidim/comments/comment_thread/show.erb
@@ -1,3 +1,3 @@
 <div class="comment-thread" role="region" aria-label="<%= t("accessibility_label", scope: "decidim.comments.comment_thread", full_name: model.author&.name, date: l(model.created_at, format: :decidim_short)) %>">
-  <%= cell("decidim/comments/comment", model, root_depth: model.depth, order:, top_comment: options[:top_comment]) %>
+  <%= cell("decidim/comments/comment", model, root_depth: model.depth, order:, top_comment: options[:top_comment], target_chain_ids: options[:target_chain_ids]) %>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
@@ -1,6 +1,6 @@
 <div class="comment-threads" id="<%= threads_node_id %>" aria-live="polite">
   <%= comments_loading %>
   <% comments.each do |comment| %>
-    <%= cell("decidim/comments/comment_thread", comment, order:) %>
+    <%= cell("decidim/comments/comment_thread", comment, order:, target_chain_ids:) %>
   <% end %>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
@@ -1,6 +1,6 @@
 <div class="comment-threads" id="<%= threads_node_id %>" aria-live="polite">
   <%= comments_loading %>
   <% comments.each do |comment| %>
-    <%= cell("decidim/comments/comment_thread", comment, order:, target_chain_ids:) %>
+    <%= cell("decidim/comments/comment_thread", comment, order: order, target_chain_ids: target_chain_ids) %>
   <% end %>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
+++ b/decidim-comments/app/cells/decidim/comments/comments/comments_in_single_column.erb
@@ -1,6 +1,6 @@
 <div class="comment-threads" id="<%= threads_node_id %>" aria-live="polite">
   <%= comments_loading %>
   <% comments.each do |comment| %>
-    <%= cell("decidim/comments/comment_thread", comment, order: order, target_chain_ids: target_chain_ids) %>
+    <%= cell("decidim/comments/comment_thread", comment, order:, target_chain_ids:) %>
   <% end %>
 </div>

--- a/decidim-comments/app/cells/decidim/comments/comments_cell.rb
+++ b/decidim-comments/app/cells/decidim/comments/comments_cell.rb
@@ -97,6 +97,12 @@ module Decidim
         single_comment.depth
       end
 
+      def target_chain_ids
+        return @target_chain_ids if defined?(@target_chain_ids)
+
+        @target_chain_ids = target_comment ? target_comment.thread_chain_ids : []
+      end
+
       def commentable_path(params = {})
         return resource_locator(Array(options[:polymorphic]).push(model)).path(params) if options[:polymorphic]
 
@@ -147,9 +153,16 @@ module Decidim
       end
 
       def single_comment
-        return if options[:single_comment].blank?
+        return if target_comment.blank?
 
-        @single_comment ||= SortedComments.for(model, id: options[:single_comment], order_by: order).first
+        @single_comment ||= target_comment.thread_root
+      end
+
+      def target_comment
+        return @target_comment if defined?(@target_comment)
+        return @target_comment = nil if options[:single_comment].blank?
+
+        @target_comment = SortedComments.for(model, id: options[:single_comment], order_by: order).first
       end
 
       def machine_translations_toggled?

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -217,17 +217,13 @@ module Decidim
         root_commentable.try(:actions_for_comment, self, current_user)
       end
 
-      # Public: Returns the depth-0 ancestor of this comment's thread. Returns
-      # self when the comment is already the thread root.
       def thread_root
         root = self
         root = root.commentable while root.commentable.is_a?(self.class)
         root
       end
 
-      # Public: Returns the ids of every comment from the thread root down to
-      # self (inclusive). Used to know which replies must be pre-expanded when
-      # rendering a deep-linked comment.
+      # Returns the ids from the thread root down to self, inclusive
       def thread_chain_ids
         ids = [id]
         current = self

--- a/decidim-comments/app/models/decidim/comments/comment.rb
+++ b/decidim-comments/app/models/decidim/comments/comment.rb
@@ -217,6 +217,27 @@ module Decidim
         root_commentable.try(:actions_for_comment, self, current_user)
       end
 
+      # Public: Returns the depth-0 ancestor of this comment's thread. Returns
+      # self when the comment is already the thread root.
+      def thread_root
+        root = self
+        root = root.commentable while root.commentable.is_a?(self.class)
+        root
+      end
+
+      # Public: Returns the ids of every comment from the thread root down to
+      # self (inclusive). Used to know which replies must be pre-expanded when
+      # rendering a deep-linked comment.
+      def thread_chain_ids
+        ids = [id]
+        current = self
+        while current.commentable.is_a?(self.class)
+          current = current.commentable
+          ids.unshift(current.id)
+        end
+        ids
+      end
+
       private
 
       def body_length

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -77,6 +77,10 @@
     @apply border-gray-2;
   }
 
+  &.comment--highlighted {
+    @apply border-tertiary ring-2 ring-tertiary/40;
+  }
+
   &__header {
     @apply flex items-center gap-x-2 mb-2 relative;
 

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -77,10 +77,6 @@
     @apply border-gray-2;
   }
 
-  &.comment--highlighted {
-    @apply border-tertiary ring-2 ring-tertiary/40;
-  }
-
   &__header {
     @apply flex items-center gap-x-2 mb-2 relative;
 

--- a/decidim-comments/app/packs/stylesheets/comments.scss
+++ b/decidim-comments/app/packs/stylesheets/comments.scss
@@ -137,6 +137,29 @@
     @apply border-0 pr-0 mt-4;
   }
 
+  &.comment--highlighted {
+    @apply -mr-3 pr-3;
+
+    > .comment__header,
+    > .comment__content,
+    > [data-comment-footer] {
+      @apply bg-secondary/10 -ml-6 -mr-3 pl-6 pr-3;
+    }
+
+    > .comment__header {
+      @apply mb-0 pt-3 pb-2 rounded-t-lg;
+    }
+
+    /* the grid's top margin would otherwise collapse out of the tinted footer */
+    > [data-comment-footer] {
+      @apply pt-4 pb-3 rounded-b-lg;
+
+      .comment__footer-grid {
+        @apply mt-0;
+      }
+    }
+  }
+
   &-thread {
     @apply mb-4;
 

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -50,6 +50,29 @@ module Decidim::Comments
           expect(subject).to have_css(".flash.secondary", text: "View all comments")
         end
 
+        context "when the single comment is a reply" do
+          let(:thread_root) { create(:comment, commentable:) }
+          let(:reply_level_1) { create(:comment, commentable: thread_root) }
+          let(:comment) { create(:comment, commentable: reply_level_1) }
+
+          it "renders the whole thread chain leading to the target comment" do
+            expect(subject).to have_text(thread_root.body.values.first)
+            expect(subject).to have_text(reply_level_1.body.values.first)
+            expect(subject).to have_text(comment.body.values.first)
+          end
+
+          it "expands the ancestor replies containers" do
+            expect(subject).to have_css("#comment-#{thread_root.id}-replies:not(.hidden)")
+            expect(subject).to have_css("#comment-#{reply_level_1.id}-replies:not(.hidden)")
+          end
+
+          it "does not render unrelated threads on the same commentable" do
+            other_comments.each do |other_comment|
+              expect(subject).to have_no_text(other_comment.body.values.first)
+            end
+          end
+        end
+
         context "with the single comment being moderated" do
           before do
             create(

--- a/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
+++ b/decidim-comments/spec/cells/decidim/comments/comments_cell_spec.rb
@@ -51,24 +51,69 @@ module Decidim::Comments
         end
 
         context "when the single comment is a reply" do
+          let(:my_cell) { cell("decidim/comments/comments", commentable, single_comment: comment.id) }
           let(:thread_root) { create(:comment, commentable:) }
-          let(:reply_level_1) { create(:comment, commentable: thread_root) }
-          let(:comment) { create(:comment, commentable: reply_level_1) }
+          let(:first_reply) { create(:comment, commentable: thread_root, root_commentable: commentable) }
+          let(:comment) { create(:comment, commentable: first_reply, root_commentable: commentable) }
 
           it "renders the whole thread chain leading to the target comment" do
             expect(subject).to have_text(thread_root.body.values.first)
-            expect(subject).to have_text(reply_level_1.body.values.first)
+            expect(subject).to have_text(first_reply.body.values.first)
             expect(subject).to have_text(comment.body.values.first)
           end
 
-          it "expands the ancestor replies containers" do
+          it "renders the ancestor replies containers unfolded" do
             expect(subject).to have_css("#comment-#{thread_root.id}-replies:not(.hidden)")
-            expect(subject).to have_css("#comment-#{reply_level_1.id}-replies:not(.hidden)")
+            expect(subject).to have_css("#comment-#{first_reply.id}-replies:not(.hidden)")
+          end
+
+          it "highlights only the target comment" do
+            expect(subject).to have_css("#comment_#{comment.id}.comment--highlighted")
+            expect(subject).to have_no_css("#comment_#{thread_root.id}.comment--highlighted")
+            expect(subject).to have_no_css("#comment_#{first_reply.id}.comment--highlighted")
+          end
+
+          it "does not render the replies toggle for the ancestors" do
+            expect(subject).to have_no_css("#comment-#{thread_root.id}-replies-trigger")
+            expect(subject).to have_no_css("#comment-#{first_reply.id}-replies-trigger")
           end
 
           it "does not render unrelated threads on the same commentable" do
             other_comments.each do |other_comment|
               expect(subject).to have_no_text(other_comment.body.values.first)
+            end
+          end
+
+          it "does not render the sibling replies of the ancestors" do
+            sibling = create(:comment, commentable: thread_root, root_commentable: commentable)
+
+            expect(subject).to have_no_text(sibling.body.values.first)
+          end
+
+          context "with a deleted comment in the chain" do
+            before { first_reply.update!(deleted_at: Time.current) }
+
+            it "still renders the target comment" do
+              expect(subject).to have_text(thread_root.body.values.first)
+              expect(subject).to have_css(".comment__deleted")
+              expect(subject).to have_text(comment.body.values.first)
+            end
+          end
+
+          context "with a hidden comment in the chain" do
+            before do
+              create(
+                :moderation,
+                :hidden,
+                reportable: first_reply,
+                participatory_space: commentable.participatory_space
+              )
+            end
+
+            it "still renders the target comment" do
+              expect(subject).to have_text(thread_root.body.values.first)
+              expect(subject).to have_css(".comment__moderated")
+              expect(subject).to have_text(comment.body.values.first)
             end
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?
  Deep-links to a nested comment (Latest Activity, share-link kebab, notification mail) dropped users on an isolated comment
  with no thread context. This PR renders the whole thread the target lives in, server-expands the ancestor `Show replies`
  toggles so the target is visible on first paint, and highlights the target via a `comment--highlighted` modifier. Nested ?commentId= links render the full thread and expand the ancestor replies. Top-level ?commentId= links continue to render only the selected comment, while all linked targets are highlighted. Views without ?commentId= are unchanged.



  #### :pushpin: Related Issues
  - Fixes #15977

  #### Testing
  1. Open a proposal/debate with a nested reply, e.g. seeded `…/proposals/5`.
  2. Kebab menu on the reply → "Get link" → open in a fresh tab. 

#### Images:
Full comment tree:

<img width="856" height="826" alt="grafik" src="https://github.com/user-attachments/assets/4837d668-3362-4285-a2e7-343f7f150e5b" />



When viewing a single comment within the lower layers of the tree:

Before:

<img width="858" height="342" alt="grafik" src="https://github.com/user-attachments/assets/1713e268-c481-464a-a528-17d81e045391" />


After:
<img width="892" height="663" alt="grafik" src="https://github.com/user-attachments/assets/cf90a664-3bfb-43cd-82a0-fdabb88efa50" />

---

  > Note: I'm quite unfamiliar with Decidim development, so please double-check that I've followed the right conventions (cell structure, locale handling, cache key, SCSS placement) and that the approach fits how you'd want this solved. Happy to iterate.   



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation to selected comments by displaying their full reply path, including ancestors and related replies.
  * Added visual highlighting for the selected comment.
  * Preserved relevant context when comments in the reply chain are deleted or hidden.

* **Bug Fixes**
  * Improved rendering of nested replies and sibling conversations when viewing a specific comment.

* **Style**
  * Updated highlighted comment styling, spacing, colors, and rounded sections for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->