### PR TITLE
Backport 'Fix flaky specs on `authentication_spec.rb`' to v0.32

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -700,7 +700,7 @@ describe "Authentication" do
               within ".new_user" do
                 fill_in :session_user_email, with: user.email
                 fill_in :session_user_password, with: "not-the-password"
-                find("*[type=submit]").click
+                perform_enqueued_jobs { find("*[type=submit]").click }
               end
             end
           end
@@ -709,10 +709,12 @@ describe "Authentication" do
             within ".new_user" do
               fill_in :session_user_email, with: user.email
               fill_in :session_user_password, with: "not-the-password"
-              perform_enqueued_jobs { find("*[type=submit]").click }
+              find("*[type=submit]").click
             end
 
             expect(page).to have_content("Invalid")
+
+            perform_enqueued_jobs(only: ActionMailer::MailDeliveryJob)
             expect(emails.count).to eq(1)
           end
         end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #17172 to v0.32

:hearts: Thank you!