### PR TITLE
Bump shakapacker from 10.3.0 to 10.3.1 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ PATH
       ruby-vips (~> 2.2)
       rubyXL (~> 3.4)
       rubyzip (>= 2, < 4)
-      shakapacker (~> 10.3.0)
+      shakapacker (~> 10.3.1)
       valid_email2 (~> 7.0)
       web-push (~> 3.0)
       wisper (~> 3.0)
@@ -864,7 +864,7 @@ GEM
     selma (0.4.15-arm64-darwin)
     selma (0.4.15-x86_64-linux)
     semantic_range (3.1.1)
-    shakapacker (10.3.0)
+    shakapacker (10.3.1)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/decidim-core/decidim-core.gemspec
+++ b/decidim-core/decidim-core.gemspec
@@ -82,7 +82,7 @@ Gem::Specification.new do |s|
   s.add_dependency "ruby-vips", "~> 2.2"
   s.add_dependency "rubyXL", "~> 3.4"
   s.add_dependency "rubyzip", ">= 2", "< 4"
-  s.add_dependency "shakapacker", "~> 10.3.0"
+  s.add_dependency "shakapacker", "~> 10.3.1"
   s.add_dependency "valid_email2", "~> 7.0"
   s.add_dependency "web-push", "~> 3.0"
   s.add_dependency "wisper", "~> 3.0"

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -107,7 +107,7 @@ PATH
       ruby-vips (~> 2.2)
       rubyXL (~> 3.4)
       rubyzip (>= 2, < 4)
-      shakapacker (~> 10.3.0)
+      shakapacker (~> 10.3.1)
       valid_email2 (~> 7.0)
       web-push (~> 3.0)
       wisper (~> 3.0)
@@ -852,7 +852,7 @@ GEM
       websocket (~> 1.0)
     selma (0.4.15-x86_64-linux)
     semantic_range (3.1.1)
-    shakapacker (10.3.0)
+    shakapacker (10.3.1)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24947,7 +24947,7 @@
         "postcss-preset-env": "^11.2.0",
         "postcss-scss": "^4.0.6",
         "sass-embedded": "^1.63.6",
-        "shakapacker": "^10.3.0",
+        "shakapacker": "^10.3.1",
         "source-map-loader": "^5.0.0",
         "style-loader": "^4.0.0",
         "tailwindcss": "^3.4.19",
@@ -26006,9 +26006,9 @@
       }
     },
     "packages/webpacker/node_modules/shakapacker": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-10.3.0.tgz",
-      "integrity": "sha512-+MsocLZYaOPoE5giLygxiIF/xpdfl4nsoENtcCI2RPEM50OX4Jb6LKqrJdsK3leJiXXcbVOy6YYCbIqasduTzQ==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-10.3.1.tgz",
+      "integrity": "sha512-yYSbA+JaFisZQL9ImB9IMmPNKUzm0Ycw/wUnwf88f7BeHX9k/M4FIa/4syq/0xx18JqgEL3MIJmsM0RaXQ5zuA==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -34,7 +34,7 @@
     "postcss-preset-env": "^11.2.0",
     "postcss-scss": "^4.0.6",
     "sass-embedded": "^1.63.6",
-    "shakapacker": "^10.3.0",
+    "shakapacker": "^10.3.1",
     "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "tailwindcss": "^3.4.19",


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed while working on #17412, the generators in the CI are failing with this error after regenerating the `development_app`: 

```
 bin/rails aborted!
       **ERROR** Shakapacker: Shakapacker gem and node package versions do not match
       Detected: 10.3.0
            gem: 10.3.1
       Ensure the installed version of the gem is the same as the version of
       your installed node package.
       Do not use >= or ~> in your Gemfile for shakapacker without a lockfile.
       Do not use ^ or ~ in your package.json for shakapacker without a lockfile.
       /home/runner/work/decidim/decidim/decidim-generators/spec/generator_test_app/config/environment.rb:5:in '<top (required)>'
       Tasks: TOP => decidim:robots:replace => environment
       (See full trace by running task with --trace)
     # ./spec/runtime/full_app_generator_spec.rb:30:in 'block (5 levels) in <module:Decidim>'

```

This is due to a release today (03/08/2026) from Shakapacker: https://rubygems.org/gems/shakapacker 

#### :pushpin: Related Issues

- Related to #17369 
- Related to #17290 


#### Testing
Pipeline should be green

rebuilding the `development_app` should result in no errors

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s frontend build tooling to a newer patch version.
  * Includes routine maintenance improvements and compatibility updates for asset compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->