### PR TITLE
Fix focus trap for mobile menus

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
@@ -2,6 +2,14 @@ import { Controller } from "@hotwired/stimulus"
 
 const OPEN_DELAY_MS = 50
 
+const FOCUSABLE_SELECTORS = "a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex='-1'])"
+
+const getFocusableElements = (container) => {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTORS)).filter(
+    (el) => el.offsetParent !== null
+  );
+}
+
 /**
  * Main menu dropdown controller and traps page scroll while the menu is open.
  *
@@ -24,6 +32,7 @@ export default class extends Controller {
     this.handleButtonClick = this.handleButtonClick.bind(this)
     this.handleKeydown = this.handleKeydown.bind(this)
     this.handleCloseButtonClick = this.handleCloseButtonClick.bind(this)
+    this.focusTrapHandler = this.focusTrapHandler.bind(this)
 
     this.menuButton.addEventListener("click", this.handleButtonClick)
     this.menuContainer.addEventListener("click", this.handleContainerClick)
@@ -96,6 +105,23 @@ export default class extends Controller {
     return this.menuContainer.getAttribute("aria-hidden") === "true"
   }
 
+  focusTrapHandler(event) {
+    if (event.key !== "Tab") {
+      return;
+    }
+    const focusable = getFocusableElements(this.menuContainer);
+    if (focusable.length === 0) {
+      return;
+    }
+    if (event.shiftKey && document.activeElement === focusable[0]) {
+      event.preventDefault();
+      focusable[focusable.length - 1].focus({ preventScroll: true });
+    } else if (!event.shiftKey && document.activeElement === focusable[focusable.length - 1]) {
+      event.preventDefault();
+      focusable[0].focus({ preventScroll: true });
+    }
+  }
+
   openMenu() {
     if (typeof this.previousBodyOverflow === "undefined") {
       this.previousBodyOverflow = document.body.style.overflow;
@@ -104,9 +130,11 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "true")
     this.menuContainer.setAttribute("aria-hidden", "false")
     this.menuContainer.setAttribute("aria-modal", "true")
+    this.menuContainer.addEventListener("keydown", this.focusTrapHandler)
   }
 
   closeMenu() {
+    this.menuContainer.removeEventListener("keydown", this.focusTrapHandler)
     document.body.style.overflow = this.previousBodyOverflow ?? ""
     this.element.setAttribute("aria-expanded", "false")
     this.menuContainer.setAttribute("aria-hidden", "true")

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
@@ -131,6 +131,11 @@ export default class extends Controller {
     this.menuContainer.setAttribute("aria-hidden", "false")
     this.menuContainer.setAttribute("aria-modal", "true")
     this.menuContainer.addEventListener("keydown", this.focusTrapHandler)
+
+    const focusable = getFocusableElements(this.menuContainer);
+    if (focusable.length > 0) {
+      focusable[0].focus({ preventScroll: true });
+    }
   }
 
   closeMenu() {

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
@@ -177,6 +177,12 @@ describe("MainMenuController", () => {
       controller.closeMenu()
     })
 
+    it("focuses the first focusable element when menu opens", () => {
+      const focusable = menuContainer.querySelectorAll("a[href], button:not([disabled])")
+      const firstEl = focusable[0]
+      expect(document.activeElement).toBe(firstEl)
+    })
+
     it("cycles focus to first element when Tab is pressed on last focusable element", () => {
       const focusable = menuContainer.querySelectorAll("a[href], button:not([disabled])")
       expect(focusable.length).toBeGreaterThan(1)

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
@@ -20,6 +20,8 @@ describe("MainMenuController", () => {
         Menu
       </button>
       <div id="main-menu-container" aria-hidden="true">
+        <a href="/link">Link</a>
+        <button>Action</button>
         <div id="main-menu-item"></div>
       </div>
       <button id="main-menu-close">Close</button>
@@ -162,6 +164,75 @@ describe("MainMenuController", () => {
       controller.handleCloseButtonClick()
 
       expect(menuContainer.getAttribute("aria-hidden")).toBe("true")
+    })
+  })
+
+  describe("focusTrapHandler", () => {
+    beforeEach(() => {
+      jest.spyOn(HTMLElement.prototype, "offsetParent", "get").mockReturnValue(menuContainer)
+      controller.openMenu()
+    })
+
+    afterEach(() => {
+      controller.closeMenu()
+    })
+
+    it("cycles focus to first element when Tab is pressed on last focusable element", () => {
+      const focusable = menuContainer.querySelectorAll("a[href], button:not([disabled])")
+      expect(focusable.length).toBeGreaterThan(1)
+      const lastEl = focusable[focusable.length - 1]
+      const firstEl = focusable[0]
+
+      lastEl.focus()
+      const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true })
+      jest.spyOn(event, "preventDefault")
+      jest.spyOn(firstEl, "focus")
+
+      menuContainer.dispatchEvent(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(firstEl.focus).toHaveBeenCalledWith({ preventScroll: true })
+    })
+
+    it("cycles focus to last element when Shift+Tab is pressed on first focusable element", () => {
+      const focusable = menuContainer.querySelectorAll("a[href], button:not([disabled])")
+      expect(focusable.length).toBeGreaterThan(1)
+      const firstEl = focusable[0]
+      const lastEl = focusable[focusable.length - 1]
+
+      firstEl.focus()
+      const event = new KeyboardEvent("keydown", { key: "Tab", shiftKey: true, bubbles: true })
+      jest.spyOn(event, "preventDefault")
+      jest.spyOn(lastEl, "focus")
+
+      menuContainer.dispatchEvent(event)
+
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(lastEl.focus).toHaveBeenCalledWith({ preventScroll: true })
+    })
+
+    it("does nothing when a non-Tab key is pressed", () => {
+      const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+      jest.spyOn(event, "preventDefault")
+
+      menuContainer.dispatchEvent(event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+    })
+
+    it("does nothing when there are no focusable elements", () => {
+      controller.closeMenu()
+      menuContainer.innerHTML = ""
+      controller.openMenu()
+
+      const event = new KeyboardEvent("keydown", { key: "Tab", bubbles: true })
+      expect(() => menuContainer.dispatchEvent(event)).not.toThrow()
+    })
+
+    it("removes the keydown handler when menu is closed", () => {
+      const spy = jest.spyOn(menuContainer, "removeEventListener")
+      controller.closeMenu()
+      expect(spy).toHaveBeenCalledWith("keydown", controller.focusTrapHandler)
     })
   })
 


### PR DESCRIPTION
#### :tophat: What? Why?

On #17142 it was reported that the focus trap doesn't apply to the mobile menus. This PR fixes it. 

#### :pushpin: Related Issues

- Related to #17159 (as that was an alternative approach for this, but it was too verbose IMO)
- Related to #17142

#### Testing

1. Log in as a participant 
2. With the web developers tool put a mobile view
3. Open the account or the main menu
4. Use the tab key for navigate
5. (Before) see that it kept looking for elements outside of the menu
5. (After) see that it doesn't look for elements outside of the menu and it stays on the menu

### :camera: Screenshots

#### Before

https://github.com/user-attachments/assets/14932bff-3d59-47da-bd99-878a95b8e780

#### After

https://github.com/user-attachments/assets/ad34c439-7f09-430a-a2c8-bb7104a4b760

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation in the main menu by adding a focus trap while the dropdown is open.
  * Tab and Shift+Tab now cycle through focusable menu items instead of moving focus outside the dropdown.
  * Focus is set to the first available menu item on open, and keyboard handling is removed on close to prevent lingering behavior.
  * Added automated tests covering focus-trap behavior, including edge cases like empty focusable content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->