### PR TITLE
Remove attachments fields from component serializers

### DIFF
--- a/decidim-meetings/lib/decidim/meetings/meeting_serializer.rb
+++ b/decidim-meetings/lib/decidim/meetings/meeting_serializer.rb
@@ -31,7 +31,6 @@ module Decidim
           address: resource.address,
           location: include_location? ? resource.location : nil,
           reference: resource.reference,
-          attachments: resource.attachments.size,
           url:,
           related_proposals:,
           related_results:,

--- a/decidim-meetings/spec/lib/decidim/meetings/meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/meeting_serializer_spec.rb
@@ -91,10 +91,6 @@ module Decidim
           expect(serialized).to include(reference: meeting.reference)
         end
 
-        it "serializes the amount of attachments" do
-          expect(serialized).to include(attachments: meeting.attachments.count)
-        end
-
         it "serializes related proposals" do
           expect(serialized[:related_proposals].length).to eq(2)
           expect(serialized[:related_proposals].first).to match(%r{http.*/proposals})

--- a/decidim-meetings/spec/serializers/decidim/meetings/download_your_data_meeting_serializer_spec.rb
+++ b/decidim-meetings/spec/serializers/decidim/meetings/download_your_data_meeting_serializer_spec.rb
@@ -91,10 +91,6 @@ module Decidim
           expect(serialized).to include(reference: meeting.reference)
         end
 
-        it "serializes the amount of attachments" do
-          expect(serialized).to include(attachments: meeting.attachments.count)
-        end
-
         it "serializes related proposals" do
           expect(serialized[:related_proposals].length).to eq(2)
           expect(serialized[:related_proposals].first).to match(%r{http.*/proposals})

--- a/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
+++ b/decidim-proposals/lib/decidim/proposals/proposal_serializer.rb
@@ -45,7 +45,6 @@ module Decidim
             user_likes:
           },
           comments: proposal.comments_count,
-          attachments: proposal.attachments.size,
           follows_count: proposal.follows_count,
           published_at: proposal.published_at,
           url:,

--- a/decidim-proposals/spec/lib/decidim/proposals/download_your_data_proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/download_your_data_proposal_serializer_spec.rb
@@ -127,10 +127,6 @@ module Decidim
           expect(serialized).to include(withdrawn_at: proposal.withdrawn_at)
         end
 
-        it "serializes the amount of attachments" do
-          expect(serialized).to include(attachments: proposal.attachments.count)
-        end
-
         it "serializes the state at which the proposal was published at" do
           expect(serialized).to include(state_published_at: proposal.state_published_at)
         end

--- a/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/proposal_serializer_spec.rb
@@ -204,10 +204,6 @@ module Decidim
           expect(serialized).to include(withdrawn_at: proposal.withdrawn_at)
         end
 
-        it "serializes the amount of attachments" do
-          expect(serialized).to include(attachments: proposal.attachments.count)
-        end
-
         it "serializes the state at which the proposal was published at" do
           expect(serialized).to include(state_published_at: proposal.state_published_at)
         end


### PR DESCRIPTION
#### :tophat: What? Why?

On #17273 @alecslupu mentioned that there are some inconsistencies with the components serializers.

This PR fixes these inconsistencies by dropping the attachments size field, as we don't see much value on having yet another column in the CSV. 

The alternative would be to add this in all the components, but we discussed about this on the last @decidim/product meeting and we preferred to just drop it. 

#### :pushpin: Related Issues
 
- Fixes #17273 

#### Testing

These fields shouldn't be on Proposals, Meetings, or other Components
Mind that in Spaces serializers (Processes, Assemblies, etc) it is actually used for the Import feature, so it should be there

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated meeting and proposal data exports to no longer include attachment counts in the exported payload.
  * Other exported meeting and proposal details remain unchanged.

* **Tests**
  * Adjusted serialization tests to remove assertions for attachment counts in the exported data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->