### PR TITLE
Pin rack-proxy to a version compatible with shakapacker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (>= 3.2.4, < 4.0)
       rack-attack (>= 6.7, < 6.9)
+      rack-proxy (~> 0.8.3, < 1.0)
       rails (~> 8.1.0)
       rails-i18n (~> 8.1.0, < 8.2)
       ransack (>= 4.2, < 4.5)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -70,6 +70,9 @@ Gem::Specification.new do |s|
   s.add_dependency "premailer-rails", "~> 1.10"
   s.add_dependency "rack", ">= 3.2.4", "< 4.0"
   s.add_dependency "rack-attack", ">= 6.7", "< 6.9"
+  # Workaround until shakapacker releases a new version compatible with rack-proxy v1.0
+  # @see https://github.com/shakacode/shakapacker/issues/1220
+  s.add_dependency "rack-proxy", "~> 0.8.3", "< 1.0"
   s.add_dependency "rails", "~> 8.1.0"
   s.add_dependency "rails-i18n", "~> 8.1.0", "< 8.2"
   s.add_dependency "ransack", ">= 4.2", "< 4.5"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -97,6 +97,7 @@ PATH
       premailer-rails (~> 1.10)
       rack (>= 3.2.4, < 4.0)
       rack-attack (>= 6.7, < 6.9)
+      rack-proxy (~> 0.8.3, < 1.0)
       rails (~> 8.1.0)
       rails-i18n (~> 8.1.0, < 8.2)
       ransack (>= 4.2, < 4.5)
@@ -670,7 +671,7 @@ GEM
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.3)
       rack
     rack-session (2.1.2)
       base64 (>= 0.1.0)


### PR DESCRIPTION
#### :tophat: What? Why?

Yesterday I noticed that Shakapacker dev server wasn't working correctly. 

After some research I noticed that the problem is that there's a new version of rack-proxy (v1.0.0) released a few days ago that isn't compatible with Shakapacker.

For now I think it is safer to just pin to rack-proxy < "1.0" and wait until the fix is provided on Shakapacker side. Once that is available we can update to that Shakapacker version and remove this pin. 

#### :pushpin: Related Issues

- Related to https://github.com/shakacode/shakapacker/issues/1220

#### Testing

1. Generate a new development app
``` 
bundle exec rake development_app
bin/dev
```
2. Visit http://localhost:3000 
3. Check out the Network tab . Do it without filters, with the options "All" and "Disable Cache" 
4. (Before) see that you have 502 errors
5. (After) see that the only errors are unrelated (web sockets that can be ignored as far as I understand) 

### :camera: Screenshots

#### Before

<img width="907" height="986" alt="image" src="https://github.com/user-attachments/assets/8aaebf50-8867-4845-9017-ec4b4c56c58e" />

#### After

<img width="908" height="983" alt="image" src="https://github.com/user-attachments/assets/d2e8709c-5c7f-4138-836d-708a134ea287" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with the Shakapacker ecosystem.
  * Added support for proxy functionality required at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->