### PR TITLE
Fix data migration for answers to responses change

### DIFF
--- a/decidim-forms/db/data/20260616144141_rename_answers_to_responses.rb
+++ b/decidim-forms/db/data/20260616144141_rename_answers_to_responses.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class RenameAnswersToResponses < ActiveRecord::Migration[7.2]
+  class Attachment < ApplicationRecord
+    self.table_name = "decidim_attachments"
+  end
+
+  class ActionLog < ApplicationRecord
+    self.table_name = "decidim_action_logs"
+  end
+
+  def up
+    # rubocop:disable Rails/SkipsModelValidations
+    Attachment.where(attached_to_type: "Decidim::Forms::Answer").update_all(attached_to_type: "Decidim::Forms::Response")
+    ActionLog.where(resource_type: "Decidim::Forms::Answer").update_all(resource_type: "Decidim::Forms::Response")
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def down
+    # rubocop:disable Rails/SkipsModelValidations
+    Attachment.where(attached_to_type: "Decidim::Forms::Response").update_all(attached_to_type: "Decidim::Forms::Answer")
+    ActionLog.where(resource_type: "Decidim::Forms::Response").update_all(resource_type: "Decidim::Forms::Answer")
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+end

--- a/decidim-forms/db/data/20260616144141_rename_answers_to_responses.rb
+++ b/decidim-forms/db/data/20260616144141_rename_answers_to_responses.rb
@@ -9,10 +9,15 @@ class RenameAnswersToResponses < ActiveRecord::Migration[7.2]
     self.table_name = "decidim_action_logs"
   end
 
+  class Version < ApplicationRecord
+    self.table_name = "versions"
+  end
+
   def up
     # rubocop:disable Rails/SkipsModelValidations
     Attachment.where(attached_to_type: "Decidim::Forms::Answer").update_all(attached_to_type: "Decidim::Forms::Response")
     ActionLog.where(resource_type: "Decidim::Forms::Answer").update_all(resource_type: "Decidim::Forms::Response")
+    Version.where(item_type: "Decidim::Forms::Answer").update_all(item_type: "Decidim::Forms::Response")
     # rubocop:enable Rails/SkipsModelValidations
   end
 
@@ -20,6 +25,7 @@ class RenameAnswersToResponses < ActiveRecord::Migration[7.2]
     # rubocop:disable Rails/SkipsModelValidations
     Attachment.where(attached_to_type: "Decidim::Forms::Response").update_all(attached_to_type: "Decidim::Forms::Answer")
     ActionLog.where(resource_type: "Decidim::Forms::Response").update_all(resource_type: "Decidim::Forms::Answer")
+    Version.where(item_type: "Decidim::Forms::Response").update_all(item_type: "Decidim::Forms::Answer")
     # rubocop:enable Rails/SkipsModelValidations
   end
 end

--- a/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
+++ b/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
@@ -80,7 +80,29 @@ describe RenameAnswersToResponses do
     expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Questionnaire").first.resource).to eq(questionnaire)
     expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Response").first).to be_nil
   end
+  class Version < ApplicationRecord
+    self.table_name = "versions"
+  end
 
+  it "updates properly the paper trail versions" do
+    Version.create!(
+      item_type: "Decidim::Forms::Answer",
+      item_id: response.id,
+      event: "update",
+      whodunnit: user.id.to_s,
+      object: "{}",
+      object_changes: "{}",
+      created_at: Time.current
+    )
+
+    expect(Version.where(item_type: "Decidim::Forms::Response").first).to be_nil
+
+    migrator.migrate(:up)
+    expect(Version.where(item_type: "Decidim::Forms::Response").first.item_id).to eq(response.id)
+
+    migrator.migrate(:down)
+    expect(Version.where(item_type: "Decidim::Forms::Response").first).to be_nil
+  end
   context "when having attachments" do
     let!(:response) { create(:response, :with_attachments, questionnaire:) }
     let!(:other_attachment) { create(:attachment, attached_to: participatory_process) }

--- a/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
+++ b/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
@@ -80,6 +80,7 @@ describe RenameAnswersToResponses do
     expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Questionnaire").first.resource).to eq(questionnaire)
     expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Response").first).to be_nil
   end
+
   class Version < ApplicationRecord
     self.table_name = "versions"
   end
@@ -103,6 +104,7 @@ describe RenameAnswersToResponses do
     migrator.migrate(:down)
     expect(Version.where(item_type: "Decidim::Forms::Response").first).to be_nil
   end
+
   context "when having attachments" do
     let!(:response) { create(:response, :with_attachments, questionnaire:) }
     let!(:other_attachment) { create(:attachment, attached_to: participatory_process) }

--- a/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
+++ b/decidim-forms/spec/db/data/rename_answers_to_responses_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "./db/data/20260616144141_rename_answers_to_responses"
+
+describe RenameAnswersToResponses do
+  let(:migrator) do
+    described_class.new.tap do |m|
+      m.verbose = false
+    end
+  end
+
+  let(:organization) { create(:organization) }
+  let!(:participatory_process) { create(:participatory_process, organization:) }
+  let(:user) { create(:user, organization:) }
+  let!(:questionnaire) { create(:questionnaire, questionnaire_for: participatory_process) }
+  let(:response) { create(:response, questionnaire:) }
+  let!(:action_logs_with_other_types) do
+    create_list(:action_log, 2, resource: create(:dummy_resource, organization:))
+  end
+  let!(:action_logs_with_old_type) do
+    # rubocop:disable Rails/SkipsModelValidations
+    Decidim::ActionLog.insert_all([
+                                    {
+                                      decidim_organization_id: organization.id,
+                                      user_id: user.id,
+                                      user_type: "Decidim::User",
+                                      resource_type: "Decidim::Forms::Questionnaire",
+                                      resource_id: questionnaire.id,
+                                      action: "create",
+                                      visibility: "public-only",
+                                      extra: {
+                                        "user" => {
+                                          "ip" => "127.0.0.1",
+                                          "name" => "Dummy user",
+                                          "nickname" => "dummy"
+                                        },
+                                        "resource" => {},
+                                        "component" => {},
+                                        "participatory_space" => {}
+                                      },
+                                      created_at: Time.current,
+                                      updated_at: Time.current
+                                    },
+                                    {
+                                      decidim_organization_id: organization.id,
+                                      user_id: user.id,
+                                      user_type: "Decidim::User",
+                                      resource_type: "Decidim::Forms::Answer",
+                                      resource_id: response.id,
+                                      action: "create",
+                                      visibility: "public-only",
+                                      extra: {
+                                        "user" => {
+                                          "ip" => "127.0.0.1",
+                                          "name" => "Dummy user",
+                                          "nickname" => "dummy"
+                                        },
+                                        "resource" => {},
+                                        "component" => {},
+                                        "participatory_space" => {}
+                                      },
+                                      created_at: Time.current,
+                                      updated_at: Time.current
+                                    }
+                                  ])
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  it "updates properly the action logs" do
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Questionnaire").first.resource).to eq(questionnaire)
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Response").first).to be_nil
+
+    migrator.migrate(:up)
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Questionnaire").first.resource).to eq(questionnaire)
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Response").first.resource).to eq(response)
+
+    migrator.migrate(:down)
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Questionnaire").first.resource).to eq(questionnaire)
+    expect(Decidim::ActionLog.where(resource_type: "Decidim::Forms::Response").first).to be_nil
+  end
+
+  context "when having attachments" do
+    let!(:response) { create(:response, :with_attachments, questionnaire:) }
+    let!(:other_attachment) { create(:attachment, attached_to: participatory_process) }
+
+    it "updates properly the attachments" do
+      # rubocop:disable Rails/SkipsModelValidations
+      Decidim::Attachment.where(attached_to_type: "Decidim::Forms::Response").update_all(attached_to_type: "Decidim::Forms::Answer")
+      # rubocop:enable Rails/SkipsModelValidations
+
+      expect(Decidim::Attachment.where(attached_to_type: "Decidim::Forms::Answer").first).to be_present
+
+      migrator.migrate(:up)
+      expect(Decidim::Attachment.where(attached_to_type: "Decidim::Forms::Response").first).to eq(response.attachments.first)
+      expect(Decidim::Attachment.where(attached_to_type: "Decidim::ParticipatoryProcess").first).to eq(other_attachment)
+
+      migrator.migrate(:down)
+      expect(Decidim::Attachment.where(attached_to_type: "Decidim::Forms::Answer").first).to be_present
+      expect(Decidim::Attachment.where(attached_to_type: "Decidim::ParticipatoryProcess").first).to eq(other_attachment)
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
It was reported that while running the upgrade script from a 0.30 to a 0.31 decidim installation, there are errors generated when the installation holds any surveys with user answers. This PR aims to fix that. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to : #14316
- Fixes #16277

#### Testing
1. Create a 0.30 application 
2. Create a survey from admin that has at least one attachment question
3. Publish survey & and answer the survev
4. Do check in console that you have some records `Decidim::Attachment.where(attached_to_type: "Decidim::Forms::Answer").count`
5. Switch the release 31, follow the upgrade steps 
6. Copy the data migration file in the branch 
7. Run a `bin/rails data:migrate`
8. Repeat step 4. See there are no records

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated stored type identifiers for form submissions, attachments, action logs, and audit trail records to consistently use the response naming.
  * Added a reversible data migration to remap existing records and restore original identifiers on rollback.
* **Tests**
  * Added RSpec coverage to validate remapping for action logs, audit trail entries, and attachments, including correct reversal behavior and protection for unrelated attachment types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->