### PR TITLE
Display meeting attendees count in participatory space statistics

### DIFF
--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -852,7 +852,7 @@ en:
         proposal_meeting: 'Related meetings:'
     statistics:
       attendees_count: Meeting attendees
-      attendees_count_tooltip: The total number of attendees of the meetings held within this participatory space. This figure is not added to the Participants figure.
+      attendees_count_tooltip: The total number of attendees of the meetings held within this participatory space.
       meetings_count: Meetings
       meetings_count_tooltip: The number of meetings that have taken place, both online and in person.
       participatory_space_meetings_count: Meetings

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -852,7 +852,7 @@ en:
         proposal_meeting: 'Related meetings:'
     statistics:
       attendees_count: Meeting attendees
-      attendees_count_tooltip: The total number of attendees of the meetings held within this participation space. This figure is not added to the Participants figure.
+      attendees_count_tooltip: The total number of attendees of the meetings held within this participatory space. This figure is not added to the Participants figure.
       meetings_count: Meetings
       meetings_count_tooltip: The number of meetings that have taken place, both online and in person.
       participatory_space_meetings_count: Meetings

--- a/decidim-meetings/config/locales/en.yml
+++ b/decidim-meetings/config/locales/en.yml
@@ -852,6 +852,7 @@ en:
         proposal_meeting: 'Related meetings:'
     statistics:
       attendees_count: Meeting attendees
+      attendees_count_tooltip: The total number of attendees of the meetings held within this participation space. This figure is not added to the Participants figure.
       meetings_count: Meetings
       meetings_count_tooltip: The number of meetings that have taken place, both online and in person.
       participatory_space_meetings_count: Meetings

--- a/decidim-meetings/lib/decidim/meetings/component.rb
+++ b/decidim-meetings/lib/decidim/meetings/component.rb
@@ -77,7 +77,12 @@ Decidim.register_component(:meetings) do |component|
     meetings.sum(:comments_count)
   end
 
-  component.register_stat :attendees_count, primary: true, priority: Decidim::StatsRegistry::LOW_PRIORITY do |components, start_at, end_at|
+  component.register_stat :attendees_count,
+                          primary: true,
+                          priority: Decidim::StatsRegistry::MEDIUM_PRIORITY,
+                          admin: false,
+                          icon_name: "group-line",
+                          tooltip_key: "attendees_count_tooltip" do |components, start_at, end_at|
     meetings = Decidim::Meetings::Meeting.closed.not_hidden.published.where(component: components, closing_visible: true)
     meetings = meetings.where(closed_at: start_at..) if start_at.present?
     meetings = meetings.where(closed_at: ..end_at) if end_at.present?

--- a/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
+++ b/decidim-meetings/spec/lib/decidim/meetings/component_spec.rb
@@ -89,6 +89,13 @@ describe "Meetings component" do # rubocop:disable RSpec/DescribeClass
         expect(Decidim::Meetings::Meeting.sum(:attendees_count)).to eq 70
         expect(subject).to eq 20
       end
+
+      it "is registered for the participatory space statistics but not for the admin dashboard" do
+        stat = Decidim.find_component_manifest(:meetings).stats.stats.find { |definition| definition[:name] == stats_name }
+
+        expect(stat[:priority]).to eq(Decidim::StatsRegistry::MEDIUM_PRIORITY)
+        expect(stat[:admin]).to be(false)
+      end
     end
   end
 


### PR DESCRIPTION
#### :tophat: What? Why?

The meetings component already registers an `attendees_count` stat, but it was registered with `LOW_PRIORITY`, which no presenter ever renders — so the number was computed and tested but never displayed anywhere.

This PR promotes the existing stat to `MEDIUM_PRIORITY` so it is displayed in the statistics block of participatory space homepages (processes, assemblies, conferences and process groups) and exposed in the GraphQL space `stats` field, adding an icon and a tooltip. It is registered with `admin: false` so the admin dashboard remains unchanged.

The way the figure is computed is untouched: it sums the attendees of closed, published, not hidden meetings with a visible closing report. Stats with a zero value are filtered out, so it only appears in spaces that have closed meetings with attendees.

Upstreamed from AjuntamentdeBarcelona/decidim-barcelona#750, reusing the existing stat registration instead of adding a wrapper stat.

#### :pushpin: Related Issues

- Related to AjuntamentdeBarcelona/decidim-barcelona#750

#### Testing

1. In a participatory space, create a meetings component with some meetings.
2. Close some of them setting an attendees count, keeping the closing report visible.
3. Visit the space homepage: the statistics block shows a "Meeting attendees" stat with the summed count and a tooltip.

### :camera: Screenshots

<img width="1477" height="495" alt="Attendees stat in the space statistics block" src="https://github.com/user-attachments/assets/24c8ed52-027e-4a1f-bd7d-1b3b83991880" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an English tooltip for the attendees count stat, clarifying it represents the total number of meeting attendees within the participatory space.
  * Improved the attendees count stat’s visibility in participatory space statistics by increasing its priority.

* **Bug Fixes**
  * Ensured the attendees count stat is explicitly not displayed in the admin dashboard statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->