### PR TITLE
Bump `chrome_version` from 139.0.7258.66 to 151.0.7922.108

### DIFF
--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -43,7 +43,7 @@ on:
       chrome_version:
         description: 'Chrome & Chromedriver version'
         required: false
-        default: "139.0.7258.66"
+        default: "151.0.7922.108"
         type: string
 
 jobs:

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -263,6 +263,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
     click_on "Save"
 
+    expect(page).to have_css(".panel-error", visible: true)
     expand_all_questions
     expect(page).to have_select("Type", selected: "Long response", wait: 10)
   end
@@ -280,6 +281,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
 
     click_on "Save"
+    expect(page).to have_css(".panel-error", visible: true)
     expand_all_questions
 
     expect(page).to have_text("Type")
@@ -303,6 +305,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
 
     click_on "Save"
+    expect(page).to have_css(".panel-error", visible: true)
     expand_all_questions
 
     expect(page).to have_text("Type")
@@ -332,6 +335,7 @@ shared_examples_for "add questions" do
     select "3", from: "Maximum number of choices"
 
     click_on "Save"
+    expect(page).to have_css(".panel-error", visible: true)
     expand_all_questions
 
     expect(page).to have_css(".questionnaire-question-response-option")
@@ -359,6 +363,7 @@ shared_examples_for "add questions" do
     click_on "Add row"
 
     click_on "Save"
+    expect(page).to have_css(".panel-error", visible: true)
     expand_all_questions
 
     within ".questionnaire-question-matrix-row:first-of-type" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/add_questions.rb
@@ -263,7 +263,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
     click_on "Save"
 
-    expect(page).to have_css(".panel-error", visible: true)
+    expect(page).to have_css(".panel-error", visible: :visible)
     expand_all_questions
     expect(page).to have_select("Type", selected: "Long response", wait: 10)
   end
@@ -281,7 +281,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
 
     click_on "Save"
-    expect(page).to have_css(".panel-error", visible: true)
+    expect(page).to have_css(".panel-error", visible: :visible)
     expand_all_questions
 
     expect(page).to have_text("Type")
@@ -305,7 +305,7 @@ shared_examples_for "add questions" do
     select "Long response", from: "Type"
 
     click_on "Save"
-    expect(page).to have_css(".panel-error", visible: true)
+    expect(page).to have_css(".panel-error", visible: :visible)
     expand_all_questions
 
     expect(page).to have_text("Type")
@@ -335,7 +335,7 @@ shared_examples_for "add questions" do
     select "3", from: "Maximum number of choices"
 
     click_on "Save"
-    expect(page).to have_css(".panel-error", visible: true)
+    expect(page).to have_css(".panel-error", visible: :visible)
     expand_all_questions
 
     expect(page).to have_css(".questionnaire-question-response-option")
@@ -363,7 +363,7 @@ shared_examples_for "add questions" do
     click_on "Add row"
 
     click_on "Save"
-    expect(page).to have_css(".panel-error", visible: true)
+    expect(page).to have_css(".panel-error", visible: :visible)
     expand_all_questions
 
     within ".questionnaire-question-matrix-row:first-of-type" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -45,7 +45,7 @@ shared_examples_for "update questions" do
       end
 
       click_on "Save"
-      expect(page).to have_css(".panel-error", visible: true)
+      expect(page).to have_css(".panel-error", visible: :visible)
       click_on "Expand all questions"
 
       expect(page).to have_callout(callout_failure)
@@ -513,7 +513,7 @@ shared_examples_for "update questions" do
       end
 
       click_on "Save"
-      expect(page).to have_css(".panel-error", visible: true)
+      expect(page).to have_css(".panel-error", visible: :visible)
       expand_all_questions
 
       within ".questionnaire-question:last-of-type" do

--- a/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
+++ b/decidim-forms/lib/decidim/forms/test/shared_examples/manage_questionnaires/update_questions.rb
@@ -45,6 +45,7 @@ shared_examples_for "update questions" do
       end
 
       click_on "Save"
+      expect(page).to have_css(".panel-error", visible: true)
       click_on "Expand all questions"
 
       expect(page).to have_callout(callout_failure)
@@ -512,6 +513,7 @@ shared_examples_for "update questions" do
       end
 
       click_on "Save"
+      expect(page).to have_css(".panel-error", visible: true)
       expand_all_questions
 
       within ".questionnaire-question:last-of-type" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed while working in #17441 , the CI was failing within the module I was working on with this error:

```
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 203645 files and directories currently installed.)
Preparing to unpack .../libu2f-udev_1.1.10-3build3_all.deb ...
Unpacking libu2f-udev (1.1.10-3build3) ...
Setting up libu2f-udev (1.1.10-3build3) ...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_139.0.7258.66-1_amd64.deb:
2026-08-13 07:32:53 ERROR 404: Not Found.

```

I have patched the `chrome_version` to the latest release: https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop_01193673229.html 

The test_app should run without issues.

#### :pushpin: Related Issues

- Related to #?
- Fixes #?

#### Testing
Pipline should be green

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated browser testing environment to use newer Chrome and Chromedriver versions.

* **Tests**
  * Expanded questionnaire validation coverage for failed saves and updates.
  * Added checks confirming that visible error messages appear for invalid question type changes, response options, matrix rows, and other questionnaire scenarios.
  * Improved confidence that form errors are clearly presented when questionnaire changes cannot be saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->