### PR TITLE
Make the icon in mobile breadcrumb clickable

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -457,7 +457,7 @@ header {
       }
 
       .menu-bar__breadcrumb-item {
-        @apply flex flex-1 min-w-0 whitespace-nowrap font-semibold underline focus:outline focus:outline-2 focus:outline-offset-2 rounded-sm;
+        @apply flex flex-1 min-w-0 items-center gap-x-1 whitespace-nowrap font-semibold underline focus:outline focus:outline-2 focus:outline-offset-2 rounded-sm;
       }
 
       /* overwrite default dropdown styles */

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -457,7 +457,7 @@ header {
       }
 
       .menu-bar__breadcrumb-item {
-        @apply block flex-1 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis font-semibold underline;
+        @apply flex flex-1 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis font-semibold underline;
       }
 
       /* overwrite default dropdown styles */

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -449,15 +449,15 @@ header {
       }
 
       &__label-wrapper {
-        @apply block min-w-0 flex-1 overflow-hidden;
+        @apply block min-w-0 flex-1;
       }
 
       &__label {
-        @apply flex w-full items-center gap-x-2 min-w-0 overflow-hidden;
+        @apply flex w-[90%] items-center gap-x-2 min-w-0;
       }
 
       .menu-bar__breadcrumb-item {
-        @apply flex flex-1 min-w-0 overflow-hidden whitespace-nowrap text-ellipsis font-semibold underline;
+        @apply flex flex-1 min-w-0 whitespace-nowrap font-semibold underline focus:outline focus:outline-2 focus:outline-offset-2 rounded-sm;
       }
 
       /* overwrite default dropdown styles */

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -453,7 +453,7 @@ header {
       }
 
       &__label {
-        @apply flex w-[90%] items-center gap-x-2 min-w-0;
+        @apply flex w-11/12 items-center gap-x-2 min-w-0;
       }
 
       .menu-bar__breadcrumb-item {

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_mobile.html.erb
@@ -5,11 +5,11 @@
 <div class="menu-bar__breadcrumb-mobile__dropdown-trigger">
   <span class="menu-bar__breadcrumb-mobile__label-wrapper">
     <span class="menu-bar__breadcrumb-mobile__label">
-      <span aria-hidden="true"><%= icon "arrow-left-s-line" %></span>
       <% if previous_item %>
         <% item_label = translated_attribute(previous_item[:label]) %>
         <% if previous_item[:url].present? && !is_active_link?(previous_item[:url], :exclusive) %>
           <%= link_to(previous_item[:url], class: "menu-bar__breadcrumb-item", data: { controller: "breadcrumb-truncate" }) do %>
+            <span aria-hidden="true" class="flex items-center"><%= icon "arrow-left-s-line" %></span>
             <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
           <% end %>
         <% else %>
@@ -19,6 +19,7 @@
         <% end %>
       <% else %>
         <%= link_to decidim.root_url, class: "menu-bar__breadcrumb-item", data: { controller: "breadcrumb-truncate" } do %>
+          <span aria-hidden="true" class="flex items-center"><%= icon "arrow-left-s-line" %></span>
           <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= t("decidim.menu.home") %></span>
         <% end %>
       <% end %>


### PR DESCRIPTION
#### :tophat: What? Why?

As reported at  #17142 

> **Problem description**
> In mobile the back arrow icon of the breadcrumb is not clickable, and this can lead to confusion. I clicked on it expecting to go back to the previous page.
> 
> **Solution you'd like:**
> Add the arrow into the clickable area of the breadcrumb.
> 

So, this PR makes the icon clickable by adding it to the link

#### :pushpin: Related Issues
 
- Related to #17142 
 
#### Testing

1. Open your web dev tools
2. Go to the Mobile/Responsive feature and select a Mobile device to simulate
3. Click in the icon:
3.1. (Before) it isn't clickable
3.2. (After) it is clickable

See also the difference with the focus (for the screenshots it is just easier to show the focus)

### :camera: Screenshots

#### Before

<img width="904" height="958" alt="2026-06-29-155105_hyprshot" src="https://github.com/user-attachments/assets/e21052c7-84b2-474c-8313-fc8bc9742f37" />

#### After

<img width="913" height="918" alt="2026-06-29-155028_hyprshot" src="https://github.com/user-attachments/assets/8fdcd8dc-1ee8-4936-86e1-eacbd804ebc1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile breadcrumb header styling by adjusting label width and removing clipping so text renders more reliably.
  * Reworked breadcrumb item layout to use flexible spacing instead of truncation, improving readability and alignment.
  * Enhanced accessibility with visible keyboard focus outlines and rounded item styling.
  * Updated the mobile breadcrumb back/home link markup so the left-arrow icon is properly aligned within the clickable area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->