### PR TITLE
Add ARIA role for the accessibility report button

### DIFF
--- a/decidim-dev/app/packs/src/decidim/dev/accessibility.js
+++ b/decidim-dev/app/packs/src/decidim/dev/accessibility.js
@@ -41,7 +41,7 @@ const htmlEncode = (text) => {
 
 document.addEventListener("turbo:load", () => {
   const $badge = $(`
-    <div lang="en" class="decidim-accessibility-badge" tabindex="0" aria-label="Toggle accessibility report">
+    <div lang="en" class="decidim-accessibility-badge" tabindex="0" role="button" aria-label="Toggle accessibility report">
       <div class="decidim-accessibility-title">WAI WCAG</div>
       <div class="decidim-accessibility-info"></div>
     </div>


### PR DESCRIPTION
#### :tophat: What? Why?
While doing some HTML validation, noticed that the accessibility report button is missing the `role` attribute which gives a HTML validation error (with the Nu validator).

The error is because elements with `aria-label` have to define a proper ARIA role.

> $${\color{red} Error}$$: The `aria-label` attribute must not be specified on any `div` element unless the element has a role value other than `caption`, `code`, `deletion`, `emphasis`, `generic`, `insertion`, `paragraph`, `presentation`, `strong`, `subscript`, or `superscript`.

#### Testing
- Load the page in development mode
- Take the full page source after the JavaScript has run
- Pass it to the Nu validator at https://validator.w3.org/nu/ as text input

### :camera: Screenshots
<img width="804" height="627" alt="HTML validation report" src="https://github.com/user-attachments/assets/5d0c7352-4539-488a-8e94-bdad2d2d0804" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accessibility badge’s labeling so it’s clearer for screen readers and assistive technologies.
  * The badge now behaves more explicitly as a button, making it easier to identify and interact with via keyboard and accessibility tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->