### PR TITLE
Fix email update order for converting groups to user

### DIFF
--- a/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
+++ b/decidim-core/db/migrate/20250217192438_convert_user_groups_into_users.rb
@@ -33,8 +33,8 @@ class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
   def up
     User.old_group.find_each do |group|
       if group.email.blank? || another_user_with_same_email_in_organization?(group)
-        group.update_attribute(:email, "user_group_#{group.id}@#{group.organization.host}.invalid")
         group.update_attribute(:extended_data, (group.extended_data || {}).merge("patched" => true, "previous_email" => group.email))
+        group.update_attribute(:email, "user_group_#{group.id}@#{group.organization.host}.invalid")
 
         group.reload
       end
@@ -49,7 +49,8 @@ class ConvertUserGroupsIntoUsers < ActiveRecord::Migration[7.0]
     User.new_group.find_each do |group|
       group.update_attribute(:officialized_at, nil)
       group.update_attribute(:type, "Decidim::UserGroup")
-      group.update_attribute(:extended_data, (group.extended_data || {}).except("group"))
+      group.update_attribute(:email, group.extended_data["previous_email"]) if group.extended_data["previous_email"].present?
+      group.update_attribute(:extended_data, (group.extended_data || {}).except("group", "patched", "previous_email"))
     end
   end
   # rubocop:enable Rails/SkipsModelValidations


### PR DESCRIPTION
#### :tophat: What? Why?
There is a bug regarding the conversion from groups to users.
The `extended_data` attribute is saving the old email of the group as introduced in https://github.com/decidim/decidim/pull/15289.

However the email of the user is changed before saving it, resulting on complete loss of the old email of the group when you execute that migration.

This fixes the issues for new migrations, but databases that already have converted the groups to users will have the old email permanently lost.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #17251 

#### Testing
Upgrade from version 0.30 to 0.31 an instance with a group that shares and email with an user.
Run the migrations, see that the old groups have the same email for the new user object and the property in `extended_data`->`previous_email`

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
N/A

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of user groups into users when email addresses are blank or duplicated.
  * Preserved and correctly restored previous email addresses during rollback.
  * Ensured conversion metadata is properly cleaned up when changes are reverted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->