### PR TITLE
Implement new design for members invitations

### DIFF
--- a/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
+++ b/decidim-admin/app/commands/decidim/admin/participatory_space/create_member.rb
@@ -62,10 +62,14 @@ module Decidim
         end
 
         def existing_user
-          @existing_user ||= User.find_by(
-            email: form.email.downcase,
-            organization: member_to.organization
-          )
+          @existing_user ||= if form.member_type == "name"
+                               form.user
+                             else
+                               User.find_by(
+                                 email: form.email.downcase,
+                                 organization: member_to.organization
+                               )
+                             end
         end
 
         def send_notification_for_existing_user
@@ -92,12 +96,22 @@ module Decidim
         end
 
         def user_form
-          OpenStruct.new(name: form.name,
-                         email: form.email.downcase,
-                         organization: member_to.organization,
-                         admin: false,
-                         invited_by: current_user,
-                         invitation_instructions:)
+          if form.member_type == "name"
+            OpenStruct.new(name: form.user.name,
+                           email: form.user.email.downcase,
+                           organization: member_to.organization,
+                           admin: false,
+                           invited_by: current_user,
+                           invitation_instructions:)
+          else
+            email_local_part = form.email.split("@").first
+            OpenStruct.new(name: email_local_part,
+                           email: form.email.downcase,
+                           organization: member_to.organization,
+                           admin: false,
+                           invited_by: current_user,
+                           invitation_instructions:)
+          end
         end
 
         def invitation_instructions

--- a/decidim-admin/app/forms/decidim/admin/participatory_space/member_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space/member_form.rb
@@ -13,13 +13,20 @@ module Decidim
 
         attribute :name, String
         attribute :email, String
+        attribute :user_id, Integer
+        attribute :member_type, String, default: "name"
         attribute :published, Boolean
 
         translatable_attribute :role, String
 
-        validates :name, :email, presence: true
+        validates :member_type, presence: true, inclusion: { in: %w(name email) }
+        validates :user, presence: true, if: proc { |object| object.member_type == "name" }
+        validates :email, presence: true, "valid_email_2/email": { disposable: true },
+                          if: proc { |object| object.member_type == "email" }
 
-        validates :name, format: { with: UserBaseEntity::REGEXP_NAME }
+        def user
+          @user ||= current_organization.users.find_by(id: user_id)
+        end
       end
     end
   end

--- a/decidim-admin/app/forms/decidim/admin/participatory_space_admin_user_form.rb
+++ b/decidim-admin/app/forms/decidim/admin/participatory_space_admin_user_form.rb
@@ -5,8 +5,11 @@ module Decidim
     class ParticipatorySpaceAdminUserForm < Decidim::Admin::ParticipatorySpace::MemberForm
       attribute :role, String
 
+      attribute :member_type, String, default: "email"
+
       validates :role, presence: true
       validates :role, inclusion: { in: ParticipatorySpaceUser::ROLES }
+      validates :name, format: { with: Decidim::UserBaseEntity::REGEXP_NAME }
 
       def roles
         ParticipatorySpaceUser::ROLES.map { |role| [I18n.t(role, scope:), role] }

--- a/decidim-admin/app/jobs/decidim/admin/participatory_space/import_member_csv_job.rb
+++ b/decidim-admin/app/jobs/decidim/admin/participatory_space/import_member_csv_job.rb
@@ -13,7 +13,8 @@ module Decidim
 
           params = {
             name: user_name,
-            email: email.downcase.strip
+            email: email.downcase.strip,
+            member_type: "email"
           }
           member_form = MemberForm.from_params(params, participatory_space:)
                                   .with_context(

--- a/decidim-admin/app/packs/entrypoints/decidim_admin.js
+++ b/decidim-admin/app/packs/entrypoints/decidim_admin.js
@@ -21,6 +21,7 @@ import "src/decidim/admin/css_preview"
 import "src/decidim/admin/sync_radio_buttons"
 import "src/decidim/admin/text_copy"
 import "src/decidim/admin/taxonomy_filters"
+import "src/decidim/admin/member_form"
 
 // CSS
 import "entrypoints/decidim_admin.scss";

--- a/decidim-admin/app/packs/src/decidim/admin/member_form.js
+++ b/decidim-admin/app/packs/src/decidim/admin/member_form.js
@@ -1,25 +1,25 @@
 import createFieldDependentInputs from "src/decidim/admin/field_dependent_inputs.component"
 
 document.addEventListener("turbo:load", () => {
-  const $attendeeType = $('[name="meeting_registration_invite[attendee_type]"]');
+  const $memberType = $('[name="member[member_type]"]');
 
   createFieldDependentInputs({
-    controllerField: $attendeeType,
+    controllerField: $memberType,
     wrapperSelector: ".user-picker-fields",
     dependentFieldsSelector: ".user-picker-fields--name",
     dependentInputSelector: "input, select",
     enablingCondition: () => {
-      return $("#meeting_registration_invite_attendee_type_name").is(":checked")
+      return $("#member_member_type_name").is(":checked")
     }
   });
 
   createFieldDependentInputs({
-    controllerField: $attendeeType,
+    controllerField: $memberType,
     wrapperSelector: ".user-picker-fields",
     dependentFieldsSelector: ".user-picker-fields--email",
     dependentInputSelector: "input",
     enablingCondition: () => {
-      return $("#meeting_registration_invite_attendee_type_email").is(":checked")
+      return $("#member_member_type_email").is(":checked")
     }
   });
 })

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/_user_picker.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/_user_picker.scss
@@ -1,0 +1,3 @@
+.user-picker-card {
+  @apply p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2;
+}

--- a/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
+++ b/decidim-admin/app/packs/stylesheets/decidim/admin/application.scss
@@ -24,6 +24,7 @@
 @use "stylesheets/decidim/admin/datepicker";
 @use "stylesheets/decidim/admin/minimap";
 @use "stylesheets/decidim/admin/proposal_status";
+@use "stylesheets/decidim/admin/user_picker";
 @use "stylesheets/decidim/editor_suggestions";
 
 :root {

--- a/decidim-admin/app/views/decidim/admin/members/_form.html.erb
+++ b/decidim-admin/app/views/decidim/admin/members/_form.html.erb
@@ -1,13 +1,48 @@
-<div class="form__wrapper">
+<div class="form__wrapper<%= " user-picker-fields" unless @form.persisted? %>">
   <div class="card pt-4">
     <div id="panel-title" class="card-section">
       <div class="row">
-        <div class="columns">
-          <%= form.text_field :name, readonly: @form.persisted? %>
-        </div>
-        <div class="columns">
-          <%= form.email_field :email, readonly: @form.persisted? %>
-        </div>
+        <% if @form.persisted? %>
+          <div class="columns">
+            <%= form.text_field :name, readonly: true %>
+          </div>
+          <div class="columns">
+            <%= form.email_field :email, readonly: true %>
+          </div>
+        <% else %>
+          <div class="columns">
+            <p class="mb-4"><%= t(".invite_explanation") %></p>
+
+            <div class="grid grid-cols-2 gap-4">
+              <%= label_tag :member_member_type_name, class: "user-picker-card" do %>
+                <%= radio_button_tag "member[member_type]", "name", form.object.member_type == "name", id: "member_member_type_name", class: "hidden peer !m-0" %>
+                <span class="text-lg font-normal">
+                  <%= t(".name_or_nickname") %>
+                </span>
+              <% end %>
+
+              <%= label_tag :member_member_type_email, class: "user-picker-card" do %>
+                <%= radio_button_tag "member[member_type]", "email", form.object.member_type == "email", id: "member_member_type_email", class: "hidden peer !m-0" %>
+                <span class="text-lg font-normal">
+                  <%= t(".email") %>
+                </span>
+              <% end %>
+            </div>
+
+            <div class="mt-4">
+              <div class="user-picker-fields--name hidden">
+                <% prompt_options = { placeholder: t(".select_user") } %>
+                <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, label: t(".name_or_nickname"), class: "autocomplete-field--results-inline" }, prompt_options) do |user|
+                  { value: user.id, label: "#{user.name} (@#{user.nickname})" }
+                end %>
+              </div>
+
+              <div class="user-picker-fields--email hidden">
+                <%= form.email_field :email %>
+              </div>
+            </div>
+          </div>
+        <% end %>
         <div class="columns">
           <%= form.translated :text_field, :role %>
         </div>
@@ -18,3 +53,4 @@
     </div>
   </div>
 </div>
+<%= append_javascript_pack_tag "decidim_admin" unless @form.persisted? %>

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -608,6 +608,11 @@ en:
         edit:
           title: Edit member
           update: Update
+        form:
+          email: Email
+          invite_explanation: The participant will be invited to join the organization.
+          name_or_nickname: Name or nickname
+          select_user: Select member
         index:
           import_via_csv: Import via CSV
           publish_all: Publish all

--- a/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
@@ -24,6 +24,7 @@ shared_examples "manage admin members examples" do
     click_on "New member"
 
     within ".new_member" do
+      choose "Email", name: "member[member_type]"
       fill_in :member_name, with: "John Doe"
       fill_in :member_email, with: other_user.email
 
@@ -95,7 +96,8 @@ shared_examples "manage admin members examples" do
       before do
         form = Decidim::Admin::ParticipatorySpace::MemberForm.from_params(
           name: "test",
-          email: "test@example.org"
+          email: "test@example.org",
+          member_type: "email"
         )
 
         Decidim::Admin::ParticipatorySpace::CreateMember.call(

--- a/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
@@ -2,6 +2,7 @@
 
 shared_examples "manage admin members examples" do
   let(:other_user) { create(:user, organization:, email: "my_email@example.org") }
+  let!(:name_user) { create(:user, :confirmed, organization:, name: "Sarah Connor", nickname: "sarahconnor") }
 
   let!(:member) { create(:member, user:, participatory_space:) }
 
@@ -38,6 +39,43 @@ shared_examples "manage admin members examples" do
 
     visit decidim_admin.root_path
     expect(page).to have_text("invited #{other_user.name} to be a member")
+  end
+
+  it "creates a new member by name or nickname" do
+    click_on "New member"
+
+    within ".new_member" do
+      choose "Name or nickname", name: "member[member_type]"
+      autocomplete_select name_user.name, from: :user_id
+
+      find("*[type=submit]").click
+    end
+
+    expect(page).to have_callout("Member access successfully created.")
+
+    within "#members table" do
+      expect(page).to have_text(name_user.email)
+    end
+
+    visit decidim_admin.root_path
+    expect(page).to have_text("invited #{name_user.name} to be a member")
+  end
+
+  it "switches between member type modes" do
+    click_on "New member"
+
+    within ".new_member" do
+      expect(page).to have_css(".user-picker-fields--name", visible: :visible)
+      expect(page).to have_css(".user-picker-fields--email", visible: :hidden)
+
+      choose "Email", name: "member[member_type]"
+      expect(page).to have_css(".user-picker-fields--name", visible: :hidden)
+      expect(page).to have_css(".user-picker-fields--email", visible: :visible)
+
+      choose "Name or nickname", name: "member[member_type]"
+      expect(page).to have_css(".user-picker-fields--name", visible: :visible)
+      expect(page).to have_css(".user-picker-fields--email", visible: :hidden)
+    end
   end
 
   describe "when import a batch of members from csv" do

--- a/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
+++ b/decidim-admin/lib/decidim/admin/test/admin_members_shared_examples.rb
@@ -25,7 +25,6 @@ shared_examples "manage admin members examples" do
 
     within ".new_member" do
       choose "Email", name: "member[member_type]"
-      fill_in :member_name, with: "John Doe"
       fill_in :member_email, with: other_user.email
 
       find("*[type=submit]").click

--- a/decidim-admin/spec/commands/decidim/admin/participatory_space/create_member_spec.rb
+++ b/decidim-admin/spec/commands/decidim/admin/participatory_space/create_member_spec.rb
@@ -20,6 +20,7 @@ module Decidim::Admin::ParticipatorySpace
         email:,
         current_user:,
         name:,
+        member_type: "email",
         role:,
         published:
       )
@@ -52,7 +53,7 @@ module Decidim::Admin::ParticipatorySpace
 
         expect(Decidim::ParticipatorySpace::Member.where(user:).count).to eq 1
 
-        form = double(invalid?: false, email:, current_user:, name:, role:, published: false)
+        form = double(invalid?: false, email:, current_user:, name:, member_type: "email", role:, published: false)
         described_class.new(form, participatory_space, via_csv:).call
 
         expect(Decidim::ParticipatorySpace::Member.where(user:).count).to eq 1

--- a/decidim-admin/spec/forms/decidim/admin/participatory_space/member_form_spec.rb
+++ b/decidim-admin/spec/forms/decidim/admin/participatory_space/member_form_spec.rb
@@ -6,15 +6,26 @@ module Decidim
   module Admin
     module ParticipatorySpace
       describe MemberForm do
-        subject { described_class.from_params(attributes) }
+        subject(:form) { described_class.from_params(attributes).with_context(context) }
+
+        let(:organization) { create(:organization) }
+        let(:context) do
+          {
+            current_organization: organization
+          }
+        end
 
         let(:email) { "my_email@example.org" }
         let(:name) { "John Wayne" }
+        let(:member_type) { "email" }
+        let(:user_id) { nil }
         let(:attributes) do
           {
             "member" => {
               "email" => email,
-              "name" => name
+              "name" => name,
+              "member_type" => member_type,
+              "user_id" => user_id
             }
           }
         end
@@ -23,8 +34,78 @@ module Decidim
           it { is_expected.to be_valid }
         end
 
-        context "when email is missing" do
-          let(:email) { nil }
+        context "when member_type is email" do
+          let(:member_type) { "email" }
+
+          context "when email is missing" do
+            let(:email) { nil }
+
+            it { is_expected.to be_invalid }
+          end
+
+          context "when email is invalid" do
+            let(:email) { "not-an-email" }
+
+            it { is_expected.to be_invalid }
+          end
+
+          context "when email is disposable" do
+            let(:email) { "test@mailinator.com" }
+
+            it { is_expected.to be_invalid }
+          end
+        end
+
+        context "when member_type is name" do
+          let(:member_type) { "name" }
+
+          context "and no user is provided" do
+            it { is_expected.to be_invalid }
+          end
+
+          context "and user exists" do
+            let(:user_id) { create(:user, organization:).id }
+
+            it { is_expected.to be_valid }
+          end
+
+          context "and no such user exists" do
+            let(:user_id) { 999_999 }
+
+            it { is_expected.to be_invalid }
+          end
+
+          describe "user" do
+            subject { form.user }
+
+            context "when the user exists" do
+              let(:user_id) { create(:user, organization:).id }
+
+              it { is_expected.to be_a(Decidim::User) }
+            end
+
+            context "when the user does not exist" do
+              let(:user_id) { 999_999 }
+
+              it { is_expected.to be_nil }
+            end
+
+            context "when the user is from another organization" do
+              let(:user_id) { create(:user).id }
+
+              it { is_expected.to be_nil }
+            end
+          end
+        end
+
+        context "when member_type is missing" do
+          let(:member_type) { nil }
+
+          it { is_expected.to be_invalid }
+        end
+
+        context "when member_type is invalid" do
+          let(:member_type) { "invalid" }
 
           it { is_expected.to be_invalid }
         end

--- a/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/admin/invites/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="form__wrapper attendee-fields">
+<div class="form__wrapper user-picker-fields">
   <div class="card" data-controller="accordion" id="accordion-attendee">
     <div class="card-divider">
       <button class="card-divider-button" data-open="true" data-controls="panel-attendee" type="button">
@@ -13,14 +13,14 @@
       <p class="mb-4"><%= t(".invite_explanation") %></p>
 
       <div class="grid grid-cols-2 gap-4">
-        <%= label_tag :meeting_registration_invite_attendee_type_name, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
+        <%= label_tag :meeting_registration_invite_attendee_type_name, class: "user-picker-card" do %>
           <%= radio_button_tag "meeting_registration_invite[attendee_type]", "name", form.object.attendee_type == "name", id: "meeting_registration_invite_attendee_type_name", class: "hidden peer !m-0", disabled: %>
           <span class="text-lg font-normal">
             <%= t(".name_or_nickname") %>
           </span>
         <% end %>
 
-        <%= label_tag :meeting_registration_invite_attendee_type_email, class: "attendee-type-card p-4 block border border-background rounded-lg cursor-pointer has-[:checked]:border-secondary has-[:checked]:border-2" do %>
+        <%= label_tag :meeting_registration_invite_attendee_type_email, class: "user-picker-card" do %>
           <%= radio_button_tag "meeting_registration_invite[attendee_type]", "email", form.object.attendee_type == "email", id: "meeting_registration_invite_attendee_type_email", class: "hidden peer !m-0", disabled: %>
           <span class="text-lg font-normal">
             <%= t(".email") %>
@@ -29,14 +29,14 @@
       </div>
 
       <div class="mt-4">
-        <div class="attendee-fields--name hidden">
+        <div class="user-picker-fields--name hidden">
           <% prompt_options = { placeholder: t(".select_user") } %>
           <%= form.autocomplete_select(:user_id, form.object.user.presence, { multiple: false, label: t(".name_or_nickname"), class: "autocomplete-field--results-inline" }, prompt_options) do |user|
             { value: user.id, label: "#{user.name} (@#{user.nickname})" }
           end %>
         </div>
 
-        <div class="attendee-fields--email hidden">
+        <div class="user-picker-fields--email hidden">
           <%= form.text_field :email, disabled: %>
         </div>
       </div>


### PR DESCRIPTION
#### :tophat: What? Why?

As explained on #17044, we're improving the design for some forms with Invitations. 

This PR applies this pattern for the New Member form. Mind that I also refactored a bit the Invite form from #17044 to DRY this implementation.


#### :pushpin: Related Issues
 
- Related to #17044 
 

#### Testing

1. Log in as admin
2. Edit a process
3. Enable "This space has members" checkbox
<img width="894" height="440" alt="image" src="https://github.com/user-attachments/assets/2f345639-f637-44cb-a24b-88500ab8018f" />
4. Go to the Members page in the sidebar
5. Click in the "New member" button
6. See the form 

### :camera: Screenshots

#### Before

<img width="1155" height="577" alt="image" src="https://github.com/user-attachments/assets/394d7691-7e50-4ef0-9f65-73bafa481e33" />

#### After

<img width="1095" height="594" alt="image" src="https://github.com/user-attachments/assets/83d48bfb-41d4-4f5e-94ed-7c557d56955c" />
<img width="1122" height="640" alt="image" src="https://github.com/user-attachments/assets/c43b53ae-2acc-4ef7-a7fb-42fe8136afae" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added member creation in the admin panel with two modes: select an existing user (“name/nickname”) or invite by email (“email”).
  * Member form now conditionally validates inputs and dynamically toggles the correct fields, including improved user-picker UI.
  * Updated member/invite UI to use the enhanced user-picker layout and styling across admin screens.

* **Bug Fixes**
  * Fixed CSV member import to correctly use email-based member/invitation handling.
  * Improved member handling when resolving existing users for email/name modes.

* **Tests**
  * Expanded coverage for member type validation and UI switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->