### PR TITLE
Fix focus when changing the "Sort by" in comments

### DIFF
--- a/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
+++ b/decidim-comments/app/views/decidim/comments/comments/reload.js.erb
@@ -3,6 +3,10 @@
 
   var $comments = $("#" + rootCommentableId);
   var component = $comments.data("comments");
+
+  // Save the focused element id to restore focus after reload
+  var activeElementId = document.activeElement ? document.activeElement.id : null;
+
   component.unmountComponent();
 
   var commentsHtml = '<%== j(inline_comments_for(commentable, order:).inline).strip %>';
@@ -15,5 +19,13 @@
 
   // Update the comments count
   $(".comments-count", $comments).text(<%== t("decidim.components.comments.title", count: @comments_count).to_json %>);
+
+  // Restore focus to the previously focused element if it still exists
+  if (activeElementId) {
+    var newActiveElement = document.getElementById(activeElementId);
+    if (newActiveElement) {
+      newActiveElement.focus();
+    }
+  }
 
 }());

--- a/decidim-comments/spec/system/order_comments_spec.rb
+++ b/decidim-comments/spec/system/order_comments_spec.rb
@@ -51,6 +51,20 @@ describe "Order comments" do
       expect(page).to have_select("order", selected: "Best rated", wait: 5)
     end
 
+    it "keeps the focus on the sort dropdown after changing the order", :js, :slow do
+      within ".comment-order-by" do
+        page.evaluate_script("document.getElementById('order').focus()")
+        select "Best rated", from: "order"
+      end
+
+      within(".comment-threads", wait: 5) do
+        expect(page).to have_css("div:first-child#comment_#{best_rated_comment.id}", wait: 5)
+      end
+
+      expect(page).to have_select("order", selected: "Best rated", wait: 5)
+      expect(page.evaluate_script("document.activeElement.id")).to eq("order")
+    end
+
     it "user selects \"Most discussed\" as sorting criteria", :js, :slow do
       within ".comment-order-by" do
         select "Most discussed", from: "order"


### PR DESCRIPTION
#### :tophat: What? Why?

During an accessibility audit in Decidim Barcelona, it was detected that when changing the "Sort by" order in a comments thread, the focus is lost (it is going back to the top).

This PR fixes it by keeping the focus there after the loading of comments.

#### Testing

1. Go to a resource with comments
2. Change the order in "Sort by"
3. Press `TAB` key
4. (Before) see that the focus go to the top of the page
5. (After) see that the focus stays in this element (as expected) 

### :camera: Screenshots 

#### Before

https://github.com/user-attachments/assets/264fced4-16d0-4cb1-b071-df8f789202c9

#### After

https://github.com/user-attachments/assets/20d35456-6141-489e-9efb-82611e67fcc0

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved keyboard focus on the comments sorting control when comments are reordered.
  * Improved accessibility by restoring focus after comments refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->