### PR TITLE
Fix the focus guard in the "QR code" modal

### DIFF
--- a/decidim-core/app/cells/decidim/share_widget/qr_code_modal.erb
+++ b/decidim-core/app/cells/decidim/share_widget/qr_code_modal.erb
@@ -2,7 +2,7 @@
   <div data-dialog-container>
     <div data-dialog-title>
       <%= icon "qr-code-line" %>
-      <h2 tabindex="-1"><%= t("decidim.share_widget.qr_code") %></h2>
+      <h2 id="dialog-title-qr-code-dialog" tabindex="-1"><%= t("decidim.share_widget.qr_code") %></h2>
     </div>
     <div class="content">
       <div>

--- a/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.js
+++ b/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.js
@@ -5,14 +5,12 @@ const focusableDisableableNodes = ["BUTTON", "INPUT", "TEXTAREA", "SELECT"];
 export default class FocusGuard {
   constructor(container) {
     this.container = container;
-    this.guardedElement = null;
-    this.triggerElement = null;
+    this.stack = [];
   }
 
   trap(element, trigger) {
     this.enable();
-    this.guardedElement = element;
-    this.triggerElement = trigger;
+    this.stack.push({ element, trigger });
   }
 
   enable() {
@@ -45,14 +43,15 @@ export default class FocusGuard {
   }
 
   disable() {
-    const guards = this.container.querySelectorAll(`:scope > .${focusGuardClass}`);
-    guards.forEach((guard) => guard.remove());
+    const current = this.stack.pop();
 
-    this.guardedElement = null;
+    if (this.stack.length === 0) {
+      const guards = this.container.querySelectorAll(`:scope > .${focusGuardClass}`);
+      guards.forEach((guard) => guard.remove());
+    }
 
-    if (this.triggerElement) {
-      this.triggerElement.focus();
-      this.triggerElement = null;
+    if (current && current.trigger) {
+      current.trigger.focus();
     }
   }
 
@@ -67,12 +66,13 @@ export default class FocusGuard {
   };
 
   handleContainerFocus(guard) {
-    if (!this.guardedElement) {
+    const current = this.stack[this.stack.length - 1];
+    if (!current || !current.element) {
       guard.blur();
       return;
     }
 
-    const visibleNodes = Array.from(this.guardedElement.querySelectorAll("*")).filter((item) => {
+    const visibleNodes = Array.from(current.element.querySelectorAll("*")).filter((item) => {
       return this.isVisible(item);
     });
 

--- a/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.test.js
+++ b/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.test.js
@@ -1,0 +1,134 @@
+import FocusGuard from "src/decidim/refactor/moved/focus_guard"
+
+describe("FocusGuard", () => {
+  let focusGuard;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    focusGuard = new FocusGuard(document.body);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  describe("single dialog", () => {
+    it("creates focus guards on trap", () => {
+      const dialog = document.createElement("div");
+      const trigger = document.createElement("button");
+      document.body.appendChild(dialog);
+      document.body.appendChild(trigger);
+
+      focusGuard.trap(dialog, trigger);
+      const guards = document.body.querySelectorAll(".focusguard");
+      expect(guards.length).toBe(2);
+    });
+
+    it("removes focus guards and returns focus on disable", () => {
+      const dialog = document.createElement("div");
+      const trigger = document.createElement("button");
+      document.body.appendChild(dialog);
+      document.body.appendChild(trigger);
+
+      focusGuard.trap(dialog, trigger);
+      focusGuard.disable();
+
+      const guards = document.body.querySelectorAll(".focusguard");
+      expect(guards.length).toBe(0);
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  describe("nested dialogs", () => {
+    it("keeps guards when inner dialog is disabled", () => {
+      const outerDialog = document.createElement("div");
+      const outerTrigger = document.createElement("button");
+      const innerDialog = document.createElement("div");
+      const innerTrigger = document.createElement("button");
+
+      document.body.appendChild(outerDialog);
+      document.body.appendChild(outerTrigger);
+      document.body.appendChild(innerDialog);
+      document.body.appendChild(innerTrigger);
+
+      focusGuard.trap(outerDialog, outerTrigger);
+      focusGuard.trap(innerDialog, innerTrigger);
+
+      expect(document.body.querySelectorAll(".focusguard").length).toBe(2);
+
+      focusGuard.disable();
+
+      expect(document.body.querySelectorAll(".focusguard").length).toBe(2);
+      expect(document.activeElement).toBe(innerTrigger);
+    });
+
+    it("removes guards when outer dialog is disabled last", () => {
+      const outerDialog = document.createElement("div");
+      const outerTrigger = document.createElement("button");
+      const innerDialog = document.createElement("div");
+      const innerTrigger = document.createElement("button");
+
+      document.body.appendChild(outerDialog);
+      document.body.appendChild(outerTrigger);
+      document.body.appendChild(innerDialog);
+      document.body.appendChild(innerTrigger);
+
+      focusGuard.trap(outerDialog, outerTrigger);
+      focusGuard.trap(innerDialog, innerTrigger);
+
+      focusGuard.disable();
+      focusGuard.disable();
+
+      expect(document.body.querySelectorAll(".focusguard").length).toBe(0);
+      expect(document.activeElement).toBe(outerTrigger);
+    });
+
+    it("cycles focus to the current top dialog when a guard receives focus", () => {
+      jest.spyOn(focusGuard, "isVisible").mockReturnValue(true);
+
+      const outerDialog = document.createElement("div");
+      const outerInput = document.createElement("input");
+      outerDialog.appendChild(outerInput);
+
+      const innerDialog = document.createElement("div");
+      const innerInput = document.createElement("input");
+      innerDialog.appendChild(innerInput);
+
+      document.body.appendChild(outerDialog);
+      document.body.appendChild(innerDialog);
+
+      focusGuard.trap(outerDialog, null);
+      focusGuard.trap(innerDialog, null);
+
+      const endGuard = document.body.querySelector('.focusguard[data-position="end"]');
+      endGuard.focus();
+
+      expect(document.activeElement).toBe(innerInput);
+    });
+
+    it("cycles focus backward to the current top dialog when the start guard receives focus", () => {
+      jest.spyOn(focusGuard, "isVisible").mockReturnValue(true);
+
+      const outerDialog = document.createElement("div");
+      const outerInput = document.createElement("input");
+      outerDialog.appendChild(outerInput);
+
+      const innerDialog = document.createElement("div");
+      const innerInput = document.createElement("input");
+      const innerButton = document.createElement("button");
+      innerDialog.appendChild(innerInput);
+      innerDialog.appendChild(innerButton);
+
+      document.body.appendChild(outerDialog);
+      document.body.appendChild(innerDialog);
+
+      focusGuard.trap(outerDialog, null);
+      focusGuard.trap(innerDialog, null);
+
+      const startGuard = document.body.querySelector('.focusguard[data-position="start"]');
+      startGuard.focus();
+
+      expect(document.activeElement).toBe(innerButton);
+    });
+  });
+});

--- a/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.test.js
+++ b/decidim-core/app/packs/src/decidim/refactor/moved/focus_guard.test.js
@@ -1,7 +1,9 @@
+/* global jest */
+
 import FocusGuard from "src/decidim/refactor/moved/focus_guard"
 
 describe("FocusGuard", () => {
-  let focusGuard;
+  let focusGuard = null;
 
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/decidim-meetings/app/views/decidim/meetings/meetings/_registration_code_modal.html.erb
+++ b/decidim-meetings/app/views/decidim/meetings/meetings/_registration_code_modal.html.erb
@@ -2,7 +2,7 @@
   <div data-dialog-container>
     <div data-dialog-title>
       <%= icon "qr-code-line" %>
-      <h2 class="h4" tabindex="-1"><%= t("registration_and_qr_code", scope: "decidim.meetings.meetings.show") %></h2>
+      <h2 id="dialog-title-registration-qr-code-dialog" class="h4" tabindex="-1"><%= t("registration_and_qr_code", scope: "decidim.meetings.meetings.show") %></h2>
     </div>
     <div class="content">
       <div>


### PR DESCRIPTION
#### :tophat: What? Why?

During an accessibility audit in Decidim Barcelona, it was detected that the focus is lost with the "QR code" modal. This is because the FocusGuard feature doesn't allow having a modal inside another modal and the focus stay in the first modal. 

We also didn't added the title correctly in this modal (and in another similar modal). 

This PR fixes this bug. 

#### Testing

1. Go to a resource with the "Share" button 
2. Click in the "Share" button
3. Click in the "QR code" button
4. Navigate using the `TAB` key
5. (Before) see that the tab stayed in the first (Share) modal 
6. (After) see that the tab works as expected (stays in the last modal - QR code - and when closed it stays in the Share modal) 

### :camera: Screenshots

<img width="1259" height="734" alt="image" src="https://github.com/user-attachments/assets/30a67398-476a-49f4-a2aa-0481847997a9" />
<img width="1242" height="850" alt="image" src="https://github.com/user-attachments/assets/8f03bda2-b2f7-420f-a8bb-fb97b0d860e1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved QR code and registration code modal dialog titles with stable identifiers for clearer, consistent labeling.
- **Bug Fixes**
  - Improved focus trapping and cycling when multiple dialogs are open, including correct behavior for nested dialogs and focus restoration after closing.
- **Tests**
  - Added automated coverage for focus guard behavior across single and nested dialog scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->