### PR TITLE
Add missing imagemagick dependency to devcontainer (v0.31)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN wget -q -O /tmp/google-chrome-key.pub https://dl-ssl.google.com/linux/linux_
     && sudo gpg --dearmor -o /usr/share/keyrings/google-chrome-keyring.gpg /tmp/google-chrome-key.pub \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google-chrome.list \
     && sudo apt-get update \
-    && sudo apt-get install -y google-chrome-stable libicu-dev \
+    && sudo apt-get install -y google-chrome-stable libicu-dev imagemagick \
     && sudo rm -rf /var/lib/apt/lists/* /tmp/google-chrome-key.pub
 
 ENV BINDING="0.0.0.0"


### PR DESCRIPTION
#### :tophat: What? Why?

While checking a problem on v0.31, I noticed that with #16743 I missed one dependency (imagemagick), so when 
  
#### :pushpin: Related Issues
 
- Related to #16743 

#### Testing

1. Run these commands
```bash
bin/devcontainer rebuild
bin/devcontainer dev
``` 
2. Go to http://localhost:3000
3. See the error

> You must have ImageMagick or GraphicsMagick installed
 

:hearts: Thank you!
