### PR TITLE
Add maps controls ('Zoom in/Zoom out') to i18n

### DIFF
--- a/decidim-core/app/packs/src/decidim/map/controller.js
+++ b/decidim-core/app/packs/src/decidim/map/controller.js
@@ -29,7 +29,16 @@ export default class MapController {
   }
 
   load() {
-    this.map = L.map(this.mapId);
+    const zoomControl = L.control.zoom({
+      zoomInTitle: this.config.zoomInText || "Zoom in",
+      zoomOutTitle: this.config.zoomOutText || "Zoom out"
+    });
+
+    this.map = L.map(this.mapId, {
+      zoomControl: false
+    });
+
+    this.map.addControl(zoomControl);
 
     this.map.scrollWheelZoom.disable();
 

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -1212,6 +1212,8 @@ en:
       dynamic:
         screen_reader_explanation: The following element is a map which presents the items on this page as map points. The element can be used with a screen reader but it may be hard to understand.
         skip_button: Skip map
+        zoom_in: Zoom in
+        zoom_out: Zoom out
       static:
         latlng_text: 'latitude: %{latitude}, longitude: %{longitude}'
         map_service_brand: OpenStreetMap

--- a/decidim-core/lib/decidim/map/dynamic_map.rb
+++ b/decidim-core/lib/decidim/map/dynamic_map.rb
@@ -30,7 +30,9 @@ module Decidim
       def builder_options
         {
           marker_color: organization.colors.fetch("primary", "#e02d2d"),
-          tile_layer: tile_layer_configuration
+          tile_layer: tile_layer_configuration,
+          zoom_in_text: I18n.t("zoom_in", scope: "decidim.map.dynamic"),
+          zoom_out_text: I18n.t("zoom_out", scope: "decidim.map.dynamic")
         }
       end
 

--- a/decidim-core/spec/lib/map/dynamic_map_spec.rb
+++ b/decidim-core/spec/lib/map/dynamic_map_spec.rb
@@ -17,7 +17,9 @@ module Decidim
           expect(Decidim::Map::DynamicMap::Builder).to receive(:new).with(
             template,
             { marker_color: "#e02d2d",
-              tile_layer: { url: nil, options: {} } }
+              tile_layer: { url: nil, options: {} },
+              zoom_in_text: "Zoom in",
+              zoom_out_text: "Zoom out" }
           ).and_call_original
 
           builder = subject.create_builder(template, options)
@@ -35,8 +37,23 @@ module Decidim
         it "prepares and returns the correct builder options" do
           expect(utility.builder_options).to eq(
             marker_color: "#e02d2d",
-            tile_layer: { url: nil, options: {} }
+            tile_layer: { url: nil, options: {} },
+            zoom_in_text: "Zoom in",
+            zoom_out_text: "Zoom out"
           )
+        end
+      end
+
+      describe "Builder" do
+        include_context "with dynamic map builder" do
+          subject { utility.create_builder(template, options) }
+        end
+
+        describe "#view_options" do
+          it "includes zoom control translations" do
+            view_opts = subject.send(:view_options)
+            expect(view_opts).to include("zoomInText" => "Zoom in", "zoomOutText" => "Zoom out")
+          end
         end
       end
     end

--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -32,7 +32,9 @@ module Decidim
                 marker_color: "#e02d2d",
                 tile_layer: {
                   api_key: "key1234", foo: "bar", language: "en"
-                }
+                },
+                zoom_in_text: "Zoom in",
+                zoom_out_text: "Zoom out"
               )
             end
 
@@ -51,7 +53,9 @@ module Decidim
                     marker_color: "#e02d2d",
                     tile_layer: {
                       api_key: "key1234", foo: "bar", language: "ca"
-                    }
+                    },
+                    zoom_in_text: "Zoom in",
+                    zoom_out_text: "Zoom out"
                   )
                 end
               end
@@ -64,7 +68,9 @@ module Decidim
                     marker_color: "#e02d2d",
                     tile_layer: {
                       api_key: "key1234", foo: "bar", language: "es"
-                    }
+                    },
+                    zoom_in_text: "Zoom in",
+                    zoom_out_text: "Zoom out"
                   )
                 end
               end
@@ -86,7 +92,9 @@ module Decidim
                     api_key: "appid123secret456",
                     foo: "bar",
                     language: "en"
-                  }
+                  },
+                  zoom_in_text: "Zoom in",
+                  zoom_out_text: "Zoom out"
                 )
               end
             end

--- a/decidim-core/spec/lib/map/provider/dynamic_map/osm_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/osm_spec.rb
@@ -34,7 +34,9 @@ module Decidim
                 tile_layer: {
                   url: "https://tiles.example.org",
                   options: {}
-                }
+                },
+                zoom_in_text: "Zoom in",
+                zoom_out_text: "Zoom out"
               )
             end
 
@@ -55,7 +57,9 @@ module Decidim
                   tile_layer: {
                     url: "https://tiles.example.org",
                     options: { foo: "bar", baz: "foobar" }
-                  }
+                  },
+                  zoom_in_text: "Zoom in",
+                  zoom_out_text: "Zoom out"
                 )
               end
             end
@@ -79,7 +83,9 @@ module Decidim
                   tile_layer: {
                     url: "https://tiles.example.org",
                     options: { api_key: "key1234", foo: "bar", baz: "foobar" }
-                  }
+                  },
+                  zoom_in_text: "Zoom in",
+                  zoom_out_text: "Zoom out"
                 )
               end
             end


### PR DESCRIPTION
#### :tophat: What? Why?

During an accessibility audit in Decidim Barcelona, it was detected that the controls in Leaflet ("Zoom in"/"Zoom out") aren't translated to Catalan (nor other locales). 

<img width="1351" height="892" alt="image" src="https://github.com/user-attachments/assets/dc4ba7cc-364c-4842-9342-e44e47cd74f6" />
 
#### Testing

1. Enable maps 
2. Go to http://localhost:3000/meetings/ 
3. Inspect the map Zoom elements and check the `aria-label` attributes 

### :camera: Screenshots
 
(For testing purposes, I changed this string locally to check that it was being picked correctly)

<img width="1536" height="878" alt="image" src="https://github.com/user-attachments/assets/335b29ee-7669-42b7-aabc-b322f1d57c2e" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Added localized “Zoom in” and “Zoom out” labels for map zoom controls, ensuring consistent UI text across supported locales.
- **Bug Fixes**
  - Updated map zoom controls to use an explicit Leaflet zoom configuration for more predictable behavior.
  - Ensured zoom control label translations are correctly propagated through map builder settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->