### PR TITLE
Prevent using reserved memoized variable names in specs

### DIFF
--- a/decidim-debates/spec/shared/manage_debates_examples.rb
+++ b/decidim-debates/spec/shared/manage_debates_examples.rb
@@ -228,8 +228,8 @@ RSpec.shared_examples "manage debates" do
   end
 
   describe "Attachments in a debate" do
-    let(:image_filename) { "city2.jpeg" }
-    let(:image_path) { Decidim::Dev.asset(image_filename) }
+    let(:attached_image_filename) { "city2.jpeg" }
+    let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
     let(:document_filename) { "Exampledocument.pdf" }
     let(:document_path) { Decidim::Dev.asset(document_filename) }
     let(:invalid_document) { Decidim::Dev.asset("invalid_extension.log") }
@@ -253,7 +253,7 @@ RSpec.shared_examples "manage debates" do
           choose "Open"
         end
 
-        dynamically_attach_file(:debate_attachments, image_path)
+        dynamically_attach_file(:debate_attachments, attached_image_path)
         dynamically_attach_file(:debate_attachments, document_path)
 
         within ".new_debate" do
@@ -267,7 +267,7 @@ RSpec.shared_examples "manage debates" do
           click_on "Edit"
         end
 
-        expect(page).to have_css("img[src*='#{image_filename}']")
+        expect(page).to have_css("img[src*='#{attached_image_filename}']")
         expect(page).to have_text(document_filename)
       end
 
@@ -294,7 +294,7 @@ RSpec.shared_examples "manage debates" do
           fill_in_i18n_editor(:debate_instructions, "#debate-instructions-tabs", **attributes[:instructions].except("machine_translations"))
         end
 
-        dynamically_attach_file(:debate_attachments, image_path)
+        dynamically_attach_file(:debate_attachments, attached_image_path)
         dynamically_attach_file(:debate_attachments, document_path)
 
         within ".edit_debate" do
@@ -308,7 +308,7 @@ RSpec.shared_examples "manage debates" do
           click_on "Edit"
         end
 
-        expect(page).to have_css("img[src*='#{image_filename}']")
+        expect(page).to have_css("img[src*='#{attached_image_filename}']")
         expect(page).to have_text(document_filename)
       end
     end

--- a/decidim-debates/spec/system/user_creates_debate_spec.rb
+++ b/decidim-debates/spec/system/user_creates_debate_spec.rb
@@ -66,8 +66,8 @@ describe "User creates debate" do
 
         context "and attachments are allowed" do
           let(:attachments_allowed) { true }
-          let(:image_filename) { "city2.jpeg" }
-          let(:image_path) { Decidim::Dev.asset(image_filename) }
+          let(:attached_image_filename) { "city2.jpeg" }
+          let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
           let(:document_filename) { "Exampledocument.pdf" }
           let(:document_path) { Decidim::Dev.asset(document_filename) }
 
@@ -84,7 +84,7 @@ describe "User creates debate" do
               fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
             end
 
-            dynamically_attach_file(:debate_attachments, image_path)
+            dynamically_attach_file(:debate_attachments, attached_image_path)
             dynamically_attach_file(:debate_attachments, document_path)
 
             within ".new_debate" do
@@ -95,7 +95,7 @@ describe "User creates debate" do
             expect(page).to have_text("Should every organization use Decidim?")
             expect(page).to have_text("Add your comments on whether Decidim is useful for every organization.")
             expect(page).to have_css("[data-author]", text: user.name)
-            expect(page).to have_css("img[src*='#{image_filename}']")
+            expect(page).to have_css("img[src*='#{attached_image_filename}']")
 
             click_on "Documents"
 

--- a/decidim-debates/spec/system/user_edits_debate_spec.rb
+++ b/decidim-debates/spec/system/user_edits_debate_spec.rb
@@ -91,8 +91,8 @@ describe "User edits a debate" do
 
     context "when attachments are allowed", :slow do
       let(:attachments_allowed) { true }
-      let(:image_filename) { "city2.jpeg" }
-      let(:image_path) { Decidim::Dev.asset(image_filename) }
+      let(:attached_image_filename) { "city2.jpeg" }
+      let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
       let(:document_filename) { "Exampledocument.pdf" }
       let(:document_path) { Decidim::Dev.asset(document_filename) }
 
@@ -109,7 +109,7 @@ describe "User edits a debate" do
           fill_in :debate_description, with: "Add your comments on whether Decidim is useful for every organization."
         end
 
-        dynamically_attach_file(:debate_attachments, image_path)
+        dynamically_attach_file(:debate_attachments, attached_image_path)
         dynamically_attach_file(:debate_attachments, document_path)
 
         within ".edit_debate" do
@@ -118,7 +118,7 @@ describe "User edits a debate" do
 
         expect(page).to have_text("Debate successfully updated.")
         expect(page).to have_css("[data-author]", text: user.name)
-        expect(page).to have_css("img[src*='#{image_filename}']")
+        expect(page).to have_css("img[src*='#{attached_image_filename}']")
 
         click_on "Documents"
 
@@ -138,7 +138,7 @@ describe "User edits a debate" do
 
     context "when the debate has an attachment", :slow do
       let(:attachments_allowed) { true }
-      let(:image_filename) { "city.jpeg" }
+      let(:attached_image_filename) { "city.jpeg" }
       let(:document_filename) { "Exampledocument.pdf" }
       let(:document_path) { Decidim::Dev.asset(document_filename) }
       let!(:image_attachment) { create(:attachment, :with_image, attached_to: debate) }
@@ -155,7 +155,7 @@ describe "User edits a debate" do
         end
 
         click_on("Save")
-        expect(page).to have_no_css("img[src*='#{image_filename}']")
+        expect(page).to have_no_css("img[src*='#{attached_image_filename}']")
       end
 
       it "can attach a file" do
@@ -185,7 +185,7 @@ describe "User edits a debate" do
         end
 
         expect(page).to have_text("Debate successfully updated.")
-        expect(page).to have_css("img[src*='#{image_filename}']")
+        expect(page).to have_css("img[src*='#{attached_image_filename}']")
       end
     end
   end

--- a/decidim-dev/config/rubocop/decidim-linters/configuration.yml
+++ b/decidim-dev/config/rubocop/decidim-linters/configuration.yml
@@ -1,8 +1,15 @@
 require:
   - decidim/dev/rubocop/cop/decidim/message_antipattern
+  - decidim/dev/rubocop/cop/decidim/rspec/memoized_name
 
 Decidim/MessageAntipattern:
   Enabled: true
   Include:
     - "**/spec/**/*"
     - "**/test/**/*"
+
+Decidim/RSpec/MemoizedName:
+  Enabled: true
+  Include:
+    - "**/spec/system/**/*"
+    - "**/spec/shared/**/*"

--- a/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
+++ b/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
@@ -26,7 +26,7 @@ module RuboCop
           MSG = "Do not use reserved names as memoized variable names in system specs: %s. Reserved by: %s."
 
           def on_send(node)
-            return unless [:let].include?(node.method_name)
+            return unless [:let, :let!].include?(node.method_name)
             return if within_block?(node)
 
             first_argument = node.first_argument

--- a/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
+++ b/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+module RuboCop
+  module Cop
+    module Decidim
+      module RSpec
+        class MemoizedName < RuboCop::Cop::Base
+          RESERVED_NAMES = {
+            "ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper" => [
+              :increment_unique,
+              :unique,
+              :image_name,
+              :image_path,
+              :html_path,
+              :absolute_path,
+              :screenshots_dir,
+              :absolute_image_path,
+              :relative_image_path,
+              :absolute_html_path,
+              :output_type
+            ]
+          }.freeze
+
+          MSG = "Do not use reserved names as memoized variable names in system specs: %s. Reserved by: %s."
+
+          def on_send(node)
+            return unless [:let].include?(node.method_name)
+            return if within_block?(node)
+
+            first_argument = node.first_argument
+            return unless first_argument
+            return unless first_argument.sym_type?
+
+            RESERVED_NAMES.each do |klass, methods|
+              next unless methods.include?(first_argument.value)
+
+              add_offense(first_argument, message: format(MSG, first_argument.value, klass))
+            end
+          end
+
+          private
+
+          def within_block?(node)
+            node.each_ancestor(:block).any? do |ancestor|
+              ancestor.send_node&.method_name == :within
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
+++ b/decidim-dev/lib/decidim/dev/rubocop/cop/decidim/rspec/memoized_name.rb
@@ -20,7 +20,7 @@ module RuboCop
               :relative_image_path,
               :absolute_html_path,
               :output_type
-            ]
+            ].freeze
           }.freeze
 
           MSG = "Do not use reserved names as memoized variable names in system specs: %s. Reserved by: %s."

--- a/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
+++ b/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "rubocop/rspec/support"
+require "decidim/dev/rubocop/cop/decidim/rspec/memoized_name"
+
+RSpec.describe RuboCop::Cop::Decidim::RSpec::MemoizedName, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  it "accepts valid name" do
+    expect_no_offenses(<<~RUBY)
+      let(:valid_name) { "value" }
+    RUBY
+  end
+
+  described_class::RESERVED_NAMES.each do |klass, names|
+    names.each do |name|
+      context "with #{name}" do
+        it "registers an offense for very short callouts" do
+          expect_offense(<<~RUBY)
+            let(:#{name}) { "value" }
+                ^#{"^" * name.length} Do not use reserved names as memoized variable names in specs: #{name}. Reserved by: #{klass}.
+          RUBY
+        end
+      end
+    end
+  end
+end

--- a/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
+++ b/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RuboCop::Cop::Decidim::RSpec::MemoizedName, :config do
   described_class::RESERVED_NAMES.each do |klass, names|
     names.each do |name|
       context "with #{name}" do
-        it "registers an offense for very short callouts" do
+        it "registers an offense for reserved name" do
           expect_offense(<<~RUBY)
             let(:#{name}) { "value" }
                 ^#{"^" * name.length} Do not use reserved names as memoized variable names in specs: #{name}. Reserved by: #{klass}.

--- a/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
+++ b/decidim-dev/spec/rubocop/cop/decidim/rspec/memoized_name_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RuboCop::Cop::Decidim::RSpec::MemoizedName, :config do
         it "registers an offense for reserved name" do
           expect_offense(<<~RUBY)
             let(:#{name}) { "value" }
-                ^#{"^" * name.length} Do not use reserved names as memoized variable names in specs: #{name}. Reserved by: #{klass}.
+                ^#{"^" * name.length} Do not use reserved names as memoized variable names in system specs: #{name}. Reserved by: #{klass}.
           RUBY
         end
       end

--- a/decidim-proposals/spec/shared/manage_proposals_examples.rb
+++ b/decidim-proposals/spec/shared/manage_proposals_examples.rb
@@ -7,8 +7,8 @@ shared_examples "manage proposals" do
   let(:participatory_process) { create(:participatory_process, :with_steps, organization:, scope: participatory_process_scope) }
   let(:participatory_process_scope) { nil }
   let(:proposal_title) { translated(proposal.title) }
-  let(:image_filename) { "city.jpeg" }
-  let(:image_path) { Decidim::Dev.asset(image_filename) }
+  let(:attached_image_filename) { "city.jpeg" }
+  let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
 
   before do
     stub_geocoding(address, [latitude, longitude])
@@ -197,7 +197,7 @@ shared_examples "manage proposals" do
               fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: "This is my proposal and I want to upload attachments."
             end
 
-            dynamically_attach_file(:proposal_attachments, image_path)
+            dynamically_attach_file(:proposal_attachments, attached_image_path)
 
             within ".new_proposal" do
               find("*[type=submit]").click

--- a/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_creates_proposal_spec.rb
@@ -7,8 +7,8 @@ describe "Admin creates proposals" do
   let(:creation_enabled?) { true }
   let(:new_title) { "This is my proposal new title" }
   let(:new_body) { "This is my proposal new body" }
-  let(:image_filename) { "city2.jpeg" }
-  let(:image_path) { Decidim::Dev.asset(image_filename) }
+  let(:attached_image_filename) { "city2.jpeg" }
+  let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
   let(:document_filename) { "Exampledocument.pdf" }
   let(:document_path) { Decidim::Dev.asset(document_filename) }
 
@@ -33,7 +33,7 @@ describe "Admin creates proposals" do
 
     fill_in_i18n :proposal_title, "#proposal-title-tabs", en: new_title
     fill_in_i18n_editor :proposal_body, "#proposal-body-tabs", en: new_body
-    dynamically_attach_file(:proposal_attachments, image_path)
+    dynamically_attach_file(:proposal_attachments, attached_image_path)
     dynamically_attach_file(:proposal_attachments, document_path)
 
     click_on("Create")
@@ -42,7 +42,7 @@ describe "Admin creates proposals" do
       click_on "Edit proposal"
     end
 
-    expect(page).to have_text(image_filename)
+    expect(page).to have_text(attached_image_filename)
     expect(page).to have_text(document_filename)
   end
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -8,8 +8,6 @@ describe "Admin edits proposals" do
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
   let!(:proposal) { create(:proposal, :official, component:) }
   let(:creation_enabled?) { true }
-  let(:attached_image_filename) { "city.jpeg" }
-  let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
 
   include_context "when managing a component as an admin"
 

--- a/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
+++ b/decidim-proposals/spec/system/admin/admin_edits_proposal_spec.rb
@@ -8,8 +8,8 @@ describe "Admin edits proposals" do
   let!(:user) { create(:user, :admin, :confirmed, organization:) }
   let!(:proposal) { create(:proposal, :official, component:) }
   let(:creation_enabled?) { true }
-  let(:image_filename) { "city.jpeg" }
-  let(:image_path) { Decidim::Dev.asset(image_filename) }
+  let(:attached_image_filename) { "city.jpeg" }
+  let(:attached_image_path) { Decidim::Dev.asset(attached_image_filename) }
 
   include_context "when managing a component as an admin"
 


### PR DESCRIPTION
#### :tophat: What? Why?
I was doing some investigation on a flaky spec and noticed that the screenshot path was incorrectly reported (note the line that says `[Screenshot Image]`):

```
Failures:

  1) Admin edits proposals editing an official proposal when the proposal has an attachment can attach a file
     Failure/Error: expect(page).to have_text("Exampledocument.pdf")
       expected to find text "Exampledocument.pdf" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nWuckert-Rau\nSee site\nEnglish\nuser1@example.org\n/\nProcesses\n/\n<script>alert(\"participatory_process_title\");</script> Deserunt earum voluptatem. 14\n/\nComponents\n/\n<script>alert(\"proposals\");</script> Proposals\nSee process\nAbout this process\nLanding page layout\nPhases\nComponents\n<script>alert(\"proposals\");</script> Proposals\n1\nAttachments\nProcess admins\nModerations\nAccess links\nUpdate proposal\nTitle*\nRequired field\nEnglish\nCatalà\nCastellano\nAt least 15 characters, 125 characters left\nAt least 15 characters, 125 characters left\nBody*\nRequired field\nEnglish\nCatalà\nCastellano\nNormal\nHeading 2\nHeading 3\nHeading 4\nHeading 5\nHeading 6\nThis is my proposal and I want to upload attachments.\n\n\nThis proposal comes from a meeting\nAdd attachments\nAdd a document or an image\nalert(\"attachment_title\"); Esse temporibus quasi. 72\nEdit attachments\nUpdate". (However, it was found 1 time including non-visible text.)
     
     [Screenshot Image]: file:///.../decidim/decidim-dev/lib/decidim/dev/assets/city.jpeg

     [Screenshot HTML]: file:///.../decidim/spec/decidim_dummy_app/tmp/screenshots/failures_r_spec_example_groups_admin_edits_proposals_editing_an_official_proposal_when_the_proposal_has_an_attachment_can_attach_a_file_983.html

```

This is because the `image_path` is a method defined by `ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper` that is used to print out that part of the message.

To prevent this issue, I am adding a Rubocop rule to detect conflicting memoized variable definitions and prevent them through the linting rules.

#### Testing
Find a failing/flaky spec which defines `let(:image_path) { ... }` and let it fail to see the output.

I got it failing with this one:

```bash
cd decidim-proposals
bundle exec rspec ./spec/system/admin/admin_edits_proposal_spec.rb:144
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated debates and proposals system/shared specs to use consistent attachment fixture variable names and assertions, covering attachment create/update (including image presence/removal).
* **Chores**
  * Added a new RuboCop correctness rule to detect risky RSpec memoized naming patterns, limited to relevant system/shared spec files, with dedicated rule coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->