### PR TITLE
Fix API `user` field returning a random user when no arguments are provided

### DIFF
--- a/decidim-api/lib/decidim/api/query_type.rb
+++ b/decidim-api/lib/decidim/api/query_type.rb
@@ -57,6 +57,8 @@ module Decidim
       end
 
       def user(id: nil, nickname: nil)
+        return nil if id.blank? && nickname.blank?
+
         Core::UserEntityFinder.new.call(object, { id:, nickname: }, context)
       end
 

--- a/decidim-core/spec/types/query_type_spec.rb
+++ b/decidim-core/spec/types/query_type_spec.rb
@@ -51,5 +51,33 @@ module Decidim::Api
         end
       end
     end
+
+    describe "user" do
+      let!(:user) { create(:user, :confirmed, organization: current_organization) }
+
+      context "with ID" do
+        let(:query) { %({ user(id: "#{user.id}") { id, name } }) }
+
+        it "returns the correct user" do
+          expect(response["user"]).to eq("id" => user.id.to_s, "name" => user.name)
+        end
+      end
+
+      context "with nickname" do
+        let(:query) { %({ user(nickname: "#{user.nickname}") { id, name } }) }
+
+        it "returns the correct user" do
+          expect(response["user"]).to eq("id" => user.id.to_s, "name" => user.name)
+        end
+      end
+
+      context "with no argument" do
+        let(:query) { %({ user { id, name } }) }
+
+        it "returns nothing" do
+          expect(response["user"]).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
When querying a specific user from the API without either argument (ID or nickname), the endpoint returns a random user.

This fixes the issue by returning `nil` if both arguments are blank / missing.

#### Testing
- Send the following query to the API `{ user { id name } }`
- Expect to see no user returned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user lookups so requests without an ID or nickname return no result instead of triggering an unnecessary lookup.

* **Tests**
  * Added coverage for retrieving users by ID and nickname.
  * Added coverage for requests that omit user search criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->