### PR TITLE
Fix "check_locale_completeness" task in CI

### DIFF
--- a/.github/workflows/check_locale_completeness.yml
+++ b/.github/workflows/check_locale_completeness.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "chore/l10n/**"
+  pull_request:
+    branches:
+      - "release/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
#### :tophat: What? Why?

I'm working on the release process and I see the typical spec failure for i18n-tasks consistency with the `decidim-releaser` script. 

This should have been detected on https://github.com/decidim/decidim/pull/17010  before the merge (see #16488), but that was missed there.

I think it is because we're missing this event in the CI configuration, so I'm adding it. 

#### :pushpin: Related Issues
 
- Related to #16488 

#### Testing

As it is a CI change, it is difficult to test it, but you can check that the CI isn't doing what it should be doing by going to the release branch and running the rake task:

```bash 
vscode ➜ /workspaces/decidim (develop) $ git checkout release/0.32-stable
Switched to branch 'release/0.32-stable'
vscode ➜ /workspaces/decidim (release/0.32-stable) $ bin/rake check_locale_completeness
.F

Failures:

  1) I18n sanity does not have missing keys
     Failure/Error:
       expect(missing_keys).to be_empty,
                               "Missing #{missing_keys.leaves.count} i18n keys, please run `ENFORCED_LOCALES=#{locales} bundle exec i18n-tasks missing --locales #{locales}' to show them"

       Missing 1 i18n keys, please run `ENFORCED_LOCALES=en,ca,es bundle exec i18n-tasks missing --locales en,ca,es' to show them
     # ./spec/i18n_spec.rb:26:in 'block (2 levels) in <top (required)>'

Finished in 23.77 seconds (files took 0.37351 seconds to load)
2 examples, 1 failure

Failed examples:

rspec ./spec/i18n_spec.rb:25 # I18n sanity does not have missing keys

F
..

Failures:

  1) I18n sanity does not have missing keys
     Failure/Error:
       expect(missing_keys).to be_empty,
                               "Missing #{missing_keys.leaves.count} i18n keys, please run `ENFORCED_LOCALES=#{locales} bundle exec i18n-tasks missing --locales #{locales}' to show them"

       Missing 1 i18n keys, please run `ENFORCED_LOCALES=en,ca,es bundle exec i18n-tasks missing --locales en,ca,es' to show them
     # ./spec/i18n_spec.rb:26:in 'block (2 levels) in <top (required)>'

Finished in 1 minute 1.17 seconds (files took 0.42017 seconds to load)
4 examples, 1 failure

Failed examples:

rspec ./spec/i18n_spec.rb:25 # I18n sanity does not have missing keys

The officially supported locales have problems in them.
Please correct these problems by following the instructions from the above outputs before release!
```


(Obviously if the inconsistency was already fixed with a Crowdin change then this failure will not happen) 

 
:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Locale completeness checks now run on pull requests targeting `release/**` branches, helping catch translation issues earlier before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->