### PR TITLE
Fix translation issue in maps

### DIFF
--- a/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
+++ b/decidim-core/spec/lib/map/provider/dynamic_map/here_spec.rb
@@ -54,8 +54,8 @@ module Decidim
                     tile_layer: {
                       api_key: "key1234", foo: "bar", language: "ca"
                     },
-                    zoom_in_text: "Zoom in",
-                    zoom_out_text: "Zoom out"
+                    zoom_in_text: "Ampliar",
+                    zoom_out_text: "Allunyar"
                   )
                 end
               end
@@ -69,8 +69,8 @@ module Decidim
                     tile_layer: {
                       api_key: "key1234", foo: "bar", language: "es"
                     },
-                    zoom_in_text: "Zoom in",
-                    zoom_out_text: "Zoom out"
+                    zoom_in_text: "Ampliar",
+                    zoom_out_text: "Alejar"
                   )
                 end
               end


### PR DESCRIPTION
#### :tophat: What? Why?
After the merge of #17252, we have an issue with the map's Zoom in and Zoom out translations that have been fixed back in #17307. 

This PR is fixing the specs that are failing constantly. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #17252
- Related to #17307

#### Testing
1. Green pipeline on Decidim Core pipeline 

### :camera: Screenshots

<img width="1119" height="884" alt="image" src="https://github.com/user-attachments/assets/90d8fa06-24f8-4e2b-8ad3-28b3ec5f9d5e" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localized map controls so Catalan and Spanish displays use the appropriate “Zoom in” and “Zoom out” translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->