### PR TITLE
Add the `aria-expanded="false"` attribute when loading the Dropdowns

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
@@ -48,7 +48,7 @@ export default class extends Controller {
     }
 
     if (!this.element.hasAttribute("aria-expanded")) {
-      this.element.setAttribute("aria-expanded", "false");
+      this.element.setAttribute("aria-expanded", dropdownOptions.isOpen ? "true" : "false");
     }
 
     const autofocus = this.element.dataset.autofocus;

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
@@ -48,7 +48,9 @@ export default class extends Controller {
     }
 
     if (!this.element.hasAttribute("aria-expanded")) {
-      this.element.setAttribute("aria-expanded", dropdownOptions.isOpen ? "true" : "false");
+      this.element.setAttribute("aria-expanded", dropdownOptions.isOpen
+        ? "true"
+        : "false");
     }
 
     const autofocus = this.element.dataset.autofocus;

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/controller.js
@@ -47,6 +47,10 @@ export default class extends Controller {
       this.element.id = `dropdown-${Math.random().toString(36).substring(7)}`
     }
 
+    if (!this.element.hasAttribute("aria-expanded")) {
+      this.element.setAttribute("aria-expanded", "false");
+    }
+
     const autofocus = this.element.dataset.autofocus;
     if (autofocus) {
       // set the focus to some inner element, use setTimeout hack due to waiting for element to display

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -143,12 +143,21 @@ describe("DropdownController", () => {
   });
 
   describe("aria-expanded initialization", () => {
-    it("sets aria-expanded to false when missing", () => {
+    it("sets aria-expanded to false when missing and isOpen is false", () => {
       const testController = createController(element);
 
       testController.connect();
 
       expect(element.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("sets aria-expanded to true when missing and data-open is true", () => {
+      element.setAttribute("data-open", "true");
+      const testController = createController(element);
+
+      testController.connect();
+
+      expect(element.getAttribute("aria-expanded")).toBe("true");
     });
 
     it("does not override existing aria-expanded attribute", () => {

--- a/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/dropdown/dropdown.test.js
@@ -142,6 +142,25 @@ describe("DropdownController", () => {
     });
   });
 
+  describe("aria-expanded initialization", () => {
+    it("sets aria-expanded to false when missing", () => {
+      const testController = createController(element);
+
+      testController.connect();
+
+      expect(element.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("does not override existing aria-expanded attribute", () => {
+      element.setAttribute("aria-expanded", "true");
+      const testController = createController(element);
+
+      testController.connect();
+
+      expect(element.getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+
   describe("data-add-aria-roles option", () => {
     it("keeps role menu when data-add-aria-roles is true", () => {
       element.setAttribute("data-add-aria-roles", "true");

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/controller.js
@@ -34,6 +34,10 @@ export default class extends Controller {
     this.handleCloseButtonClick = this.handleCloseButtonClick.bind(this)
     this.focusTrapHandler = this.focusTrapHandler.bind(this)
 
+    if (!this.menuButton.hasAttribute("aria-expanded")) {
+      this.menuButton.setAttribute("aria-expanded", "false");
+    }
+
     this.menuButton.addEventListener("click", this.handleButtonClick)
     this.menuContainer.addEventListener("click", this.handleContainerClick)
 

--- a/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/main_menu/main_menu.test.js
@@ -70,6 +70,29 @@ describe("MainMenuController", () => {
       expect(closeSpy).toHaveBeenCalledWith("click", controller.handleCloseButtonClick)
     })
 
+    it("sets aria-expanded to false when missing", async () => {
+      document.body.innerHTML = `
+        <button data-controller="main-menu" data-target="main-menu-container" data-close-button="main-menu-close">
+          Menu
+        </button>
+        <div id="main-menu-container" aria-hidden="true"></div>
+        <button id="main-menu-close">Close</button>
+      `
+
+      application.stop()
+      application = Application.start()
+      application.register("main-menu", MainMenuController)
+
+      const newButton = document.querySelector('[data-controller="main-menu"]')
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(application.getControllerForElementAndIdentifier(newButton, "main-menu"))
+        }, 0)
+      })
+
+      expect(newButton.getAttribute("aria-expanded")).toBe("false")
+    })
+
     it("returns early when menu container is missing", async () => {
       document.body.innerHTML = `
         <button data-controller="main-menu" data-target="missing-menu"></button>

--- a/decidim-core/app/views/decidim/searches/_filters.html.erb
+++ b/decidim-core/app/views/decidim/searches/_filters.html.erb
@@ -16,7 +16,7 @@
         </button>
       <% end %>
     </div>
-    <button id="dropdown-trigger-search" data-controller="dropdown" data-target="dropdown-menu-search" data-auto-close="true" aria-expanded="true">
+    <button id="dropdown-trigger-search" data-controller="dropdown" data-target="dropdown-menu-search" data-auto-close="true">
       <%= content_tag :span, t("decidim.searches.filters_small_view.filter_by"), class: "#{"is-active" if params.dig(:filter, :with_resource_type) == nil}" %>
       <% @blocks.each do |elements| %>
         <% elements.each do |type, results| %>


### PR DESCRIPTION
#### :tophat: What? Why?

During an accessibility audit in Decidim Barcelona, it was detected that the language chooser button doesn't have the `aria-expanded` attribute on load, and it appears when clicking on it. 

After further inspection, I noticed that it also happens in other Dropdowns. This PR fixes them.

#### Testing

1. Inspect the element `trigger-dropdown-menu-language-chooser-desktop` and check its HTML attributes

### :camera: Screenshots

#### Before

<img width="1350" height="868" alt="image" src="https://github.com/user-attachments/assets/fbcd15f3-87f4-4ed9-bdb0-dae488df905c" />

#### After 

<img width="1170" height="867" alt="image" src="https://github.com/user-attachments/assets/a0a3db70-cd76-4a2b-8bde-59ab91249c6e" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Dropdown triggers and the main menu button now initialize `aria-expanded` reliably (set to `"false"` when missing).
  * Existing `aria-expanded` values are preserved instead of being overridden.
  * Search filter dropdown triggers no longer render as expanded by default.
* **Tests**
  * Added/extended Jest coverage to verify `aria-expanded` initialization for the dropdown and main menu controllers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->