### PR TITLE
Make consistent the eslint configuration between versions

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
@@ -68,6 +68,8 @@ export default class extends Controller {
   /**
    * Applies viewport-conditional data-open attributes and resets
    * previously applied values when the viewport no longer matches.
+   *
+   * @returns {void}
    */
   _applyBreakpointOpenAttributes() {
     const controlledTriggers = new Set();
@@ -107,6 +109,8 @@ export default class extends Controller {
   /**
    * Listens for viewport changes that cross breakpoints relevant
    * to this accordion and reconnects to keep state in sync.
+   *
+   * @returns {void}
    */
   _listenForBreakpointChanges() {
     this._mediaQueries = [];

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -284,7 +284,7 @@ module.exports = {
     "jsdoc/require-jsdoc": "error",
     "jsdoc/require-param": "error",
     "jsdoc/require-param-type": "error",
-    "jsdoc/require-returns": "error",
+    "jsdoc/require-returns": ["error", { "forceRequireReturn": true }],
     "jsdoc/require-returns-type": "error",
     "jsdoc/check-tag-names": ["error", {definedTags: ["jest-environment"]}],
     "jsdoc/check-alignment": "warn",


### PR DESCRIPTION
#### :tophat: What? Why?

On #17381 we have a linter error that we don't have in `develop`: 

```
/home/runner/work/decidim/decidim/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
Error:    68:3  error  Missing JSDoc @returns for function  valid-jsdoc
Error:   107:3  error  Missing JSDoc @returns for function  valid-jsdoc
```

This is because back in https://github.com/decidim/decidim/pull/16882 we updated the version with the new syntax, but it seems like the "require returns" eslint jsdoc configuration doesn't actually require the return on this new version (!!), and you need to force it. 

This PR does that, so we don't have these kind of inconsistencies between versions and backports (and because this behavior is what makes sense IMO). 
 

#### Testing

Linter should fail in one commit, then it should pass when fixed (and everything should be green) 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Strengthened linting rules to require `@returns` annotations for documented functions.
  * Updated JSDoc for controller methods to include missing `@returns {void}` annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->