### PR TITLE
Fix flaky on mention with rich text editor

### DIFF
--- a/decidim-core/app/packs/src/decidim/editor/common/suggestion.js
+++ b/decidim-core/app/packs/src/decidim/editor/common/suggestion.js
@@ -134,7 +134,9 @@ export const createSuggestionRenderer = (node, { itemConverter } = {}) => () => 
       }
     },
 
-    onUpdate({ clientRect, items }) {
+    onUpdate({ clientRect, items, command }) {
+      selectCommand = command;
+
       if (!clientRect || !suggestion) {
         return;
       }

--- a/decidim-core/spec/system/editor_spec.rb
+++ b/decidim-core/spec/system/editor_spec.rb
@@ -1406,7 +1406,7 @@ describe "Editor" do
 
       prosemirror.native.send_keys [:enter]
 
-      expect_value(%(<p><span data-type="mention" data-id="@doe_john" data-label="@doe_john (John Doe)">@doe_john (John Doe)</span> doe</p>))
+      expect_value(%(<p><span data-type="mention" data-id="@doe_john" data-label="@doe_john (John Doe)">@doe_john (John Doe)</span> </p>))
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Since yesterday we've seen a new flaky in `develop`, realted to the mention feature using rich text (TipTap). 

The problem is that we're not consistent on the user and the resource mentions, as with the user mentions the prompt that started the command gets deleted and with the resource mention this isn't happening. 

I could not reproduce it locally (nor understood why this was happening now!!) until I saw @alecslupu [comment](https://github.com/decidim/decidim/pull/17139#issuecomment-4732626758) that this is related to a TipTap upgrade. Once I got this piece of information everything made sense :)



#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/27687549097/job/81889907240 
 

#### Testing

Note that you need a fresh test app to get TipTap latest version: 

```
bundle exec rake test_app
for i in $(seq 1 10) ; do echo $i ; bin/rspec decidim-core/spec/system/editor_spec.rb -e mention || break ; done
``` 

### :camera: Stacktrace

```

Failures:

  1) Editor with resource mentions allows selecting resource mentions with a slash
     Failure/Error: expect(input.value).to eq(html.strip.gsub(/\n\s*/, ""))

       expected: "<p><span data-type=\"mentionResource\" data-id=\"gid://decidim.org/Proposal/1\" data-label=\"Proposal 1\">Proposal 1</span> </p>"
            got: "<p><span data-type=\"mentionResource\" data-id=\"gid://decidim.org/Proposal/1\" data-label=\"Proposal 1\">Proposal 1</span> pro</p>"

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_editor_with_resource_mentions_allows_selecting_resource_mentions_with_a_slash_137.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_editor_with_resource_mentions_allows_selecting_resource_mentions_with_a_slash_137.html


     # ./spec/system/editor_spec.rb:1563:in 'RSpec::ExampleGroups::Editor#expect_value'
     # ./spec/system/editor_spec.rb:1442:in 'block (3 levels) in <top (required)>'

Finished in 9 minutes 17 seconds (files took 18.18 seconds to load)
125 examples, 1 failure

Failed examples:

rspec ./spec/system/editor_spec.rb:1418 # Editor with resource mentions allows selecting resource mentions with a slash

Randomized with seed 34738

```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed mention selection in the editor to properly handle selected suggestions without leaving trailing text fragments behind. The editor now correctly processes mention commands and updates references during suggestion selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->