### PR TITLE
Implement explicit state filter fallback for initiatives index

### DIFF
--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -40,7 +40,10 @@ module Decidim
       # GET /initiatives
       def index
         enforce_permission_to :list, :initiative
-        return unless search.result.blank? && params.dig("filter", "with_any_state") != %w(closed)
+        @default_state_filter = Array(default_filter_params[:with_any_state])
+        submitted_state = Array(params.dig("filter", "with_any_state")).compact_blank
+        state_is_default = submitted_state.empty? || submitted_state.sort == @default_state_filter.sort
+        return unless search.result.blank? && state_is_default
 
         @closed_initiatives ||= search_with(filter_params.merge(with_any_state: %w(closed)))
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/initiatives_controller.rb
@@ -41,8 +41,9 @@ module Decidim
       def index
         enforce_permission_to :list, :initiative
         @default_state_filter = Array(default_filter_params[:with_any_state])
+        state_param_provided = params.dig("filter").respond_to?(:key?) && params.dig("filter").key?("with_any_state")
         submitted_state = Array(params.dig("filter", "with_any_state")).compact_blank
-        state_is_default = submitted_state.empty? || submitted_state.sort == @default_state_filter.sort
+        state_is_default = !state_param_provided || submitted_state.sort == @default_state_filter.sort
         return unless search.result.blank? && state_is_default
 
         @closed_initiatives ||= search_with(filter_params.merge(with_any_state: %w(closed)))

--- a/decidim-initiatives/app/packs/src/decidim/initiatives/application.js
+++ b/decidim-initiatives/app/packs/src/decidim/initiatives/application.js
@@ -1,2 +1,3 @@
 import "src/decidim/initiatives/check_code"
 import "src/decidim/initiatives/scoped_type"
+import "src/decidim/initiatives/state_filter_fallback"

--- a/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
+++ b/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
@@ -1,9 +1,3 @@
-// When every state checkbox on the public initiatives index is unchecked by
-// the user, re-check the server-declared default(s) so the filter never
-// collapses to "show every state". The CheckBoxesTree "All" toggle
-// mass-unchecks via JS without dispatching change events, so this listener
-// never fires for that path.
-
 const STATE_INPUT_SELECTOR = 'input[type="checkbox"][name="filter[with_any_state][]"]';
 const FALLBACK_ATTR = "data-state-filter-fallback";
 
@@ -25,18 +19,18 @@ const ensureFallback = () => {
   const fallbackValues = readFallbackValues();
   if (!fallbackValues.length) return;
 
-  let dispatched = false;
+  const toggledLeaves = [];
   fallbackValues.forEach((value) => {
     const leaf = inputs.find((el) => el.value === value);
     if (leaf && !leaf.checked) {
       leaf.checked = true;
-      dispatched = true;
+      toggledLeaves.push(leaf);
     }
   });
 
-  if (dispatched) {
-    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
-  }
+  toggledLeaves.forEach((leaf) => {
+    leaf.dispatchEvent(new Event("change", { bubbles: true }));
+  });
 };
 
 document.addEventListener("change", (event) => {

--- a/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
+++ b/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
@@ -1,0 +1,49 @@
+// When every state checkbox on the public initiatives index is unchecked by
+// the user, re-check the server-declared default(s) so the filter never
+// collapses to "show every state". The CheckBoxesTree "All" toggle
+// mass-unchecks via JS without dispatching change events, so this listener
+// never fires for that path.
+
+const STATE_INPUT_SELECTOR = 'input[type="checkbox"][name="filter[with_any_state][]"]';
+const FALLBACK_ATTR = "data-state-filter-fallback";
+
+const readFallbackValues = () => {
+  const host = document.querySelector(`[${FALLBACK_ATTR}]`);
+  if (!host) return [];
+  return host.getAttribute(FALLBACK_ATTR).split(",").map((v) => v.trim()).filter(Boolean);
+};
+
+const stateInputs = () => Array.from(document.querySelectorAll(STATE_INPUT_SELECTOR));
+
+const ensureFallback = () => {
+  const inputs = stateInputs();
+  if (!inputs.length) return;
+
+  const checkedWithValue = inputs.filter((el) => el.checked && el.value !== "");
+  if (checkedWithValue.length > 0) return;
+
+  const fallbackValues = readFallbackValues();
+  if (!fallbackValues.length) return;
+
+  let dispatched = false;
+  fallbackValues.forEach((value) => {
+    const leaf = inputs.find((el) => el.value === value);
+    if (leaf && !leaf.checked) {
+      leaf.checked = true;
+      dispatched = true;
+    }
+  });
+
+  if (dispatched) {
+    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
+  }
+};
+
+document.addEventListener("change", (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLInputElement)) return;
+  if (target.name !== "filter[with_any_state][]") return;
+  if (target.value === "") return;
+
+  ensureFallback();
+});

--- a/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
+++ b/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
@@ -3,11 +3,17 @@ const FALLBACK_ATTR = "data-state-filter-fallback";
 
 const readFallbackValues = () => {
   const host = document.querySelector(`[${FALLBACK_ATTR}]`);
-  if (!host) return [];
+  if (!host) {
+    return [];
+  }
   try {
     const parsed = JSON.parse(host.getAttribute(FALLBACK_ATTR));
-    return Array.isArray(parsed) ? parsed.filter((v) => typeof v === "string" && v.length > 0) : [];
-  } catch (_) {
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((value) => typeof value === "string" && value.length > 0);
+  } catch (error) {
+    console.warn("Invalid state-filter-fallback attribute", error);
     return [];
   }
 };
@@ -16,20 +22,26 @@ const stateInputs = () => Array.from(document.querySelectorAll(STATE_INPUT_SELEC
 
 const ensureFallback = () => {
   const inputs = stateInputs();
-  if (!inputs.length) return;
+  if (!inputs.length) {
+    return;
+  }
 
   // Any checked checkbox counts as a deliberate selection — including the
   // "All" toggle (value === ""). Only when nothing is checked do we apply
   // the server-declared default.
-  const anyChecked = inputs.some((el) => el.checked);
-  if (anyChecked) return;
+  const anyChecked = inputs.some((input) => input.checked);
+  if (anyChecked) {
+    return;
+  }
 
   const fallbackValues = readFallbackValues();
-  if (!fallbackValues.length) return;
+  if (!fallbackValues.length) {
+    return;
+  }
 
   const toggledLeaves = [];
   fallbackValues.forEach((value) => {
-    const leaf = inputs.find((el) => el.value === value);
+    const leaf = inputs.find((input) => input.value === value);
     if (leaf && !leaf.checked) {
       leaf.checked = true;
       toggledLeaves.push(leaf);
@@ -43,9 +55,15 @@ const ensureFallback = () => {
 
 document.addEventListener("change", (event) => {
   const target = event.target;
-  if (!(target instanceof HTMLInputElement)) return;
-  if (target.name !== "filter[with_any_state][]") return;
-  if (target.value === "") return;
+  if (!(target instanceof HTMLInputElement)) {
+    return;
+  }
+  if (target.name !== "filter[with_any_state][]") {
+    return;
+  }
+  if (target.value === "") {
+    return;
+  }
 
   ensureFallback();
 });

--- a/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
+++ b/decidim-initiatives/app/packs/src/decidim/initiatives/state_filter_fallback.js
@@ -4,7 +4,12 @@ const FALLBACK_ATTR = "data-state-filter-fallback";
 const readFallbackValues = () => {
   const host = document.querySelector(`[${FALLBACK_ATTR}]`);
   if (!host) return [];
-  return host.getAttribute(FALLBACK_ATTR).split(",").map((v) => v.trim()).filter(Boolean);
+  try {
+    const parsed = JSON.parse(host.getAttribute(FALLBACK_ATTR));
+    return Array.isArray(parsed) ? parsed.filter((v) => typeof v === "string" && v.length > 0) : [];
+  } catch (_) {
+    return [];
+  }
 };
 
 const stateInputs = () => Array.from(document.querySelectorAll(STATE_INPUT_SELECTOR));
@@ -13,8 +18,11 @@ const ensureFallback = () => {
   const inputs = stateInputs();
   if (!inputs.length) return;
 
-  const checkedWithValue = inputs.filter((el) => el.checked && el.value !== "");
-  if (checkedWithValue.length > 0) return;
+  // Any checked checkbox counts as a deliberate selection — including the
+  // "All" toggle (value === ""). Only when nothing is checked do we apply
+  // the server-declared default.
+  const anyChecked = inputs.some((el) => el.checked);
+  if (anyChecked) return;
 
   const fallbackValues = readFallbackValues();
   if (!fallbackValues.length) return;

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
@@ -14,9 +14,11 @@ edit_link(
   <h1 class="title-decorator"><%= component_name %></h1>
   <%= render partial: "new_initiative_button" %>
 
-  <%= render layout: "decidim/shared/filters", locals: { filter_sections: , search_variable: :search_text_cont, skip_to_id: "initiatives" } do %>
-    <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
-  <% end %>
+  <div data-state-filter-fallback="<%= @default_state_filter.join(",") %>">
+    <%= render layout: "decidim/shared/filters", locals: { filter_sections: , search_variable: :search_text_cont, skip_to_id: "initiatives" } do %>
+      <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
+    <% end %>
+  </div>
 <% end %>
 
 <%= render layout: "layouts/decidim/shared/layout_two_col" do %>

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/index.html.erb
@@ -14,7 +14,7 @@ edit_link(
   <h1 class="title-decorator"><%= component_name %></h1>
   <%= render partial: "new_initiative_button" %>
 
-  <div data-state-filter-fallback="<%= @default_state_filter.join(",") %>">
+  <div data-state-filter-fallback="<%= @default_state_filter.to_json %>">
     <%= render layout: "decidim/shared/filters", locals: { filter_sections: , search_variable: :search_text_cont, skip_to_id: "initiatives" } do %>
       <%= hidden_field_tag :order, order, id: nil, class: "order_filter" %>
     <% end %>

--- a/decidim-initiatives/spec/requests/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/requests/initiative_search_spec.rb
@@ -222,21 +222,13 @@ RSpec.describe "Initiative search" do
     end
 
     context "and the state filter does not match the default" do
-      let(:state) { %w(rejected) }
-
-      before do
-        Decidim::Initiative.where(state: :rejected).destroy_all
-        get(
-          request_path,
-          params: { filter: filter_params },
-          headers: { "HOST" => organization.host }
-        )
-      end
+      let(:filter_params) { { with_any_state: %w(rejected), search_text_cont: "definitely-not-a-match-#{SecureRandom.hex(4)}" } }
 
       it "does not silently fall back to closed initiatives" do
         expect(subject).not_to include(decidim_escape_translated(initiative1.title))
         expect(subject).not_to include(decidim_escape_translated(closed_initiative.title))
         expect(subject).not_to include(decidim_escape_translated(accepted_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(rejected_initiative.title))
         expect(subject).not_to include(decidim_escape_translated(answered_rejected_initiative.title))
       end
     end

--- a/decidim-initiatives/spec/requests/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/requests/initiative_search_spec.rb
@@ -222,10 +222,21 @@ RSpec.describe "Initiative search" do
     end
 
     context "and the state filter does not match the default" do
-      let(:filter_params) { { with_any_state: %w(rejected), search_text_cont: "definitely-not-a-match-#{SecureRandom.hex(4)}" } }
+      let(:filter_params) { { with_any_state: %w(rejected), search_text_cont: "zzz-no-initiative-matches-this-needle-zzz" } }
 
       it "does not silently fall back to closed initiatives" do
         expect(subject).not_to include(decidim_escape_translated(initiative1.title))
+        expect(subject).not_to include(decidim_escape_translated(closed_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(accepted_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(rejected_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(answered_rejected_initiative.title))
+      end
+    end
+
+    context "and the state filter is submitted explicitly empty" do
+      let(:filter_params) { { with_any_state: [""] } }
+
+      it "does not silently fall back to closed initiatives" do
         expect(subject).not_to include(decidim_escape_translated(closed_initiative.title))
         expect(subject).not_to include(decidim_escape_translated(accepted_initiative.title))
         expect(subject).not_to include(decidim_escape_translated(rejected_initiative.title))

--- a/decidim-initiatives/spec/requests/initiative_search_spec.rb
+++ b/decidim-initiatives/spec/requests/initiative_search_spec.rb
@@ -220,6 +220,26 @@ RSpec.describe "Initiative search" do
         expect(subject).not_to include(decidim_escape_translated(user1_created_initiative.title))
       end
     end
+
+    context "and the state filter does not match the default" do
+      let(:state) { %w(rejected) }
+
+      before do
+        Decidim::Initiative.where(state: :rejected).destroy_all
+        get(
+          request_path,
+          params: { filter: filter_params },
+          headers: { "HOST" => organization.host }
+        )
+      end
+
+      it "does not silently fall back to closed initiatives" do
+        expect(subject).not_to include(decidim_escape_translated(initiative1.title))
+        expect(subject).not_to include(decidim_escape_translated(closed_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(accepted_initiative.title))
+        expect(subject).not_to include(decidim_escape_translated(answered_rejected_initiative.title))
+      end
+    end
   end
 
   context "when filtering by scope" do


### PR DESCRIPTION
#### :tophat: What? Why?
  Non-default state picks on the public initiatives index silently swapped to closed. Now the swap fires only when the
  submitted state is blank or matches the default (`open`), so explicit non-default picks are respected. Also: when the user
  unchecks the last individual state checkbox, a small JS fallback re-checks the server-declared default (read from a
  `data-state-filter-fallback` attr) so the filter never collapses to "show all". The "All" toggle is unaffected.

  #### :pushpin: Related Issues
  - Fixes #15917

  #### Testing
  1. Seed a `development_app` and visit `/initiatives`. **Open** is auto-checked, banner + closed list shown via swap.
  2. Tick a non-default state (e.g. **Rejected**) with no matches -> expect "0 initiatives", no swap.
  3. Uncheck every state one by one -> the last uncheck re-checks **Open**.
  4. Click the **All** toggle -> expect every state selected and full list.
  5. `/initiatives` with only a scope filter, no open in that scope -> swap banner + closed.
  6. `bundle exec rspec decidim-initiatives/spec/requests/initiative_search_spec.rb`

> Note: I'm quite unfamiliar with Decidim development, so please double-check that I've followed the right conventions    
  and  that the approach fits how you'd want this solved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-side fallback for the initiatives **“state any”** filter, applying server defaults only when the user hasn’t selected any states.

* **Bug Fixes**
  * Improved initiatives state-filter defaulting and search behavior so user selections are respected, and filtering doesn’t unintentionally fall back when search results are empty.

* **Tests**
  * Added request spec coverage for state filtering with non-matching search text and explicitly empty state input to ensure fallback behavior doesn’t trigger incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->