### PR TITLE
Handle password mismatch validation on system admin user form

### DIFF
--- a/decidim-system/app/commands/decidim/system/update_admin.rb
+++ b/decidim-system/app/commands/decidim/system/update_admin.rb
@@ -21,6 +21,7 @@ module Decidim
       # Returns nothing.
       def call
         return broadcast(:invalid) if form.invalid?
+        return broadcast(:password_mismatch) if form.password != form.password_confirmation
 
         update_admin
         broadcast(:ok)

--- a/decidim-system/app/controllers/decidim/system/admins_controller.rb
+++ b/decidim-system/app/controllers/decidim/system/admins_controller.rb
@@ -44,6 +44,11 @@ module Decidim
             redirect_to admins_path
           end
 
+          on(:password_mismatch) do
+            flash.now[:alert] = I18n.t("errors.decidim/user.password_confirmation", scope: "decidim.forms")
+            render :edit, status: :unprocessable_content
+          end
+
           on(:invalid) do
             flash.now[:alert] = I18n.t("admins.update.error", scope: "decidim.system")
             render :edit, status: :unprocessable_content

--- a/decidim-system/spec/system/manage_admins_spec.rb
+++ b/decidim-system/spec/system/manage_admins_spec.rb
@@ -86,6 +86,23 @@ describe "Manage admins" do
         expect(page).to have_css(".form-error.is-visible", text: "is too common")
       end
     end
+
+    context "when password and password confirmation missmatch" do
+      it "gives an error" do
+        within "tr", text: admin.email do
+          click_on "Edit"
+        end
+
+        within ".edit_admin" do
+          fill_in :admin_password, with: "decidim123456789"
+          fill_in :admin_password_confirmation, with: "123456789decidim"
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_callout("Password confirmation must match the password")
+      end
+    end
   end
 
   it "deletes an admin" do


### PR DESCRIPTION
#### :tophat: What? Why?
When a system admin updates a user and provides different values for the password and password confirmation fields, the application crashes instead of showing a validation error. To fix this issue, I have:
- Added a `:password_mismatch` broadcast when the password and password confirmation do not match.
- Displayed a flash alert informing the user that the password confirmation is invalid.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/15792

#### Testing
1. Access the system dashboard.
2. Edit any admin.
3. Insert 2 different passwords in the "Password" and "Password confirmation" fields.
4. See the flash message displayed and that no other error is displayed.

<img width="1903" height="863" alt="image" src="https://github.com/user-attachments/assets/a263640f-a16c-4e50-9e3a-ee5574c8d3ca" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit handling for password confirmation mismatches when updating an admin account.
  * If the password and confirmation differ, the app now displays the translated password confirmation error and re-renders the edit form with an “unprocessable” status, preventing the update.
  * Extended system tests to cover this specific mismatch scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->