### PR TITLE
Exclude closed meetings from upcoming scope

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -65,8 +65,8 @@ module Decidim
       scope :closed, -> { where.not(closed_at: nil) }
       scope :not_closed, -> { where(closed_at: nil) }
       scope :published, -> { where.not(published_at: nil) }
-      scope :past, -> { where(arel_table[:end_time].lteq(Time.current)).or(closed) }
-      scope :upcoming, -> { not_closed.where(arel_table[:end_time].gteq(Time.current)) }
+      scope :past, -> { where(arel_table[:end_time].lteq(Time.current)).or(where.not(closed_at: nil)) }
+      scope :upcoming, -> { where(arel_table[:end_time].gteq(Time.current)).where(closed_at: nil) }
       scope :withdrawn, -> { where.not(withdrawn_at: nil) }
       scope :not_withdrawn, -> { where(withdrawn_at: nil) }
       scope :with_availability, lambda { |state_key|

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -67,7 +67,6 @@ module Decidim
       scope :published, -> { where.not(published_at: nil) }
       scope :past, -> { where(arel_table[:end_time].lteq(Time.current)).or(closed) }
       scope :upcoming, -> { not_closed.where(arel_table[:end_time].gteq(Time.current)) }
-      scope :withdrawn, -> { where(state: "withdrawn") }
       scope :withdrawn, -> { where.not(withdrawn_at: nil) }
       scope :not_withdrawn, -> { where(withdrawn_at: nil) }
       scope :with_availability, lambda { |state_key|
@@ -194,7 +193,7 @@ module Decidim
       end
 
       def past?
-        end_time < Time.current
+        end_time < Time.current || closed?
       end
 
       def emendation?

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -63,9 +63,10 @@ module Decidim
       geocoded_by :address
 
       scope :closed, -> { where.not(closed_at: nil) }
+      scope :not_closed, -> { where(closed_at: nil) }
       scope :published, -> { where.not(published_at: nil) }
-      scope :past, -> { where(arel_table[:end_time].lteq(Time.current)) }
-      scope :upcoming, -> { where(arel_table[:end_time].gteq(Time.current)) }
+      scope :past, -> { where(arel_table[:end_time].lteq(Time.current)).or(closed) }
+      scope :upcoming, -> { not_closed.where(arel_table[:end_time].gteq(Time.current)) }
       scope :withdrawn, -> { where(state: "withdrawn") }
       scope :withdrawn, -> { where.not(withdrawn_at: nil) }
       scope :not_withdrawn, -> { where(withdrawn_at: nil) }

--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -65,6 +65,8 @@ module Decidim
       scope :closed, -> { where.not(closed_at: nil) }
       scope :not_closed, -> { where(closed_at: nil) }
       scope :published, -> { where.not(published_at: nil) }
+      # Closed meetings count as past regardless of end_time so admins can
+      # mark a meeting finished early and it leaves the upcoming list.
       scope :past, -> { where(arel_table[:end_time].lteq(Time.current)).or(where.not(closed_at: nil)) }
       scope :upcoming, -> { where(arel_table[:end_time].gteq(Time.current)).where(closed_at: nil) }
       scope :withdrawn, -> { where.not(withdrawn_at: nil) }
@@ -192,6 +194,8 @@ module Decidim
         start_time < Time.current
       end
 
+      # True once the meeting is finished: end_time has passed OR an admin
+      # closed it.
       def past?
         end_time < Time.current || closed?
       end

--- a/decidim-meetings/app/permissions/decidim/meetings/meeting_permissions.rb
+++ b/decidim-meetings/app/permissions/decidim/meetings/meeting_permissions.rb
@@ -55,7 +55,8 @@ module Decidim
 
       def can_close?
         meeting.authored_by?(user) &&
-          meeting.past?
+          meeting.past? &&
+          !meeting.closed?
       end
 
       def can_register?

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -145,6 +145,21 @@ module Decidim::Meetings
       end
     end
 
+    describe ".withdrawn" do
+      subject { described_class.withdrawn }
+
+      let!(:withdrawn_meeting) { create(:meeting, :withdrawn) }
+      let!(:active_meeting) { create(:meeting) }
+
+      it "includes meetings with a withdrawn_at timestamp" do
+        expect(subject).to include(withdrawn_meeting)
+      end
+
+      it "excludes meetings without a withdrawn_at timestamp" do
+        expect(subject).not_to include(active_meeting)
+      end
+    end
+
     describe "#withdrawable_by" do
       let(:organization) { create(:organization, available_locales: [:en]) }
       let(:participatory_process) { create(:participatory_process, organization:) }

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -409,14 +409,26 @@ module Decidim::Meetings
           expect(subject.past?).to be false
         end
       end
+
+      context "when closed meeting with a future end_time" do
+        let(:meeting) { build(:meeting, :closed, start_time: 5.days.from_now, end_time: 5.days.from_now + 2.hours) }
+
+        it "returns true" do
+          expect(subject.past?).to be true
+        end
+      end
     end
 
     describe ".upcoming" do
       subject { described_class.upcoming }
 
-      let!(:upcoming_meeting) { create(:meeting, :published) }
-      let!(:past_meeting) { create(:meeting, :published, :past) }
-      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed) }
+      around do |example|
+        travel_to(Time.zone.local(2026, 6, 14, 12, 0, 0)) { example.run }
+      end
+
+      let!(:upcoming_meeting) { create(:meeting, :published, start_time: 5.days.from_now, end_time: 5.days.from_now + 2.hours) }
+      let!(:past_meeting) { create(:meeting, :published, start_time: 5.days.ago, end_time: 5.days.ago + 2.hours) }
+      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed, start_time: 5.days.from_now, end_time: 5.days.from_now + 2.hours) }
 
       it "includes meetings with a future end_time that are not closed" do
         expect(subject).to include(upcoming_meeting)
@@ -434,9 +446,13 @@ module Decidim::Meetings
     describe ".past" do
       subject { described_class.past }
 
-      let!(:upcoming_meeting) { create(:meeting, :published) }
-      let!(:past_meeting) { create(:meeting, :published, :past) }
-      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed) }
+      around do |example|
+        travel_to(Time.zone.local(2026, 6, 14, 12, 0, 0)) { example.run }
+      end
+
+      let!(:upcoming_meeting) { create(:meeting, :published, start_time: 5.days.from_now, end_time: 5.days.from_now + 2.hours) }
+      let!(:past_meeting) { create(:meeting, :published, start_time: 5.days.ago, end_time: 5.days.ago + 2.hours) }
+      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed, start_time: 5.days.from_now, end_time: 5.days.from_now + 2.hours) }
 
       it "includes meetings whose end_time has passed" do
         expect(subject).to include(past_meeting)

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -411,6 +411,46 @@ module Decidim::Meetings
       end
     end
 
+    describe ".upcoming" do
+      subject { described_class.upcoming }
+
+      let!(:upcoming_meeting) { create(:meeting, :published) }
+      let!(:past_meeting) { create(:meeting, :published, :past) }
+      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed) }
+
+      it "includes meetings with a future end_time that are not closed" do
+        expect(subject).to include(upcoming_meeting)
+      end
+
+      it "excludes meetings whose end_time has passed" do
+        expect(subject).not_to include(past_meeting)
+      end
+
+      it "excludes closed meetings even if their end_time is in the future" do
+        expect(subject).not_to include(closed_upcoming_meeting)
+      end
+    end
+
+    describe ".past" do
+      subject { described_class.past }
+
+      let!(:upcoming_meeting) { create(:meeting, :published) }
+      let!(:past_meeting) { create(:meeting, :published, :past) }
+      let!(:closed_upcoming_meeting) { create(:meeting, :published, :closed) }
+
+      it "includes meetings whose end_time has passed" do
+        expect(subject).to include(past_meeting)
+      end
+
+      it "includes closed meetings even if their end_time is in the future" do
+        expect(subject).to include(closed_upcoming_meeting)
+      end
+
+      it "excludes meetings with a future end_time that are not closed" do
+        expect(subject).not_to include(upcoming_meeting)
+      end
+    end
+
     describe "#has_contributions?" do
       context "when the meeting has contributions" do
         let(:meeting) { build(:meeting, contributions_count: 10) }


### PR DESCRIPTION
#### :tophat: What? Why?
  A meeting that admins had **closed and published** (closure report saved, `closed_at` set, `closing_visible = true`) still
  showed up under "Upcoming meetings" on the public list whenever its `end_time` was still in the future — and was missing  from "Past meetings". The `upcoming` and `past` scopes on `Decidim::Meetings::Meeting` only looked at `end_time` and ignored   `closed_at`.

  This PR chains `not_closed` onto the `upcoming` scope and OR-s `closed` into the `past` scope, so a closed meeting always
  belongs to the past bucket regardless of its `end_time`. Admin-side filtering uses a separate `is_upcoming` ransacker and is
   intentionally untouched.

  #### :pushpin: Related Issues
  - Fixes #16679

  #### Testing
  1. Seed a `development_app`, visit a meetings component (e.g. `/processes/message-arena/f/7/meetings`).
  2. As admin, close + publish a meeting whose `end_time` is in the future. Confirm in the rails console / DB that `closed_at`
   is set and `closing_visible = true`.
  3. On the public list, filter by `Upcoming` → the closed meeting should NOT appear.
  4. Filter by `Past` → the closed meeting should appear.
  5. `bundle exec rspec decidim-meetings/spec/models/meeting_spec.rb` (new `.upcoming` / `.past` contexts cover the
  regression).

  :hearts: Thank you!

  ---

  > Note: I'm quite unfamiliar with Decidim development, so please double-check that I've followed the right conventions and  that the approach fits how you'd want this solved. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved meeting status categorization: meetings are **past** when their end time has passed or when they’re manually marked as closed.
  * Refined **upcoming** filtering to only include non-closed meetings with an end time in the future (excluding closed meetings even if their end time is later).
* **Security/Permissions**
  * Updated closing authorization to prevent closing meetings that are already closed.
* **Tests**
  * Expanded coverage for withdrawn meetings and for past/upcoming and `past?` behavior, including scenarios involving closed meetings with time travel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->