### PR TITLE
Fix check-spelling github action 

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -92,7 +92,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.26
+      uses: check-spelling/check-spelling@v0.0.25
       with:
         suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
         checkout: true
@@ -143,7 +143,7 @@ jobs:
       cancel-in-progress: false
     steps:
     - name: apply spelling updates
-      uses: check-spelling/check-spelling@v0.0.26
+      uses: check-spelling/check-spelling@v0.0.25
       with:
         experimental_apply_changes_via_bot: 1
         checkout: true


### PR DESCRIPTION
#### :tophat: What? Why?
This PR pins the check-spelling github action to the previous version to `v0.0.25` instead of `v0.0.26` which are breaking a few pipelines. Pins to the version before being updated here: https://github.com/decidim/decidim/pull/16528

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing
Pipeline should be green

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->