### PR TITLE
Fix taxonomies import when filters already exist

### DIFF
--- a/decidim-core/lib/decidim/maintenance/taxonomy_importer.rb
+++ b/decidim-core/lib/decidim/maintenance/taxonomy_importer.rb
@@ -85,7 +85,10 @@ module Decidim
           component = GlobalID::Locator.locate(component_id)
           if component
             begin
-              component.update!(settings: component.settings.to_h.merge(taxonomy_filters: [filter.id.to_s]))
+              settings = component.settings.to_h
+              settings[:taxonomy_filters] ||= []
+              settings[:taxonomy_filters] << filter.id.to_s unless settings[:taxonomy_filters].include?(filter.id.to_s)
+              component.update!(settings:)
               result[:components_assigned][filter.internal_name[organization.default_locale]] ||= []
               result[:components_assigned][filter.internal_name[organization.default_locale]] << component_id
             rescue ActiveRecord::RecordInvalid

--- a/decidim-core/spec/lib/maintenance/taxonomy_importer_spec.rb
+++ b/decidim-core/spec/lib/maintenance/taxonomy_importer_spec.rb
@@ -180,6 +180,51 @@ module Decidim::Maintenance
         end
       end
 
+      context "when component already has taxonomy filters" do
+        let(:json_filters) do
+          [
+            {
+              "name" => "New root taxonomy",
+              "internal_name" => "Imported filter",
+              "participatory_space_manifests" => participatory_space_manifests,
+              "items" => [["New taxonomy", "New child taxonomy"]],
+              "components" => [
+                component_id
+              ]
+            }
+          ]
+        end
+        let!(:existing_filter) { create(:taxonomy_filter, root_taxonomy: create(:taxonomy, organization:)) }
+        let!(:another_existing_filter) { create(:taxonomy_filter, root_taxonomy: create(:taxonomy, organization:)) }
+
+        before do
+          component.update!(settings: { taxonomy_filters: [existing_filter.id.to_s, another_existing_filter.id.to_s] })
+        end
+
+        it "preserves existing taxonomy filters and appends the imported one without duplicates" do
+          subject.import!
+
+          imported_filter = Decidim::TaxonomyFilter.find_by!(
+            internal_name: { organization.default_locale => "Imported filter" },
+            root_taxonomy:
+          )
+
+          expect(component.reload.settings[:taxonomy_filters]).to contain_exactly(
+            existing_filter.id.to_s,
+            another_existing_filter.id.to_s,
+            imported_filter.id.to_s
+          )
+
+          subject.import!
+
+          expect(component.reload.settings[:taxonomy_filters]).to contain_exactly(
+            existing_filter.id.to_s,
+            another_existing_filter.id.to_s,
+            imported_filter.id.to_s
+          )
+        end
+      end
+
       context "when a filter already exists" do
         let!(:root_taxonomy) { create(:taxonomy, organization:, name: { organization.default_locale => "New root taxonomy" }) }
         let!(:filter) { create(:taxonomy_filter, root_taxonomy:, participatory_space_manifests: ["participatory_processes"]) }


### PR DESCRIPTION
#### :tophat: What? Why?

The rake task `bin/rails decidim:taxonomies:import_plan` imports filters created from the old categorization system. However there is a small bug and only imports the last filter defined.

For instance if you have JSON file defined like:

```json
{
  "imported_taxonomies": {
    "Scopes": {
      "taxonomies": {...}
      "filters": [
        {
          "name": "Scopes filter",
          "components": [
            "gid://decidim-nyc/Decidim::Component/11"
          ]
        }
      ]
    },
    "Categories": {
      "taxonomies": {...}
      "filters": [
        {
          "name": "Categories filter",
          "components": [
            "gid://decidim-nyc/Decidim::Component/11"
          ]
        }
      ]
    }

  }
}
```
Only the last filter will be imported in the Component 11.
This fixes the situation by ensuring to import whatever configuration already available.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
This probably only happens on situations where you customiza the JSON plan file created from a migration from version 29 to 30.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
N/A

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing taxonomy filters when importing additional filters.
  * Prevented duplicate taxonomy filter entries during repeated imports.
  * Ensured repeated imports produce consistent results.
  * Prevented scope filters from being applied when scopes are unavailable or disabled for the relevant participatory space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->