### PR TITLE
Implement attachments for pages

### DIFF
--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -1105,7 +1105,7 @@ en:
           previous_title: Previous item
         attachments:
           add_attachments: Add attachments
-          attachment_legend: Add an attachment gallery (Optional)
+          attachment_legend: Add a document or an image
           edit_attachments: Edit attachments
       static_page_topics:
         create:

--- a/decidim-blogs/app/views/decidim/blogs/posts/_form.html.erb
+++ b/decidim-blogs/app/views/decidim/blogs/posts/_form.html.erb
@@ -19,7 +19,7 @@
                         button_edit_label: t("decidim.blogs.posts.edit.edit_attachments"),
                         button_class: "button button__lg button__transparent-secondary w-full",
                         help_i18n_scope: "decidim.forms.file_help.file",
-                        help_text: t("attachment_legend", scope: "decidim.blogs.posts.edit") %>
+                        help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
   </div>
 <% end %>
 

--- a/decidim-blogs/config/locales/en.yml
+++ b/decidim-blogs/config/locales/en.yml
@@ -77,7 +77,6 @@ en:
       posts:
         edit:
           add_attachments: Add attachments
-          attachment_legend: Add a document or an image
           back: Back to post
           button: Update
           edit_attachments: Edit attachments

--- a/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/admin/debates/_form.html.erb
@@ -69,7 +69,7 @@
                               button_edit_label: t("decidim.debates.admin.debates.form.edit_attachments"),
                               button_class: "button button__sm button__transparent-secondary",
                               help_i18n_scope: "decidim.forms.file_help.file",
-                              help_text: t("decidim.debates.admin.debates.form.attachment_legend") %>
+                              help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
         </div>
       <% end %>
     </div>

--- a/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
+++ b/decidim-debates/app/views/decidim/debates/debates/_form.html.erb
@@ -19,7 +19,7 @@
                           button_edit_label: t("decidim.debates.admin.debates.form.edit_attachments"),
                           button_class: "button button__lg button__transparent-secondary w-full",
                           help_i18n_scope: "decidim.forms.file_help.file",
-                          help_text: t("decidim.debates.admin.debates.form.attachment_legend") %>
+                          help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
     </div>
   <% end %>
 </div>

--- a/decidim-debates/config/locales/en.yml
+++ b/decidim-debates/config/locales/en.yml
@@ -76,7 +76,6 @@ en:
             update: Update debate
           form:
             add_attachments: Add attachments
-            attachment_legend: Add a document or an image
             comments_layout_locked_warning: The comment layout cannot be changed because comments have already been posted.
             comments_visualization: Comments visualization
             comments_warning: Once the first comment is posted, the selected display option cannot be changed.

--- a/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
+++ b/decidim-elections/app/views/decidim/elections/admin/elections/_form.html.erb
@@ -28,7 +28,7 @@
                               button_edit_label: t("decidim.elections.admin.elections.form.edit_attachments"),
                               button_class: "button button__sm button__transparent-secondary",
                               help_i18n_scope: "decidim.forms.file_help.image",
-                              help_text: t("decidim.elections.admin.elections.form.attachment_legend") %>
+                              help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
         </div>
       </div>
     </div>

--- a/decidim-elections/config/locales/en.yml
+++ b/decidim-elections/config/locales/en.yml
@@ -122,7 +122,6 @@ en:
             title: Edit election
           form:
             add_images: Add images
-            attachment_legend: Add an image gallery (optional)
             basic_title: Basic info
             calendar: Calendar
             calendar_description: Check that the organization time zone is correct in the organization settings. The current configuration is %{timezone}.

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -47,7 +47,7 @@
                        button_label: t("decidim.initiatives.form.add_attachments"),
                        button_class: "button button__lg button__transparent-secondary w-full",
                        button_edit_label: t("decidim.initiatives.form.edit_attachments"),
-                       help_text: t("attachment_legend", scope: "decidim.initiatives.form") %>
+                       help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
       <%= f.attachment :photos,
                        multiple: true,
                        label: t("decidim.initiatives.form.add_image"),

--- a/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -53,7 +53,7 @@
                       button_label: t("decidim.initiatives.form.add_attachments"),
                       button_class: "button button__lg button__transparent-secondary w-full",
                       button_edit_label: t("decidim.initiatives.form.edit_attachments"),
-                      help_text: t("decidim.initiatives.form.attachment_legend") %>
+                      help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
 
   <%= form.attachment :photos,
                       multiple: true,

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -460,7 +460,6 @@ en:
       form:
         add_attachments: Add attachments
         add_image: Add image
-        attachment_legend: Add a document or an image
         edit_attachments: Edit attachments
         edit_image: Edit image
         image_legend: "(Optional) Add an image"

--- a/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
@@ -29,7 +29,7 @@ module Decidim
             return broadcast(:invalid) if attachments_invalid?
           end
 
-          transaction do
+          with_events(with_transaction: true) do
             update_page
             attachment_cleanup!(include_all_attachments: true)
             create_attachments(first_weight: first_attachment_weight) if process_attachments?
@@ -39,6 +39,16 @@ module Decidim
         end
 
         private
+
+        def event_arguments
+          {
+            resource: @page,
+            extra: {
+              event_author: @form.current_user,
+              locale:
+            }
+          }
+        end
 
         def update_page
           Decidim.traceability.update!(

--- a/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/admin/update_page.rb
@@ -6,6 +6,8 @@ module Decidim
       # This command is executed when the user changes a Page from the admin
       # panel.
       class UpdatePage < Decidim::Command
+        include ::Decidim::MultipleAttachmentsMethods
+
         # Initializes a UpdatePage Command.
         #
         # form - The form from which to get the data.
@@ -13,6 +15,7 @@ module Decidim
         def initialize(form, page)
           @form = form
           @page = page
+          @attached_to = page
         end
 
         # Updates the page if valid.
@@ -21,7 +24,17 @@ module Decidim
         def call
           return broadcast(:invalid) if @form.invalid?
 
-          update_page
+          if process_attachments?
+            build_attachments
+            return broadcast(:invalid) if attachments_invalid?
+          end
+
+          transaction do
+            update_page
+            attachment_cleanup!(include_all_attachments: true)
+            create_attachments(first_weight: first_attachment_weight) if process_attachments?
+          end
+
           broadcast(:ok)
         end
 
@@ -33,6 +46,10 @@ module Decidim
             @form.current_user,
             body: @form.body
           )
+        end
+
+        def first_attachment_weight
+          @page.attachments.count
         end
       end
     end

--- a/decidim-pages/app/commands/decidim/pages/copy_page.rb
+++ b/decidim-pages/app/commands/decidim/pages/copy_page.rb
@@ -14,12 +14,37 @@ module Decidim
         Decidim::Pages::Page.transaction do
           pages = Decidim::Pages::Page.where(component: @context[:old_component])
           pages.each do |page|
-            Decidim::Pages::Page.create!(component: @context[:new_component], body: page.body)
+            new_page = Decidim::Pages::Page.create!(component: @context[:new_component], body: page.body)
+            copy_attachments(page, new_page)
           end
         end
         broadcast(:ok)
       rescue ActiveRecord::RecordInvalid
         broadcast(:invalid)
+      end
+
+      private
+
+      def copy_attachments(original_page, new_page)
+        original_page.attachments.each do |attachment|
+          new_attachment = Decidim::Attachment.new(
+            {
+              attached_to: new_page
+            }.merge(
+              attachment.attributes.slice("content_type", "description", "file_size", "title", "weight")
+            )
+          )
+
+          if attachment.file.attached?
+            new_attachment.file = attachment.file.blob
+          else
+            new_attachment.attached_uploader(:file).remote_url = attachment.attached_uploader(:file).url
+          end
+
+          new_attachment.save!
+        rescue Errno::ENOENT, OpenURI::HTTPError => e
+          Rails.logger.warn("[ERROR] Could not copy attachment from page #{original_page.id} when copying to component due to #{e.message}")
+        end
       end
     end
   end

--- a/decidim-pages/app/controllers/decidim/pages/admin/pages_controller.rb
+++ b/decidim-pages/app/controllers/decidim/pages/admin/pages_controller.rb
@@ -11,6 +11,7 @@ module Decidim
           enforce_permission_to :update, :page
 
           @form = form(Admin::PageForm).from_model(page)
+          @form.attachment = form(AttachmentForm).from_params({})
         end
 
         def update

--- a/decidim-pages/app/controllers/decidim/pages/application_controller.rb
+++ b/decidim-pages/app/controllers/decidim/pages/application_controller.rb
@@ -8,6 +8,8 @@ module Decidim
     # Note that it inherits from `Decidim::Components::Basecontroller`, which
     # override its layout and provide all kinds of useful methods.
     class ApplicationController < Decidim::Components::BaseController
+      include Decidim::AttachmentsHelper
+
       def show
         @page = Page.find_by(component: current_component)
       end

--- a/decidim-pages/app/forms/decidim/pages/admin/page_form.rb
+++ b/decidim-pages/app/forms/decidim/pages/admin/page_form.rb
@@ -6,8 +6,26 @@ module Decidim
       # This class holds a Form to update pages from Decidim's admin panel.
       class PageForm < Decidim::Form
         include TranslatableAttributes
+        include Decidim::AttachmentAttributes
 
         translatable_attribute :body, Decidim::Attributes::RichText
+
+        attribute :attachment, AttachmentForm
+        attachments_attribute :attachments
+
+        validate :notify_missing_attachment_if_errored
+
+        def map_model(model)
+          super
+          return unless model.respond_to?(:attachments)
+
+          self.attachments = model.attachments.ids
+          self.add_attachments = model.attachments.map { |att| { id: att.id, title: att.title } }
+        end
+
+        def notify_missing_attachment_if_errored
+          errors.add(:add_attachments, :needs_to_be_reattached) if errors.any? && add_attachments.present?
+        end
       end
     end
   end

--- a/decidim-pages/app/models/decidim/pages/page.rb
+++ b/decidim-pages/app/models/decidim/pages/page.rb
@@ -7,6 +7,7 @@ module Decidim
     class Page < Pages::ApplicationRecord
       include Decidim::Resourceable
       include Decidim::HasComponent
+      include Decidim::HasAttachments
       include Decidim::Traceable
       include Decidim::Loggable
       include Decidim::TranslatableResource
@@ -23,6 +24,10 @@ module Decidim
       # Public: Pages do not have title so we assign the component one to it.
       def title
         component.name
+      end
+
+      def attachment_context
+        :admin
       end
     end
   end

--- a/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
@@ -12,7 +12,8 @@
                             button_label: t("decidim.pages.admin.pages.edit.add_attachments"),
                             button_edit_label: t("decidim.pages.admin.pages.edit.edit_attachments"),
                             button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
-                            help_i18n_scope: "decidim.forms.file_help.file" %>
+                            help_i18n_scope: "decidim.forms.file_help.file",
+                            help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
       </div>
     </div>
   </div>

--- a/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
@@ -4,6 +4,18 @@
       <div class="row column">
         <%= form.translated :editor, :body, lines: 30, label: t("models.components.body", scope: "decidim.pages.admin") %>
       </div>
+
+      <% if component_settings.attachments_allowed? %>
+        <div class="row column">
+          <%= form.attachment :attachments,
+                              multiple: true,
+                              label: t("decidim.pages.admin.pages.edit.add_attachments"),
+                              button_label: t("decidim.pages.admin.pages.edit.add_attachments"),
+                              button_edit_label: t("decidim.pages.admin.pages.edit.edit_attachments"),
+                              button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
+                              help_i18n_scope: "decidim.forms.file_help.file" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
+++ b/decidim-pages/app/views/decidim/pages/admin/pages/_form.html.erb
@@ -5,17 +5,15 @@
         <%= form.translated :editor, :body, lines: 30, label: t("models.components.body", scope: "decidim.pages.admin") %>
       </div>
 
-      <% if component_settings.attachments_allowed? %>
-        <div class="row column">
-          <%= form.attachment :attachments,
-                              multiple: true,
-                              label: t("decidim.pages.admin.pages.edit.add_attachments"),
-                              button_label: t("decidim.pages.admin.pages.edit.add_attachments"),
-                              button_edit_label: t("decidim.pages.admin.pages.edit.edit_attachments"),
-                              button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
-                              help_i18n_scope: "decidim.forms.file_help.file" %>
-        </div>
-      <% end %>
+      <div class="row column">
+        <%= form.attachment :attachments,
+                            multiple: true,
+                            label: t("decidim.pages.admin.pages.edit.add_attachments"),
+                            button_label: t("decidim.pages.admin.pages.edit.add_attachments"),
+                            button_edit_label: t("decidim.pages.admin.pages.edit.edit_attachments"),
+                            button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
+                            help_i18n_scope: "decidim.forms.file_help.file" %>
+      </div>
     </div>
   </div>
 </div>

--- a/decidim-pages/app/views/decidim/pages/application/show.html.erb
+++ b/decidim-pages/app/views/decidim/pages/application/show.html.erb
@@ -21,5 +21,7 @@
         <%= decidim_sanitize_editor_admin translated_attribute(@page.body) %>
       <% end %>
     </div>
+
+    <%= attachments_for(@page) %>
   </div>
 <% end %>

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -15,6 +15,7 @@ en:
         settings:
           global:
             announcement: Announcement
+            attachments_allowed: Allow attachments
           step:
             announcement: Announcement
     open_data:
@@ -35,6 +36,8 @@ en:
             body: Body
         pages:
           edit:
+            add_attachments: Add attachments
+            edit_attachments: Edit attachments
             save: Update
             title: Edit page
           update:

--- a/decidim-pages/config/locales/en.yml
+++ b/decidim-pages/config/locales/en.yml
@@ -15,7 +15,6 @@ en:
         settings:
           global:
             announcement: Announcement
-            attachments_allowed: Allow attachments
           step:
             announcement: Announcement
     open_data:

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -39,7 +39,6 @@ Decidim.register_component(:pages) do |component|
 
   component.settings(:global) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
-    settings.attribute :attachments_allowed, type: :boolean, default: false
   end
 
   component.settings(:step) do |settings|

--- a/decidim-pages/lib/decidim/pages/component.rb
+++ b/decidim-pages/lib/decidim/pages/component.rb
@@ -39,6 +39,7 @@ Decidim.register_component(:pages) do |component|
 
   component.settings(:global) do |settings|
     settings.attribute :announcement, type: :text, translated: true, editor: true
+    settings.attribute :attachments_allowed, type: :boolean, default: false
   end
 
   component.settings(:step) do |settings|

--- a/decidim-pages/lib/decidim/pages/test/factories.rb
+++ b/decidim-pages/lib/decidim/pages/test/factories.rb
@@ -19,6 +19,10 @@ FactoryBot.define do
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     component { build(:component, manifest_name: "pages") }
 
+    transient do
+      skip_injection { false }
+    end
+
     trait :with_photo do
       after :create do |page, evaluator|
         page.attachments << create(:attachment, :with_image, attached_to: page, skip_injection: evaluator.skip_injection)

--- a/decidim-pages/lib/decidim/pages/test/factories.rb
+++ b/decidim-pages/lib/decidim/pages/test/factories.rb
@@ -5,10 +5,30 @@ FactoryBot.define do
     name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :pages).i18n_name }
     manifest_name { :pages }
     participatory_space { create(:participatory_process, :with_steps, organization:) }
+
+    trait :with_attachments_allowed do
+      settings do
+        {
+          attachments_allowed: true
+        }
+      end
+    end
   end
 
   factory :page, class: "Decidim::Pages::Page" do
     body { Decidim::Faker::Localized.wrapped("<p>", "</p>") { generate_localized_title } }
     component { build(:component, manifest_name: "pages") }
+
+    trait :with_photo do
+      after :create do |page, evaluator|
+        page.attachments << create(:attachment, :with_image, attached_to: page, skip_injection: evaluator.skip_injection)
+      end
+    end
+
+    trait :with_document do
+      after :create do |page, evaluator|
+        page.attachments << create(:attachment, :with_pdf, attached_to: page, skip_injection: evaluator.skip_injection)
+      end
+    end
   end
 end

--- a/decidim-pages/lib/decidim/pages/test/factories.rb
+++ b/decidim-pages/lib/decidim/pages/test/factories.rb
@@ -5,14 +5,6 @@ FactoryBot.define do
     name { Decidim::Components::Namer.new(participatory_space.organization.available_locales, :pages).i18n_name }
     manifest_name { :pages }
     participatory_space { create(:participatory_process, :with_steps, organization:) }
-
-    trait :with_attachments_allowed do
-      settings do
-        {
-          attachments_allowed: true
-        }
-      end
-    end
   end
 
   factory :page, class: "Decidim::Pages::Page" do

--- a/decidim-pages/spec/commands/copy_page_spec.rb
+++ b/decidim-pages/spec/commands/copy_page_spec.rb
@@ -42,6 +42,18 @@ module Decidim
           end
 
           context "when the page has attachments" do
+            before do
+              # We do not optimize the eager loading here, as these associations are loaded by
+              # .with_attached_file and .includes(:attachment_collection) and used internally
+              # by ActiveStorage callbacks or the machine_translation callback, which Bullet does not track.
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "Decidim::Attachment", association: :file_attachment
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :variant_records
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :preview_image_attachment
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :record
+              Bullet.add_safelist type: :unused_eager_loading, class_name: "Decidim::Attachment", association: :attachment_collection
+            end
+
             let!(:document) { create(:attachment, :with_pdf, attached_to: page) }
             let!(:photo) { create(:attachment, :with_image, attached_to: page) }
 

--- a/decidim-pages/spec/commands/copy_page_spec.rb
+++ b/decidim-pages/spec/commands/copy_page_spec.rb
@@ -40,6 +40,22 @@ module Decidim
               command.call
             end.to change(Page, :count).by(1)
           end
+
+          context "when the page has attachments" do
+            let!(:document) { create(:attachment, :with_pdf, attached_to: page) }
+            let!(:photo) { create(:attachment, :with_image, attached_to: page) }
+
+            it "copies attachments to the new page" do
+              expect do
+                command.call
+              end.to change(Decidim::Attachment, :count).by(2)
+
+              new_page = Page.last
+              expect(new_page.attachments.count).to eq(2)
+              expect(new_page.documents.count).to eq(1)
+              expect(new_page.photos.count).to eq(1)
+            end
+          end
         end
       end
     end

--- a/decidim-pages/spec/commands/update_page_spec.rb
+++ b/decidim-pages/spec/commands/update_page_spec.rb
@@ -65,6 +65,17 @@ module Decidim
         end
 
         describe "with attachments" do
+          before do
+            # We do not optimize the eager loading here, as these associations are loaded by
+            # .with_attached_file and used internally by ActiveStorage callbacks during destroy,
+            # which Bullet does not track.
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "Decidim::Attachment", association: :file_attachment
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :record
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Attachment", association: :blob
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :variant_records
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :preview_image_attachment
+          end
+
           let!(:existing_attachment) { create(:attachment, :with_pdf, attached_to: page) }
           let(:form_params) do
             {

--- a/decidim-pages/spec/commands/update_page_spec.rb
+++ b/decidim-pages/spec/commands/update_page_spec.rb
@@ -46,6 +46,9 @@ module Decidim
             expect { command.call }.to broadcast(:ok)
           end
 
+          it_behaves_like "fires an ActiveSupport::Notification event", "decidim.pages.admin.update_page:before"
+          it_behaves_like "fires an ActiveSupport::Notification event", "decidim.pages.admin.update_page:after"
+
           it "creates a new page with the same name as the component" do
             expect(page).to receive(:update!)
             command.call

--- a/decidim-pages/spec/commands/update_page_spec.rb
+++ b/decidim-pages/spec/commands/update_page_spec.rb
@@ -63,6 +63,35 @@ module Decidim
             expect(action_log.version.event).to eq "update"
           end
         end
+
+        describe "with attachments" do
+          let!(:existing_attachment) { create(:attachment, :with_pdf, attached_to: page) }
+          let(:form_params) do
+            {
+              "body" => { "en" => "My new body" },
+              "attachments" => [existing_attachment.id.to_s]
+            }
+          end
+
+          it "keeps existing attachments" do
+            command.call
+            expect(page.reload.attachments).to include(existing_attachment)
+          end
+
+          context "when removing attachments" do
+            let(:form_params) do
+              {
+                "body" => { "en" => "My new body" },
+                "attachments" => []
+              }
+            end
+
+            it "removes attachments not in the list" do
+              command.call
+              expect(page.reload.attachments).not_to include(existing_attachment)
+            end
+          end
+        end
       end
     end
   end

--- a/decidim-pages/spec/forms/page_form_spec.rb
+++ b/decidim-pages/spec/forms/page_form_spec.rb
@@ -36,6 +36,14 @@ module Decidim
         context "when everything is OK" do
           it { is_expected.to be_valid }
         end
+
+        describe "attachment attributes" do
+          it "includes attachment attributes" do
+            expect(subject).to respond_to(:attachment)
+            expect(subject).to respond_to(:attachments)
+            expect(subject).to respond_to(:add_attachments)
+          end
+        end
       end
     end
   end

--- a/decidim-pages/spec/lib/decidim/pages/component_spec.rb
+++ b/decidim-pages/spec/lib/decidim/pages/component_spec.rb
@@ -19,6 +19,14 @@ describe "Pages component" do # rubocop:disable RSpec/DescribeClass
     it "copies the page" do
       expect { subject }.to change { Decidim::Pages::Page.where(body: original_page.body).count }.by(1)
     end
+
+    context "when the page has attachments" do
+      let!(:document) { create(:attachment, :with_pdf, attached_to: original_page) }
+
+      it "copies the page with attachments" do
+        expect { subject }.to change(Decidim::Attachment, :count).by(1)
+      end
+    end
   end
 
   context "with assembly" do

--- a/decidim-pages/spec/models/page_spec.rb
+++ b/decidim-pages/spec/models/page_spec.rb
@@ -44,6 +44,15 @@ module Decidim
         end
 
         context "when page has attachments" do
+          before do
+            # We do not optimize the eager loading here, as these associations are loaded by
+            # .with_attached_file and .includes(:attachment_collection) and used internally
+            # by ActiveStorage callbacks or the machine_translation callback, which Bullet does not track.
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :variant_records
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "ActiveStorage::Blob", association: :preview_image_attachment
+            Bullet.add_safelist type: :unused_eager_loading, class_name: "Decidim::Attachment", association: :attachment_collection
+          end
+
           let!(:photo) { create(:attachment, :with_image, attached_to: page) }
           let!(:document) { create(:attachment, :with_pdf, attached_to: page) }
 

--- a/decidim-pages/spec/models/page_spec.rb
+++ b/decidim-pages/spec/models/page_spec.rb
@@ -31,6 +31,33 @@ module Decidim
       it "has an associated component" do
         expect(page.component).to be_a(Decidim::Component)
       end
+
+      describe "attachments" do
+        it "has attachments association" do
+          expect(page).to respond_to(:attachments)
+          expect(page).to respond_to(:photos)
+          expect(page).to respond_to(:documents)
+        end
+
+        it "has admin attachment context" do
+          expect(page.attachment_context).to eq(:admin)
+        end
+
+        context "when page has attachments" do
+          let!(:photo) { create(:attachment, :with_image, attached_to: page) }
+          let!(:document) { create(:attachment, :with_pdf, attached_to: page) }
+
+          it "returns photos" do
+            expect(page.photos).to include(photo)
+            expect(page.photos).not_to include(document)
+          end
+
+          it "returns documents" do
+            expect(page.documents).to include(document)
+            expect(page.documents).not_to include(photo)
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-pages/spec/system/admin_spec.rb
+++ b/decidim-pages/spec/system/admin_spec.rb
@@ -51,7 +51,7 @@ describe "Edit a page" do
   end
 
   describe "attachments" do
-    let(:component) { create(:page_component, :with_attachments_allowed, participatory_space: participatory_process) }
+    let(:component) { create(:page_component, participatory_space: participatory_process) }
 
     before do
       create(:page, component:, body:)

--- a/decidim-pages/spec/system/admin_spec.rb
+++ b/decidim-pages/spec/system/admin_spec.rb
@@ -49,4 +49,19 @@ describe "Edit a page" do
 
     it_behaves_like "manage announcements"
   end
+
+  describe "attachments" do
+    let(:component) { create(:page_component, :with_attachments_allowed, participatory_space: participatory_process) }
+
+    before do
+      create(:page, component:, body:)
+      visit_component_admin
+    end
+
+    it "shows the attachment upload field" do
+      within "form.edit_page" do
+        expect(page).to have_text("Add attachments")
+      end
+    end
+  end
 end

--- a/decidim-pages/spec/system/page_show_spec.rb
+++ b/decidim-pages/spec/system/page_show_spec.rb
@@ -93,5 +93,19 @@ describe "Show a page" do
         end
       end
     end
+
+    context "when the page has attachments" do
+      let!(:document) { create(:attachment, :with_pdf, attached_to: page_component) }
+      let!(:photo) { create(:attachment, :with_image, attached_to: page_component) }
+
+      before do
+        visit_component
+      end
+
+      it "displays the attachments" do
+        expect(page).to have_css("[data-controls='panel-images']")
+        expect(page).to have_css("[data-controls='panel-documents']")
+      end
+    end
   end
 end

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals/_form.html.erb
@@ -43,7 +43,7 @@
                               button_edit_label: t("decidim.proposals.proposals.edit.edit_attachments"),
                               button_class: "button button__sm button__transparent-secondary mt-2 md:w-auto w-full",
                               help_i18n_scope: "decidim.forms.file_help.file",
-                              help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit") %>
+                              help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
         </div>
       <% end %>
     </div>

--- a/decidim-proposals/app/views/decidim/proposals/admin/proposals_merges/_form.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/admin/proposals_merges/_form.html.erb
@@ -40,7 +40,7 @@
                               button_edit_label: t("decidim.proposals.proposals.edit.edit_attachments"),
                               button_class: "button button__lg button__transparent-secondary w-full",
                               help_i18n_scope: "decidim.forms.file_help.file",
-                              help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit") %>
+                              help_text: t("decidim.admin.shared.attachments.attachment_legend") %>
         </div>
       <% end %>
     </div>

--- a/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/_edit_form_fields.html.erb
@@ -30,6 +30,6 @@
                       button_edit_label: t("decidim.proposals.proposals.edit.edit_attachments"),
                       button_class: "button button__lg button__transparent-secondary w-full",
                       help_i18n_scope: "decidim.forms.file_help.file",
-                      help_text: t("attachment_legend", scope: "decidim.proposals.proposals.edit"),
+                      help_text: t("decidim.admin.shared.attachments.attachment_legend"),
                       paragraph: true %>
 <% end %>

--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -816,7 +816,6 @@ en:
           instructions: You can move the point on the map.
         edit:
           add_attachments: Add attachments
-          attachment_legend: Add a document or an image
           back: Back
           edit_attachments: Edit attachments
           send: Send


### PR DESCRIPTION
#### :tophat: What? Why?

We have this long standing issue for implementing attachments in Pages. This PR implements it.

~~One doubt that I had is that if we should implement the "Allow attachments" checkbox for this, as it is 100% an admin feature, but for being consistent with the rest of components, I'd prefer to just copy this pattern.~~ We don't have the "Allow attachments" checkbox in this case, as it doesn't make sense: this only should be available on components that can be user generated, such as Debates, Meetings, Proposals, Blogs. On this case as the Pages can't be user generated we don't need it. 

#### :pushpin: Related Issues

- Fixes https://github.com/decidim/decidim/issues/14663

#### Testing

1. Restart the server 
2. Go to a pages component in the admin 
4. Edit the page
5. See that you have the "Add attachments" section 
6. Create/Edit/Delete attachments
7. See the page in the public view (aka Preview)
8. See that you have the Attachments there 

For the "CopyPage" command, you need to duplicate a Space:

1. On the same Space that you've worked with these attachments in the Page, go to the Spaces lists  (for instance, Processes) 
2. Click in the Meatball menu, click in the Duplicate option
3. Fill the form, click in the "Duplicate components" checkbox
4. See that the Process duplicated has a Page component with this attachment 


### :camera: Screenshots

<img width="1593" height="1344" alt="image" src="https://github.com/user-attachments/assets/9ed08f6b-ee84-4762-891a-e4f7c61dbea5" />
<img width="1378" height="1071" alt="image" src="https://github.com/user-attachments/assets/78e253cc-01bc-4687-90a4-074cde8a6335" />

#### Copy Page

<img width="1532" height="609" alt="image" src="https://github.com/user-attachments/assets/b4c9d8fe-535e-4595-9e05-2209b2cf3de7" />
<img width="1600" height="1026" alt="image" src="https://github.com/user-attachments/assets/3e731866-11a0-4af8-8915-ab76ae3bea4b" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page attachments support via a new per-component setting, including multi-attachment upload in the admin editor and attachments display on public page views.
  * Copying a page now duplicates associated attachments in addition to page content.
* **Bug Fixes**
  * Admin page updates now better manage attachment reattachment and selection: existing attachments are preserved when appropriate, and removed when no longer selected; invalid attachment data is handled safely.
  * Attachment-copy errors for missing/unavailable files no longer break the full copy operation.
* **Chores**
  * Added/updated attachment UI labels and settings (including English locale strings).
* **Tests**
  * Expanded coverage for attachment behavior in commands, forms, models, and system flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->