### PR TITLE
Backport 'Fix API `user` field returning a random user when no arguments are provided' to v0.32

### DIFF
--- a/decidim-api/lib/decidim/api/query_type.rb
+++ b/decidim-api/lib/decidim/api/query_type.rb
@@ -57,6 +57,8 @@ module Decidim
       end
 
       def user(id: nil, nickname: nil)
+        return nil if id.blank? && nickname.blank?
+
         Core::UserEntityFinder.new.call(object, { id:, nickname: }, context)
       end
 

--- a/decidim-core/spec/types/query_type_spec.rb
+++ b/decidim-core/spec/types/query_type_spec.rb
@@ -51,5 +51,33 @@ module Decidim::Api
         end
       end
     end
+
+    describe "user" do
+      let!(:user) { create(:user, :confirmed, organization: current_organization) }
+
+      context "with ID" do
+        let(:query) { %({ user(id: "#{user.id}") { id, name } }) }
+
+        it "returns the correct user" do
+          expect(response["user"]).to eq("id" => user.id.to_s, "name" => user.name)
+        end
+      end
+
+      context "with nickname" do
+        let(:query) { %({ user(nickname: "#{user.nickname}") { id, name } }) }
+
+        it "returns the correct user" do
+          expect(response["user"]).to eq("id" => user.id.to_s, "name" => user.name)
+        end
+      end
+
+      context "with no argument" do
+        let(:query) { %({ user { id, name } }) }
+
+        it "returns nothing" do
+          expect(response["user"]).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Backport #17468 to v0.32

:hearts: Thank you!