### PR TITLE
Fix comments `loginModal` for non-logged in users

### DIFF
--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -23,7 +23,9 @@ module Decidim
     end
 
     def path
-      "#add-comment-anchor"
+      return "#add-comment-anchor" if current_user
+
+      "#"
     end
 
     def text

--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -43,7 +43,9 @@ module Decidim
     def html_options
       return super if current_user
 
-      super.merge(data: { dialog_open: "loginModal" })
+      super.tap do |opts|
+        opts[:data] = (opts[:data] || {}).merge(dialog_open: "loginModal")
+      end
     end
   end
 end

--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -25,7 +25,7 @@ module Decidim
     def path
       return "#add-comment-anchor" if current_user
 
-      "#"
+      nil
     end
 
     def text

--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -41,11 +41,9 @@ module Decidim
     end
 
     def html_options
-      return super if current_user
+      return {} if current_user
 
-      super.tap do |opts|
-        opts[:data] = (opts[:data] || {}).merge(dialog_open: "loginModal")
-      end
+      { data: { "dialog-open": "loginModal" } }
     end
   end
 end

--- a/decidim-core/app/cells/decidim/comments_button_cell.rb
+++ b/decidim-core/app/cells/decidim/comments_button_cell.rb
@@ -39,5 +39,11 @@ module Decidim
     def button_classes
       "button button__sm button__transparent-secondary add-comment-mobile"
     end
+
+    def html_options
+      return super if current_user
+
+      super.merge(data: { dialog_open: "loginModal" })
+    end
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -212,6 +212,22 @@ shared_examples "comments" do
       expect(page).to have_css(".add-comment form")
     end
 
+    it "does not show login modal when clicking the comment button" do
+      visit resource_path
+
+      find("a.add-comment-mobile").click
+
+      expect(page).to have_no_css("#loginModal-content", visible: :visible)
+    end
+
+    it "guides the user to the comment form when clicking the comment button" do
+      visit resource_path
+
+      find("a.add-comment-mobile").click
+
+      expect(page).to have_css("#add-comment-anchor")
+    end
+
     context "when user visit a computer browser" do
       before do
         switch_to_host(organization.host)

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -173,6 +173,16 @@ shared_examples "comments" do
       expect(page).to have_css(".comment-thread")
     end
 
+    it "opens the login modal when clicking the comment button" do
+      visit resource_path
+
+      expect(page).to have_no_css("#loginModal-content", visible: :visible)
+
+      find("a.add-comment-mobile").click
+
+      expect(page).to have_css("#loginModal-content", visible: :visible)
+    end
+
     context "when user visit a mobile browser" do
       before do
         driven_by(:iphone)

--- a/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/comments_examples.rb
@@ -178,7 +178,7 @@ shared_examples "comments" do
 
       expect(page).to have_no_css("#loginModal-content", visible: :visible)
 
-      find("a.add-comment-mobile").click
+      find(".add-comment-mobile").click
 
       expect(page).to have_css("#loginModal-content", visible: :visible)
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The `loginModal` was not triggered when clicking the comment button in components as a user/participant not logged in. 

With a small change and addition to the `decidim-core/app/cells/decidim/comments_button_cell.rb` the dialog window opens the modal successfully if triggered as a non authenticated user.

#### :pushpin: Related Issues
- Fixes #16059 

#### Testing
1. In the dev app head to a configured, published component like Proposals or Meetings as a *non-logged* user
2. Click the comment button
3. See the `loginModal` triggered

Comment out the condition in `path` and `html_options` method in the `comments_button_cell.rb`. 

Run a suite with an the block I added in the comments example, in Blogs for eg `decidim-blogs/spec/system/comments_spec.rb`. See that it creates a failing spec.

### :camera: Screenshots

[Screencast from 2026-06-25 09-51-01.webm](https://github.com/user-attachments/assets/c058b5f6-112f-42c3-a7a9-cdcc889f5832)


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Unauthenticated users tapping the mobile add-comment button now open the sign-in login modal instead of navigating to the comment anchor.
  * Authenticated users continue to open the comment form directly and do not trigger the login modal.

* **Tests**
  * Expanded shared comment specs to verify unauthenticated mobile interactions show the login modal, and authenticated mobile interactions both avoid the modal and navigate to `#add-comment-anchor`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->