### PR TITLE
Fix layout for members pages

### DIFF
--- a/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
+++ b/decidim-assemblies/app/views/decidim/assemblies/members/index.html.erb
@@ -11,14 +11,16 @@ edit_link(
 )
 %>
 
-<% content_for :aside do %>
-  <h1 class="title-decorator">
-    <%= t("members", scope: "decidim.participatory_space_members.index") %>
-  </h1>
-<% end %>
+<%= render layout: "layouts/decidim/shared/layout_center", locals: { columns: 10 } do %>
+  <header class="text-center py-10">
+    <h1 class="title-decorator inline-block text-left mb-12">
+      <%= t("members", scope: "decidim.participatory_space_members.index") %>
+    </h1>
+  </header>
 
-<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
   <section class="layout-main__section">
-    <%= render(collection) %>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-12">
+      <%= render(collection) %>
+    </div>
   </section>
 <% end %>

--- a/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
+++ b/decidim-participatory_processes/app/views/decidim/participatory_processes/members/index.html.erb
@@ -11,14 +11,16 @@ edit_link(
 )
 %>
 
-<% content_for :aside do %>
-  <h1 class="title-decorator">
-    <%= t("members", scope: "decidim.participatory_space_members.index") %>
-  </h1>
-<% end %>
+<%= render layout: "layouts/decidim/shared/layout_center", locals: { columns: 10 } do %>
+  <header class="text-center py-10">
+    <h1 class="title-decorator inline-block text-left mb-12">
+      <%= t("members", scope: "decidim.participatory_space_members.index") %>
+    </h1>
+  </header>
 
-<%= render layout: "layouts/decidim/shared/layout_two_col" do %>
   <section class="layout-main__section">
-    <%= render(collection) %>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-12">
+      <%= render(collection) %>
+    </div>
   </section>
 <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

Sometime ago we broke the Members page when there are many Members. This PR fixes it

#### :pushpin: Related Issues
 
- Fixes  #16577 
- Related to https://github.com/decidim/decidim/pull/17137

#### Testing

1. Edit a space and enable members ("This space has members" checkbox)
2. Create multiple members for this space. I imported this CSV (and edited them to make them Publicable) 
```csv
admin@example.org;Hello
amendment-author-assembly-1-89eb812b@example.org;Hello
amendment-author-assembly-1-ad80da62@example.org;Hello
amendment-author-conference-1-5b02ca83@example.org;Hello
amendment-author-conference-1-db7b1768@example.org;Hello
amendment-author-conference-1-ee349ab3@example.org;Hello
amendment-author-participatory_process-1-3b5a52fb@example.org;Hello
amendment-author-participatory_process-1-d4fb53fb@example.org;Hello
assembly_1_admin@example.org;Hello
assembly_1_collaborator@example.org;Hello
assembly_1_evaluator@example.org;Hello
assembly_1_moderator@example.org;Hello
budget-1-vote-0-author-participatory_process-1-786de27c@example.org;Hello
budget-1-vote-1-author-participatory_process-1-4e231fca@example.org;Hello
```
3. Go to the landing page of the Space 
4. Click in Members
5. See the page

### :camera: Screenshots

#### Before

<img width="1414" height="877" alt="image" src="https://github.com/user-attachments/assets/c3b8ad88-f56b-4a09-b660-90044d8b4a2f" />

#### After

<img width="1377" height="804" alt="image" src="https://github.com/user-attachments/assets/d3451c82-4230-44f8-9305-e049f24436a9" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated member list layouts to use centered, responsive grid designs for improved visual presentation across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->