### PR TITLE
Improve personal data retention and add retention period

### DIFF
--- a/decidim-core/app/commands/decidim/destroy_account.rb
+++ b/decidim-core/app/commands/decidim/destroy_account.rb
@@ -19,7 +19,6 @@ module Decidim
         destroy_user_account!
         destroy_user_identities
         destroy_follows
-        destroy_user_versions
         destroy_user_private_exports
         destroy_user_access_grants
         destroy_user_access_tokens
@@ -70,10 +69,6 @@ module Decidim
 
     def destroy_user_identities
       current_user.identities.find_each(&:destroy)
-    end
-
-    def destroy_user_versions
-      current_user.versions.find_each(&:destroy)
     end
 
     def destroy_user_private_exports

--- a/decidim-core/app/jobs/decidim/delete_old_user_versions_job.rb
+++ b/decidim-core/app/jobs/decidim/delete_old_user_versions_job.rb
@@ -11,7 +11,7 @@ module Decidim
 
     # Include only deleted users.
     def include_records
-      Decidim::User.where.not(deleted_at: nil)
+      Decidim::UserBaseEntity.where.not(deleted_at: nil)
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/delete_old_user_versions_job.rb
+++ b/decidim-core/app/jobs/decidim/delete_old_user_versions_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A job to delete version data for old deleted users.
+  class DeleteOldUserVersionsJob < DeleteOldVersionsJob
+    queue_as :delete_old_personal_data_versions
+
+    item_type "Decidim::UserBaseEntity"
+
+    private
+
+    # Include only deleted users.
+    def include_records
+      Decidim::User.where.not(deleted_at: nil)
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/delete_old_versions_job.rb
+++ b/decidim-core/app/jobs/decidim/delete_old_versions_job.rb
@@ -16,6 +16,8 @@ module Decidim
     end
 
     def perform(cutoff_days)
+      raise InvalidArgument, "The cutoff days must be a positive integer or zero." unless cutoff_days.is_a?(Integer) && cutoff_days >= 0
+
       cutoff_date = Time.current - cutoff_days.days
 
       versions = PaperTrail::Version.where(
@@ -27,5 +29,7 @@ module Decidim
 
       versions.delete_all
     end
+
+    class InvalidArgument < StandardError; end
   end
 end

--- a/decidim-core/app/jobs/decidim/delete_old_versions_job.rb
+++ b/decidim-core/app/jobs/decidim/delete_old_versions_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A job to delete version data for old records. Extend this class and define
+  # the item type for deletion within the class with:
+  #   item_type "Decidim::TargetRecord"
+  class DeleteOldVersionsJob < ApplicationJob
+    class << self
+      def item_type(*values)
+        if values.present?
+          @item_type = values
+        else
+          @item_type
+        end
+      end
+    end
+
+    def perform(cutoff_days)
+      cutoff_date = Time.current - cutoff_days.days
+
+      versions = PaperTrail::Version.where(
+        item_type: self.class.item_type,
+        created_at: ...cutoff_date
+      )
+      versions = versions.where(item_id: include_records) if respond_to?(:include_records, true)
+      versions = versions.where.not(item_id: exclude_records) if respond_to?(:exclude_records, true)
+
+      versions.delete_all
+    end
+  end
+end

--- a/decidim-core/app/jobs/decidim/delete_revoked_authorizations_versions_job.rb
+++ b/decidim-core/app/jobs/decidim/delete_revoked_authorizations_versions_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Decidim
+  # A job to delete version data for revoked (i.e. deleted) authorizations.
+  class DeleteRevokedAuthorizationsVersionsJob < DeleteOldVersionsJob
+    queue_as :delete_old_personal_data_versions
+
+    item_type "Decidim::Authorization"
+
+    private
+
+    # Exclude authorizations that still exist in the system.
+    def exclude_records
+      Decidim::Authorization.all
+    end
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -329,6 +329,9 @@ module Decidim
   # Users will be warned for the last time this amount of days before the final removal
   mattr_accessor :delete_inactive_users_last_warning_days_before, default: Decidim::Env.new("DECIDIM_DELETE_INACTIVE_USERS_LAST_WARNING_DAYS_BEFORE", 7).to_i
 
+  # For authorizations that have been revoked/deleted, delete their version data after retention period
+  mattr_accessor :delete_old_personal_data_versions_days, default: Decidim::Env.new("DECIDIM_DELETE_OLD_PERSONAL_DATA_VERSIONS_DAYS", 365).to_i
+
   # Returns the inactivity threshold (in days) to trigger the first warning email.
   def self.first_warning_inactive_users_after_days
     delete_inactive_users_after_days - delete_inactive_users_first_warning_days_before

--- a/decidim-core/lib/tasks/decidim_participants_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_participants_tasks.rake
@@ -18,5 +18,13 @@ namespace :decidim do
         Decidim::DeleteInactiveParticipantsJob.perform_later(organization)
       end
     end
+
+    desc "Delete old personal data versions for participants"
+    task :delete_old_versions, [:days] => :environment do |_task, args|
+      cutoff_days = args.days&.to_i || Decidim.delete_old_personal_data_versions_days
+
+      Decidim::DeleteOldUserVersionsJob.perform_later(cutoff_days)
+      Decidim::DeleteRevokedAuthorizationsVersionsJob.perform_later(cutoff_days)
+    end
   end
 end

--- a/decidim-core/lib/tasks/decidim_participants_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_participants_tasks.rake
@@ -21,9 +21,10 @@ namespace :decidim do
 
     desc "Delete old personal data versions for participants"
     task :delete_old_versions, [:days] => :environment do |_task, args|
-      cutoff_days = args.days&.to_i || Decidim.delete_old_personal_data_versions_days
+      raise "The days argument must be a positive integer or zero." if args.days.is_a?(String) && !args.days.match?(/\A[0-9]+\z/)
 
-      raise "The cutoff days must be a positive integer or zero." unless cutoff_days.is_a?(Integer) && cutoff_days >= 0
+      cutoff_days = args.days&.to_i || Decidim.delete_old_personal_data_versions_days
+      raise "The days argument must be a positive integer or zero." unless cutoff_days.is_a?(Integer) && cutoff_days >= 0
 
       Decidim::DeleteOldUserVersionsJob.perform_later(cutoff_days)
       Decidim::DeleteRevokedAuthorizationsVersionsJob.perform_later(cutoff_days)

--- a/decidim-core/lib/tasks/decidim_participants_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_participants_tasks.rake
@@ -23,6 +23,8 @@ namespace :decidim do
     task :delete_old_versions, [:days] => :environment do |_task, args|
       cutoff_days = args.days&.to_i || Decidim.delete_old_personal_data_versions_days
 
+      raise "The cutoff days must be a positive integer or zero." unless cutoff_days.is_a?(Integer) && cutoff_days >= 0
+
       Decidim::DeleteOldUserVersionsJob.perform_later(cutoff_days)
       Decidim::DeleteRevokedAuthorizationsVersionsJob.perform_later(cutoff_days)
     end

--- a/decidim-core/spec/commands/decidim/destroy_account_spec.rb
+++ b/decidim-core/spec/commands/decidim/destroy_account_spec.rb
@@ -125,12 +125,6 @@ module Decidim
           expect { command.call }.to change(Decidim::Identity, :count).by(-1)
         end
 
-        it "deletes user's versions" do
-          expect(user.reload.versions.count).to eq(1)
-          command.call
-          expect(user.reload.versions.count).to eq(0)
-        end
-
         it "deletes the follows" do
           other_user = create(:user)
           create(:follow, followable: user, user: other_user)

--- a/decidim-core/spec/jobs/decidim/delete_old_user_versions_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/delete_old_user_versions_job_spec.rb
@@ -18,6 +18,8 @@ describe Decidim::DeleteOldUserVersionsJob, versioning: true do
     Decidim::DestroyAccount.call(destroy_form_for(recently_deleted_user))
   end
 
+  it_behaves_like "delete old versions job"
+
   it "deletes the versions for deleted users created before the cutoff date" do
     expect(versions.where(item_id: old_deleted_user.id).count).to eq(3)
     expect(versions.where(item_id: recently_deleted_user.id).count).to eq(3)

--- a/decidim-core/spec/jobs/decidim/delete_old_user_versions_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/delete_old_user_versions_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::DeleteOldUserVersionsJob, versioning: true do
+  subject { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:recently_deleted_user) { create(:user, organization:) }
+  let(:old_deleted_user) { create(:user, organization:, created_at: 60.days.ago) }
+  let(:versions) { PaperTrail::Version.where(item_type: described_class.item_type) }
+
+  before do
+    travel(-30.days) do
+      Decidim::DestroyAccount.call(destroy_form_for(old_deleted_user))
+    end
+
+    Decidim::DestroyAccount.call(destroy_form_for(recently_deleted_user))
+  end
+
+  it "deletes the versions for deleted users created before the cutoff date" do
+    expect(versions.where(item_id: old_deleted_user.id).count).to eq(3)
+    expect(versions.where(item_id: recently_deleted_user.id).count).to eq(3)
+    perform_enqueued_jobs { subject.perform_later(20) }
+    expect(versions.where(item_id: old_deleted_user.id).count).to eq(0)
+    expect(versions.where(item_id: recently_deleted_user.id).count).to eq(3)
+  end
+
+  context "with existing user" do
+    let(:existing_old_user) { create(:user, organization:, created_at: 60.days.ago) }
+
+    before do
+      travel(-30.days) do
+        existing_old_user
+      end
+    end
+
+    it "does not delete data for existing users" do
+      expect(versions.where(item_id: existing_old_user.id).count).to eq(1)
+      perform_enqueued_jobs { subject.perform_later(20) }
+      expect(versions.where(item_id: existing_old_user.id).count).to eq(1)
+    end
+  end
+
+  def destroy_form_for(user)
+    double(valid?: true, delete_reason: "Testing", current_user: user)
+  end
+end

--- a/decidim-core/spec/jobs/decidim/delete_revoked_authorizations_versions_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/delete_revoked_authorizations_versions_job_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::DeleteRevokedAuthorizationsVersionsJob, versioning: true do
+  subject { described_class }
+
+  let(:organization) { create(:organization) }
+  let(:user1) { create(:user, organization:) }
+  let(:user2) { create(:user, organization:) }
+
+  let(:recently_deleted_authorization) { create(:authorization, name: "example", granted_at: Time.current, user: user1) }
+  let(:recently_deleted_authorization_id) { recently_deleted_authorization.id }
+  let(:old_deleted_authorization) { create(:authorization, name: "example", granted_at: Time.current, user: user2) }
+  let(:old_deleted_authorization_id) { old_deleted_authorization.id }
+
+  let(:versions) { PaperTrail::Version.where(item_type: described_class.item_type) }
+
+  before do
+    travel(-30.days) do
+      old_deleted_authorization_id
+      old_deleted_authorization.destroy!
+    end
+
+    recently_deleted_authorization_id
+    recently_deleted_authorization.destroy!
+  end
+
+  it "deletes the versions for deleted authorizations created before the cutoff date" do
+    expect(versions.where(item_id: old_deleted_authorization_id).count).to eq(2)
+    expect(versions.where(item_id: recently_deleted_authorization_id).count).to eq(2)
+    perform_enqueued_jobs { subject.perform_later(20) }
+    expect(versions.where(item_id: old_deleted_authorization_id).count).to eq(0)
+    expect(versions.where(item_id: recently_deleted_authorization_id).count).to eq(2)
+  end
+
+  context "with existing authorization" do
+    let(:existing_old_authorization) { create(:authorization, name: "example", granted_at: Time.current, user: user1) }
+
+    before do
+      travel(-30.days) do
+        existing_old_authorization
+      end
+    end
+
+    it "does not delete data for existing authorizations" do
+      expect(versions.where(item_id: existing_old_authorization.id).count).to eq(1)
+      perform_enqueued_jobs { subject.perform_later(20) }
+      expect(versions.where(item_id: existing_old_authorization.id).count).to eq(1)
+    end
+  end
+end

--- a/decidim-core/spec/jobs/decidim/delete_revoked_authorizations_versions_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/delete_revoked_authorizations_versions_job_spec.rb
@@ -26,6 +26,8 @@ describe Decidim::DeleteRevokedAuthorizationsVersionsJob, versioning: true do
     recently_deleted_authorization.destroy!
   end
 
+  it_behaves_like "delete old versions job"
+
   it "deletes the versions for deleted authorizations created before the cutoff date" do
     expect(versions.where(item_id: old_deleted_authorization_id).count).to eq(2)
     expect(versions.where(item_id: recently_deleted_authorization_id).count).to eq(2)

--- a/decidim-core/spec/shared/delete_old_versions_job_examples.rb
+++ b/decidim-core/spec/shared/delete_old_versions_job_examples.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+shared_examples "delete old versions job" do
+  context "when an invalid cutoff days argument" do
+    subject { described_class.perform_now(cutoff_days) }
+
+    context "with a negative value" do
+      let(:cutoff_days) { -1 }
+
+      it "raises InvalidArgument" do
+        expect { subject }.to raise_error(described_class::InvalidArgument)
+      end
+    end
+
+    context "with a Float" do
+      let(:cutoff_days) { 1.2 }
+
+      it "raises InvalidArgument" do
+        expect { subject }.to raise_error(described_class::InvalidArgument)
+      end
+    end
+
+    context "with a String" do
+      let(:cutoff_days) { "20" }
+
+      it "raises InvalidArgument" do
+        expect { subject }.to raise_error(described_class::InvalidArgument)
+      end
+    end
+  end
+end

--- a/decidim-core/spec/shared/delete_old_versions_job_examples.rb
+++ b/decidim-core/spec/shared/delete_old_versions_job_examples.rb
@@ -1,7 +1,17 @@
 # frozen_string_literal: true
 
 shared_examples "delete old versions job" do
-  context "when an invalid cutoff days argument" do
+  context "when a valid cutoff days argument is provided" do
+    context "with zero" do
+      let(:cutoff_days) { 0 }
+
+      it "does not raise" do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
+  context "when an invalid cutoff days argument is provided" do
     subject { described_class.perform_now(cutoff_days) }
 
     context "with a negative value" do

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -41,7 +41,7 @@ describe "rake decidim:participants:delete_old_versions", type: :task do
     context "with an empty string" do
       let(:cutoff_days) { "" }
 
-      it "raises uses the default configured value" do
+      it "uses the default configured value and enqueues the jobs" do
         expect do
           task.execute(args)
         end

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -25,14 +25,34 @@ describe "rake decidim:participants:delete_old_versions", type: :task do
     context "with a negative value" do
       let(:cutoff_days) { -1 }
 
-      it "raises InvalidArgument" do
-        expect { task.execute(args) }.to raise_error(RuntimeError, "The cutoff days must be a positive integer or zero.")
+      it "raises RuntimeError" do
+        expect { task.execute(args) }.to raise_error(RuntimeError, "The days argument must be a positive integer or zero.")
+      end
+    end
+
+    context "with incorrectly formed string" do
+      let(:cutoff_days) { "abc" }
+
+      it "raises RuntimeError" do
+        expect { task.execute(args) }.to raise_error(RuntimeError, "The days argument must be a positive integer or zero.")
+      end
+    end
+
+    context "with an empty string" do
+      let(:cutoff_days) { "" }
+
+      it "raises uses the default configured value" do
+        expect do
+          task.execute(args)
+        end
+          .to have_enqueued_job(Decidim::DeleteOldUserVersionsJob).with(300)
+          .and have_enqueued_job(Decidim::DeleteRevokedAuthorizationsVersionsJob).with(300)
       end
     end
   end
 
   context "when a valid days argument is provided" do
-    it "executes the job for each organization" do
+    it "executes the job" do
       ActiveJob::Base.queue_adapter = :test
 
       expect do

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -52,7 +52,7 @@ describe "rake decidim:participants:delete_old_versions", type: :task do
   end
 
   context "when a valid days argument is provided" do
-    it "executes the job" do
+    it "executes the jobs" do
       ActiveJob::Base.queue_adapter = :test
 
       expect do

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:participants:delete_old_versions", type: :task do
+  let!(:organization1) { create(:organization) }
+  let!(:organization2) { create(:organization) }
+
+  before do
+    allow(Decidim).to receive(:delete_old_personal_data_versions_days).and_return(300)
+  end
+
+  context "when no days argument is provided" do
+    it "uses the default inactivity period" do
+      expect(Decidim::DeleteOldUserVersionsJob).to receive(:perform_later).with(300)
+      expect(Decidim::DeleteRevokedAuthorizationsVersionsJob).to receive(:perform_later).with(300)
+
+      task.execute
+    end
+  end
+
+  context "when a valid days argument is provided" do
+    it "executes the job for each organization" do
+      ActiveJob::Base.queue_adapter = :test
+
+      expect do
+        task.invoke(100)
+      end
+        .to have_enqueued_job(Decidim::DeleteOldUserVersionsJob).with(100)
+        .and have_enqueued_job(Decidim::DeleteRevokedAuthorizationsVersionsJob).with(100)
+    end
+  end
+end

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -52,7 +52,7 @@ describe "rake decidim:participants:delete_old_versions", type: :task do
   end
 
   context "when a valid days argument is provided" do
-    it "executes the jobs" do
+    it "enqueues the cleanup jobs" do
       ActiveJob::Base.queue_adapter = :test
 
       expect do

--- a/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_participants_delete_old_versions_spec.rb
@@ -19,6 +19,18 @@ describe "rake decidim:participants:delete_old_versions", type: :task do
     end
   end
 
+  context "when invalid days argument is provided" do
+    let(:args) { Rake::TaskArguments.new([:days], [cutoff_days]) }
+
+    context "with a negative value" do
+      let(:cutoff_days) { -1 }
+
+      it "raises InvalidArgument" do
+        expect { task.execute(args) }.to raise_error(RuntimeError, "The cutoff days must be a positive integer or zero.")
+      end
+    end
+  end
+
   context "when a valid days argument is provided" do
     it "executes the job for each organization" do
       ActiveJob::Base.queue_adapter = :test

--- a/decidim-generators/lib/decidim/generators/test/generator_examples.rb
+++ b/decidim-generators/lib/decidim/generators/test/generator_examples.rb
@@ -128,6 +128,7 @@ shared_context "with application env vars" do
       "DECIDIM_MINIMUM_INACTIVITY_PERIOD_IN_DAYS" => "",
       "DECIDIM_DELETE_INACTIVE_USERS_FIRST_WARNING_DAYS_BEFORE" => "",
       "DECIDIM_DELETE_INACTIVE_USERS_LAST_WARNING_DAYS_BEFORE" => "",
+      "DECIDIM_DELETE_OLD_PERSONAL_DATA_VERSIONS_DAYS" => "",
       "DECIDIM_SERVICE_WORKER_ENABLED" => "",
       "STORAGE_PROVIDER" => ""
     }
@@ -220,6 +221,7 @@ shared_context "with application env vars" do
       "DECIDIM_MINIMUM_INACTIVITY_PERIOD_IN_DAYS" => "30",
       "DECIDIM_DELETE_INACTIVE_USERS_FIRST_WARNING_DAYS_BEFORE" => "30",
       "DECIDIM_DELETE_INACTIVE_USERS_LAST_WARNING_DAYS_BEFORE" => "7",
+      "DECIDIM_DELETE_OLD_PERSONAL_DATA_VERSIONS_DAYS" => "365",
       "RAILS_LOG_LEVEL" => "fatal",
       "RAILS_ASSET_HOST" => "http://assets.example.org",
       "ETHERPAD_SERVER" => "http://a-etherpad-server.com",

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -656,6 +656,11 @@ A content processor is a concept to refer to a set of two classes:
 | 7
 | No
 
+| DECIDIM_DELETE_OLD_PERSONAL_DATA_VERSIONS_DAYS
+| Number of days after which the version data is deleted for deleted users or revoked authorizations.
+| 365
+| No
+
 |*DECIDIM_SERVICE_WORKER_ENABLED*
 |Enable/Disable the service worker. This is used to enable offline support and to deliver push notifications. In development it is recommended to be disabled because its aggressive cache configuration might cause some issues when submitting forms.
 |false


### PR DESCRIPTION
#### :tophat: What? Why?
Currently there are few problems with the personal data retention:
1. Authorization versions are never deleted (even after the authorization is deleted / revoked) and they may contain personal data
2. All version data for users is destroyed at the same time when the account is destroyed

I think the first one is self explanatory but the second point might need some explanation. The issue with the second point is that it makes auditing the user record changes impossible after the account is destroyed. This is problem e.g. when inspecting spammer accounts on the platform as they can easily destroy all data related to their account by deleting their account. This data could be important also if the data controller needs to prove when and how the personal details have been changed (can be a regulatory requirement in some contexts).

This PR solves both problems and includes the following changes:

- Removes old version data for deleted/revoked authorizations
- Implements a personal data retention period that defines how long the personal data related versions are retained (both for authorizations and users)
- Preserve the user record versions for the retention period instead of destroying them during the account destroy
- Introduces a new environment variable `DECIDIM_DELETE_OLD_PERSONAL_DATA_VERSIONS_DAYS` that allows changing the personal data version retention period (by default 365 days)

#### :pushpin: Related Issues
- Related to
  * #10608 
  * #14731
  * OpenSourcePolitics/decidim-module-cleaner#11

#### Testing
See and run the added specs that should explain the functionality in detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cleanup of historical version data for deleted accounts and revoked authorizations.
  * Added a configurable retention period, defaulting to 365 days.
  * Added a task to manually trigger cleanup with a custom retention period.

* **Bug Fixes**
  * Account deletion no longer immediately removes historical version records; eligible data is cleaned up after the retention period.

* **Documentation**
  * Documented the new retention-period configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->