### PR TITLE
Fix status filter for proposals

### DIFF
--- a/decidim-proposals/config/locales/en.yml
+++ b/decidim-proposals/config/locales/en.yml
@@ -126,9 +126,9 @@ en:
               'false': Proposals
               'true': Amendments
           proposal_state_id_eq:
-            label: State
+            label: Status
           state_eq:
-            label: State
+            label: Status
             values:
               accepted: Accepted
               evaluating: Evaluating

--- a/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/admin/filter_proposals_spec.rb
@@ -57,7 +57,7 @@ describe "Admin filters proposals" do
 
     STATES.each do |state|
       context "when filtering proposals by state: #{I18n.t(state, scope: "decidim.admin.filters.proposals.state_eq.values")}" do
-        it_behaves_like "a filtered collection", options: "State", filter: I18n.t(state, scope: "decidim.admin.filters.proposals.state_eq.values") do
+        it_behaves_like "a filtered collection", options: "Status", filter: I18n.t(state, scope: "decidim.admin.filters.proposals.state_eq.values") do
           let(:in_filter) { translated(proposal_with_state(state).title) }
           let(:not_in_filter) { translated(proposal_without_state(state).title) }
         end
@@ -65,7 +65,7 @@ describe "Admin filters proposals" do
     end
 
     context "when filtering proposals by state: Withdrawn" do
-      it_behaves_like "a filtered collection", options: "State", filter: "Withdrawn" do
+      it_behaves_like "a filtered collection", options: "Status", filter: "Withdrawn" do
         let(:in_filter) { translated(withdrawn_proposal.title) }
         let(:not_in_filter) { translated(proposals.sample.title) }
       end


### PR DESCRIPTION
#### :tophat: What? Why?
The filter within proposals that allows us to filter for "statues" was incorrectly using "state" which I detailed was the wrong format in #15764. 

I have fixed according the requirement in the issue here: https://github.com/decidim/decidim/issues/15764#issuecomment-3669850737

#### :pushpin: Related Issues
- Fixes #15764 

#### Testing
1. Login 
2. Head to the proposal component
3. Filter via the drop down at the top
4. See the correct name "status" for proposal statues, instead of "state"

### :camera: Screenshots
<img width="1158" height="903" alt="Screenshot from 2026-08-12 15-24-29" src="https://github.com/user-attachments/assets/161cc5ff-7abd-498c-b981-44762c2a9757" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated proposal administration filter labels from “State” to “Status” for clearer filtering.
* **Tests**
  * Updated coverage to reflect the revised filter labels for regular and withdrawn proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->