### PR TITLE
Fix flaky specs on edit attachments examples

### DIFF
--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -168,9 +168,12 @@ describe "Admin manages projects" do
 
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(attachment.file.blob.filename.to_s))
+        expect(page).to have_css("li progress[value='100']", wait: 5)
+        click_on("Save")
       end
 
-      click_on("Save")
+      expect(page).to have_no_css(".upload-modal", wait: 5)
+
       click_on("Update")
 
       expect(page).to have_text("Project successfully updated.")

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -170,13 +170,13 @@ describe "Admin manages projects" do
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
         within "li[data-filename='#{filename}']:not([data-attachment-id])" do
-          expect(page).to have_css("progress[value='100']", wait: 5)
+          expect(page).to have_css("progress[value='100']")
         end
-        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])")
         click_on("Save")
       end
 
-      expect(page).to have_no_css(".upload-modal", wait: 5)
+      expect(page).to have_no_css(".upload-modal")
 
       click_on("Update")
 

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -166,9 +166,11 @@ describe "Admin manages projects" do
 
       click_on("Edit attachments")
 
+      filename = attachment.file.blob.filename.to_s
       within ".upload-modal" do
-        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(attachment.file.blob.filename.to_s))
-        expect(page).to have_css("li progress[value='100']", wait: 5)
+        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
+        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end
 

--- a/decidim-budgets/spec/system/admin_manages_projects_spec.rb
+++ b/decidim-budgets/spec/system/admin_manages_projects_spec.rb
@@ -169,7 +169,9 @@ describe "Admin manages projects" do
       filename = attachment.file.blob.filename.to_s
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
-        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        within "li[data-filename='#{filename}']:not([data-attachment-id])" do
+          expect(page).to have_css("progress[value='100']", wait: 5)
+        end
         expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end

--- a/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
+++ b/decidim-core/app/packs/src/decidim/direct_uploads/upload_modal.js
@@ -253,7 +253,8 @@ export default class UploadModal {
   }
 
   setProgressBar(name, value) {
-    const item = Array.from(this.uploadItems.querySelectorAll("[data-filename]")).find((el) => el.dataset.filename === name);
+    const items = Array.from(this.uploadItems.querySelectorAll("[data-filename]"));
+    const item = items.filter((el) => el.dataset.filename === name).pop();
     if (item) {
       item.querySelector("progress").value = value;
     }

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -340,11 +340,11 @@ describe "Admin manages elections" do
 
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(document.file.blob.filename.to_s))
+        expect(page).to have_css("li progress[value='100']", wait: 5)
+        click_on("Save")
       end
 
-      click_on("Save")
-
-      sleep 1
+      expect(page).to have_no_css(".upload-modal", wait: 5)
 
       click_on("Save and continue")
       expect(page).to have_text("Election updated successfully")

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -338,9 +338,11 @@ describe "Admin manages elections" do
 
       click_on("Edit attachments")
 
+      filename = document.file.blob.filename.to_s
       within ".upload-modal" do
-        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(document.file.blob.filename.to_s))
-        expect(page).to have_css("li progress[value='100']", wait: 5)
+        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
+        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end
 

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -342,13 +342,13 @@ describe "Admin manages elections" do
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
         within "li[data-filename='#{filename}']:not([data-attachment-id])" do
-          expect(page).to have_css("progress[value='100']", wait: 5)
+          expect(page).to have_css("progress[value='100']")
         end
-        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])")
         click_on("Save")
       end
 
-      expect(page).to have_no_css(".upload-modal", wait: 5)
+      expect(page).to have_no_css(".upload-modal")
 
       click_on("Save and continue")
       expect(page).to have_text("Election updated successfully")

--- a/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
+++ b/decidim-elections/spec/system/admin/admin_manages_elections_spec.rb
@@ -341,7 +341,9 @@ describe "Admin manages elections" do
       filename = document.file.blob.filename.to_s
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
-        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        within "li[data-filename='#{filename}']:not([data-attachment-id])" do
+          expect(page).to have_css("progress[value='100']", wait: 5)
+        end
         expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -166,7 +166,9 @@ describe "Admin manages initiatives" do
       filename = "city3.jpeg"
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
-        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        within "li[data-filename='#{filename}']:not([data-attachment-id])" do
+          expect(page).to have_css("progress[value='100']", wait: 5)
+        end
         expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -163,10 +163,13 @@ describe "Admin manages initiatives" do
 
       click_on("Add file")
 
-      within(".upload-modal") do
+      within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("city3.jpeg"))
+        expect(page).to have_css("li progress[value='100']", wait: 5)
         click_on("Save")
       end
+
+      expect(page).to have_no_css(".upload-modal", wait: 5)
 
       click_on("Create attachment")
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -167,13 +167,13 @@ describe "Admin manages initiatives" do
       within ".upload-modal" do
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
         within "li[data-filename='#{filename}']:not([data-attachment-id])" do
-          expect(page).to have_css("progress[value='100']", wait: 5)
+          expect(page).to have_css("progress[value='100']")
         end
-        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])")
         click_on("Save")
       end
 
-      expect(page).to have_no_css(".upload-modal", wait: 5)
+      expect(page).to have_no_css(".upload-modal")
 
       click_on("Create attachment")
 

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiatives_spec.rb
@@ -163,9 +163,11 @@ describe "Admin manages initiatives" do
 
       click_on("Add file")
 
+      filename = "city3.jpeg"
       within ".upload-modal" do
-        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("city3.jpeg"))
-        expect(page).to have_css("li progress[value='100']", wait: 5)
+        find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
+        expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on("Save")
       end
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -153,7 +153,9 @@ describe "Admin edits proposals" do
         filename = "Exampledocument.pdf"
         within ".upload-modal" do
           find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
-          expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+          within "li[data-filename='#{filename}']:not([data-attachment-id])" do
+            expect(page).to have_css("progress[value='100']", wait: 5)
+          end
           expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
           click_on("Save")
         end

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -150,9 +150,11 @@ describe "Admin edits proposals" do
 
         click_on("Edit attachments")
 
+        filename = "Exampledocument.pdf"
         within ".upload-modal" do
-          find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("Exampledocument.pdf"))
-          expect(page).to have_css("li progress[value='100']", wait: 5)
+          find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
+          expect(page).to have_css("li[data-filename='#{filename}']:not([data-attachment-id])", wait: 5)
+          expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
           click_on("Save")
         end
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -154,13 +154,13 @@ describe "Admin edits proposals" do
         within ".upload-modal" do
           find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset(filename))
           within "li[data-filename='#{filename}']:not([data-attachment-id])" do
-            expect(page).to have_css("progress[value='100']", wait: 5)
+            expect(page).to have_css("progress[value='100']")
           end
-          expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
+          expect(page).to have_css("button[data-dropzone-save]:not([disabled])")
           click_on("Save")
         end
 
-        expect(page).to have_no_css(".upload-modal", wait: 5)
+        expect(page).to have_no_css(".upload-modal")
 
         click_on("Update")
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -152,16 +152,22 @@ describe "Admin edits proposals" do
 
         within ".upload-modal" do
           find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("Exampledocument.pdf"))
+          expect(page).to have_css("li progress[value='100']", wait: 5)
+          click_on("Save")
         end
 
-        click_on("Save")
+        expect(page).to have_no_css(".upload-modal", wait: 5)
+
         click_on("Update")
+
+        expect(page).to have_text("Proposal successfully updated.")
 
         within "tr", text: translated_attribute(proposal.title) do
           find("button[data-controller='dropdown']").click
           click_on "Edit proposal"
         end
 
+        click_on "Edit attachments"
         expect(page).to have_text("Exampledocument.pdf")
       end
 

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -446,9 +446,9 @@ describe "Edit proposals" do
         end
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("Exampledocument.pdf"))
         within "li[data-filename='Exampledocument.pdf']:not([data-attachment-id])" do
-          expect(page).to have_css("progress[value='100']", wait: 5)
+          expect(page).to have_css("progress[value='100']")
         end
-        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])")
         click_on "Save"
       end
       click_on("Send")

--- a/decidim-proposals/spec/system/edit_proposal_spec.rb
+++ b/decidim-proposals/spec/system/edit_proposal_spec.rb
@@ -445,10 +445,10 @@ describe "Edit proposals" do
           click_on("Remove")
         end
         find("input[type='file']", visible: :all).attach_file(Decidim::Dev.asset("Exampledocument.pdf"))
-        within "[data-filename='Exampledocument.pdf']" do
-          expect(page).to have_css("li progress[value='100']")
+        within "li[data-filename='Exampledocument.pdf']:not([data-attachment-id])" do
+          expect(page).to have_css("progress[value='100']", wait: 5)
         end
-        expect(page).to have_button("Save", disabled: false)
+        expect(page).to have_css("button[data-dropzone-save]:not([disabled])", wait: 5)
         click_on "Save"
       end
       click_on("Send")


### PR DESCRIPTION
#### :tophat: What? Why?

After #16429 we have some flaky related to this feature. See https://github.com/decidim/decidim/actions/runs/28389572032/job/84112944248 

This PR fixes them.

I'm linking to Initiatives CI run, but with Proposals I could more consistently reproduce it locally. Mind that this happen in these two but could also happen in the other specs changed by #16429

#### :pushpin: Related Issues
 
- Related to #16429 
- https://github.com/decidim/decidim/actions/runs/28389572032/job/84112944248 

#### Testing

Try this oneliner before and after this patch:

```bash
for i in $(seq 1 20) ; do echo $i ; bin/rspec decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb:165 || break ; done
```

### :camera: Stacktrace

```

Failures:

  1) Admin manages initiatives when the initiative has an attachment can attach a file
     Failure/Error: expect(page).to have_text("Super city!")
       expected to find text "Super city!" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nZiemann and Sons\nSee site\nEnglish\nuser187@example.org\n/\nInitiatives\n/\n<script>alert(\"initiative_title\");</script> Itaque sequi molestias. 1202\n/\nAttachments\nSee initiative\nThere was a problem creating a new attachment.\n  About this initiative\nCommittee members\nComponents\nAttachments\nModerations\nAccess links\nNew attachment\nAttachment or image name*\nRequired field\nEnglish\nCatalà\nCastellano\nOrder position\nDescription*\nRequired field\nEnglish\nCatalà\nCastellano\nFolder\nUpload file\nLink\nFile*\nRequired field\nAdd file\ncannot be blank\nCreate attachment"

     [Screenshot Image]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_initiatives_when_the_initiative_has_an_attachment_can_attach_a_file_327.png

     [Screenshot HTML]: file:///home/runner/work/decidim/decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_manages_initiatives_when_the_initiative_has_an_attachment_can_attach_a_file_327.html


     # ./spec/system/admin/admin_manages_initiatives_spec.rb:173:in 'block (3 levels) in <top (required)>'

Finished in 7 minutes 25 seconds (files took 19.44 seconds to load)
89 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_initiatives_spec.rb:146 # Admin manages initiatives when the initiative has an attachment can attach a file

Randomized with seed 20003

/home/runner/work/decidim/decidim/vendor/bundle/ruby/3.4.0/gems/cmdparse-3.0.7/setup.rb:283: warning: key "bin-dir" is duplicated and overwritten on line 284
simplecov: /home/runner/work/decidim/decidim/coverage/coverage.json was written at 2026-06-29T17:36:57+00:00 — after this process started at 2026-06-29T17:31:56+00:00. Overwriting likely loses coverage data from a concurrent test run. For parallel test setups, use SimpleCov::ResultMerger or run a single collation step after all workers finish.
JSON Coverage report generated for RSpec (2/3), RSpec (3/3) to /home/runner/work/decidim/decidim/coverage/coverage.json
Line coverage: 0 / 0 (100.00%)
Stopped processing SimpleCov as a previous error not related to SimpleCov has been detected
Only 2 of 3 parallel-test workers reported within 60s, so coverage totals are partial and minimum / maximum coverage checks are skipped for this run. Increase SimpleCov.parallel_wait_timeout if a worker routinely needs longer.
simplecov: /home/runner/work/decidim/decidim/coverage/coverage.json was written at 2026-06-29T17:40:03+00:00 — after this process started at 2026-06-29T17:31:56+00:00. Overwriting likely loses coverage data from a concurrent test run. For parallel test setups, use SimpleCov::ResultMerger or run a single collation step after all workers finish.
JSON Coverage report generated for RSpec (1/3), RSpec (2/3), RSpec (3/3) to /home/runner/work/decidim/decidim/coverage/coverage.json
Line coverage: 0 / 0 (100.00%)
Tests Failed

176 examples, 1 failure
``` 


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file uploads in admin screens by ensuring the upload completes (progress reaches 100%) and the modal save action is enabled before saving.
  * Fixed cases where attachments could be saved too early, leading to missing or incomplete uploads.
  * Enhanced replacement/edit attachment behavior so the newly uploaded document is correctly reflected after saving across admin proposal and related editing flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->