### PR TITLE
Use Ubuntu 24.04 in github actions

### DIFF
--- a/.github/workflows/check_locale_completeness.yml
+++ b/.github/workflows/check_locale_completeness.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check-locale:
     name: Check locale completeness
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/check_locale_completeness.yml
+++ b/.github/workflows/check_locale_completeness.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check-locale:
     name: Check locale completeness
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci_backporter.yml
+++ b/.github/workflows/ci_backporter.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   backport:
     name: "Backporter"
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     # the below IF structure checks:
     #  - PR repository must be the official Decidim repository ( decidim/decidim )

--- a/.github/workflows/ci_backporter.yml
+++ b/.github/workflows/ci_backporter.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   backport:
     name: "Backporter"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     # the below IF structure checks:
     #  - PR repository must be the official Decidim repository ( decidim/decidim )

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -56,7 +56,7 @@ jobs:
           - command: bundle exec parallel_test --type rspec --pattern spec/lib/
             name: Lib
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 90
     services:

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -56,7 +56,7 @@ jobs:
           - command: bundle exec parallel_test --type rspec --pattern spec/lib/
             name: Lib
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 90
     services:

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci_javascript.yml
+++ b/.github/workflows/ci_javascript.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     services:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.language }}

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -37,7 +37,7 @@ jobs:
           - ./.github/run_spelling_check.sh
           - npm run linthtml
     name: Lint code
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -37,7 +37,7 @@ jobs:
           - ./.github/run_spelling_check.sh
           - npm run linthtml
     name: Lint code
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     steps:

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   check_title:
     name: Check PR title
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
@@ -48,7 +48,7 @@ jobs:
   check_label:
     needs: labeler
     name: Check PR labels
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   check_title:
     name: Check PR title
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: deepakputhraya/action-pr-title@master
         with:
@@ -48,7 +48,7 @@ jobs:
   check_label:
     needs: labeler
     name: Check PR labels
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:

--- a/.github/workflows/lint_pr_format.yml
+++ b/.github/workflows/lint_pr_format.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
       - uses: actions/labeler@v7

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   trigger_documentation_build:
     name: Trigger decidim/documentation build
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow

--- a/.github/workflows/on_docs_update.yml
+++ b/.github/workflows/on_docs_update.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   trigger_documentation_build:
     name: Trigger decidim/documentation build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for trigger_build workflow

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   trigger_docker_build:
     name: Trigger decidim/docker build
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for Docker Hub build

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   trigger_docker_build:
     name: Trigger decidim/docker build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 60
     steps:
     - name: Send dispatch for Docker Hub build

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build_app:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     env:

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   build_app:
     name: Test
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     if: "!startsWith(github.head_ref, 'chore/l10n')"
     timeout-minutes: 60
     env:

--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-26.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     services:
       postgres:

--- a/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml
+++ b/decidim-generators/lib/decidim/generators/component_templates/github/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   main:
     name: Tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     services:
       postgres:


### PR DESCRIPTION
#### :tophat: What? Why?
While investigating #17391, i have noticed that our libvips version is outdated. Investigating further i have found out this link : https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2604-Readme.md
 And also https://github.com/actions/runner-images/issues/14254

Since the date of the start of deprecation is next month, and i want to fix the Dependabot pipeline, i have opened the PR. 

**Note to the reviewer**: I have tried to upgrade to Ubuntu 26.04, but the pipeline failed because of the ruby version. Since i did not want to make a bulk PR with ruby version and ubuntu, i have changed to the latest version where ruby 3.4.7 is available.

#### Testing
Green pipeline.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated automated CI workflows (including checks, linting, main CI, JavaScript CI, production compile checks, CodeQL, performance monitoring, documentation builds, release triggering, and backporting) to use the Ubuntu **24.04** runner image.
  - Updated the generated CI workflow template to match the Ubuntu **24.04** runner environment.
  - Workflow logic, triggers, and configuration were otherwise left unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->