### PR TITLE
Update supported versions in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,9 +12,9 @@ include the latest design and features.
 
 | Version       | Supported          |
 |---------------|--------------------|
+| 0.32.x        | :white_check_mark: |
 | 0.31.x        | :white_check_mark: |
-| 0.30.x        | :white_check_mark: |
-| \<= 0.29.x    | :x:                |
+| \<= 0.30.x    | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/docs/modules/install/pages/manual.adoc
+++ b/docs/modules/install/pages/manual.adoc
@@ -4,7 +4,7 @@ In order to develop on decidim, you will need:
 
 * *Git* 2.34+
 * *PostgreSQL* 17.4+
-* *Ruby* 3.3.4
+* *Ruby* 3.4.7
 * *NodeJS* 22.14.x
 * *Npm* 10.9.x
 * *ImageMagick*
@@ -34,8 +34,8 @@ echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-rbenv install 3.3.4
-rbenv global 3.3.4
+rbenv install 3.4.7
+rbenv global 3.4.7
 ----
 
 == 2. Installing PostgreSQL

--- a/docs/modules/install/partials/version_matrix.adoc
+++ b/docs/modules/install/partials/version_matrix.adoc
@@ -4,10 +4,10 @@
 
 |develop | 3.4.7 | 22.14.x | Unreleased
 
+|v0.32 | 3.4.7 | 22.14.x | Bug fixes and security updates
+
 |v0.31 | 3.3.4 | 22.14.x | Bug fixes and security updates
 
-|v0.30 | 3.3.4 | 18.17.x | Bug fixes and security updates
-
-|v0.29 | 3.2.2 | 18.17.x | Not maintained
+|v0.30 | 3.2.2 | 18.17.x | Not maintained
 
 |===


### PR DESCRIPTION
#### :tophat: What? Why?
Updates our security policy to match the supported versions we maintain, due to the release of v32.0

#### :pushpin: Related Issues
- Related to #17238 

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated supported-version information to include version 0.32.
  * Clarified that version 0.30 is no longer maintained.
  * Updated Ruby compatibility details for versions 0.30–0.32.
  * Removed the outdated version 0.29 entry from the compatibility matrix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->