### PR TITLE
Fix account mobile menu details

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_dropdown.scss
@@ -1,5 +1,5 @@
 [id*="dropdown-menu"] {
-  @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3 cursor-pointer;
+  @apply flex flex-col py-0 mx-3.5 md:mx-0 border-t-0 border-gray-3;
 
   &[aria-hidden="true"] {
     @apply hidden md:flex;

--- a/decidim-core/app/packs/stylesheets/decidim/_header.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_header.scss
@@ -248,6 +248,10 @@ header {
         .account-container {
           @apply before:block before:absolute before:top-16 before:right-14 before:content-[""] before:bg-white before:w-2 before:h-12 before:-mt-8;
         }
+
+        #dropdown-trigger-links-mobile-close {
+          @apply relative z-10;
+        }
       }
 
       &__item {


### PR DESCRIPTION
#### :tophat: What? Why?

Here we solve two more bugs from https://github.com/decidim/decidim/issues/17142

> ## User menu close button hover
> 
> When opening the user menu and having the close button on hover the box isn't correctly shown
> 
> <img width="1432" height="924" alt="Image" src="https://github.com/user-attachments/assets/b57f348f-f425-4ea5-afb5-45ecd9dac8a8" />
> 
> ## User menu top hover mishandling 
> 
> When opening the user menu and hovering between the title of the organization and the close button, the cursor has the hand click icon, but it isn't clickable 
> 
> <img width="1432" height="922" alt="Image" src="https://github.com/user-attachments/assets/eacdb501-b613-4413-b258-6fe5c457f91d" />

#### :pushpin: Related Issues

- Related to #17142

#### Testing

1. Log in as a participant
2. Change to a mobile view
3. Open the account menu
4. (First bug) hover with your cursor
5. (Second bug) tab/focus to the close icon

### :camera: Screenshots

#### Before

https://github.com/user-attachments/assets/ae62749b-9633-4443-a132-81b1b50c596d

#### After

https://github.com/user-attachments/assets/6bf10f54-89bb-424f-ab9b-4b0144d76b24


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dropdown menu styling to better match default interaction behavior.
  * Improved mobile header link/account controls with refined stacking so the close button appears correctly above surrounding elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->