### PR TITLE
Transfer onboarding data to already existing ephemeral user

### DIFF
--- a/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/authorizations_controller.rb
@@ -78,6 +78,7 @@ module Decidim
           end
 
           on(:transfer_user) do |authorized_user|
+            transfer_onboarding_action(current_user, authorized_user)
             authorized_user.update(last_sign_in_at: Time.current, deleted_at: nil)
             sign_out(current_user)
             sign_in(authorized_user)
@@ -185,6 +186,19 @@ module Decidim
       end
 
       private
+
+      # Preserves the pending onboarding action of the transferring session on
+      # the user that takes over it, so the onboarding flow resumes the action
+      # the visitor was trying to complete (e.g. voting a budget) instead of the
+      # transferred user's stale action (e.g. a survey already answered).
+      def transfer_onboarding_action(from_user, to_user)
+        pending_action = from_user.extended_data[Decidim::OnboardingManager::DATA_KEY]
+        return if pending_action.blank?
+
+        to_user.update!(
+          extended_data: to_user.extended_data.merge(Decidim::OnboardingManager::DATA_KEY => pending_action)
+        )
+      end
 
       def authorization
         @authorization ||= Decidim::Authorization.find_by(

--- a/decidim-verifications/spec/controllers/decidim/authorizations_controller_spec.rb
+++ b/decidim-verifications/spec/controllers/decidim/authorizations_controller_spec.rb
@@ -108,6 +108,46 @@ module Decidim::Verifications
             end
           end
         end
+
+        context "when both the current user and the duplicate user are ephemeral" do
+          let(:handler_name) { "ephemeral_dummy_authorization_handler" }
+          # Non-parseable model values keep OnboardingManager#valid? false so the
+          # ephemeral session checker does not interfere; the test only cares that
+          # the pending action data is carried over on transfer.
+          let(:pending_action) { { "action" => "vote", "model" => "budget" } }
+          let(:stale_action) { { "action" => "answer", "model" => "survey" } }
+          let(:user) do
+            create(:user, :ephemeral, :confirmed, extended_data: { "ephemeral" => true, Decidim::OnboardingManager::DATA_KEY => pending_action })
+          end
+          let!(:other_user) do
+            create(:user, :ephemeral, :confirmed, organization: user.organization, extended_data: { "ephemeral" => true, Decidim::OnboardingManager::DATA_KEY => stale_action })
+          end
+          let!(:duplicate_authorization) do
+            create(:authorization, :granted, user: other_user, unique_id: document_number, name: handler_name)
+          end
+
+          it "transfers the session and redirects to the onboarding pending page" do
+            expect do
+              post :create, params: {
+                handler: handler_name,
+                authorization_handler: handler_params
+              }
+            end.not_to change(Decidim::Authorization, :count)
+
+            expect(response).to redirect_to(onboarding_pending_authorizations_path)
+          end
+
+          it "carries the current session's pending onboarding action onto the transferred user" do
+            post :create, params: {
+              handler: handler_name,
+              authorization_handler: handler_params
+            }
+
+            # The transferred user keeps the action the current session was trying
+            # to complete instead of its own stale action.
+            expect(other_user.reload.extended_data[Decidim::OnboardingManager::DATA_KEY]).to eq(pending_action)
+          end
+        end
       end
 
       context "when the handler is not valid" do


### PR DESCRIPTION
#### :tophat: What? Why?

Fixes a [bug](https://github.com/decidim/decidim/issues/17278) in the **ephemeral user session transfer**: when the same ephemeral authorization workflow is used as the permission on two different components (e.g. answering a **Survey** and voting in a **Budgets** component), an ephemeral user who has already completed one action is redirected back to that *old* action when trying to perform the second and can never reach the second component.

When an ephemeral user verifies with credentials whose `unique_id` already belongs to another ephemeral user, `Decidim::Verifications::AuthorizeUser` broadcasts `:transfer_user` and the session is transferred to that pre-existing user (introduced in decidim/decidim#13981). The controller's `on(:transfer_user)` handler signed in the pre-existing user **without carrying over the current session's pending onboarding action**, so the transferred user's own stale `extended_data["onboarding"]` won, and `onboarding_pending` redirected the visitor to the wrong resource.

This PR copies the pending onboarding action of the current session onto the transferred user before signing them in, so the onboarding flow resumes the action the visitor was actually trying to complete. Reusing the ephemeral identity per `unique_id` (to prevent double voting) is preserved.


#### :pushpin: Related Issues

- Related to decidim/decidim#13981 (which introduced the ephemeral session transfer)
- Fixes decidim/decidim#17278

#### Testing

- Added a spec context in `decidim-verifications/spec/controllers/decidim/authorizations_controller_spec.rb` covering the case where both the current user and the duplicate user are ephemeral:
  - the session is transferred and redirected to the onboarding pending page;
  - the current session's pending onboarding action is carried onto the transferred user.

To reproduce manually follow the steps described in the issue.

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Preserved pending onboarding progress when transferring verification to a newly authorized account.
* Redirected users to the onboarding pending page after a duplicate authorization transfer.
* Ensured transferred accounts use the current session’s pending onboarding action instead of outdated information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->