### PR TITLE
Fix `Meeting.authored_by` not considering the type of the author

### DIFF
--- a/decidim-meetings/app/models/decidim/meetings/meeting.rb
+++ b/decidim-meetings/app/models/decidim/meetings/meeting.rb
@@ -140,7 +140,7 @@ module Decidim
 
       scope :visible, -> { where("decidim_meetings_meetings.private_meeting != ? OR decidim_meetings_meetings.transparent = ?", true, true) }
 
-      scope :authored_by, ->(author) { where(decidim_author_id: author) }
+      scope :authored_by, ->(author) { where(author:) }
 
       scope_search_multi :with_any_type, TYPE_OF_MEETING.keys
 

--- a/decidim-meetings/spec/models/meeting_spec.rb
+++ b/decidim-meetings/spec/models/meeting_spec.rb
@@ -528,5 +528,31 @@ module Decidim::Meetings
         expect(described_class.ransackable_attributes(admin)).to include("translated_title")
       end
     end
+
+    describe ".authored_by" do
+      subject { described_class.authored_by(provided_author) }
+
+      let(:organization) { create(:organization, id: 1) }
+      let(:component) { create(:meeting_component, organization:) }
+      let(:user_author) { create(:user, :confirmed, id: 1, organization:) }
+      let!(:meeting_by_user) { create(:meeting, component:, author: user_author) }
+      let!(:meeting_by_organization) { create(:meeting, component:, author: organization) }
+
+      context "with user author" do
+        let(:provided_author) { user_author }
+
+        it "returns the correct meeting" do
+          expect(subject).to contain_exactly(meeting_by_user)
+        end
+      end
+
+      context "with organization author" do
+        let(:provided_author) { organization }
+
+        it "returns the correct meeting" do
+          expect(subject).to contain_exactly(meeting_by_organization)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed a failing spec that I first thought to be flaky at example run:
https://github.com/decidim/decidim/actions/runs/31412732072/job/93534410998

But it turns out this is actually a bug that the `Decidim::Meetings::Meeting.authored_by` method/scope does not consider the type of the meeting. So if the user and organization have the same ID, it will result to unexpected search results.

This fixes the issue and adds a spec to check the scope works correctly.

Relevant test output from the failed test run:
```
Failures:

  1) Meeting search when searching by activity and activity is 'my meetings' returns only the meeting created by the current user
     Failure/Error: expect(subject).not_to include(decidim_escape_translated(meeting2.title))
       expected "\n<!DOCTYPE html>\n<html lang=\"en\" dir=\"ltr\" class=\"no-js\">\n  <head>\n    <title>&lt;script&g...ata-dialog-open=\"dc-modal\">\n    Change cookie settings\n  </a>\n</div>\n\n\n  </body>\n</html>\n" not to include "&lt;script&gt;alert(&quot;meeting_title&quot;);&lt;/script&gt; Ut et consequuntur. 1886"
     # ./spec/requests/meeting_search_spec.rb:220:in 'block (4 levels) in <top (required)>'

Finished in 7 minutes 9 seconds (files took 18.38 seconds to load)
423 examples, 1 failure

Failed examples:

rspec ./spec/requests/meeting_search_spec.rb:218 # Meeting search when searching by activity and activity is 'my meetings' returns only the meeting created by the current user
```

#### Testing
To replicate the bug **without** this patch:
- Go to the test dummy app `cd spec/decidim_dummy_app`
- Recreate the database with reseted IDs (so it starts from 1) `RAILS_ENV=test bundle exec rails db:purge db:schema:load`
- Go to the meetings component `cd ../../decidim-meetings`
- Run the single spec that failed `bundle exec rspec ./spec/requests/meeting_search_spec.rb:218`

Repeat the test process with this patch applied and expect to see it green.

Note that when re-creating the test DB, you may get spring related error. You can fix it by following the instructions in the error for the `test` environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting filtering by author, ensuring authored meetings are returned correctly for both users and organizations.

* **Tests**
  * Added coverage validating author-based meeting searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->