### PR TITLE
Fix validation in online meeting URL

### DIFF
--- a/decidim-core/lib/decidim/content_security_policy.rb
+++ b/decidim-core/lib/decidim/content_security_policy.rb
@@ -55,6 +55,7 @@ module Decidim
 
       message = "Invalid Content Security Policy directive: #{directive}, supported directives: #{SUPPORTED_POLICIES.join(", ")}"
       raise message unless SUPPORTED_POLICIES.include?(directive)
+      raise "Invalid Content Security Policy value: #{value.inspect}" unless valid_csp_value?(value)
 
       policy[directive] ||= []
       policy[directive] << value
@@ -78,6 +79,10 @@ module Decidim
       policy.map do |directive, values|
         [directive, values.uniq.join(" ")].join(" ")
       end.join("; ")
+    end
+
+    def valid_csp_value?(value)
+      value.to_s.match?(/\A[^;\s]+\z/)
     end
 
     def append_multiple_csp_directives(directive, values)

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -64,11 +64,15 @@ module Decidim
       end
 
       it "rejects values containing semicolons" do
-        expect { subject.append_csp_directive("frame-src", "https://example.org/;script-src 'none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
+        expect { subject.append_csp_directive("frame-src", "https://example.org/;script-src='none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
       end
 
       it "rejects values containing whitespace" do
         expect { subject.append_csp_directive("frame-src", "https://example.org 'none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
+      end
+
+      it "rejects values containing both semicolons and whitespace" do
+        expect { subject.append_csp_directive("frame-src", "https://example.org/;script-src 'none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
       end
 
       it "accepts values without separators" do

--- a/decidim-core/spec/lib/content_security_policy_spec.rb
+++ b/decidim-core/spec/lib/content_security_policy_spec.rb
@@ -62,6 +62,18 @@ module Decidim
       it "when has invalid rule" do
         expect { subject.append_csp_directive("invalid-rule", "https://example.org") }.to raise_error(RuntimeError)
       end
+
+      it "rejects values containing semicolons" do
+        expect { subject.append_csp_directive("frame-src", "https://example.org/;script-src 'none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
+      end
+
+      it "rejects values containing whitespace" do
+        expect { subject.append_csp_directive("frame-src", "https://example.org 'none'") }.to raise_error(RuntimeError, /Invalid Content Security Policy value/)
+      end
+
+      it "accepts values without separators" do
+        expect { subject.append_csp_directive("frame-src", "https://example.org/abc") }.not_to raise_error
+      end
     end
   end
 end

--- a/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
@@ -15,10 +15,11 @@ module Decidim
       def add_additional_csp_directives
         return unless respond_to?(:meeting) || meeting.present?
 
-        embedded = MeetingIframeEmbedder.new(meeting.online_meeting_url).embed_transformed_url(request.host)
-        return if embedded.blank?
+        embedder = MeetingIframeEmbedder.new(meeting.online_meeting_url)
+        return unless embedder.embeddable?
 
-        content_security_policy.append_csp_directive("frame-src", embedded)
+        embedded = embedder.embed_transformed_url(request.host)
+        content_security_policy.append_csp_directive("frame-src", embedded) if embedded.present?
       end
     end
   end

--- a/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/application_controller.rb
@@ -16,10 +16,12 @@ module Decidim
         return unless respond_to?(:meeting) || meeting.present?
 
         embedder = MeetingIframeEmbedder.new(meeting.online_meeting_url)
-        return unless embedder.embeddable?
+        return unless embedder.csp_safe?
 
         embedded = embedder.embed_transformed_url(request.host)
-        content_security_policy.append_csp_directive("frame-src", embedded) if embedded.present?
+        return unless MeetingIframeEmbedder.csp_safe_value?(embedded)
+
+        content_security_policy.append_csp_directive("frame-src", embedded)
       end
     end
   end

--- a/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
@@ -8,6 +8,19 @@ module Decidim
     # in the live event. For some services it is required to transform a bit
     # the structure of the URL.
     class MeetingIframeEmbedder
+      # Public: Validates that a value is safe to include in a CSP source list.
+      # It checks that the value contains no semicolons or whitespace and that
+      # it is a valid HTTP/HTTPS URL with a host.
+      def self.csp_safe_value?(value)
+        return false if value.blank?
+        return false unless value.match?(/\A[^;\s]+\z/)
+
+        uri = URI.parse(value)
+        (uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)) && uri.host.present?
+      rescue URI::InvalidURIError
+        false
+      end
+
       # Public: Initializes the service.
       # online_meeting_service_url - A String containing the url of the online meeting
       def initialize(online_meeting_service_url)
@@ -31,6 +44,10 @@ module Decidim
         return nil if parsed_online_meeting_uri.nil?
 
         embeddable_services.include?(parsed_online_meeting_uri.host)
+      end
+
+      def csp_safe?
+        valid_csp_url? && embeddable?
       end
 
       def embed_code(request_host)
@@ -84,6 +101,10 @@ module Decidim
 
       def parsed_online_meeting_uri
         @parsed_online_meeting_uri ||= URI.parse(online_meeting_service_url) if online_meeting_service_url.present?
+      end
+
+      def valid_csp_url?
+        self.class.csp_safe_value?(online_meeting_service_url)
       end
     end
   end

--- a/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
+++ b/decidim-meetings/app/services/decidim/meetings/meeting_iframe_embedder.rb
@@ -101,6 +101,8 @@ module Decidim
 
       def parsed_online_meeting_uri
         @parsed_online_meeting_uri ||= URI.parse(online_meeting_service_url) if online_meeting_service_url.present?
+      rescue URI::InvalidURIError
+        nil
       end
 
       def valid_csp_url?

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -132,6 +132,19 @@ describe Decidim::Meetings::MeetingsController do
             expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://www.youtube-nocookie.com/embed/pj_2G3x6-Zk")
           end
         end
+
+        context "when online_meeting_url uses an allowlisted host with a malicious path" do
+          it "does not crash and keeps the frame-src directive clean" do
+            meeting.update!(online_meeting_url: "https://meet.jit.si/room;script-src-elem 'none'")
+
+            expect { get :show, params: { id: meeting.id } }.not_to raise_error
+            expect(response).to render_template(:show)
+
+            csp = response.headers["Content-Security-Policy"]
+            expect(csp).not_to include("script-src-elem 'none'")
+            expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com")
+          end
+        end
       end
 
       it "can access private but transparent meetings" do

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -120,6 +120,17 @@ describe Decidim::Meetings::MeetingsController do
           expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com")
         end
 
+        it "does not allow CSP injection via an allowed host with CSP-breaking characters" do
+          meeting.update!(online_meeting_url: "https://meet.jit.si/room;script-src-elem 'none';report-uri https://attacker.example/collect")
+
+          expect { get :show, params: { id: meeting.id } }.not_to raise_error
+
+          csp = response.headers["Content-Security-Policy"]
+          expect(csp).not_to include("report-uri https://attacker.example/collect")
+          expect(csp).not_to include("script-src-elem 'none'")
+          expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com")
+        end
+
         context "when online_meeting_url points to an embeddable service" do
           let(:meeting) do
             create(:meeting, :published, :online, :embeddable, component: meeting_component)

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -106,6 +106,34 @@ describe Decidim::Meetings::MeetingsController do
         expect(flash[:alert]).to be_blank
       end
 
+      context "with an online meeting" do
+        let(:meeting) { create(:meeting, :published, :online, component: meeting_component) }
+
+        it "does not allow CSP injection through online_meeting_url" do
+          meeting.update!(online_meeting_url: "https://meet.evil.example/?a=1;script-src-elem 'none';report-uri https://attacker.example/collect")
+
+          expect { get :show, params: { id: meeting.id } }.not_to raise_error
+
+          csp = response.headers["Content-Security-Policy"]
+          expect(csp).not_to include("report-uri https://attacker.example/collect")
+          expect(csp).not_to include("script-src-elem 'none'")
+          expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com")
+        end
+
+        context "when online_meeting_url points to an embeddable service" do
+          let(:meeting) do
+            create(:meeting, :published, :online, :embeddable, component: meeting_component)
+          end
+
+          it "adds the transformed URL to frame-src" do
+            get :show, params: { id: meeting.id }
+
+            csp = response.headers["Content-Security-Policy"]
+            expect(csp).to include("frame-src 'self' www.youtube-nocookie.com player.vimeo.com https://www.youtube-nocookie.com/embed/pj_2G3x6-Zk")
+          end
+        end
+      end
+
       it "can access private but transparent meetings" do
         meeting.update(private_meeting: true, transparent: true)
 

--- a/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
+++ b/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
@@ -99,6 +99,48 @@ module Decidim
         end
       end
 
+      describe "#csp_safe?" do
+        context "with a valid youtube URL" do
+          let(:url) { "https://www.youtube.com/watch?v=aiyHi9MzW30" }
+
+          it "is safe for CSP" do
+            expect(subject).to be_csp_safe
+          end
+        end
+
+        context "with a valid Twitch URL" do
+          let(:url) { "https://www.twitch.tv/videos/920134652?collection=YQZOzRslZRZ0TQ" }
+
+          it "is safe for CSP" do
+            expect(subject).to be_csp_safe
+          end
+        end
+
+        context "with a valid Jitsi URL" do
+          let(:url) { "https://meet.jit.si/decidim-meeting" }
+
+          it "is safe for CSP" do
+            expect(subject).to be_csp_safe
+          end
+        end
+
+        context "with an allowlisted host containing CSP-breaking characters" do
+          let(:url) { "https://meet.jit.si/room;script-src-elem 'none'" }
+
+          it "is not safe for CSP" do
+            expect(subject).not_to be_csp_safe
+          end
+        end
+
+        context "with a not recognized streaming URL" do
+          let(:url) { "https://example.org/decidim-meeting" }
+
+          it "is not safe for CSP" do
+            expect(subject).not_to be_csp_safe
+          end
+        end
+      end
+
       describe "#embed_code" do
         let(:url) { "https://www.youtube.com/watch?v=aiyHi9MzW30" }
 

--- a/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
+++ b/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
@@ -63,6 +63,16 @@ module Decidim
             expect(subject).not_to be_embeddable
           end
         end
+
+        context "with an allowed host containing CSP-breaking characters" do
+          let(:url) { "https://meet.jit.si/room;script-src-elem 'none';report-uri https://attacker.example/collect" }
+
+          it "is not transformed, embeddable, or CSP-safe" do
+            expect(subject.embed_transformed_url(request_host)).to be_nil
+            expect(subject).not_to be_embeddable
+            expect(subject).not_to be_csp_safe
+          end
+        end
       end
 
       describe "#embeddable?" do

--- a/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
+++ b/decidim-meetings/spec/services/meeting_iframe_embedder_spec.rb
@@ -54,6 +54,15 @@ module Decidim
             expect(subject.embed_transformed_url(request_host)).to eq(url)
           end
         end
+
+        context "with a URL containing CSP-breaking characters" do
+          let(:url) { "https://meet.evil.example/?a=1;script-src-elem 'none';report-uri https://attacker.example/collect" }
+
+          it "returns the URL verbatim but is not considered embeddable" do
+            expect(subject.embed_transformed_url(request_host)).to eq(url)
+            expect(subject).not_to be_embeddable
+          end
+        end
       end
 
       describe "#embeddable?" do


### PR DESCRIPTION
#### :tophat: What? Why?

There's a validation missing in the Online Meeting URL field in decidim-meetings. This PR fixes it. 
 

#### Testing

All the specs should pass 
A participant nor an admin shouldn't add non-valid characters in this field

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened Content Security Policy validation to reject directive values containing unsafe characters.
  * Hardened meeting page CSP generation to prevent attacker-controlled meeting URLs from injecting malicious security-header content.
  * Improved CSP-safe handling for embeddable online meetings by only adding the expected `frame-src` sources when the embedded URL is valid and safe.

* **Tests**
  * Added scenarios asserting CSP header cleanliness against injected payloads and invalid CSP values.
  * Added coverage for CSP-safe embeddable meeting URLs and rejection of unsafe/unrecognized streaming URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->