### PR TITLE
Speed improvement on data seeding

### DIFF
--- a/decidim-comments/app/models/decidim/comments/seed.rb
+++ b/decidim-comments/app/models/decidim/comments/seed.rb
@@ -22,20 +22,27 @@ module Decidim
 
           @organization = resource.organization
 
-          rand(0..config_value(:comments_count)).times do
-            comment1 = create_comment(resource)
-            NewCommentNotificationCreator.new(comment1, []).create
+          Decidim::Comments::Comment.skip_callback(:save, :after, :update_counter)
 
-            if rand < config_value(:comments_nested_probability)
-              comment2 = create_comment(comment1, resource)
-              NewCommentNotificationCreator.new(comment2, []).create
+          ActiveRecord::Base.transaction(requires_new: true) do
+            rand(0..config_value(:comments_count)).times do
+              comment1 = create_comment(resource)
+              NewCommentNotificationCreator.new(comment1, []).create
+
+              if rand < config_value(:comments_nested_probability)
+                comment2 = create_comment(comment1, resource)
+                NewCommentNotificationCreator.new(comment2, []).create
+              end
+
+              next if rand < config_value(:comments_vote_skip_probability)
+
+              create_votes(comment1) if comment1
+              create_votes(comment2) if comment2
             end
-
-            next if rand < config_value(:comments_vote_skip_probability)
-
-            create_votes(comment1) if comment1
-            create_votes(comment2) if comment2
           end
+
+          resource.update_comments_count if resource.respond_to?(:update_comments_count)
+          Decidim::Comments::Comment.set_callback(:save, :after, :update_counter)
         end
 
         private
@@ -84,12 +91,21 @@ module Decidim
         #
         # @return nil
         def create_votes(comment)
-          rand(0..config_value(:comments_votes_count)).times do
-            author = random_user
-            next if CommentVote.where(comment:, author:).any?
+          Decidim::Comments::CommentVote.skip_callback(:create, :after, :update_comment_votes_count)
 
+          user_ids = CommentVote.where(comment:, decidim_author_type: "Decidim::UserBaseEntity").pluck(:decidim_author_id)
+
+          users = Decidim::UserBaseEntity.not_deleted.not_blocked.confirmed.where.not(id: user_ids).order("RANDOM()").take(rand(0..50))
+          users.each do |author|
             CommentVote.create!(comment:, author:, weight: [1, -1].sample)
           end
+
+          comment.update(
+            up_votes_count: comment.up_votes.count,
+            down_votes_count: comment.down_votes.count
+          )
+
+          Decidim::Comments::CommentVote.set_callback(:create, :after, :update_comment_votes_count)
 
           nil
         rescue ActiveRecord::AssociationTypeMismatch

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -205,12 +205,14 @@ module Decidim
   def self.seed_gamification_badges!
     Gamification.badges.each do |badge|
       puts "Setting random values for the \"#{badge.name}\" badge..." # rubocop:disable Rails/Output
-      User.all.find_each do |user|
-        Gamification::BadgeScore.find_or_create_by!(
-          user:,
-          badge_name: badge.name,
-          value: Random.rand(0...20)
-        )
+      ActiveRecord::Base.transaction(requires_new: true) do
+        User.find_each do |user|
+          Gamification::BadgeScore.find_or_create_by!(
+            user:,
+            badge_name: badge.name,
+            value: Random.rand(0...20)
+          )
+        end
       end
     end
   end
@@ -221,18 +223,18 @@ module Decidim
                              .select { |resource| resource.constantize.include? Decidim::Likeable }
 
     resources_types.each do |resource_type|
+      puts "Setting random random likes for #{resource_type}" # rubocop:disable Rails/Output
       resource_type.constantize.find_each do |resource|
-        # exclude the users that already liked
-        users = resource.likes.map(&:author)
-        remaining_count = Decidim::User.count - users.count
-        next if remaining_count < 1
+        ActiveRecord::Base.transaction(requires_new: true) do
+          # exclude the users that already liked
+          users = resource.likes.map(&:author)
+          remaining_count = Decidim::User.count - users.count
+          next if remaining_count < 1
 
-        rand([50, remaining_count].min).times do
-          user = (Decidim::User.all - users).sample
-          next unless user
-
-          Decidim::Like.create!(resource:, author: user)
-          users << user
+          Decidim::User.where.not(id: users).order("RANDOM()").take([50, remaining_count].min).each do |user|
+            Decidim::Like.create!(resource:, author: user)
+            users << user
+          end
         end
       end
     end

--- a/decidim-core/lib/decidim/seeds.rb
+++ b/decidim-core/lib/decidim/seeds.rb
@@ -172,7 +172,9 @@ module Decidim
 
     def seed_components_manifests!(participatory_space:)
       Decidim.component_manifests.each do |manifest|
-        manifest.seed!(participatory_space.reload)
+        ActiveRecord::Base.transaction do
+          manifest.seed!(participatory_space.reload)
+        end
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
As i needed the full data in order to work on #17160, i made a pit stop on #14945 and managed to improve a bit the speed of seeds. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #14945
- Fixes #?

#### Testing
1. Set the `SLOW_SEEDS` env variable to true 
2. Run `time ./bin/rails db:seeds:replant`
3. See the time 
4. Apply the patch 
5. Repeat steps 2 & 3. Should be a speed decrease from around 120 mins down to 100 

:hearts: Thank you!
