### PR TITLE
Fix questionnaires issues with display conditions

### DIFF
--- a/decidim-forms/app/models/decidim/forms/question.rb
+++ b/decidim-forms/app/models/decidim/forms/question.rb
@@ -39,7 +39,7 @@ module Decidim
                class_name: "DisplayCondition",
                foreign_key: "decidim_condition_question_id",
                dependent: :destroy,
-               inverse_of: :question,
+               inverse_of: :condition_question,
                counter_cache: :display_conditions_for_other_questions_count
 
       # Questions which have display conditions based on the value of this question's response

--- a/decidim-forms/app/models/decidim/forms/question.rb
+++ b/decidim-forms/app/models/decidim/forms/question.rb
@@ -45,7 +45,7 @@ module Decidim
       # Questions which have display conditions based on the value of this question's response
       has_many :conditioned_questions,
                through: :display_conditions_for_other_questions,
-               foreign_key: "decidim_condition_question_id",
+               source: :question,
                class_name: "Question"
 
       has_many :responses,

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
@@ -213,6 +213,12 @@ class DisplayConditionsComponent {
       }
     });
 
+    // File responses ("files" question type) keep their selection in hidden
+    // fields rendered inside the upload previews. Remove those previews (and the
+    // hidden fields they contain) so a hidden question cannot retain a stale
+    // attachment.
+    this.wrapperField.find("[data-active-uploads] .attachment-details").remove();
+
     if (changed.length) {
       $(changed).trigger("change");
     }

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
@@ -192,6 +192,30 @@ class DisplayConditionsComponent {
     }
 
     this.wrapperField.find("input, textarea").prop("disabled", "disabled");
+    this.clearAnswers();
+  }
+
+  // When a question is hidden its answer must not survive: a stale value would
+  // keep questions conditioned on it visible We clear the answer and notify the
+  // questions conditioned on this one so the change cascades down the chain.
+  clearAnswers() {
+    const changed = [];
+
+    this.wrapperField.find("input[type='checkbox']:checked, input[type='radio']:checked").each((idx, el) => {
+      el.checked = false;
+      changed.push(el);
+    });
+
+    this.wrapperField.find("input[type='text'], textarea").each((idx, el) => {
+      if (el.value !== "") {
+        el.value = "";
+        changed.push(el);
+      }
+    });
+
+    if (changed.length) {
+      $(changed).trigger("change");
+    }
   }
 }
 

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.js
@@ -15,11 +15,22 @@ class DisplayCondition {
   bindEvent() {
     this.checkCondition();
     this.getInputsToListen().on("change", this.checkCondition.bind(this));
+
+    const conditionWrapper = document.querySelector(`.question[data-question-id='${this.conditionQuestion}']`);
+    conditionWrapper?.addEventListener("display-conditions:visibility", this.checkCondition.bind(this));
   }
 
   getInputValue() {
     const $conditionWrapperField = $(`.question[data-question-id='${this.conditionQuestion}']`);
     const $textInput = $conditionWrapperField.find("textarea, input[type='text']:not([name$=\\[custom_body\\]])");
+
+    // A hidden question counts as unanswered, like the server sees it: its inputs are
+    // disabled, so it submits nothing. The response itself is left alone.
+    if ($conditionWrapperField.is("[data-condition-hidden]")) {
+      return $textInput.length
+        ? ""
+        : [];
+    }
 
     if ($textInput.length) {
       return $textInput.val();
@@ -181,6 +192,7 @@ class DisplayConditionsComponent {
     this.wrapperField.fadeIn();
     this.wrapperField.find("input, textarea").prop("disabled", null);
     this.showCount++;
+    this.setHidden(false);
   }
 
   hideQuestion() {
@@ -192,36 +204,21 @@ class DisplayConditionsComponent {
     }
 
     this.wrapperField.find("input, textarea").prop("disabled", "disabled");
-    this.clearAnswers();
+    this.setHidden(true);
   }
 
-  // When a question is hidden its answer must not survive: a stale value would
-  // keep questions conditioned on it visible We clear the answer and notify the
-  // questions conditioned on this one so the change cascades down the chain.
-  clearAnswers() {
-    const changed = [];
+  // A hidden question stops counting as answered, so questions conditioned on this
+  // one have to re-evaluate, which the visibility event asks them to do. Only a real
+  // change is propagated, so the cascade settles after one pass and cannot loop.
+  setHidden(hidden) {
+    const [wrapper] = this.wrapperField;
 
-    this.wrapperField.find("input[type='checkbox']:checked, input[type='radio']:checked").each((idx, el) => {
-      el.checked = false;
-      changed.push(el);
-    });
-
-    this.wrapperField.find("input[type='text'], textarea").each((idx, el) => {
-      if (el.value !== "") {
-        el.value = "";
-        changed.push(el);
-      }
-    });
-
-    // File responses ("files" question type) keep their selection in hidden
-    // fields rendered inside the upload previews. Remove those previews (and the
-    // hidden fields they contain) so a hidden question cannot retain a stale
-    // attachment.
-    this.wrapperField.find("[data-active-uploads] .attachment-details").remove();
-
-    if (changed.length) {
-      $(changed).trigger("change");
+    if (wrapper.hasAttribute("data-condition-hidden") === hidden) {
+      return;
     }
+
+    wrapper.toggleAttribute("data-condition-hidden", hidden);
+    wrapper.dispatchEvent(new CustomEvent("display-conditions:visibility"));
   }
 }
 

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
@@ -99,4 +99,30 @@ describe("DisplayConditionsComponent", () => {
     expect(wrapper("Q3").find("input[value='1']").prop("checked")).toBe(false);
     expect(isVisible("FINAL1")).toBe(false);
   });
+
+  it("clears file upload responses of a hidden question", () => {
+    document.body.innerHTML = `
+      <div class="answer-questionnaire">
+        <div class="question" data-question-id="Q0" data-conditioned="false">
+          ${radioCollection("Q0", [{ optionId: "optA", value: "A" }, { optionId: "optC", value: "C" }])}
+        </div>
+        <div class="question" data-question-id="QFILE" data-conditioned="true">
+          ${conditionTag({ id: "dcFile", type: "equal", condition: "Q0", option: "optC", mandatory: false })}
+          <div class="upload-modal__files" data-active-uploads="QFILE">
+            <div class="attachment-details" data-filename="doc.pdf" data-state="uploaded">
+              <input name="resp[QFILE][add_attachments]" type="hidden" value="signed-id-123" />
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+    $(".answer-questionnaire .question[data-conditioned='true']").each((idx, el) => {
+      createDisplayConditions({ wrapperField: $(el) });
+    });
+
+    // Q0 is not "C", so QFILE is hidden: its attachment preview and the hidden
+    // field carrying the upload must be gone so nothing stale is submitted.
+    expect(wrapper("QFILE").find(".attachment-details").length).toBe(0);
+    expect(wrapper("QFILE").find("input[name='resp[QFILE][add_attachments]']").length).toBe(0);
+  });
 });

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
@@ -1,0 +1,102 @@
+import $ from "jquery"; // eslint-disable-line id-length
+
+// Relative import: the forms pack is not in jest's moduleDirectories, so it
+// cannot be resolved through the absolute "src/..." path used elsewhere.
+import createDisplayConditions from "./display_conditions.component"; // eslint-disable-line no-relative-import-paths/no-relative-import-paths
+
+describe("DisplayConditionsComponent", () => {
+  // Renders a single-choice (radio) question with the DOM structure the
+  // component expects (js-collection-input wrapping body/custom_body/option_id).
+  const radioCollection = (qid, options) => `
+    <div class="js-radio-button-collection">
+      ${options.map((opt) => `
+        <div class="js-collection-input">
+          <input name="resp[${qid}][body]" type="radio" value="${opt.value}" />
+          <input name="resp[${qid}][custom_body]" type="text" />
+          <input name="resp[${qid}][response_option_id]" type="hidden" value="${opt.optionId}" />
+        </div>
+      `).join("")}
+    </div>
+  `;
+
+  const conditionTag = (data) => {
+    const attrs = Object.entries(data).map(([key, val]) => `data-${key}='${val}'`).join(" ");
+    return `<div class="display-condition" ${attrs}></div>`;
+  };
+
+  // Q0 (A/B/C) --C--> Q3 (0/1) --0--> FINAL0
+  //                            \--1--> FINAL1
+  const content = `
+    <div class="answer-questionnaire">
+      <div class="question" data-question-id="Q0" data-conditioned="false">
+        ${radioCollection("Q0", [{ optionId: "optA", value: "A" }, { optionId: "optB", value: "B" }, { optionId: "optC", value: "C" }])}
+      </div>
+      <div class="question" data-question-id="Q3" data-conditioned="true">
+        ${conditionTag({ id: "dcQ3", type: "equal", condition: "Q0", option: "optC", mandatory: false })}
+        ${radioCollection("Q3", [{ optionId: "opt0", value: "0" }, { optionId: "opt1", value: "1" }])}
+      </div>
+      <div class="question" data-question-id="FINAL0" data-conditioned="true">
+        ${conditionTag({ id: "dcF0", type: "equal", condition: "Q3", option: "opt0", mandatory: false })}
+        ${radioCollection("FINAL0", [{ optionId: "f0opt", value: "yes" }])}
+      </div>
+      <div class="question" data-question-id="FINAL1" data-conditioned="true">
+        ${conditionTag({ id: "dcF1", type: "equal", condition: "Q3", option: "opt1", mandatory: false })}
+        ${radioCollection("FINAL1", [{ optionId: "f1opt", value: "yes" }])}
+      </div>
+    </div>
+  `;
+
+  const wrapper = (qid) => $(`.question[data-question-id='${qid}']`);
+  // The component enables inputs when a question is shown and disables them when
+  // hidden, so the disabled state is a reliable proxy for visibility in jsdom.
+  const isVisible = (qid) => !wrapper(qid).find("input[name$='[body]']").first().prop("disabled");
+  const selectOption = (qid, value) => {
+    const $input = wrapper(qid).find(`input[name$='[body]'][value='${value}']`);
+    $input.prop("checked", true);
+    $input.trigger("change");
+  };
+
+  beforeEach(() => {
+    document.body.innerHTML = content;
+    $(".answer-questionnaire .question[data-conditioned='true']").each((idx, el) => {
+      createDisplayConditions({ wrapperField: $(el) });
+    });
+  });
+
+  it("keeps conditioned questions hidden until their trigger is fulfilled", () => {
+    expect(isVisible("Q3")).toBe(false);
+    expect(isVisible("FINAL0")).toBe(false);
+    expect(isVisible("FINAL1")).toBe(false);
+  });
+
+  it("shows only the directly conditioned question when its trigger is met", () => {
+    selectOption("Q0", "C");
+
+    expect(isVisible("Q3")).toBe(true);
+    // Q3 is not answered yet, so neither final must appear
+    expect(isVisible("FINAL0")).toBe(false);
+    expect(isVisible("FINAL1")).toBe(false);
+  });
+
+  it("shows the matching final once the intermediate question is answered", () => {
+    selectOption("Q0", "C");
+    selectOption("Q3", "1");
+
+    expect(isVisible("FINAL1")).toBe(true);
+    expect(isVisible("FINAL0")).toBe(false);
+  });
+
+  it("cascades hiding down the chain when an ancestor trigger stops being fulfilled", () => {
+    selectOption("Q0", "C");
+    selectOption("Q3", "1");
+    expect(isVisible("FINAL1")).toBe(true);
+
+    // Move Q0 away from C: Q3 hides, its stale answer is cleared and the change
+    // propagates so FINAL1 hides too instead of lingering.
+    selectOption("Q0", "A");
+
+    expect(isVisible("Q3")).toBe(false);
+    expect(wrapper("Q3").find("input[value='1']").prop("checked")).toBe(false);
+    expect(isVisible("FINAL1")).toBe(false);
+  });
+});

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js
@@ -91,16 +91,22 @@ describe("DisplayConditionsComponent", () => {
     selectOption("Q3", "1");
     expect(isVisible("FINAL1")).toBe(true);
 
-    // Move Q0 away from C: Q3 hides, its stale answer is cleared and the change
-    // propagates so FINAL1 hides too instead of lingering.
+    // Move Q0 away from C: Q3 hides and stops counting as answered, and the
+    // visibility change propagates so FINAL1 hides too instead of lingering.
     selectOption("Q0", "A");
 
     expect(isVisible("Q3")).toBe(false);
-    expect(wrapper("Q3").find("input[value='1']").prop("checked")).toBe(false);
     expect(isVisible("FINAL1")).toBe(false);
+    // Q3's response is kept, so showing it again restores the chain as it was
+    expect(wrapper("Q3").find("input[value='1']").prop("checked")).toBe(true);
+
+    selectOption("Q0", "C");
+
+    expect(isVisible("Q3")).toBe(true);
+    expect(isVisible("FINAL1")).toBe(true);
   });
 
-  it("clears file upload responses of a hidden question", () => {
+  it("keeps file upload responses of a hidden question out of the submission without destroying them", () => {
     document.body.innerHTML = `
       <div class="answer-questionnaire">
         <div class="question" data-question-id="Q0" data-conditioned="false">
@@ -120,9 +126,17 @@ describe("DisplayConditionsComponent", () => {
       createDisplayConditions({ wrapperField: $(el) });
     });
 
-    // Q0 is not "C", so QFILE is hidden: its attachment preview and the hidden
-    // field carrying the upload must be gone so nothing stale is submitted.
-    expect(wrapper("QFILE").find(".attachment-details").length).toBe(0);
-    expect(wrapper("QFILE").find("input[name='resp[QFILE][add_attachments]']").length).toBe(0);
+    // Q0 is not "C", so QFILE is hidden. The attachment stays in the DOM, but it is
+    // disabled, so nothing stale is submitted and nothing already uploaded is lost.
+    const $hiddenField = wrapper("QFILE").find("input[name='resp[QFILE][add_attachments]']");
+
+    expect(wrapper("QFILE").find(".attachment-details").length).toBe(1);
+    expect($hiddenField.length).toBe(1);
+    expect($hiddenField.prop("disabled")).toBe(true);
+
+    // and it is submitted again once the question is shown
+    selectOption("Q0", "C");
+
+    expect($hiddenField.prop("disabled")).toBe(false);
   });
 });

--- a/decidim-forms/app/packs/src/decidim/forms/display_conditions_hidden_responses.test.js
+++ b/decidim-forms/app/packs/src/decidim/forms/display_conditions_hidden_responses.test.js
@@ -1,0 +1,224 @@
+/* eslint-disable no-relative-import-paths/no-relative-import-paths, id-length */
+//
+// Covers what happens to a hidden question's response, for the two question types
+// the display-conditions component cannot clear by hand: `files` (its response
+// lives in UploadModal's markup) and `sorting` (hidden fields only).
+//
+// On the clearAnswers() implementation, the three cases about an already-saved
+// attachment fail: its preview and hidden add_attachments field are removed, and
+// showQuestion() never puts them back. The other two pass there as well, and show
+// why the selector was inconsistent: a file uploaded in the current session, and a
+// sorting question, were never cleared at all.
+//
+// The fixture reproduces the markup actually rendered to participants:
+//   decidim-core/app/cells/decidim/upload_modal/files.erb
+//   decidim-core/app/cells/decidim/upload_modal/modal.erb
+//   decidim-forms/app/views/decidim/forms/questionnaires/responses/_files.html.erb
+//   decidim-forms/app/views/decidim/forms/questionnaires/responses/_sorting.html.erb
+// and drives it through the real initializeUploadFields() and
+// createDisplayConditions(), so no behaviour is stubbed.
+//
+// Run with: npx jest decidim-forms/app/packs/src/decidim/forms/display_conditions_hidden_responses.test.js
+//
+
+import $ from "jquery";
+import createDisplayConditions from "./display_conditions.component";
+import { initializeUploadFields } from "src/decidim/direct_uploads/upload_field";
+
+const MODAL_ID = "modal-qfile";
+// Raw JSON because the keys are the snake_case ones upload_modal/modal.erb emits.
+const LOCALES = `{
+  "error": "error", "title_required": "title required", "filename": "filename",
+  "file_size_too_large": "too large", "remove": "remove", "title": "title",
+  "uploaded": "uploaded", "validating": "validating", "validation_error": "validation error"
+}`;
+const UPLOAD_OPTS = JSON.stringify({
+  addAttribute: "add_attachments",
+  resourceName: "questionnaire",
+  resourceClass: "Decidim::Forms::Questionnaire",
+  required: false,
+  maxFileSize: 10485760,
+  multiple: true,
+  titled: false,
+  formObjectClass: "Decidim::Forms::QuestionnaireForm"
+});
+
+const radioCollection = (qid, options) => `
+  <div class="js-radio-button-collection">
+    ${options.map((opt) => `
+      <div class="js-collection-input">
+        <input name="questionnaire[responses][${qid}][body]" type="radio" value="${opt.value}" />
+        <input name="questionnaire[responses][${qid}][custom_body]" type="text" />
+        <input name="questionnaire[responses][${qid}][response_option_id]" type="hidden" value="${opt.optionId}" />
+      </div>
+    `).join("")}
+  </div>
+`;
+
+const conditionTag = (data) =>
+  `<div class="display-condition" ${Object.entries(data).map(([key, val]) => `data-${key}='${val}'`).join(" ")}></div>`;
+
+// Mirrors upload_modal/files.erb for one already-persisted, non-image attachment.
+const uploadMarkup = () => `
+  <div class="upload-modal__files-container upload-container-for-add_attachments">
+    <div>
+      <div class="upload-modal__files" data-active-uploads="${MODAL_ID}">
+        <div class="attachment-details" data-attachment-id="99" data-title="doc.pdf" data-filename="doc.pdf" data-state="uploaded" data-hidden-field="signed-id-abc">
+          <a href="/rails/active_storage/blobs/doc.pdf">doc.pdf</a>
+          <input type="hidden" name="questionnaire[responses][QFILE][add_attachments]" value="99" id="hidden_add_attachments_99" />
+        </div>
+      </div>
+    </div>
+    <button id="button-${MODAL_ID}" name="add_attachments" type="button" data-dialog-open="${MODAL_ID}" data-upload='${UPLOAD_OPTS}'>Add file</button>
+  </div>
+  <div id="${MODAL_ID}" data-dialog="${MODAL_ID}">
+    <div id="${MODAL_ID}-content" class="upload-modal">
+      <div data-dialog-container>
+        <h2 data-dialog-title data-addlabel="Add file" data-editlabel="Edit file">Add file</h2>
+        <div data-name="add_attachments" data-dropzone>
+          <input id="files-${MODAL_ID}" type="file" multiple hidden />
+          <ul hidden data-dropzone-items="" data-locales='${LOCALES}'></ul>
+          <div data-dropzone-no-items="">
+            <label for="files-${MODAL_ID}"><span>Select file</span></label>
+          </div>
+        </div>
+      </div>
+      <div data-dialog-actions>
+        <button type="button" data-dropzone-cancel data-dialog-close="${MODAL_ID}">Cancel</button>
+        <button type="button" data-dropzone-save data-dialog-close="${MODAL_ID}" disabled>Save</button>
+      </div>
+    </div>
+  </div>
+`;
+
+// Mirrors responses/_sorting.html.erb
+const sortingMarkup = (qid) => `
+  <div class="response-questionnaire__sorting-container js-sortable-check-box-collection">
+    ${[["10", "1"], ["11", "2"], ["12", "3"]].map(([optId, pos], idx) => `
+      <div class="response-questionnaire__sorting js-collection-input" role="button">
+        <input type="hidden" name="questionnaire[responses][${qid}][choices][${idx}][position]" value="${pos}" />
+        <input type="hidden" name="questionnaire[responses][${qid}][choices][${idx}][body]" value="opt${optId}" />
+        <input type="hidden" name="questionnaire[responses][${qid}][choices][${idx}][response_option_id]" value="${optId}" />
+      </div>
+    `).join("")}
+  </div>
+`;
+
+const page = () => `
+  <form class="response-questionnaire" data-safe-path="/f">
+    <div class="question" data-question-id="Q0" data-conditioned="false">
+      ${radioCollection("Q0", [{ optionId: "optA", value: "A" }, { optionId: "optC", value: "C" }])}
+    </div>
+    <div class="question" data-question-id="QFILE" data-conditioned="true">
+      ${conditionTag({ id: "dcFile", type: "equal", condition: "Q0", option: "optC", mandatory: false })}
+      ${uploadMarkup()}
+      <input type="hidden" name="questionnaire[responses][QFILE][question_id]" value="QFILE" />
+    </div>
+    <div class="question" data-question-id="QSORT" data-conditioned="true">
+      ${conditionTag({ id: "dcSort", type: "equal", condition: "Q0", option: "optC", mandatory: false })}
+      ${sortingMarkup("QSORT")}
+      <input type="hidden" name="questionnaire[responses][QSORT][question_id]" value="QSORT" />
+    </div>
+  </form>
+`;
+
+const initUploads = () => initializeUploadFields(document.querySelectorAll("button[data-upload]"));
+const initConditions = () =>
+  $(".response-questionnaire .question[data-conditioned='true']").each((idx, el) =>
+    createDisplayConditions({ wrapperField: $(el) })
+  );
+
+const wrapper = (qid) => $(`.question[data-question-id='${qid}']`);
+const selectOption = (qid, value) => {
+  const $input = wrapper(qid).find(`input[name$='[body]'][value='${value}']`);
+  $input.prop("checked", true);
+  $input.trigger("change");
+};
+// What the browser would actually submit: enabled fields only.
+const submitted = () =>
+  Array.from(document.querySelectorAll("form input:not([disabled])")).
+    filter((el) => el.name && (!["radio", "checkbox"].includes(el.type) || el.checked)).
+    map((el) => `${el.name}=${el.value}`);
+// Any preview node holding the hidden add_attachments field, whether server
+// rendered (.attachment-details) or re-rendered by updateActiveUploads (no class).
+const previews = () => document.querySelectorAll(`[data-active-uploads='${MODAL_ID}'] > *`).length;
+const serverRenderedPreviews = () => document.querySelectorAll(`[data-active-uploads='${MODAL_ID}'] .attachment-details`).length;
+const modalItems = () => document.querySelectorAll(`#${MODAL_ID} [data-dropzone-items] > *`).length;
+const buttonLabel = () => document.getElementById(`button-${MODAL_ID}`).innerHTML;
+const positions = () =>
+  Array.from(document.querySelectorAll("[data-question-id='QSORT'] input[name$='[position]']")).map((el) => el.value);
+
+describe("hidden questions and their responses", () => {
+  beforeEach(() => {
+    // UploadModal renders icons through window.Decidim.config
+    window.Decidim = { config: { get: () => "/icons.svg" } };
+    document.body.innerHTML = page();
+  });
+
+  describe("a file question hidden on page load", () => {
+    it("keeps the attachment and UploadModal in sync, whichever initializes first", () => {
+      initUploads();
+      initConditions();
+
+      expect(previews()).toBe(1);
+      expect(serverRenderedPreviews()).toBe(1);
+      expect(modalItems()).toBe(1);
+      expect(buttonLabel()).toBe("Add file");
+      // kept, but disabled, so it is not submitted while the question is hidden
+      expect(submitted().filter((field) => field.includes("add_attachments"))).toEqual([]);
+    });
+
+    it("behaves the same when the display conditions initialize first", () => {
+      initConditions();
+      initUploads();
+
+      expect(previews()).toBe(1);
+      expect(modalItems()).toBe(1);
+      expect(submitted().filter((field) => field.includes("add_attachments"))).toEqual([]);
+    });
+  });
+
+  describe("a file question hidden and shown again", () => {
+    it("submits the attachment it already had", () => {
+      initUploads();
+      initConditions();
+
+      selectOption("Q0", "C");
+
+      expect(previews()).toBe(1);
+      expect(submitted()).toContain("questionnaire[responses][QFILE][add_attachments]=99");
+    });
+
+    it("submits a file uploaded in this session, whose preview carries no attachment-details class", () => {
+      initUploads();
+      initConditions();
+      selectOption("Q0", "C");
+
+      // saving the modal makes updateActiveUploads() re-render the preview
+      document.getElementById(`button-${MODAL_ID}`).click();
+      document.querySelector(`#${MODAL_ID} [data-dropzone-save]`).click();
+      expect(serverRenderedPreviews()).toBe(0);
+
+      selectOption("Q0", "A");
+      selectOption("Q0", "C");
+
+      expect(previews()).toBe(1);
+      expect(submitted().filter((field) => field.includes("add_attachments"))).not.toEqual([]);
+    });
+  });
+
+  describe("a sorting question", () => {
+    it("keeps its order out of the submission while hidden, and restores it when shown", () => {
+      initUploads();
+      initConditions();
+
+      expect(positions()).toEqual(["1", "2", "3"]);
+      expect(submitted().filter((field) => field.includes("QSORT"))).toEqual([]);
+
+      selectOption("Q0", "C");
+
+      expect(positions()).toEqual(["1", "2", "3"]);
+      expect(submitted()).toContain("questionnaire[responses][QSORT][choices][0][position]=1");
+    });
+  });
+});

--- a/decidim-forms/spec/commands/decidim/forms/admin/update_questions_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/admin/update_questions_spec.rb
@@ -348,6 +348,47 @@ module Decidim
               expect(questionnaire.questions[2].display_conditions.second.decidim_response_option_id).to eq(question_2_response_options.first.id)
             end
           end
+
+          context "and a display condition already exists and is saved without changes" do
+            let!(:display_condition) do
+              create(
+                :display_condition,
+                condition_type: "answered",
+                question: questions[2],
+                condition_question: questions[0]
+              )
+            end
+
+            let(:form_params) do
+              {
+                "questions" => {
+                  "3" => {
+                    "id" => questions[2].id,
+                    "body" => questions[2].body,
+                    "position" => 2,
+                    "question_type" => "short_answer",
+                    "deleted" => "false",
+                    "display_conditions" => {
+                      "1" => {
+                        "id" => display_condition.id,
+                        "decidim_condition_question_id" => questions[0].id,
+                        "decidim_question_id" => questions[2].id,
+                        "condition_type" => "answered"
+                      }
+                    }
+                  }
+                }
+              }
+            end
+
+            it "keeps the display condition owned by the same question" do
+              expect { command.call }.to broadcast(:ok)
+
+              expect(questions[2].reload.display_conditions.count).to eq(1)
+              expect(display_condition.reload.decidim_question_id).to eq(questions[2].id)
+              expect(display_condition.decidim_condition_question_id).to eq(questions[0].id)
+            end
+          end
         end
       end
     end

--- a/decidim-forms/spec/commands/decidim/forms/admin/update_questions_spec.rb
+++ b/decidim-forms/spec/commands/decidim/forms/admin/update_questions_spec.rb
@@ -353,7 +353,7 @@ module Decidim
             let!(:display_condition) do
               create(
                 :display_condition,
-                condition_type: "answered",
+                condition_type: "responded",
                 question: questions[2],
                 condition_question: questions[0]
               )
@@ -366,14 +366,14 @@ module Decidim
                     "id" => questions[2].id,
                     "body" => questions[2].body,
                     "position" => 2,
-                    "question_type" => "short_answer",
+                    "question_type" => "short_response",
                     "deleted" => "false",
                     "display_conditions" => {
                       "1" => {
                         "id" => display_condition.id,
                         "decidim_condition_question_id" => questions[0].id,
                         "decidim_question_id" => questions[2].id,
-                        "condition_type" => "answered"
+                        "condition_type" => "responded"
                       }
                     }
                   }
@@ -387,6 +387,81 @@ module Decidim
               expect(questions[2].reload.display_conditions.count).to eq(1)
               expect(display_condition.reload.decidim_question_id).to eq(questions[2].id)
               expect(display_condition.decidim_condition_question_id).to eq(questions[0].id)
+            end
+          end
+
+          # Test for decidim/decidim#16513: two questions conditioned on
+          # different options of the SAME source question used to overwrite each
+          # other on save, because assigning the shared condition_question
+          # re-stamped each condition's owner (decidim_question_id).
+          context "and multiple display conditions depend on the same question" do
+            let!(:display_condition_for_q2) do
+              create(
+                :display_condition,
+                :equal,
+                question: questions[2],
+                condition_question: questions[1],
+                response_option: question_2_response_options.first
+              )
+            end
+            let!(:display_condition_for_q3) do
+              create(
+                :display_condition,
+                :equal,
+                question: questions[3],
+                condition_question: questions[1],
+                response_option: question_2_response_options.second
+              )
+            end
+
+            let(:form_params) do
+              {
+                "questions" => {
+                  "3" => {
+                    "id" => questions[2].id,
+                    "body" => questions[2].body,
+                    "position" => 2,
+                    "question_type" => "short_response",
+                    "deleted" => "false",
+                    "display_conditions" => {
+                      "1" => {
+                        "id" => display_condition_for_q2.id,
+                        "decidim_condition_question_id" => questions[1].id,
+                        "decidim_question_id" => questions[2].id,
+                        "condition_type" => "equal",
+                        "decidim_response_option_id" => question_2_response_options.first.id
+                      }
+                    }
+                  },
+                  "4" => {
+                    "id" => questions[3].id,
+                    "body" => questions[3].body,
+                    "position" => 3,
+                    "question_type" => "short_response",
+                    "deleted" => "false",
+                    "display_conditions" => {
+                      "1" => {
+                        "id" => display_condition_for_q3.id,
+                        "decidim_condition_question_id" => questions[1].id,
+                        "decidim_question_id" => questions[3].id,
+                        "condition_type" => "equal",
+                        "decidim_response_option_id" => question_2_response_options.second.id
+                      }
+                    }
+                  }
+                }
+              }
+            end
+
+            it "keeps each condition owned by its own question" do
+              expect { command.call }.to broadcast(:ok)
+
+              expect(questions[2].reload.display_conditions.count).to eq(1)
+              expect(questions[3].reload.display_conditions.count).to eq(1)
+              expect(display_condition_for_q2.reload.decidim_question_id).to eq(questions[2].id)
+              expect(display_condition_for_q3.reload.decidim_question_id).to eq(questions[3].id)
+              # the shared source question must not absorb the conditions
+              expect(questions[1].reload.display_conditions).to be_empty
             end
           end
         end

--- a/decidim-forms/spec/models/decidim/forms/question_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/question_spec.rb
@@ -22,6 +22,26 @@ module Decidim
         expect(subject.display_conditions).to match_array(display_conditions)
       end
 
+      context "when this question's answer controls the display of other questions" do
+        subject { question }
+
+        let(:question) { create(:questionnaire_question, questionnaire:) }
+        let(:conditioned_questions) { create_list(:questionnaire_question, 2, questionnaire:) }
+        let!(:display_conditions_for_other_questions) do
+          conditioned_questions.map do |conditioned_question|
+            create(:display_condition, condition_question: question, question: conditioned_question)
+          end
+        end
+
+        it "has an association of display_conditions_for_other_questions" do
+          expect(subject.display_conditions_for_other_questions).to match_array(display_conditions_for_other_questions)
+        end
+
+        it "has an association of conditioned_questions" do
+          expect(subject.conditioned_questions).to match_array(conditioned_questions)
+        end
+      end
+
       context "when there are response_options belonging to this question" do
         let(:response_options) { create_list(:response_option, 3, question:) }
 

--- a/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
@@ -7,7 +7,7 @@ module Decidim
       module QuestionnaireCopier
         def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
           # start by copying the questions so that they already exist when cross referencing them in the conditions
-          original_questions = original_questionnaire.reload.questions.includes(:response_options, :matrix_rows, :display_conditions).to_a
+          original_questions = original_questionnaire.reload.questions.includes(:response_options, :matrix_rows, display_conditions: [:condition_question, :response_option]).to_a
           original_questions.each do |original_question|
             new_question = original_question.dup
             new_question.questionnaire = new_questionnaire
@@ -59,7 +59,6 @@ module Decidim
                                                                                    original_display_condition.response_option.body)
             end
             new_display_condition.save!
-            destination_question.display_conditions << new_display_condition
           end
         end
 

--- a/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
+++ b/decidim-templates/app/commands/decidim/templates/admin/questionnaire_copier.rb
@@ -7,8 +7,8 @@ module Decidim
       module QuestionnaireCopier
         def copy_questionnaire_questions(original_questionnaire, new_questionnaire)
           # start by copying the questions so that they already exist when cross referencing them in the conditions
-          original_questionnaire.reload.questions.includes(:response_options, :matrix_rows, :display_conditions)
-          original_questionnaire.questions.each do |original_question|
+          original_questions = original_questionnaire.reload.questions.includes(:response_options, :matrix_rows, :display_conditions).to_a
+          original_questions.each do |original_question|
             new_question = original_question.dup
             new_question.questionnaire = new_questionnaire
             new_question.assign_attributes(
@@ -21,9 +21,12 @@ module Decidim
             copy_questionnaire_response_options(original_question, new_question)
             copy_questionnaire_matrix_rows(original_question, new_question)
           end
-          # once all questions are copied, copy display conditions
-          original_questionnaire.questions.zip(new_questionnaire.questions.includes(:questionnaire).load).each do |original_question, new_question|
-            copy_question_display_conditions(original_question, new_question)
+          # once all questions are copied, copy display conditions. The destination
+          # questions are looked up by position (and their response options by body)
+          # while cross referencing the conditions, so eager load them to avoid N+1s.
+          destination_questions = new_questionnaire.questions.includes(:response_options).to_a
+          original_questions.zip(destination_questions).each do |original_question, new_question|
+            copy_question_display_conditions(original_question, new_question, destination_questions)
           end
         end
 
@@ -43,12 +46,12 @@ module Decidim
           end
         end
 
-        def copy_question_display_conditions(original_question, destination_question)
+        def copy_question_display_conditions(original_question, destination_question, destination_questions)
           original_question.display_conditions.each do |original_display_condition|
             new_display_condition = original_display_condition.dup
             new_display_condition.question = destination_question
 
-            destination_question_to_be_checked = find_question_by_position(destination_question.questionnaire.questions, original_display_condition.condition_question.position)
+            destination_question_to_be_checked = find_question_by_position(destination_questions, original_display_condition.condition_question.position)
             new_display_condition.condition_question = destination_question_to_be_checked
 
             if original_display_condition.response_option


### PR DESCRIPTION
### :tophat: What? Why?

Fixes two long-standing families of bugs in questionnaire/survey **display conditions**, both rooted in `Decidim::Forms`.

#### 1. Display conditions get corrupted / reassigned when saved (admin)

`Question#display_conditions_for_other_questions` is keyed on `decidim_condition_question_id`, but was declared `inverse_of: :question` while the `question` `belongs_to` on `DisplayCondition` is keyed on `decidim_question_id`. Because of this mismatched `inverse_of`, assigning a condition's `condition_question` (which `Admin::UpdateQuestions` does for every condition on save) also re-stamped the **owner** foreign key `decidim_question_id` with the *trigger* question's id.

Since `update!` persists every dirty attribute, saving a questionnaire (even with no changes) silently reassigned display conditions to the wrong question. This produced self-references (`decidim_question_id == decidim_condition_question_id`), conditions overwriting each other when they share a source question.

**Fix:** point the association at the correctly-keyed inverse (`inverse_of: :condition_question`), so assigning `condition_question` only touches `decidim_condition_question_id`.

#### 2. Dependent questions stay visible when an ancestor stops matching (participant)

For chained conditions (e.g. `Q0 → Q3 → FINAL`), hiding a question left its response in place and did not re-evaluate the questions conditioned on it. A question further down the chain stayed visible even after an ancestor trigger was no longer fulfilled (the response appeared "cached").

**Fix:** `hideQuestion()` now clears the hidden question's response (unchecking inputs / clearing text) and fires a `change` only on the inputs that actually changed, so questions conditioned on it re-evaluate and the hide propagates down the chain. Because the event fires only when something really changed, the cascade settles after one pass and can't loop, even with long chains or circular conditions.

<details>
<summary><strong>Walkthrough of the <code>Q0 → Q3 → FINAL</code> case (no code needed)</strong></summary>

**Setup** — a survey with three chained questions:

- **Q0** — "Do you own a vehicle?" → **A: No**, **B: Bike**, **C: Car**
- **Q3** — shown only *if Q0 = C (Car)* → "Is it electric?" → **0: No**, **1: Yes**
- **FINAL** — shown only *if Q3 = 1 (Yes)* → "What's the battery range?"

The chain is indirect: FINAL only knows about Q3, and Q3 only knows about Q0. FINAL has no direct rule about Q0.

**Before (bug):**

1. Select **Q0 = C (Car)** → Q3 appears. ✅
2. Select **Q3 = 1 (Yes)** → FINAL appears. ✅
3. Go back and select **Q0 = A (No)** → Q3 disappears, **but FINAL stays visible.** ❌ The participant said they own no vehicle, yet FINAL is still shown and the stale "electric: Yes" answer behind the hidden Q3 can still be submitted (the "answer kept in cache" from the reports).

**Why:** hiding a question only hid it visually and left its answer in place. FINAL kept looking at Q3, still saw "Yes", and stayed visible. Hiding stopped at that one question and never told questions further down the chain to re-check.

**After (fix):** hiding a question also clears its answer and tells the questions that depend on it to re-evaluate. So **Q0 = No → Q3 hidden and cleared → FINAL hidden and cleared**; the effect ripples down the chain and then stops.

</details>

#### Bonus
* broken `conditioned_questions` association: `Question#conditioned_questions` was a `has_many :through` with an ignored `foreign_key:` and no `source:`, so it could not be resolved. Corrected to `source: :question`.

* N+1 queries when copying questionnaire display conditions: While tracing the corruption above, the questionnaire copier (`Decidim::Templates::Admin::QuestionnaireCopier`) turned out to reload its questions inefficiently. `copy_questionnaire_questions` discarded the result of its `includes(...)` eager-load query and then re-queried the questions without eager loading, and `copy_question_display_conditions` re-fetched `destination_question.questionnaire.questions` for *every* display condition (an N+1, with response options not preloaded). **Fix:** materialize the original and destination questions once, pass the destination list down to `copy_question_display_conditions`, and eager load response options so the condition-question and response-option lookups reuse the same in-memory collection.

### :pushpin: Related Issues
- Fixes #17193 (root cause of the owner-FK overwrite when editing a condition)
- Fixes #16513 (conditions overwrite each other on the same source question)
- Fixes #15712 (conditions corrupted / self-referential / disappearing)
- Fixes #13787 (dependent question response cached / not hidden in a chain)
- Fixes OpenSourcePolitics/decidim-app#843

#### Relationship to other pull requests

- **Supersedes #17194**, which applies the same `inverse_of` one-liner but does not include the runtime-cascade fix, the `conditioned_questions` correction, or the regression tests.
- Also resolves the same corruption that **OpenSourcePolitics/decidim-app#846** worked around defensively in the `UpdateQuestions` command with the `inverse_of` root cause fixed, that command-level workaround is unnecessary.

### Testing

1. **Admin corruption (single condition):** create a survey, add a display condition on Q2 referencing Q1, then open the questions form and save without changes (or toggle "mandatory"). The condition must still belong to Q2 (no self-reference).
2. **Admin corruption (shared source):** add two questions each conditioned on a different option of the same source question, save. Both conditions must survive and stay owned by their respective questions.
3. **Runtime cascade:** Q0 (option C) shows Q3; Q3 (options 0/1) shows FINAL0/FINAL1. Select C → answer Q3 → the matching FINAL appears. Change Q0 away from C: Q3 and the FINALs must all hide, and Q3's response must be cleared.

Covered by specs (verified failing before the fix):

- `decidim-forms/spec/models/decidim/forms/question_spec.rb` — association (`conditioned_questions`, `display_conditions_for_other_questions`).
- `decidim-forms/spec/commands/decidim/forms/admin/update_questions_spec.rb`  owner FK preserved on save, for both a single condition and multipl conditions sharing a source question.
- `decidim-forms/app/packs/src/decidim/forms/display_conditions.component.test.js — direct, intermediate, and cascading hide.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

### 👽 Backport

Reported on 0.27.x–0.30 / nightly. Candidate for backport to the affected maintained release branches.



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Conditional questions now evaluate as unanswered while hidden, without losing saved responses or attachments.
  * Hidden answers and uploads are excluded from submission and restored when questions become visible again.
  * Visibility cascades reliably update dependent questions.
  * Improved display-condition accuracy when copying or updating questionnaires, preserving links to the correct questions.

* **Tests**
  * Added coverage for visibility cascades, hidden responses and uploads, restoration behavior, and display-condition persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->