### PR TITLE
fix: Add focus trap functionality to dropdown and main menu controllers

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
@@ -2,6 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 import { screens } from "tailwindcss/defaultTheme"
 import Dropdowns from "a11y-dropdown-component";
 
+const DROPDOWN_FOCUSABLE_SELECTOR = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled])"
+
 /**
  * Create dropdown from a component
  *
@@ -80,6 +82,105 @@ export default class extends Controller {
     const addAriaRoles = this.element.dataset.addAriaRoles !== "false";
     if (!addAriaRoles) {
       this.removeAriaRoles();
+    }
+
+    if (this.element.dataset.focusTrap === "true") {
+      this.setupFocusTrap();
+    }
+  }
+
+  disconnect() {
+    this.teardownFocusTrap();
+  }
+
+  setupFocusTrap() {
+    this.dropdownMenu = document.getElementById(this.element.dataset.target);
+
+    if (!this.dropdownMenu) {
+      return;
+    }
+
+    this.focusTrapEnabled = false;
+    this.handleFocusTrapKeydown = this.handleFocusTrapKeydown.bind(this);
+    this.focusTrapObserver = new MutationObserver(() => this.syncFocusTrap());
+    this.focusTrapObserver.observe(this.dropdownMenu, { attributes: true, attributeFilter: ["aria-hidden"] });
+    this.syncFocusTrap();
+  }
+
+  teardownFocusTrap() {
+    this.disableFocusTrap();
+    this.focusTrapObserver?.disconnect();
+  }
+
+  isDropdownOpen() {
+    return this.dropdownMenu?.getAttribute("aria-hidden") === "false";
+  }
+
+  syncFocusTrap() {
+    if (this.isDropdownOpen()) {
+      this.enableFocusTrap();
+    } else {
+      this.disableFocusTrap();
+    }
+  }
+
+  getFocusableElements() {
+    return Array.from(this.dropdownMenu.querySelectorAll(DROPDOWN_FOCUSABLE_SELECTOR)).filter(
+      (element) => !element.disabled && (element.offsetWidth > 0 || element.offsetHeight > 0)
+    );
+  }
+
+  handleFocusTrapKeydown(event) {
+    if (!this.isDropdownOpen() || event.key !== "Tab") {
+      return;
+    }
+
+    const focusable = this.getFocusableElements();
+
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const firstElement = focusable[0];
+    const lastElement = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus({ preventScroll: true });
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus({ preventScroll: true });
+    }
+  }
+
+  enableFocusTrap() {
+    if (this.focusTrapEnabled) {
+      return;
+    }
+
+    this.focusTrapEnabled = true;
+    document.addEventListener("keydown", this.handleFocusTrapKeydown);
+
+    if (window.focusGuard) {
+      window.focusGuard.trap(this.dropdownMenu, this.element);
+    }
+
+    const focusable = this.getFocusableElements();
+    if (focusable.length > 0) {
+      focusable[0].focus({ preventScroll: true });
+    }
+  }
+
+  disableFocusTrap() {
+    if (!this.focusTrapEnabled) {
+      return;
+    }
+
+    this.focusTrapEnabled = false;
+    document.removeEventListener("keydown", this.handleFocusTrapKeydown);
+
+    if (window.focusGuard) {
+      window.focusGuard.disable();
     }
   }
 

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -144,8 +144,8 @@ describe("DropdownController", () => {
 
   describe("focus trap", () => {
     const makeFocusable = (anchor) => {
-      Object.defineProperty(anchor, "offsetWidth", { configurable: true, value: 1 })
-      Object.defineProperty(anchor, "offsetHeight", { configurable: true, value: 1 })
+      Reflect.defineProperty(anchor, "offsetWidth", { configurable: true, value: 1 })
+      Reflect.defineProperty(anchor, "offsetHeight", { configurable: true, value: 1 })
       return anchor
     }
 

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -142,6 +142,63 @@ describe("DropdownController", () => {
     });
   });
 
+  describe("focus trap", () => {
+    const makeFocusable = (anchor) => {
+      Object.defineProperty(anchor, "offsetWidth", { configurable: true, value: 1 })
+      Object.defineProperty(anchor, "offsetHeight", { configurable: true, value: 1 })
+      return anchor
+    }
+
+    beforeEach(() => {
+      window.focusGuard = {
+        trap: jest.fn(),
+        disable: jest.fn()
+      }
+      element.setAttribute("data-focus-trap", "true")
+    })
+
+    afterEach(() => {
+      Reflect.deleteProperty(window, "focusGuard")
+    })
+
+    it("enables focus trap when the dropdown opens", () => {
+      const testController = createController(element)
+      testController.connect()
+
+      dropdownMenuEl.setAttribute("aria-hidden", "false")
+      testController.syncFocusTrap()
+
+      expect(window.focusGuard.trap).toHaveBeenCalledWith(dropdownMenuEl, element)
+    })
+
+    it("traps focus on Tab from the last focusable element", () => {
+      const firstLink = makeFocusable(dropdownMenuEl.querySelector("a"))
+      const lastLink = makeFocusable(dropdownMenuEl.querySelectorAll("a")[2])
+      const testController = createController(element)
+      testController.connect()
+      testController.setupFocusTrap()
+      dropdownMenuEl.setAttribute("aria-hidden", "false")
+      testController.enableFocusTrap()
+      lastLink.focus()
+
+      const event = { key: "Tab", shiftKey: false, preventDefault: jest.fn() }
+      testController.handleFocusTrapKeydown(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(document.activeElement).toBe(firstLink)
+    })
+
+    it("disables focus trap when the dropdown closes", () => {
+      const testController = createController(element)
+      testController.connect()
+      testController.enableFocusTrap()
+
+      testController.disableFocusTrap()
+
+      expect(window.focusGuard.disable).toHaveBeenCalled()
+    })
+  })
+
   describe("data-add-aria-roles option", () => {
     it("keeps role menu when data-add-aria-roles is true", () => {
       element.setAttribute("data-add-aria-roles", "true");

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 const OPEN_DELAY_MS = 50
+const FOCUSABLE_SELECTOR = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])"
 
 /**
  * Main menu dropdown controller and traps page scroll while the menu is open.
@@ -74,14 +75,18 @@ export default class extends Controller {
   }
 
   handleKeydown(event) {
-    if (event.key !== "Escape") {
-      return;
-    }
     if (this.isHidden()) {
       return;
     }
 
-    this.closeMenu()
+    if (event.key === "Escape") {
+      this.closeMenu()
+      return;
+    }
+
+    if (event.key === "Tab") {
+      this.handleFocusTrap(event)
+    }
   }
 
   handleCloseButtonClick() {
@@ -96,6 +101,31 @@ export default class extends Controller {
     return this.menuContainer.getAttribute("aria-hidden") === "true"
   }
 
+  getFocusableElements() {
+    return Array.from(this.menuContainer.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+      (element) => !element.disabled && (element.offsetWidth > 0 || element.offsetHeight > 0)
+    )
+  }
+
+  handleFocusTrap(event) {
+    const focusable = this.getFocusableElements()
+
+    if (focusable.length === 0) {
+      return;
+    }
+
+    const firstElement = focusable[0]
+    const lastElement = focusable[focusable.length - 1]
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault()
+      lastElement.focus({ preventScroll: true })
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault()
+      firstElement.focus({ preventScroll: true })
+    }
+  }
+
   openMenu() {
     if (typeof this.previousBodyOverflow === "undefined") {
       this.previousBodyOverflow = document.body.style.overflow;
@@ -104,6 +134,15 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "true")
     this.menuContainer.setAttribute("aria-hidden", "false")
     this.menuContainer.setAttribute("aria-modal", "true")
+
+    if (window.focusGuard) {
+      window.focusGuard.trap(this.menuContainer, this.menuButton)
+    }
+
+    const focusable = this.getFocusableElements()
+    if (focusable.length > 0) {
+      focusable[0].focus({ preventScroll: true })
+    }
   }
 
   closeMenu() {
@@ -111,5 +150,11 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "false")
     this.menuContainer.setAttribute("aria-hidden", "true")
     this.menuContainer.removeAttribute("aria-modal")
+
+    if (window.focusGuard) {
+      window.focusGuard.disable()
+    } else {
+      this.menuButton.focus({ preventScroll: true })
+    }
   }
 }

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
@@ -3,6 +3,12 @@ import { Application } from "@hotwired/stimulus"
 import MainMenuController from "src/decidim/controllers/main_menu/controller"
 
 describe("MainMenuController", () => {
+  const makeFocusable = (element) => {
+    Object.defineProperty(element, "offsetWidth", { configurable: true, value: 1 })
+    Object.defineProperty(element, "offsetHeight", { configurable: true, value: 1 })
+    return element
+  }
+
   let application = null
   let controller = null
   let menuButton = null
@@ -41,6 +47,11 @@ describe("MainMenuController", () => {
     menuButton = document.querySelector('[data-controller="main-menu"]')
     menuContainer = document.getElementById("main-menu-container")
     closeButton = document.getElementById("main-menu-close")
+
+    window.focusGuard = {
+      trap: jest.fn(),
+      disable: jest.fn()
+    }
 
     jest.spyOn(window, "scrollTo").mockImplementation(() => {})
 
@@ -89,6 +100,27 @@ describe("MainMenuController", () => {
     })
   })
 
+  describe("openMenu", () => {
+    it("enables focus guard and focuses the first element", () => {
+      const focusableButton = makeFocusable(document.createElement("button"))
+      focusableButton.textContent = "First"
+      menuContainer.prepend(focusableButton)
+      controller.openMenu()
+
+      expect(window.focusGuard.trap).toHaveBeenCalledWith(menuContainer, menuButton)
+      expect(document.activeElement).toBe(focusableButton)
+    })
+  })
+
+  describe("closeMenu", () => {
+    it("disables focus guard when available", () => {
+      controller.openMenu()
+      controller.closeMenu()
+
+      expect(window.focusGuard.disable).toHaveBeenCalled()
+    })
+  })
+
   describe("handleButtonClick", () => {
     it("opens the menu after the delay and scrolls to top", () => {
       jest.useFakeTimers()
@@ -133,6 +165,38 @@ describe("MainMenuController", () => {
       controller.handleKeydown({ key: "Enter" })
 
       expect(menuContainer.getAttribute("aria-hidden")).toBe("false")
+    })
+
+    it("traps focus on Tab from the last focusable element", () => {
+      const firstButton = makeFocusable(document.createElement("button"))
+      firstButton.textContent = "First"
+      const lastButton = makeFocusable(document.createElement("button"))
+      lastButton.textContent = "Last"
+      menuContainer.append(firstButton, lastButton)
+      controller.openMenu()
+      lastButton.focus()
+
+      const event = { key: "Tab", shiftKey: false, preventDefault: jest.fn() }
+      controller.handleKeydown(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(document.activeElement).toBe(firstButton)
+    })
+
+    it("traps focus on Shift+Tab from the first focusable element", () => {
+      const firstButton = makeFocusable(document.createElement("button"))
+      firstButton.textContent = "First"
+      const lastButton = makeFocusable(document.createElement("button"))
+      lastButton.textContent = "Last"
+      menuContainer.append(firstButton, lastButton)
+      controller.openMenu()
+      firstButton.focus()
+
+      const event = { key: "Tab", shiftKey: true, preventDefault: jest.fn() }
+      controller.handleKeydown(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(document.activeElement).toBe(lastButton)
     })
   })
 

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
@@ -4,8 +4,8 @@ import MainMenuController from "src/decidim/controllers/main_menu/controller"
 
 describe("MainMenuController", () => {
   const makeFocusable = (element) => {
-    Object.defineProperty(element, "offsetWidth", { configurable: true, value: 1 })
-    Object.defineProperty(element, "offsetHeight", { configurable: true, value: 1 })
+    Reflect.defineProperty(element, "offsetWidth", { configurable: true, value: 1 })
+    Reflect.defineProperty(element, "offsetHeight", { configurable: true, value: 1 })
     return element
   }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -1,4 +1,4 @@
-[id*="dropdown-menu"] {
+[id*="dropdown-menu"]:not(#dropdown-menu-account-mobile):not(#dropdown-menu-main-mobile):not(#dropdown-menu-main-desktop) {
   @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3 cursor-pointer;
 
   &[aria-hidden="true"] {

--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -1,4 +1,6 @@
-[id*="dropdown-menu"]:not(#dropdown-menu-account-mobile):not(#dropdown-menu-main-mobile):not(#dropdown-menu-main-desktop) {
+[id*="dropdown-menu"]:not(#dropdown-menu-account-mobile):not(
+    #dropdown-menu-main-mobile
+  ):not(#dropdown-menu-main-desktop) {
   @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3 cursor-pointer;
 
   &[aria-hidden="true"] {
@@ -56,6 +58,13 @@
   > span,
   > svg {
     @apply hidden md:block;
+  }
+}
+
+#dropdown-menu-main-mobile,
+#dropdown-menu-main-desktop {
+  &[aria-hidden="true"] {
+    @apply hidden pointer-events-none;
   }
 }
 

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -154,22 +154,33 @@ header {
 
         #main-dropdown-summary-desktop-close {
           @apply self-end;
+
+          &:hover,
+          &:focus-visible {
+            @apply bg-secondary rounded-[4px] text-white;
+
+            svg,
+            span {
+              @apply text-white fill-current;
+            }
+          }
         }
       }
 
       &__trigger {
-        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2;
+        @apply text-secondary cursor-pointer py-1 px-2 text-md leading-[22px] w-fit flex items-center gap-x-2 rounded;
 
         span {
           @apply text-secondary;
         }
 
-        &:hover {
+        &:hover,
+        &:focus-visible {
           @apply bg-secondary rounded-[4px] text-white;
 
           svg,
           span {
-            @apply text-white;
+            @apply text-white fill-current;
           }
         }
 
@@ -223,7 +234,11 @@ header {
       }
 
       &__account {
-        @apply fixed top-0 left-0 w-full h-full z-30 bg-white;
+        @apply fixed top-0 left-0 w-full h-full z-30 m-0 flex flex-col border-0 bg-white cursor-default;
+
+        &[aria-hidden="true"] {
+          @apply hidden;
+        }
 
         ul {
           @apply my-6 divide-y divide-gray-3;
@@ -243,10 +258,6 @@ header {
 
         .main-bar__avatar-name {
           @apply w-12 h-12 text-2xl;
-        }
-
-        .account-container {
-          @apply before:block before:absolute before:top-16 before:right-14 before:content-[""] before:bg-white before:w-2 before:h-12 before:-mt-8;
         }
       }
 
@@ -285,7 +296,16 @@ header {
       }
 
       &-trigger {
-        @apply flex flex-col items-center text-secondary relative px-2 py-1;
+        @apply flex flex-col items-center text-secondary relative px-2 py-1 rounded;
+
+        &:hover,
+        &:focus-visible {
+          @apply bg-secondary text-white;
+
+          svg {
+            @apply fill-white;
+          }
+        }
       }
     }
 
@@ -358,7 +378,11 @@ header {
       }
 
       &__dropdown-wrapper {
-        @apply flex flex-none items-center cursor-pointer underline;
+        @apply flex flex-none items-center cursor-pointer underline rounded;
+
+        &:focus-visible {
+          @apply outline outline-2 outline-white outline-offset-[-2px];
+        }
       }
 
       &__label--truncatable {
@@ -457,7 +481,11 @@ header {
       }
 
       .menu-bar__breadcrumb-item {
-        @apply block flex-1 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis font-semibold underline;
+        @apply flex flex-1 min-w-0 items-center gap-x-2 overflow-hidden font-semibold underline rounded;
+
+        &:focus-visible {
+          @apply outline outline-2 outline-white outline-offset-[-2px];
+        }
       }
 
       /* overwrite default dropdown styles */
@@ -505,11 +533,16 @@ header {
         }
       }
 
-      li:hover {
+      li:hover,
+      li:focus-within {
         @apply bg-[var(--secondary)] rounded-[4px];
 
         a {
           @apply text-white;
+        }
+
+        svg {
+          @apply fill-white;
         }
       }
     }
@@ -541,7 +574,7 @@ header {
           }
 
           a {
-            @apply flex items-center justify-start gap-1 font-semibold text-lg text-secondary;
+            @apply flex items-center justify-start gap-1 font-semibold text-lg text-secondary rounded;
 
             span {
               @apply min-w-0 truncate;
@@ -549,6 +582,15 @@ header {
 
             svg {
               @apply flex-none fill-current;
+            }
+
+            &:hover,
+            &:focus-visible {
+              @apply bg-secondary text-white;
+
+              svg {
+                @apply fill-white;
+              }
             }
           }
         }

--- a/decidim-core/app/views/layouts/decidim/header/_main_language_chooser.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_language_chooser.html.erb
@@ -1,6 +1,6 @@
 <% if available_locales.length > 1 %>
   <div class="main-bar__language-chooser">
-    <button id="trigger-<%= id %>" data-controller="dropdown" data-target="<%= id %>" class="main-bar__language-chooser-trigger">
+    <button id="trigger-<%= id %>" data-controller="dropdown" data-target="<%= id %>" data-focus-trap="true" class="main-bar__language-chooser-trigger">
       <span class="main-bar__language-chooser-holder">
         <%= icon "global-line" %>
         <span><%= t("name", scope: "locale" ) %></span>

--- a/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_main_links_desktop.html.erb
@@ -7,7 +7,7 @@
     </div>
   <% else %>
     <div class="main-bar__dropdown-container">
-      <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account">
+      <button id="trigger-dropdown-account" class="main-bar__dropdown-trigger" data-controller="dropdown" data-target="dropdown-menu-account" data-focus-trap="true">
         <% unread_data = current_user_unread_data %>
         <% if unread_data[:unread_items] %>
           <%= content_tag :span, "", class: "main-bar__notification", data: unread_data %>

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
@@ -4,25 +4,25 @@
 <% end %>
 <div class="menu-bar__breadcrumb-mobile__dropdown-trigger">
   <span class="menu-bar__breadcrumb-mobile__label-wrapper">
-    <span class="menu-bar__breadcrumb-mobile__label">
-      <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
-      <% if previous_item %>
-        <% item_label = translated_attribute(previous_item[:label]) %>
-        <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
-          <%= link_to(previous_item[:url], class: "menu-bar__breadcrumb-item", data: { controller: "breadcrumb-truncate" }) do %>
-            <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
-          <% end %>
-        <% else %>
-          <span class="menu-bar__breadcrumb-item" data-controller="breadcrumb-truncate">
-            <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
-          </span>
+    <% if previous_item %>
+      <% item_label = translated_attribute(previous_item[:label]) %>
+      <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
+        <%= link_to(previous_item[:url], class: "menu-bar__breadcrumb-item menu-bar__breadcrumb-mobile__label", data: { controller: "breadcrumb-truncate" }) do %>
+          <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
+          <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
         <% end %>
       <% else %>
-        <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-item", data: { controller: "breadcrumb-truncate" } do %>
-          <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= t("decidim.menu.home") %></span>
-        <% end %>
+        <span class="menu-bar__breadcrumb-item menu-bar__breadcrumb-mobile__label" data-controller="breadcrumb-truncate">
+          <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
+          <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
+        </span>
       <% end %>
-    </span>
+    <% else %>
+      <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-item menu-bar__breadcrumb-mobile__label", data: { controller: "breadcrumb-truncate" } do %>
+        <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
+        <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= t("decidim.menu.home") %></span>
+      <% end %>
+    <% end %>
   </span>
   <% if content_for?(:participatory_space_mobile_actions) %>
     <div class="menu-bar__actions-mobile">

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/component_context.rb
@@ -191,7 +191,7 @@ shared_examples "cycling through publication states" do
     visit decidim_admin_participatory_processes.components_path(component.participatory_space)
 
     within ".sidebar-menu" do
-      click_on "Components"
+      click_on "Components", match: :first
     end
 
     within "tr", text: title do


### PR DESCRIPTION
:tophat: What? Why?
Keyboard users could tab out of open header dropdowns and the mobile main menu, leaving focus on elements behind the overlay. That breaks expected modal/dropdown behavior and makes the header harder to use with assistive technologies.

### This PR:

- Dropdown controller — Adds an opt-in focus trap via data-focus-trap="true". When a dropdown opens, focus moves to the first focusable item, Tab/Shift+Tab cycle inside the menu, and focusGuard prevents focus from escaping. The trap is torn down when the dropdown closes.
- Main menu controller — Traps focus while the mobile menu is open (using focusGuard and Tab wrapping), moves focus to the first item on open, and restores focus to the menu button on close.
- Templates — Enables focus traps on the account dropdown and language chooser (data-focus-trap="true").
- Styles — Improves :focus-visible feedback on header triggers and refines mobile breadcrumb, account menu, and dropdown layout for accessibility.
- Tests — Covers focus trap enable/disable for dropdowns and Tab cycling for the main menu.
### :pushpin: Related Issues
Related to #17142
Fixes #17142

### Testing
#### Automated
npm test -- decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
npm test -- decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
#### Manual (keyboard)

- Run the development app and open any page with the standard header.
- Account dropdown (desktop): Tab to the account trigger → Enter/Space to open → Tab should stay inside the menu → Shift+Tab from the first item wraps to the last → Escape or click outside closes and focus behaves correctly.
- Language chooser: Repeat the same Tab/Shift+Tab checks.
- Mobile main menu: Resize to mobile width → open the menu → Tab cycles only within the menu → close returns focus to the menu button.
- Visual: Tab through header controls and confirm :focus-visible styles on triggers (account, language, menu).

#### Regression
Nested dropdowns and desktop navigation still open/close as before.
Mobile breadcrumb back link and participatory space actions still render correctly.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard focus trapping to header dropdowns (including language chooser and account menus), keeping Tab navigation within the open menu.
  * Main menu now supports focus cycling with Tab/Shift+Tab and closes on Escape.

* **Improvements**
  * Enhanced keyboard-visible focus styles across header dropdown triggers and items.
  * Hidden dropdown menus no longer accept pointer interactions; mobile dropdown and breadcrumb presentation were refined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->