### PR TITLE
Make idempotent the "show password" toggle

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/password_toggler/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/password_toggler/controller.js
@@ -55,6 +55,18 @@ export default class extends Controller {
       hide: icon("eye-off-line")
     }
 
+    const existingWrapper = this.input.closest(".input-group__password");
+    if (existingWrapper) {
+      const existingButton = existingWrapper.querySelector('button[type="button"]');
+      const existingStatusText = existingWrapper.querySelector('span.sr-only[aria-live="polite"]');
+      if (existingButton && existingStatusText) {
+        this.button = existingButton;
+        this.statusText = existingStatusText;
+        this.bindListeners();
+        return;
+      }
+    }
+
     this.init();
   }
 
@@ -81,8 +93,17 @@ export default class extends Controller {
    */
   init() {
     this.createControls();
+    this.bindListeners();
+  }
 
-    // Bind methods to maintain correct context
+  bindListeners() {
+    if (this.button && this.boundToggleVisibility) {
+      this.button.removeEventListener("click", this.boundToggleVisibility);
+    }
+    if (this.form && this.boundHidePassword) {
+      this.form.removeEventListener("submit", this.boundHidePassword);
+    }
+
     this.boundToggleVisibility = this.toggleVisibility.bind(this);
     this.boundHidePassword = this.hidePassword.bind(this);
 

--- a/decidim-core/app/packs/src/decidim/controllers/password_toggler/password_toggler.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/password_toggler/password_toggler.test.js
@@ -22,17 +22,7 @@ describe("PasswordToggler", () => {
     container = document.createElement("div");
     container.innerHTML = `
       <div data-controller="password-toggler" class="flex flex-row items-center gap-x-2" data-show-password="Show secret" data-hide-password="Hide Secret" data-hidden-password="Secret is hidden" data-shown-password="Secret is shown">
-        <div class="input-group__password">
-          <div class="input-group__password">
-            <button type="button" aria-controls="token_162" aria-label="Show password">
-              <svg width="0.75em" height="0.75em" role="img" aria-hidden="true">
-                <title>eye-line</title>
-                <use href="/decidim-packs/media/images/remixicon.symbol-e643e553623ffcd49f94.svg#ri-eye-line"></use>
-              </svg>
-            </button>
-            <input type="password" id="token_162" value="AXXXXXXXX" class="w-full" autocomplete="off">
-          </div>
-        </div>
+        <input type="password" id="token_162" value="AXXXXXXXX" class="w-full" autocomplete="off">
         <div class="basis-1/4">
           <button type="button" class="button button__sm button__text-primary" data-clipboard-copy="#token_162">
             <span>Copy secret</span>
@@ -204,22 +194,23 @@ describe("PasswordToggler", () => {
     });
   });
 
-  describe("integration with existing markup", () => {
-    it("works with existing button structure", () => {
-      const existingButton = passwordElement.querySelector('button[aria-controls="token_162"]');
-      expect(existingButton).toBeTruthy();
+  describe("idempotency", () => {
+    it("does not duplicate controls on reconnect", () => {
+      controller.disconnect();
+      controller.connect();
 
-      controller.init();
+      const wrappers = passwordElement.querySelectorAll(".input-group__password");
+      const buttons = passwordElement.querySelectorAll('button[aria-controls="token_162"]');
 
-      // Should work alongside existing button
-      expect(controller.button).toBeDefined();
-      expect(controller.input.getAttribute("type")).toBe("password");
+      expect(wrappers.length).toBe(1);
+      expect(buttons.length).toBe(1);
     });
+  });
 
+  describe("integration with existing markup", () => {
     it("handles password input with existing value", () => {
       expect(controller.input.value).toBe("AXXXXXXXX");
 
-      controller.init();
       controller.showPassword();
 
       expect(controller.input.getAttribute("type")).toBe("text");

--- a/decidim-system/app/views/decidim/system/shared/_api_users.html.erb
+++ b/decidim-system/app/views/decidim/system/shared/_api_users.html.erb
@@ -22,15 +22,14 @@
         </td>
         <td>
           <% if fresh_token?(api_user) %>
-            <div data-controller="password-toggler" class="flex flex-row items-center gap-x-2">
-              <div class="input-group__password">
-                <input type="password" id="<%= "token_#{api_user.id}" %>" value="<%= @secret_user[:secret] %>" class="w-full" autocomplete="off">
-              </div>
-              <div class="basis-1/4"
-                data-show-password="<%= t "api_user.show_secret", scope: "decidim.system.actions" %>"
-                data-hide-password="<%= t "api_user.hide_secret", scope: "decidim.system.actions" %>"
-                data-hidden-password="<%= t "api_user.hidden_secret", scope: "decidim.system.actions" %>"
-                data-shown-password="<%= t "api_user.shown_secret", scope: "decidim.system.actions" %>">
+            <div data-controller="password-toggler"
+                 class="flex flex-row items-center gap-x-2"
+                 data-show-password="<%= t "api_user.show_secret", scope: "decidim.system.actions" %>"
+                 data-hide-password="<%= t "api_user.hide_secret", scope: "decidim.system.actions" %>"
+                 data-hidden-password="<%= t "api_user.hidden_secret", scope: "decidim.system.actions" %>"
+                 data-shown-password="<%= t "api_user.shown_secret", scope: "decidim.system.actions" %>">
+              <input type="password" id="<%= "token_#{api_user.id}" %>" value="<%= @secret_user[:secret] %>" class="w-full" autocomplete="off">
+              <div class="basis-1/4">
                 <button type="button"
                       class="button button__sm button__text-primary"
                       data-controller="clipboard-copy"

--- a/decidim-system/spec/system/explore_api_credentials_spec.rb
+++ b/decidim-system/spec/system/explore_api_credentials_spec.rb
@@ -137,8 +137,8 @@ describe "Explore API credentials" do
       secret_input = find("input#token_#{masked_user.id}")
       expect(secret_input[:type]).to eq("password")
       expect(secret_input.value).to eq(dummy_token)
-      expect(page).to have_css('button[aria-label="Show password"]', count: 1)
-      find('button[aria-label="Show password"]').click
+      expect(page).to have_css('button[aria-label="Show secret"]', count: 1)
+      find('button[aria-label="Show secret"]').click
       expect(secret_input[:type]).to eq("text")
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

During an accessibility audit in Decidim Barcelona, it was detected that the "Show password" button doesn't behave correctly in the Login modal. 

Basically, it shows two times, and makes it invisible and not working. This is a problem when navigating with the `TAB` key, as you have a "phantom" element that doesn't do anything.

The root cause is that the "Show password" button logic isn't idempotent (i.e. it doesn't have any kind of guard clause to skipping rendering in case it is already shown), and how the login modal works (it is rendered once, then again once the modal goes to the bottom of the document), generates this buggy behavior. 

This PR fixes it by making it idempotent.

#### Testing

1. Open a Private/Incognito session
2. Go to a page with an action for logged in users
3. Click in this action, press `TAB` 3 times
4. (Before) see that you have in an "invisible" element
5. (After) see that you don't have this invisible element anymore (and you're in the "Show password" button)

### :camera: Screenshots

#### Before

https://github.com/user-attachments/assets/f242e7f2-dfab-461c-a65b-9292c3ae0881

#### After

https://github.com/user-attachments/assets/fe8f400e-1096-423b-a46d-d4a65fc7d60a

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented password show/hide controls from duplicating when the page reconnects the controller.
  * Reused existing password input-group markup when present, avoiding repeated wrapper/button creation.
  * Improved “show secret” behavior for API credentials so reveal/hide controls remain consistent.
  * Ensured toggling visibility does not change or clear the entered password/secret value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->