### PR TITLE
Fix duplicate aria-current attributes in main menu and breadcrumb

### DIFF
--- a/decidim-assemblies/spec/system/assemblies_breadcrumbs_spec.rb
+++ b/decidim-assemblies/spec/system/assemblies_breadcrumbs_spec.rb
@@ -104,4 +104,27 @@ describe "Assemblies Breadcrumb" do
       end
     end
   end
+
+  context "when checking the current page marker" do
+    scenario "marks only the breadcrumb item as the current page on the assemblies index page" do
+      visit decidim_assemblies.assemblies_path(locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text("Assemblies")
+    end
+
+    scenario "marks only the deepest active breadcrumb item as the current page on an assembly page" do
+      visit decidim_assemblies.assembly_path(parent_assembly, locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(parent_assembly.title))
+    end
+
+    scenario "marks only the deepest active breadcrumb item as the current page on a component page" do
+      visit router.root_path
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(child_assembly.title))
+    end
+  end
 end

--- a/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
+++ b/decidim-conferences/spec/system/conferences_breadcrumbs_spec.rb
@@ -73,4 +73,27 @@ describe "Conferences Breadcrumb" do
       end
     end
   end
+
+  context "when checking the current page marker" do
+    scenario "marks only the breadcrumb item as the current page on the conferences index page" do
+      visit decidim_conferences.conferences_path(locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text("Conferences")
+    end
+
+    scenario "marks only the deepest active breadcrumb item as the current page on a conference page" do
+      visit decidim_conferences.conference_path(participatory_space, locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(participatory_space.title))
+    end
+
+    scenario "marks only the deepest active breadcrumb item as the current page on a component page" do
+      visit router.root_path
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(participatory_space.title))
+    end
+  end
 end

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -48,11 +48,7 @@ module Decidim
     private
 
     def link_options
-      if is_active_link?(url, :exclusive)
-        { aria: { current: "page" } }
-      else
-        {}
-      end.merge({ class: link_classes, role: menuitem_role })
+      { class: link_classes, role: menuitem_role }
     end
 
     def composed_label

--- a/decidim-core/app/presenters/decidim/menu_item_presenter.rb
+++ b/decidim-core/app/presenters/decidim/menu_item_presenter.rb
@@ -48,7 +48,7 @@ module Decidim
     private
 
     def link_options
-      if active?
+      if is_active_link?(url, :exclusive)
         { aria: { current: "page" } }
       else
         {}

--- a/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
+++ b/decidim-core/app/views/layouts/decidim/header/_menu_breadcrumb_desktop.html.erb
@@ -2,6 +2,7 @@
   <span><%= t("decidim.menu.home") %></span>
 <% end %>
 <% truncatable_items = breadcrumb_items.compact_blank.drop(1) %>
+<% current_page_item = breadcrumb_items.compact_blank.select { |breadcrumb_item| breadcrumb_item[:active] }.last %>
 <% breadcrumb_items.each do |item| %>
   <% next if item.blank? %>
 
@@ -16,7 +17,7 @@
   <% end %>
   <span aria-hidden="true"><%= icon "arrow-right-s-line", class: "fill-white" %></span>
   <% if item[:url].present? && !is_active_link?(item[:url], :exclusive) %>
-    <%= link_to item[:url], class: trigger_classes.join(" "), data: (truncatable ? { breadcrumb_truncate_target: "item" } : {}), "aria-current": (item[:active] ? "page" : nil) do %>
+    <%= link_to item[:url], class: trigger_classes.join(" "), data: (truncatable ? { breadcrumb_truncate_target: "item" } : {}), "aria-current": (item == current_page_item ? "page" : nil) do %>
       <% if truncatable %>
         <span class="menu-bar__breadcrumb-desktop__label--truncatable">
           <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>
@@ -27,7 +28,7 @@
     <% end %>
   <% else %>
     <%# This block is executed if the condition is false %>
-    <%= content_tag :span, class: [*trigger_classes, "no-interactive"].join(" "), data: (truncatable ? { breadcrumb_truncate_target: "item" } : {}), "aria-current": (item[:active] ? "page" : nil) do %>
+    <%= content_tag :span, class: [*trigger_classes, "no-interactive"].join(" "), data: (truncatable ? { breadcrumb_truncate_target: "item" } : {}), "aria-current": (item == current_page_item ? "page" : nil) do %>
       <% if truncatable %>
         <span class="menu-bar__breadcrumb-desktop__label--truncatable">
           <span class="menu-bar__breadcrumb-text" data-breadcrumb-truncate-target="text"><%= item_label %></span>

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -36,15 +36,19 @@ module Decidim
         allow(request).to receive(:original_fullpath).and_return(current_path)
       end
 
-      it "adds the aria-current attribute to the link" do
-        expect(subject.render).to include('aria-current="page"')
+      it "does not add the aria-current attribute to the link" do
+        expect(subject.render).not_to include("aria-current")
+      end
+
+      it "adds the active class to the item" do
+        expect(subject.render).to have_css("li.is-active")
       end
 
       context "and the page is a sub-page of the menu link" do
         let(:current_path) { "/boo/bar" }
 
         it "does not add the aria-current attribute to the link" do
-          expect(subject.render).not_to include('aria-current="page"')
+          expect(subject.render).not_to include("aria-current")
         end
 
         it "keeps the active class on the item" do

--- a/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/menu_item_presenter_spec.rb
@@ -26,6 +26,8 @@ module Decidim
     end
 
     context "when the link URL is active" do
+      subject { MenuItemPresenter.new(menu_item, view, active_class: "is-active") }
+
       let(:request) { double }
       let(:current_path) { "/boo" }
 
@@ -41,8 +43,12 @@ module Decidim
       context "and the page is a sub-page of the menu link" do
         let(:current_path) { "/boo/bar" }
 
-        it "adds the aria-current attribute to the link" do
-          expect(subject.render).to include('aria-current="page"')
+        it "does not add the aria-current attribute to the link" do
+          expect(subject.render).not_to include('aria-current="page"')
+        end
+
+        it "keeps the active class on the item" do
+          expect(subject.render).to have_css("li.is-active")
         end
       end
     end

--- a/decidim-participatory_processes/spec/system/participatory_processes_breadcrumbs_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_breadcrumbs_spec.rb
@@ -70,6 +70,13 @@ describe "Participatory Processes Breadcrumb" do
   end
 
   context "when checking the current page marker" do
+    scenario "marks only the breadcrumb item as the current page on the processes index page" do
+      visit decidim_participatory_processes.participatory_processes_path(locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text("Processes")
+    end
+
     scenario "marks only the deepest active breadcrumb item as the current page on a participatory process page" do
       visit decidim_participatory_processes.participatory_process_path(participatory_space, locale: I18n.locale)
 

--- a/decidim-participatory_processes/spec/system/participatory_processes_breadcrumbs_spec.rb
+++ b/decidim-participatory_processes/spec/system/participatory_processes_breadcrumbs_spec.rb
@@ -68,4 +68,20 @@ describe "Participatory Processes Breadcrumb" do
       end
     end
   end
+
+  context "when checking the current page marker" do
+    scenario "marks only the deepest active breadcrumb item as the current page on a participatory process page" do
+      visit decidim_participatory_processes.participatory_process_path(participatory_space, locale: I18n.locale)
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(participatory_space.title))
+    end
+
+    scenario "marks only the deepest active breadcrumb item as the current page on a component page" do
+      visit router.root_path
+
+      expect(page).to have_css("[aria-current='page']", count: 1, visible: :all)
+      expect(find("[aria-current='page']")).to have_text(translated(participatory_space.title))
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This PR fixes duplicated aria-current="page" attributes reported by the accessibility audit of decidim.barcelona (WCAG 2.1 – 4.1.2 Name, Role, Value, level A). Screen readers announced several links as "current page" at once, coming from two independent sources:

  1. Menus (header and footer): MenuItemPresenter emitted aria-current="page" based on each item's registered broad matcher (e.g. %r{^/process(es|_groups)}), so the "Processes" link announced "current page" on every page under a process — in the header menu and again in the footer.
  2. Breadcrumb: the desktop breadcrumb marked every active item. On a component page at least two items are active at once (the root menu item and the participatory space item), producing several markers in the breadcrumb itself.

#### :pushpin: Related Issues

#### Testing
1. Start a development app and visit any page inside a participatory space — e.g. /processes → open a process → open its Proposals component.
2. In the browser console run: `document.querySelectorAll('[aria-current="page"]')`
3. It should return exactly 1 element: the deepest active breadcrumb item. On develop before this change, the same page returns three (the "Processes" main-menu link plus multiple breadcrumb items).
4. Check that the main menu's "Processes" entry is still visually highlighted while browsing inside a process

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*

Before:
<img width="1887" height="704" alt="image" src="https://github.com/user-attachments/assets/13da3cd2-2727-400b-88dc-243853a0615d" />

After:
<img width="1861" height="673" alt="image" src="https://github.com/user-attachments/assets/38287e3b-6940-4a42-860e-22ae93750025" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation accessibility by reserving the current-page indicator for exact page matches.
  * Preserved active styling for menu items on sub-pages without incorrectly marking them as the current page.
  * Updated breadcrumbs so exactly one, deepest active item is identified as the current page.

* **Tests**
  * Added accessibility coverage for current-page indicators across process, assembly, and conference breadcrumbs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->