### PR TITLE
Fix map overlap budgets

### DIFF
--- a/decidim-budgets/app/packs/stylesheets/budgets.scss
+++ b/decidim-budgets/app/packs/stylesheets/budgets.scss
@@ -1,6 +1,6 @@
 .budget {
   &-list__map {
-    @apply lg:-ml-16 -mt-6 lg:-mt-12 mb-6 aspect-square lg:aspect-[21/9] [&>*]:h-full [&+*]:mt-6 lg:[&+*]:mt-12;
+    @apply lg:-ml-16 -mt-6 lg:-mt-8 mb-0 lg:mb-4 aspect-square lg:aspect-[21/9] [&>*]:h-full [&+*]:mt-6 lg:[&+*]:mt-12;
   }
 
   &-summary {


### PR DESCRIPTION
#### :tophat: What? Why?
A slight change to the container `list-map` container within `decidim-budgets` fixes a slight overlap detected within the `budget-summary__content` on top the map itself.

#### :pushpin: Related Issues
- Fixes #16370 

#### Testing
1. Configure a HERE maps api key and add to your list of `.rbenv.vars` keys for eg:
```
MAPS_API_KEY=ADD_KEY_HERE
MAPS_PROVIDER=here
```
2. Login
3. Enable budgets with maps in configuration settings
4. Edit or create a Budget 
5. Enable voting on projects
6. Head to projects index 
7. Inspect element 
8. Find `budget-summary__content` element
9. See no overlap with the `budget-summary__content` class on to the map

### :camera: Screenshots
<img width="2653" height="969" alt="Screenshot from 2026-08-11 10-28-40" src="https://github.com/user-attachments/assets/1c7bd6d3-4d02-4d81-9f49-aa2a59d65edb" />

:hearts: Thank you!
