### PR TITLE
Ensure a random coauthor is always returned by the proposals seeds

### DIFF
--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -160,7 +160,9 @@ module Decidim
         when 1
           meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
 
-          Decidim::Meetings::Meeting.where(component: meeting_component).sample || random_coauthor
+          Decidim::Meetings::Meeting.where(component: meeting_component).sample ||
+            Decidim::User.visible.where(organization:).sample ||
+            organization
         else
           organization
         end

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -156,7 +156,7 @@ module Decidim
 
         case n
         when 0
-          Decidim::User.visible.where(organization:).sample
+          Decidim::User.visible.where(organization:).sample || organization
         when 1
           meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
 

--- a/decidim-proposals/lib/decidim/proposals/seeds.rb
+++ b/decidim-proposals/lib/decidim/proposals/seeds.rb
@@ -160,7 +160,7 @@ module Decidim
         when 1
           meeting_component = participatory_space.components.find_by(manifest_name: "meetings")
 
-          Decidim::Meetings::Meeting.where(component: meeting_component).sample
+          Decidim::Meetings::Meeting.where(component: meeting_component).sample || random_coauthor
         else
           organization
         end


### PR DESCRIPTION
#### :tophat: What? Why?
While working with the seeds, I noticed that the proposal seeds assume that there is always a meeting available within the same participatory space. This is not true if the meetings component seeds have not been run prior to proposals.

Particularly this came up when isolating the seeding process per component to analyze it better, as per this comment:
https://github.com/decidim/decidim/issues/14945#issuecomment-4542676459

If there are no meetings available, the seeding process ends with the following error:

```
/.../decidim/decidim-core/lib/decidim/coauthorable.rb:145:in 'Decidim::Proposals::Proposal#add_coauthor': undefined method 'id' for nil (NoMethodError)

        return if coauthorships.exists?(decidim_author_id: author.id, decidim_author_type: author.class.base_class.name)
                                                                 ^^^
        from /.../decidim/decidim-proposals/lib/decidim/proposals/seeds.rb:119:in 'block in Decidim::Proposals::Seeds#create_proposal!'
```

#### :pushpin: Related Issues
- Related to #14945

#### Testing

Use the following process to test the seeding **without** this PR:

1. Create the development app
2. Create a file `bin/custom-test-seed` with the following content:
```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true

require_relative "../config/boot"
require_relative "../config/environment"

require "decidim/participatory_processes/seeds"

puts "Creating process..."
pseeds = Decidim::ParticipatoryProcesses::Seeds.new
participatory_space = pseeds.create_process!
pseeds.create_process_step!(process: participatory_space)

manifest = Decidim.find_component_manifest("proposals")
manifest.seed!(participatory_space.reload)
```
3. Make it executable `chmod +x bin/custom-test-seed`
4. Run it multiple times `bundle exec bin/custom-test-seed`

If you cannot get the random generator to return number `1` for a meeting coauthor, hard code it to return `1` on this line:
https://github.com/decidim/decidim/blob/205d9abbd5e855a2af154b650ff05e71e3e3f362/decidim-proposals/lib/decidim/proposals/seeds.rb#L154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proposal seed generation so a coauthor is always assigned instead of returning `nil`, including when the “meetings” coauthor source has no results. The selection now falls back to a visible user from the proposal’s organization, and then to the organization itself if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->