### PR TITLE
Make the proposal official when importing

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
@@ -26,7 +26,7 @@ module Decidim
         #
         # Returns a proposal
         def produce
-          resource.add_coauthor(context[:current_user])
+          resource.add_coauthor(component.organization)
 
           resource
         end

--- a/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
+++ b/decidim-proposals/lib/decidim/proposals/import/proposal_creator.rb
@@ -101,8 +101,7 @@ module Decidim
           Decidim::EventsManager.publish(
             event: "decidim.events.proposals.proposal_published",
             event_class: Decidim::Proposals::PublishProposalEvent,
-            resource: proposal,
-            followers: coauthors_followers(proposal)
+            resource: proposal
           )
         end
 
@@ -111,15 +110,11 @@ module Decidim
             event: "decidim.events.proposals.proposal_published",
             event_class: Decidim::Proposals::PublishProposalEvent,
             resource: proposal,
-            followers: proposal.participatory_space.followers - coauthors_followers(proposal),
+            followers: proposal.participatory_space.followers,
             extra: {
               participatory_space: true
             }
           )
-        end
-
-        def coauthors_followers(proposal)
-          @coauthors_followers ||= proposal.authors.flat_map(&:followers)
         end
       end
     end

--- a/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
+++ b/decidim-proposals/spec/lib/decidim/proposals/import/proposal_creator_spec.rb
@@ -80,17 +80,26 @@ describe Decidim::Proposals::Import::ProposalCreator do
       expect(record.longitude).to eq(data[:longitude])
       expect(record.published_at).to be >= (moment)
     end
+
+    it "sets the organization as author (official proposal)" do
+      record = subject.produce
+
+      expect(record.authors).to contain_exactly(organization)
+      expect(record.official?).to be true
+    end
   end
 
   describe "#finish!" do
     it "saves the proposal" do
       record = subject.produce
       subject.finish!
+
       expect(record.new_record?).to be(false)
     end
 
     it "creates admin log" do
       record = subject.produce
+
       expect { subject.finish! }.to change(Decidim::ActionLog, :count).by(1)
       expect(Decidim::ActionLog.last.user).to eq(user)
       expect(Decidim::ActionLog.last.resource).to eq(record)


### PR DESCRIPTION
#### :tophat: What? Why?

As explained at #17298: 

> As an admin, when I imported proposals from a file. Then, I become the author of the imported proposals. However, my expectation is that the proposals' authorship should be "Official proposal" as I'm creating them from the admin panel.

This PR fixes that by making the proposal Official (as expected) 

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/17298

#### Testing

1. Import proposals from a file 
2. See the authorship of the imported proposals

Example file:

```csv
title/en;body/en;taxonomies/ids
Hello world this is my proposal;This is the body of the proposal;
```

### :camera: Screenshots

#### Before

<img width="1305" height="617" alt="image" src="https://github.com/user-attachments/assets/96b6fb58-ddfa-430a-a60c-5969531357b9" />

#### After

<img width="1227" height="724" alt="image" src="https://github.com/user-attachments/assets/fdff893f-a267-47d5-afd7-4f638df4c1c5" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Imported proposals are now correctly attributed to the importing organization.
  * Imported proposals are marked as official proposals.
  * Proposal notifications now reach all followers of the relevant participatory space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->