### PR TITLE
Fix expected taxonomy order in specs

### DIFF
--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -622,7 +622,7 @@ FactoryBot.define do
     name { generate_localized_title(:taxonomy_name, skip_injection:) }
     organization
     parent { nil }
-    weight { nil }
+    sequence(:weight)
 
     trait :with_parent do
       parent { create(:taxonomy, organization:, skip_injection:) }


### PR DESCRIPTION
#### :tophat: What? Why?
Adds weight sequence to the taxonomies factory for specs for them to appear in expected order.

This is because noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/30454684680/job/90585203320

Relevant test output:
```
Failures:

  1) Decidim::Proposals::Admin::ImportProposals call when the form is valid only imports wanted attributes
     Failure/Error: expect(new_proposal.taxonomies).to eq(proposal.taxonomies)

       expected: #<ActiveRecord::Associations::CollectionProxy [#<Decidim::Taxonomy id: 22, children_count: 0, created... [24, 23], taxonomizations_count: 1, updated_at: "2026-07-29 13:27:13.345791000 +0000", weight: 0>]>
            got: #<ActiveRecord::Associations::CollectionProxy [#<Decidim::Taxonomy id: 24, children_count: 0, created... [22, 21], taxonomizations_count: 2, updated_at: "2026-07-29 13:27:13.311652000 +0000", weight: 0>]>

       (compared using ==)

       Diff:





       @@ -1,28 +1,28 @@
       -[#<Decidim::Taxonomy:0x00007f16c4c3d700
       -  id: 22,
       +[#<Decidim::Taxonomy:0x00007f16c4b6f648
       +  id: 24,
          children_count: 0,
       -  created_at: "2026-07-29 13:27:13.299413000 +0000",
       +  created_at: "2026-07-29 13:27:13.334184000 +0000",
          decidim_organization_id: 78,
          filter_items_count: 0,
          filters_count: 0,
          name:
       -   {"en" => "<script>alert(\"taxonomy_name\");</script> Nam qui expedita. 6116", "ca" => "<script>alert(\"taxonomy_name\");</script> Est doloremque eveniet. 6117", "machine_translations" => {"es" => "<script>alert(\"taxonomy_name\");</script> Enim officiis sit. 6118"}},
       -  parent_id: 21,
       -  part_of: [22, 21],
       -  taxonomizations_count: 1,
       -  updated_at: "2026-07-29 13:27:13.311652000 +0000",
       +   {"ca" => "<script>alert(\"taxonomy_name\");</script> Omnis sed sit. 6123", "en" => "<script>alert(\"taxonomy_name\");</script> Id pariatur assumenda. 6122", "machine_translations" => {"es" => "<script>alert(\"taxonomy_name\");</script> Quasi eaque officiis. 6124"}},
       +  parent_id: 23,
       +  part_of: [24, 23],
       +  taxonomizations_count: 2,
       +  updated_at: "2026-07-29 13:27:13.345791000 +0000",
          weight: 0>,
       - #<Decidim::Taxonomy:0x00007f16c4c38340
       -  id: 24,
       + #<Decidim::Taxonomy:0x00007f16c4b6f508
       +  id: 22,
          children_count: 0,
       -  created_at: "2026-07-29 13:27:13.334184000 +0000",
       +  created_at: "2026-07-29 13:27:13.299413000 +0000",
          decidim_organization_id: 78,
          filter_items_count: 0,
          filters_count: 0,
          name:
       -   {"en" => "<script>alert(\"taxonomy_name\");</script> Id pariatur assumenda. 6122", "ca" => "<script>alert(\"taxonomy_name\");</script> Omnis sed sit. 6123", "machine_translations" => {"es" => "<script>alert(\"taxonomy_name\");</script> Quasi eaque officiis. 6124"}},
       -  parent_id: 23,
       -  part_of: [24, 23],
       -  taxonomizations_count: 1,
       -  updated_at: "2026-07-29 13:27:13.345791000 +0000",
       +   {"ca" => "<script>alert(\"taxonomy_name\");</script> Est doloremque eveniet. 6117", "en" => "<script>alert(\"taxonomy_name\");</script> Nam qui expedita. 6116", "machine_translations" => {"es" => "<script>alert(\"taxonomy_name\");</script> Enim officiis sit. 6118"}},
       +  parent_id: 21,
       +  part_of: [22, 21],
       +  taxonomizations_count: 2,
       +  updated_at: "2026-07-29 13:27:13.311652000 +0000",
          weight: 0>]
     # ./spec/commands/decidim/proposals/admin/import_proposals_spec.rb:125:in 'block (4 levels) in <module:Admin>'

Finished in 6 minutes 58 seconds (files took 19.05 seconds to load)
462 examples, 1 failure

Failed examples:

rspec ./spec/commands/decidim/proposals/admin/import_proposals_spec.rb:118 # Decidim::Proposals::Admin::ImportProposals call when the form is valid only imports wanted attributes
```

#### :pushpin: Related Issues
- Related to #17363

#### Testing
Run the spec several times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default taxonomy test data by assigning consistent weight values instead of leaving them blank.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->