### PR TITLE
Fix ENV var for setting inactive users deletion period

### DIFF
--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -288,7 +288,7 @@ module Decidim
   mattr_accessor :default_locale, default: (Decidim::Env.new("DECIDIM_DEFAULT_LOCALE", "en").presence || :en).to_s
 
   # Users that have not logged in for this period of time will be deleted
-  mattr_accessor :delete_inactive_users_after_days, default: Decidim::Env.new("DELETE_INACTIVE_USERS_AFTER_DAYS", 365).to_i
+  mattr_accessor :delete_inactive_users_after_days, default: Decidim::Env.new("DECIDIM_DELETE_INACTIVE_USERS_AFTER_DAYS", 365).to_i
 
   # The minimum allowed inactivity period for deleting participants.
   mattr_accessor :minimum_inactivity_period, default: Decidim::Env.new("DECIDIM_MINIMUM_INACTIVITY_PERIOD_IN_DAYS", 30).to_i


### PR DESCRIPTION
#### :tophat: What? Why?

The documentation for setting a custom period for deleting inactive users states that the env var DECIDIM_DELETE_INACTIVE_USERS_AFTER_DAYS is used to control. However the code was using 
DELETE_INACTIVE_USERS_AFTER_DAYS.

This changes the core.rb to accept the documented variable.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
Set up the documented DECIDIM_DELETE_INACTIVE_USERS_AFTER_DAYS to custom bigger than the default (365 days).
Wait a year (alternative, if you are impatient, change the `current_sign_in_at` property of a user to an older day)
Run the sidekiq, see that users receive a warning.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
N/A

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment variable naming convention for system configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->