### PR TITLE
Fix questionnaire machine translation locale resolution by exposing organization

### DIFF
--- a/decidim-forms/app/models/decidim/forms/questionnaire.rb
+++ b/decidim-forms/app/models/decidim/forms/questionnaire.rb
@@ -11,6 +11,7 @@ module Decidim
 
       translatable_fields :title, :description, :tos
       belongs_to :questionnaire_for, polymorphic: true
+      delegate :organization, to: :questionnaire_for, allow_nil: true
 
       has_many :questions, -> { order(:position) }, class_name: "Question", foreign_key: "decidim_questionnaire_id", dependent: :destroy
       has_many :responses, class_name: "Response", foreign_key: "decidim_questionnaire_id", dependent: :destroy

--- a/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
+++ b/decidim-forms/spec/models/decidim/forms/questionnaire_spec.rb
@@ -34,6 +34,12 @@ module Decidim
         expect(questionnaire.questionnaire_for).to eq(questionable)
       end
 
+      describe "#organization" do
+        it "delegates organization to questionnaire_for" do
+          expect(questionnaire.organization).to eq(questionable.organization)
+        end
+      end
+
       describe "#count_participants" do
         it "returns the unique participants number" do
           user1 = create(:user, organization: questionable.organization)


### PR DESCRIPTION
#### :tophat: What? Why?
MachineTranslationResourceJob resolves the default/source locale through the resource.
For resources that expose organization, it uses organization.default_locale.
For resources that do not, it falls back to Decidim.available_locales.first.

Decidim::Forms::Questionnaire currently does not expose organization, so it may use the fallback locale instead of the organization locale.

This PR makes Decidim::Forms::Questionnaire expose organization by delegating to questionnaire_for.organization. With that in place, Decidim can resolve the correct organization default locale during machine translation updates and regenerate the translated text properly.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing

1. Configure [Decidim.available_locales] so first locale is different from org default locale (e.g. ["en", "ca", ...]).
2. Organization default locale is ca.
3. Enable machine translations.
4. Create questionnaire (translations are generated).
5. Update questionnaire title only in ca.
6. Observe machine-translated value (e.g. en) is refreshed.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Questionnaires now provide access to their associated organization when available.

* **Bug Fixes**
  * Safely handles questionnaires without an associated record.

* **Tests**
  * Added coverage validating organization access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->