### PR TITLE
Add validation for password confirmation mismatch in admin system form

### DIFF
--- a/decidim-system/app/forms/decidim/system/admin_form.rb
+++ b/decidim-system/app/forms/decidim/system/admin_form.rb
@@ -32,9 +32,8 @@ module Decidim
       def admin_exists?
         id.present?
       end
-
       def password_present?
-        password.present?
+        password.present? || password_confirmation.present?
       end
     end
   end

--- a/decidim-system/app/forms/decidim/system/admin_form.rb
+++ b/decidim-system/app/forms/decidim/system/admin_form.rb
@@ -12,8 +12,9 @@ module Decidim
       attribute :password_confirmation, String
 
       validates :email, presence: true
-      validates :password, confirmation: true, presence: true, unless: :admin_exists?
-      validates :password_confirmation, presence: true, unless: :admin_exists?
+      validates :password, presence: true, unless: :admin_exists?
+      validates :password, confirmation: true, if: :password_present?
+      validates :password_confirmation, presence: true, if: :password_present?
 
       validates :password, password: { email: :email }
 
@@ -30,6 +31,10 @@ module Decidim
 
       def admin_exists?
         id.present?
+      end
+
+      def password_present?
+        password.present?
       end
     end
   end

--- a/decidim-system/app/forms/decidim/system/admin_form.rb
+++ b/decidim-system/app/forms/decidim/system/admin_form.rb
@@ -32,6 +32,7 @@ module Decidim
       def admin_exists?
         id.present?
       end
+
       def password_present?
         password.present? || password_confirmation.present?
       end

--- a/decidim-system/spec/forms/decidim/system/admin_form_spec.rb
+++ b/decidim-system/spec/forms/decidim/system/admin_form_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module System
+    describe AdminForm do
+      subject { described_class.from_params(attributes) }
+
+      let(:email) { "admin@example.org" }
+      let(:password) { "decidim123456789" }
+      let(:password_confirmation) { "decidim123456789" }
+
+      let(:attributes) do
+        {
+          "admin" => {
+            "email" => email,
+            "password" => password,
+            "password_confirmation" => password_confirmation
+          }
+        }
+      end
+
+      context "when everything is OK" do
+        it { is_expected.to be_valid }
+      end
+
+      context "when the email is missing" do
+        let(:email) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the password is missing on create" do
+        let(:password) { nil }
+        let(:password_confirmation) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the password confirmation is missing on create" do
+        let(:password_confirmation) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the password is too common" do
+        let(:password) { "password1234" }
+        let(:password_confirmation) { "password1234" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the password and confirmation do not match" do
+        let(:password_confirmation) { "mismatched123456" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when the email is already taken" do
+        let!(:existing_admin) { create(:admin, email:) }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when updating an existing admin" do
+        let(:admin) { create(:admin) }
+
+        let(:attributes) do
+          {
+            "admin" => {
+              "id" => admin.id,
+              "email" => email,
+              "password" => password,
+              "password_confirmation" => password_confirmation
+            }
+          }
+        end
+
+        context "and everything is OK" do
+          it { is_expected.to be_valid }
+        end
+
+        context "and the password fields are blank" do
+          let(:password) { "" }
+          let(:password_confirmation) { "" }
+
+          it { is_expected.to be_valid }
+        end
+
+        context "and only the password confirmation is blank" do
+          let(:password_confirmation) { "" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "and the password and confirmation do not match" do
+          let(:password_confirmation) { "mismatched123456" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "and the password is too common" do
+          let(:password) { "password1234" }
+          let(:password_confirmation) { "password1234" }
+
+          it { is_expected.not_to be_valid }
+        end
+
+        context "and the email is already taken by another admin" do
+          let!(:another_admin) { create(:admin) }
+          let(:email) { another_admin.email }
+
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+end

--- a/decidim-system/spec/system/manage_admins_spec.rb
+++ b/decidim-system/spec/system/manage_admins_spec.rb
@@ -87,7 +87,7 @@ describe "Manage admins" do
       end
     end
 
-    context "when password and password confirmation missmatch" do
+    context "when password and password confirmation mismatch" do
       it "gives an error" do
         within "tr", text: admin.email do
           click_on "Edit"
@@ -100,7 +100,7 @@ describe "Manage admins" do
           find("*[type=submit]").click
         end
 
-        expect(page).to have_callout("Password confirmation must match the password")
+        expect(page).to have_css(".form-error.is-visible", text: "does not match Password")
       end
     end
   end

--- a/decidim-system/spec/system/manage_admins_spec.rb
+++ b/decidim-system/spec/system/manage_admins_spec.rb
@@ -86,6 +86,23 @@ describe "Manage admins" do
         expect(page).to have_css(".form-error.is-visible", text: "is too common")
       end
     end
+
+    context "when password and password confirmation missmatch" do
+      it "gives an error" do
+        within "tr", text: admin.email do
+          click_on "Edit"
+        end
+
+        within ".edit_admin" do
+          fill_in :admin_password, with: "decidim123456789"
+          fill_in :admin_password_confirmation, with: "123456789decidim"
+
+          find("*[type=submit]").click
+        end
+
+        expect(page).to have_callout("Password confirmation must match the password")
+      end
+    end
   end
 
   it "deletes an admin" do


### PR DESCRIPTION
#### :tophat: What? Why?

While reviewing #17270, I noticed that instead of doing it as a Command/Controller change, it could be cleaner to just do it as a Form change. This PR implements that.

I extracted the system spec from that PR, and also added a unit spec. 

#### :pushpin: Related Issues
 
- Fixes https://github.com/decidim/decidim/issues/15792 

#### Testing

1. Access the system dashboard.
2. Edit any admin.
3. Insert 2 different passwords in the "Password" and "Password confirmation" fields.
4. See the flash message displayed and that no other error is displayed.

### :camera: Screenshots

<img width="1837" height="719" alt="image" src="https://github.com/user-attachments/assets/1cf74b2b-6a25-491a-8b03-4f1635039118" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined administrator password validation so password and password confirmation rules apply only under the correct conditions.
  * Password and password confirmation behavior during admin updates is more consistent, including handling blank fields and mismatches.
* **Tests**
  * Expanded form and admin-management specs to cover missing/invalid credentials, too-common passwords, and password/confirmation mismatches when updating an admin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->