### PR TITLE
Fix inverted survey response pagination

### DIFF
--- a/decidim-surveys/app/views/decidim/surveys/admin/responses/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/responses/show.html.erb
@@ -5,8 +5,8 @@
     <h1 class="item_show__header-title">
       <%= t(".title", number: current_idx) %>
 
+      <%= link_to t("actions.previous", scope: "decidim.forms.admin.questionnaires.responses").html_safe, prev_url, rel: "prev", class: "button button__sm button__secondary prev" unless first? %>
       <%= link_to t("actions.next", scope: "decidim.forms.admin.questionnaires.responses").html_safe, next_url, rel: "next", class: "button button__sm button__secondary next" unless last? %>
-     <%= link_to t("actions.previous", scope: "decidim.forms.admin.questionnaires.responses").html_safe, prev_url, rel: "prev", class: "button button__sm button__secondary prev" unless first? %>
       <%= link_to t("actions.export", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_export_response_url(@participant.session_token), class: "button button__sm button__secondary export" %>
       <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_participants_url, class: "button button__sm button__secondary back" %>
     </h1>

--- a/decidim-surveys/app/views/decidim/surveys/admin/responses/show.html.erb
+++ b/decidim-surveys/app/views/decidim/surveys/admin/responses/show.html.erb
@@ -5,10 +5,10 @@
     <h1 class="item_show__header-title">
       <%= t(".title", number: current_idx) %>
 
-      <%= link_to t("actions.previous", scope: "decidim.forms.admin.questionnaires.responses").html_safe, prev_url, rel: "prev", class: "button button__sm button__secondary prev" unless first? %>
-      <%= link_to t("actions.next", scope: "decidim.forms.admin.questionnaires.responses").html_safe, next_url, rel: "next", class: "button button__sm button__secondary next" unless last? %>
-      <%= link_to t("actions.export", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_export_response_url(@participant.session_token), class: "button button__sm button__secondary export" %>
-      <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_participants_url, class: "button button__sm button__secondary back" %>
+      <%= link_to t("actions.previous", scope: "decidim.forms.admin.questionnaires.responses").html_safe, prev_url, rel: "prev", class: "button button__sm button__transparent-secondary prev" unless first? %>
+      <%= link_to t("actions.next", scope: "decidim.forms.admin.questionnaires.responses").html_safe, next_url, rel: "next", class: "button button__sm button__transparent-secondary next" unless last? %>
+      <%= link_to t("actions.export", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_export_response_url(@participant.session_token), class: "button button__sm button__transparent-secondary export" %>
+      <%= link_to t("actions.back", scope: "decidim.forms.admin.questionnaires.responses"), questionnaire_participants_url, class: "button button__sm button__transparent-secondary back" %>
     </h1>
   </div>
   <div class="card-section">


### PR DESCRIPTION
#### :tophat: What? Why?
Viewing and navigating through survey responses uses confusing logic as after the first question the "Next" button is always first. The "Prev" button after the first response should always be next and the following responses to create correctly positioned pagination.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/17281

#### Testing
1. Login 
2. Head to a space with surveys component configured
3. Find a open or closed survey with responses. Create or generate these (more than 2) with the console if needed.
4. Click on the actions menu on index of that survey "Responses"
5. Click next on the first response 
6. See the pagination buttons correctly positioned

### :camera: Screenshots
BEFORE:
<img width="391" height="180" alt="image" src="https://github.com/user-attachments/assets/26fb979c-311e-4479-8f02-612573130f3a" />

AFTER:
<img width="575" height="265" alt="image" src="https://github.com/user-attachments/assets/a0403e23-b132-4da5-987c-86b23f799c58" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Reordered the Previous and Next navigation controls in survey response details for a more natural browsing flow.
  * Updated the visual styling for Previous/Next (and related header actions) to use the transparent-secondary button appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->