### PR TITLE
Fix focus on desktop breadcrumb menu

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -342,7 +342,7 @@ header {
       }
 
       &__dropdown-trigger {
-        @apply flex flex-none rounded py-1 z-20 font-semibold;
+        @apply flex flex-none rounded px-2 py-1 z-20 font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-inset;
 
         &--truncatable {
           @apply min-w-0 overflow-hidden;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -337,10 +337,6 @@ header {
         @apply min-w-0;
       }
 
-      .no-interactive {
-        @apply font-normal px-0 min-w-0;
-      }
-
       &__dropdown-trigger {
         @apply flex flex-none rounded px-2 py-1 z-20 font-semibold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-inset;
 
@@ -355,6 +351,10 @@ header {
         svg {
           @apply w-6 h-6 fill-current;
         }
+      }
+
+      .no-interactive {
+        @apply font-normal px-0 min-w-0;
       }
 
       &__dropdown-wrapper {


### PR DESCRIPTION
#### :tophat: What? Why?

As reported at  #17142

> **Breadcrumb focus mode is not well displayed on desktop**
> 
> **Problem**:
> On desktop when you use the keyboard to browse the breadcrumb, the focus mode is not completely visible. This is not compliying with basic accessibility standards, such as [WCAG2.2. - 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/quickref/#focus-visible)
> 
> **Solution you'd like:**
> The focus mode should be visible and compliance with [WCAG standards](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance).
> 
>> When the keyboard [focus indicator](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance#dfn-focus-indicator) is visible, an area of the focus indicator meets all the following:
>>
>> is at least as large as the area of a 2 [CSS pixel](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance#dfn-css-pixel) thick [perimeter](https://www.w3.org/WAI/WCAG22/Understanding/focus-appearance#dfn-perimeter) of the unfocused component or sub-component, and
>> has a contrast ratio of at least 3:1 between the same pixels in the focused and unfocused states.
> 

#### :pushpin: Related Issues
 
- Related to #17142 
 
#### Testing

Navigate with tab and see the focus on the desktop breadcrumb menu

### :camera: Screenshots

#### Before

<img width="1507" height="442" alt="image" src="https://github.com/user-attachments/assets/76826ec5-7655-4280-9226-874570090a19" />

#### After

<img width="1471" height="430" alt="image" src="https://github.com/user-attachments/assets/b0068a59-3677-4bd9-b3f8-f46571228257" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the desktop breadcrumb dropdown trigger’s spacing and keyboard focus visibility, making it easier to use and navigate with a keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->