### PR TITLE
(Deprecated) Fix members page layout page

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_profile.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_profile.scss
@@ -156,6 +156,10 @@
 
     &-grid {
       @apply grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-10;
+
+      &--three-cols {
+        @apply grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-x-4 md:gap-x-8 gap-y-8 md:gap-y-10;
+      }
     }
 
     &-avatar {

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
@@ -11,14 +11,15 @@ edit_link(
 )
 %>
 
-<% content_for :aside do %>
-  <h1 class="title-decorator">
-    <%= t("members", scope: "decidim.participatory_space_members.index") %>
-  </h1>
-<% end %>
+<main class="container" role="main">
+  <section class="layout-main__section" id="participatory_process_members">
+    <h1 class="title-decorator my-12 inline-flex items-center gap-3">
+      <span><%= t("members", scope: "decidim.participatory_space_members.index") %></span>
+      <span class="text-sm font-semibold text-gray-2 bg-background rounded px-2 py-0.5"><%= collection.size %></span>
+    </h1>
 
-<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
-  <section class="layout-main__section">
-    <%= render(collection) %>
+    <div class="profile__user-grid profile__user-grid--three-cols mb-12">
+      <%= render(collection) %>
+    </div>
   </section>
-<% end %>
+</main>


### PR DESCRIPTION
Add three-column grid option for user profiles and update members index layout to include user count.

#### :tophat: What? Why?
The participatory process Members page used the two-column layout (layout_two_col), with the title in a sidebar and members listed in a single column. This did not match the intended design: a full-width page with a prominent heading, member count, and a responsive grid of member cards.

#### This PR:
Replaces the two-column layout on the participatory process members index with a single full-width container layout.
Displays the Members title with a count badge (collection.size) next to it.
Introduces a new CSS modifier profile__user-grid--three-cols for a responsive grid (1 column on mobile, 2 from md, 3 from lg).
Renders members in that grid using the existing decidim/member cell.

#### :pushpin: Related Issues
Related to #16577
Fixes #16577

#### Testing
- Start the development app.
- Ensure a participatory process has members enabled and at least a few published members (Admin → Participatory process → Members).
- Visit /en/processes/{slug}/members

### :camera: Screenshots
<img width="1046" height="252" alt="image" src="https://github.com/user-attachments/assets/8a56fcbf-4b5d-4689-a0c0-27e88dc7ca7a" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the members page layout to display profiles in a responsive 3-column grid format, improving visibility and organization across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->