### PR TITLE
Fix date/time picker initial time format and invalid attribute `default_time`

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
@@ -81,7 +81,9 @@ const splitTime = (value) => {
 };
 
 export const formatInputTime = (time, format, input) => {
-  if (time.length < 1) {
+  if (!time) {
+    return "";
+  } else if (time.length < 1) {
     return time;
   }
 

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
@@ -50,10 +50,7 @@ export const setMinute = (value) => {
 };
 
 export const formatInputDate = (date, formats) => {
-  const dateList = date.split("-");
-  const year = dateList[0];
-  const month = dateList[1];
-  const day = dateList[2];
+  const [year, month, day] = date.split("-");
 
   if (formats.order === "m-d-y") {
     return `${month}${formats.separator}${day}${formats.separator}${year}`;
@@ -64,9 +61,11 @@ export const formatInputDate = (date, formats) => {
 };
 
 export const formatInputTime = (time, format, input) => {
-  const timeList = time.split(":");
-  let hour = timeList[0];
-  const minute = timeList[1];
+  if (time.length < 1) {
+    return time;
+  }
+
+  let [hour, minute] = time.split(":");
 
   if (format === 12) {
     if (Number(hour) === 12) {
@@ -80,11 +79,9 @@ export const formatInputTime = (time, format, input) => {
     } else if (Number(hour) === 0) {
       hour = "12";
     }
-
-    return `${hour}:${minute}`;
   };
 
-  return time;
+  return `${hour}:${minute}`;
 };
 
 export const changeHourDisplay = (change, hour, format) => {
@@ -199,29 +196,21 @@ export const formatDate = (value, formats) => {
 };
 
 export const formatTime = (value, format, inputname) => {
-  if (format === 12) {
-    const splitValue = value.split(":");
-    let hour = splitValue[0];
-    const minute = splitValue[1];
-    if (document.getElementById(`period_am_${inputname}`).checked) {
-      switch (hour) {
-      case "12":
-        hour = "00";
+  let [hour, minute] = value.split(":").map((part) => part.padStart(2, "0"));
 
-        return `${hour}:${minute}`;
-      default:
-        return value;
-      };
+  if (format === 12) {
+    if (document.getElementById(`period_am_${inputname}`).checked) {
+      if (hour === "12") {
+        hour = "00";
+      }
     } else if (document.getElementById(`period_pm_${inputname}`).checked) {
       if (Number(hour) > 0 && Number(hour) < 12) {
         hour = `${Number(hour) + 12}`;
       };
-
-      return `${hour}:${minute}`
     };
   };
 
-  return value;
+  return `${hour}:${minute}`;
 };
 
 export const updateInputValue = (input, formats, time) => {

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
@@ -60,12 +60,32 @@ export const formatInputDate = (date, formats) => {
   return `${day}${formats.separator}${month}${formats.separator}${year}`;
 };
 
+/**
+ * Splits a time string into two elements: hours and minutes. Ensures a returned
+ * array of size 2 for any kind of strings or `null` values.
+ *
+ * Examples:
+ * splitTime("") => ["00", "00"]
+ * splitTime(null) => ["00", "00"]
+ * splitTime("12") => ["12", "00"]
+ * splitTime("12:30") => ["12", "30"]
+ * splitTime("2:4") => ["02", "04"]
+ * splitTime("12:30:45") => ["12", "30"]
+ *
+ * @param {String} value The original time string, typically hh:ss.
+ * @returns {Array} An array with two elements where the first element is the
+ *   hour part and the second element is the minute part.
+ */
+const splitTime = (value) => {
+  return [...(value || "").split(":"), "00"].splice(0, 2).map((part) => part.padStart(2, "0"));
+};
+
 export const formatInputTime = (time, format, input) => {
   if (time.length < 1) {
     return time;
   }
 
-  let [hour, minute] = time.split(":");
+  let [hour, minute] = splitTime(time);
 
   if (format === 12) {
     if (Number(hour) === 12) {
@@ -196,7 +216,7 @@ export const formatDate = (value, formats) => {
 };
 
 export const formatTime = (value, format, inputname) => {
-  let [hour, minute] = value.split(":").map((part) => part.padStart(2, "0"));
+  let [hour, minute] = splitTime(value);
 
   if (format === 12) {
     if (document.getElementById(`period_am_${inputname}`).checked) {

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/generate_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/generate_datepicker.js
@@ -51,7 +51,7 @@ export default function generateDatePicker(input, row, formats) {
   dateColumn.appendChild(datePickerContainer);
 
   let prevDate = null;
-  let defaultTime = input.getAttribute("default_time") || "00:00"
+  let defaultTime = input.dataset.defaultTime || "00:00"
 
   const datePickerDisplay = (event) => {
     if (!dateColumn.contains(event.target)) {
@@ -72,7 +72,7 @@ export default function generateDatePicker(input, row, formats) {
       if (input.type === "date") {
         input.value = `${formatDate(date.value, formats)}`;
       } else if (input.type === "datetime-local") {
-        input.value = `${formatDate(date.value, formats)}T${formatTime(document.querySelector(`#${input.id}_time`).value, formats.time, input.id) || defaultTime}`;
+        input.value = `${formatDate(date.value, formats)}T${formatTime(document.querySelector(`#${input.id}_time`).value || defaultTime, formats.time, input.id)}`;
       };
     };
   });
@@ -88,7 +88,7 @@ export default function generateDatePicker(input, row, formats) {
       if (input.type === "date") {
         input.value = `${formatDate(date.value, formats)}`;
       } else if (input.type === "datetime-local") {
-        input.value = `${formatDate(date.value, formats)}T${formatTime(document.querySelector(`#${input.id}_time`).value, formats.time, input.id) || defaultTime}`;
+        input.value = `${formatDate(date.value, formats)}T${formatTime(document.querySelector(`#${input.id}_time`).value || defaultTime, formats.time, input.id)}`;
       };
     };
   });

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/generate_datepicker.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/generate_datepicker.js
@@ -103,7 +103,7 @@ export default function generateDatePicker(input, row, formats) {
     if (input.type === "date") {
       input.value = `${pickedDate}`;
     } else if (input.type === "datetime-local") {
-      input.value = `${pickedDate}T${formatTime(document.querySelector(`#${input.id}_time`).value, formats.time, input.id) || defaultTime}`;
+      input.value = `${pickedDate}T${formatTime(document.querySelector(`#${input.id}_time`).value || defaultTime, formats.time, input.id)}`;
     };
     datePickerContainer.style.display = "none";
   });

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/test/time.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/test/time.test.js
@@ -49,34 +49,42 @@ describe("setMinute", () => {
 });
 
 describe("formatInputTime", () => {
-  const setupDOM = () => {
-    document.body.innerHTML = `
-      <input type="radio" id="period_am_exampleInput" name="period">
-      <input type="radio" id="period_pm_exampleInput" name="period">
-    `;
-  };
-
   describe("24-hour format", () => {
-    it("returns the value in correct format", () => {
-      setupDOM();
-      const time = "15:30";
-      const format = 24;
-      const input = { id: "exampleInput" };
+    const format = 24;
+    const input = { id: "exampleInput" };
 
-      const result = formatInputTime(time, format, input);
+    it("returns the value in correct format", () => {
+      const result = formatInputTime("15:30", format, input);
 
       expect(result).toBe("15:30");
+    });
+
+    it("returns the value in correct format if seconds are provided", () => {
+      const result = formatInputTime("15:30:04", format, input);
+
+      expect(result).toBe("15:30");
+    });
+
+    it("returns an empty string if an empty string is provided", () => {
+      const result = formatInputTime("", 24, { id: "exampleInput" });
+
+      expect(result).toBe("");
     });
   })
 
   describe("12-hour format", () => {
-    it("returns the value in correct format and checks the PM radio-button", () => {
-      setupDOM();
-      const time = "12:45";
-      const format = 12;
-      const input = { id: "exampleInput" };
+    beforeEach(() => {
+      document.body.innerHTML = `
+        <input type="radio" id="period_am_exampleInput" name="period">
+        <input type="radio" id="period_pm_exampleInput" name="period">
+      `;
+    });
 
-      const result = formatInputTime(time, format, input);
+    const format = 12;
+    const input = { id: "exampleInput" };
+
+    it("returns the value in correct format and checks the PM radio-button", () => {
+      const result = formatInputTime("12:45", format, input);
 
       expect(result).toBe("12:45");
       expect(document.getElementById("period_pm_exampleInput").checked).toBeTruthy();
@@ -84,16 +92,23 @@ describe("formatInputTime", () => {
     });
 
     it("returns the value in correct format", () => {
-      setupDOM();
-      const time = "00:25";
-      const format = 12;
-      const input = { id: "exampleInput" };
-
-      const result = formatInputTime(time, format, input);
+      const result = formatInputTime("00:25", format, input);
 
       expect(result).toBe("12:25");
       // We are not expecting a radio button to be selected here since in a real environment the selected button is not
       // handled by this method for values < 12
+    });
+
+    it("returns the value in correct format if seconds are provided", () => {
+      const result = formatInputTime("00:25:04", format, input);
+
+      expect(result).toBe("12:25");
+    });
+
+    it("returns an empty string if an empty string is provided", () => {
+      const result = formatInputTime("", 24, { id: "exampleInput" });
+
+      expect(result).toBe("");
     });
   })
 });

--- a/decidim-core/lib/decidim/legacy_form_builder.rb
+++ b/decidim-core/lib/decidim/legacy_form_builder.rb
@@ -31,6 +31,10 @@ module Decidim
         options[:data][:controller] ||= ""
         options[:data][:controller] += " date-picker"
 
+        if (default_time = options.delete(:default_time))
+          options[:data][:default_time] = default_time
+        end
+
         @template.append_javascript_pack_tag "decidim_date_picker", defer: false
 
         field(attribute, options) do |opts|


### PR DESCRIPTION
#### :tophat: What? Why?
While working with #17404 I noticed that the time field in the date/time picker displays seconds which is different from the format described in the help text. This fixes the issue.

While fixing it, also noticed that there is a non-standard `default_time` attribute possibly passed to the picker input field. This changes the attribute name to `data-default-time`.

#### :pushpin: Related Issues
- Related to #17404

#### Testing
- Go to any view where date/time picker is displayed (e.g. edit a process phase)
- See that seconds are not displayed in the field when the page is loaded

### :camera: Screenshots
**Before**
<img width="1228" height="711" alt="The time input before the change" src="https://github.com/user-attachments/assets/862c511a-1229-40ce-9aab-9e5be1830dc0" />

**After**
<img width="1228" height="711" alt="The time input after the change" src="https://github.com/user-attachments/assets/70d61f68-3ab5-4bc7-9df9-d4e8a210948a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date and time input formatting with consistent zero-padding.
  - Preserved empty time fields and correctly handled values containing seconds.
  - Improved conversion between 12-hour and 24-hour time formats.
  - Applied configured default times consistently when entering, pasting, or selecting datetime values.
  - Date and time fields now receive their configured default time automatically.
  - Improved handling of varied or incomplete time values for more reliable input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->