### PR TITLE
Fix flaky specs on `authentication_spec.rb`

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -714,9 +714,7 @@ describe "Authentication" do
 
             expect(page).to have_text("Invalid")
 
-            # Ensure the unlock email job is enqueued before processing
-            sleep 1
-            perform_enqueued_jobs
+            perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob)
             expect(emails.count).to eq(1)
           end
         end

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -700,7 +700,7 @@ describe "Authentication" do
               within ".new_user" do
                 fill_in :session_user_email, with: user.email
                 fill_in :session_user_password, with: "not-the-password"
-                find("*[type=submit]").click
+                perform_enqueued_jobs { find("*[type=submit]").click }
               end
             end
           end
@@ -709,10 +709,14 @@ describe "Authentication" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
               fill_in :session_user_password, with: "not-the-password"
-              perform_enqueued_jobs { find("*[type=submit]").click }
+              find("*[type=submit]").click
             end
 
             expect(page).to have_text("Invalid")
+
+            # Ensure the unlock email job is enqueued before processing
+            sleep 1
+            perform_enqueued_jobs
             expect(emails.count).to eq(1)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

We have a flaky spec on develop on this file. This PR (tries to) fix it. 

#### :pushpin: Related Issues
 
- Related to https://github.com/decidim/decidim/actions/runs/27803124280/job/82277368029 

#### Testing

```bash
for i in {1..100}; do bin/rspec decidim-core/spec/system/authentication_spec.rb:716  || break; done
```

### :camera: Stacktrace

```
  1) Authentication when a user is already registered with lockable account when attempting to log in with failing password locks the account when reached maximum failed attempts
     Failure/Error: expect(emails.count).to eq(1)

       expected: 1
            got: 0

       (compared using ==)

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_with_lockable_account_when_attempting_to_log_in_with_failing_password_locks_the_account_when_reached_maximum_failed_attempts_647.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_authentication_when_a_user_is_already_registered_with_lockable_account_when_attempting_to_log_in_with_failing_password_locks_the_account_when_reached_maximum_failed_attempts_647.html


     # ./spec/system/authentication_spec.rb:716:in 'block (6 levels) in <top (required)>'
     # ./spec/system/authentication_spec.rb:659:in 'block (4 levels) in <top (required)>'
     # ./spec/system/authentication_spec.rb:41:in 'block (2 levels) in <top (required)>'

Finished in 11 minutes 18 seconds (files took 19.36 seconds to load)
180 examples, 1 failure

Failed examples:

rspec ./spec/system/authentication_spec.rb:708 # Authentication when a user is already registered with lockable account when attempting to log in with failing password locks the account when reached maximum failed attempts
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved the way authentication lockout flow tests trigger job execution to better match real processing timing.
  * Updated job handling so locked-account prep attempts are processed consistently, while maximum-failed-attempts cases still verify the “Invalid” message and only deliver related emails.
  * Kept existing email-count assertions to maintain coverage and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->