### PR TITLE
Convert to a proper table the cookies information

### DIFF
--- a/decidim-core/app/cells/decidim/data_consent/category.erb
+++ b/decidim-core/app/cells/decidim/data_consent/category.erb
@@ -30,39 +30,26 @@
     <p><%= category[:description] %></p>
 
     <% if category[:items].present? %>
-    <div>
-      <div class="cookies__category-panel__tr">
-        <div class="cookies__category-panel__th">
-          <%= t("layouts.decidim.data_consent.details.columns.type") %>
-        </div>
-        <div class="cookies__category-panel__th">
-          <%= t("layouts.decidim.data_consent.details.columns.name") %>
-        </div>
-        <div class="cookies__category-panel__th">
-          <%= t("layouts.decidim.data_consent.details.columns.service") %>
-        </div>
-        <div class="cookies__category-panel__th">
-          <%= t("layouts.decidim.data_consent.details.columns.description") %>
-        </div>
-      </div>
-
-      <% category[:items].each do |item| %>
-        <div class="cookies__category-panel__tr">
-          <div class="cookies__category-panel__td">
-            <%= t("layouts.decidim.data_consent.details.types.#{item[:type]}") %>
-          </div>
-          <div class="cookies__category-panel__td">
-            <%= item[:name] %>
-          </div>
-          <div class="cookies__category-panel__td">
-            <%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.service") %>
-          </div>
-          <div class="cookies__category-panel__td">
-            <%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.description") %>
-          </div>
-        </div>
-      <% end %>
-    </div>
+    <table>
+      <thead>
+        <tr>
+          <th><%= t("layouts.decidim.data_consent.details.columns.type") %></th>
+          <th><%= t("layouts.decidim.data_consent.details.columns.name") %></th>
+          <th><%= t("layouts.decidim.data_consent.details.columns.service") %></th>
+          <th><%= t("layouts.decidim.data_consent.details.columns.description") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% category[:items].each do |item| %>
+          <tr>
+            <td><%= t("layouts.decidim.data_consent.details.types.#{item[:type]}") %></td>
+            <td><%= item[:name] %></td>
+            <td><%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.service") %></td>
+            <td><%= t("layouts.decidim.data_consent.details.items.#{item[:name]}.description") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
     <% end %>
   </div>
 </div>

--- a/decidim-core/app/packs/stylesheets/decidim/_cookies.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_cookies.scss
@@ -65,16 +65,24 @@
     &-panel {
       @apply divide-y divide-gray-3 [&>*]:py-4 [&>p]:text-gray-2;
 
-      &__tr {
-        @apply flex items-center justify-between rounded first-of-type:bg-background-4;
+      table {
+        @apply w-full border-collapse;
       }
 
-      &__th {
-        @apply w-1/4 p-2 bg-background-4 text-gray-2 font-bold text-sm;
+      thead tr {
+        @apply bg-background-4;
       }
 
-      &__td {
+      th {
+        @apply w-1/4 p-2 text-gray-2 font-bold text-sm text-left;
+      }
+
+      td {
         @apply w-1/4 p-2 text-gray-2 text-xs;
+      }
+
+      tbody tr {
+        @apply border-b border-gray-3;
       }
     }
 


### PR DESCRIPTION
#### :tophat: What? Why?
During an accessibility audit in Decidim Barcelona, it was detected that the cookie banner doesn't shown the elements in a real HTML table. 

This PR fixes this problem.  

Related to this, I noticed some inconsistency issues in the modals (for instance, here the title is show in the side). I'll handle that in another PR.

#### Testing

1. Go to the footer
2. Click in
3. Check out the HTML markup before and after this change in this modal. 

### :camera: Screenshots

#### Before

<img width="1433" height="988" alt="image" src="https://github.com/user-attachments/assets/4019bf0c-e6f4-4527-accc-038cdb8e05fd" />

#### After

<img width="1600" height="977" alt="image" src="https://github.com/user-attachments/assets/c30455a2-50fe-44de-a92d-43da6de36995" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved cookie consent category details with semantic HTML tables.
  * Added clear column headings for cookie type, name, service, and description.

* **Style**
  * Refined table layout, spacing, borders, column widths, and header presentation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->