### PR TITLE
Bump ruby from 3.3.0 to 3.3.4 in manual.adoc

### DIFF
--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -4,7 +4,7 @@ In order to develop on decidim, you will need:
 
 * *Git* 2.34+
 * *PostgreSQL* 17.4+
-* *Ruby* 3.3.0
+* *Ruby* 3.3.4
 * *NodeJS* 22.14.x
 * *Npm* 10.9.x
 * *ImageMagick*
@@ -34,8 +34,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 3.3.0
-rbenv global 3.3.0
+rbenv install 3.3.4
+rbenv global 3.3.4
 ----
 
 == 2. Installing PostgreSQL


### PR DESCRIPTION
#### :tophat: What? Why?

I believe that the version of Ruby in the [Manual installation tutorial](https://docs.decidim.org/en/develop/install/manual) should be 3.3.4 and not 3.3.0.

When creating the application with the `decidim` executable, I got ruby version 3.3.4 : 
```sh
$ ruby -v
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [x86_64-linux]

$ cd my_decicim_app

$ ruby -v
rbenv: version `3.3.4' is not installed

$ cat .ruby-version 
3.3.4
```

#### :pushpin: Related Issues

#### Testing

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the manual installation guide to require Ruby 3.3.4.
  * Adjusted the setup steps so rbenv installs and sets Ruby 3.3.4 as the global version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->