### PR TITLE
Fix machine_translation prioritization misleading

### DIFF
--- a/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
@@ -23,7 +23,9 @@
             <%= t("activemodel.attributes.organization.machine_translation_display_priority") %>
           </legend>
           <div class="radio-group">
-            <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last  do |builder|%>
+            <%# i18n-tasks-use t("decidim.admin.organization.form.machine_translation_display_priority.options.original") %>
+            <%# i18n-tasks-use t("decidim.admin.organization.form.machine_translation_display_priority.options.translation") %>
+            <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last  do |builder| %>
               <%= builder.label(for: nil, class: "form__wrapper-checkbox-label") do %>
                 <%= builder.radio_button(id: nil, label: false) %>
                 <span>

--- a/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
+++ b/decidim-admin/app/views/decidim/admin/organization/form/_extra_features.html.erb
@@ -18,8 +18,22 @@
       </div>
 
       <div class="row column">
-        <%= form.label :machine_translation_display_priority, t("activemodel.attributes.organization.machine_translation_display_priority") %>
-          <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last %>
+        <fieldset class="row column" id="machine_translation_display_priority">
+          <legend>
+            <%= t("activemodel.attributes.organization.machine_translation_display_priority") %>
+          </legend>
+          <div class="radio-group">
+            <%= form.collection_radio_buttons :machine_translation_display_priority, form.object.machine_translation_priorities, :first, :last  do |builder|%>
+              <%= builder.label(for: nil, class: "form__wrapper-checkbox-label") do %>
+                <%= builder.radio_button(id: nil, label: false) %>
+                <span>
+                  <strong class="font-semibold"><%= builder.text %></strong>
+                  <%= t(builder.value, scope: "decidim.admin.organization.form.machine_translation_display_priority.options") %>
+                </span>
+              <% end %>
+            <% end %>
+          </div>
+        </fieldset>
       </div>
     <% end %>
 

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -978,6 +978,10 @@ en:
           logos:
             organization_logos: Organization logos
             preview: Preview
+          machine_translation_display_priority:
+            options:
+              original: the system display the information in the language used by author
+              translation: the system will display a translation if available, otherwise original language will be used
           rich_text_editor_in_public_views_help: In some text areas, participants will be able to insert some HTML tags by using the rich text editor.
           social_handlers: Social
           twitter: X

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -980,8 +980,8 @@ en:
             preview: Preview
           machine_translation_display_priority:
             options:
-              original: the system display the information in the language used by author. Content created from admin with manual translations, will display the translations.
-              translation: the system will display a translation if available, otherwise original language will be used.
+              original: The system displays the information in the language used by the author. Content created from admin with manual translations, will display the admin translated values.
+              translation: The system will display a translation if available, otherwise original language will be used.
           rich_text_editor_in_public_views_help: In some text areas, participants will be able to insert some HTML tags by using the rich text editor.
           social_handlers: Social
           twitter: X

--- a/decidim-admin/config/locales/en.yml
+++ b/decidim-admin/config/locales/en.yml
@@ -980,8 +980,8 @@ en:
             preview: Preview
           machine_translation_display_priority:
             options:
-              original: the system display the information in the language used by author
-              translation: the system will display a translation if available, otherwise original language will be used
+              original: the system display the information in the language used by author. Content created from admin with manual translations, will display the translations.
+              translation: the system will display a translation if available, otherwise original language will be used.
           rich_text_editor_in_public_views_help: In some text areas, participants will be able to insert some HTML tags by using the rich text editor.
           social_handlers: Social
           twitter: X


### PR DESCRIPTION
#### :tophat: What? Why?
While i reviewing #17242, i remembered that we already have #10198 assigned. Since i do not have any input from the reporter, but the functionality seems to be working as expected (from Commision point of view), I am adding this PR that does 2 things: 
1. Improves the interface by moving the options each one of its line (like the transparency in processes)
2. Improves the labels in order to set the correct expectation for each one of the setting.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #10198

#### Testing
1. having the machine translation enabled visit the organization admin interface 
2. See the layout
3. Apply the patch 
4. See the new layout

### :camera: Screenshots
Before:
<img width="645" height="294" alt="image" src="https://github.com/user-attachments/assets/92178b7c-de4e-479f-b9cd-97b15c13db1f" />

After:
<img width="1068" height="303" alt="image" src="https://github.com/user-attachments/assets/c685d6b7-f16e-4202-9562-35f9a4e7d156" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved machine-translation display-priority controls with clearer grouping, custom radio buttons, descriptive labels, and translated explanations.

- **Enhancements**
  - Added options to prioritize the original author’s language or show translated content when available, with fallback to the original language.
  - Clarified display-priority choices in the organization settings form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->