### PR TITLE
Fix expanded state indication on collapsible description toggles

### DIFF
--- a/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
+++ b/decidim-core/app/cells/decidim/content_blocks/participatory_space_main_data/title.erb
@@ -23,15 +23,11 @@
         <% end %>
       </div>
 
-      <button class="button button__sm button__text-secondary mt-2" data-controls="panel-view-more-<%= seed %>" aria-expanded="false" onclick="document.querySelector('div[id^=panel-view-more]').toggleAttribute('inert')">
+      <button class="button button__sm button__text-secondary mt-2" data-controls="panel-view-more-<%= seed %>" aria-expanded="false">
         <span>
           <%= t("view_more", scope: "layouts.decidim.announcements") %>
         </span>
         <%= icon "arrow-down-s-line" %>
-        <span>
-          <%= t("view_less", scope: "layouts.decidim.announcements") %>
-        </span>
-        <%= icon "arrow-up-s-line" %>
       </button>
     <% else %>
       <% if rich_text_processors? %>
@@ -42,12 +38,3 @@
     <% end %>
   </div>
 <% end %>
-<script>
-  const button = document.querySelector('button[data-controls^="panel-view-more"]')
-  button.addEventListener('keydown', function(e){
-    // press space or enter
-    if (e.keyCode === 32 || e.keyCode === 13){
-      document.querySelector('div[id^=panel-view-more]').toggleAttribute('inert')
-    }
-  })
-</script>

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/accordion.test.js
@@ -1,3 +1,4 @@
+/* eslint max-lines: ["error", 350] */
 /* global jest */
 
 import AccordionController from "src/decidim/controllers/accordion/controller";
@@ -96,6 +97,69 @@ describe("AccordionController", () => {
       trigger.dataset.controls = "nonexistent-panel";
       accordionElement.appendChild(trigger);
       expect(() => controller.fixPanelRole()).not.toThrow();
+    });
+  });
+
+  describe("_setupInertPanels", () => {
+    const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    beforeEach(() => {
+      panel1.setAttribute("inert", "");
+      panel1.setAttribute("aria-hidden", "true");
+      panel1.setAttribute("tabindex", "-1");
+      panel2.setAttribute("aria-hidden", "true");
+    });
+
+    it("only manages panels with the inert attribute", async () => {
+      controller._setupInertPanels();
+      expect(controller._panelObservers.length).toBe(1);
+
+      panel2.setAttribute("aria-hidden", "false");
+      await nextTick();
+      expect(panel2.hasAttribute("inert")).toBe(false);
+      expect("inertManaged" in panel2.dataset).toBe(false);
+    });
+
+    it("removes inert and moves focus to the panel when it gets expanded", async () => {
+      controller._setupInertPanels();
+
+      panel1.setAttribute("aria-hidden", "false");
+      await nextTick();
+      expect(panel1.hasAttribute("inert")).toBe(false);
+      expect(document.activeElement).toBe(panel1);
+    });
+
+    it("restores inert when the panel gets collapsed again", async () => {
+      controller._setupInertPanels();
+
+      panel1.setAttribute("aria-hidden", "false");
+      await nextTick();
+      panel1.setAttribute("aria-hidden", "true");
+      await nextTick();
+      expect(panel1.hasAttribute("inert")).toBe(true);
+    });
+
+    it("keeps managing an expanded panel across teardown and setup", async () => {
+      controller._setupInertPanels();
+
+      panel1.setAttribute("aria-hidden", "false");
+      await nextTick();
+      controller._teardownInertPanels();
+
+      panel1.setAttribute("aria-hidden", "true");
+      controller._setupInertPanels();
+      expect(controller._panelObservers.length).toBe(1);
+      expect(panel1.hasAttribute("inert")).toBe(true);
+    });
+
+    it("stops syncing after teardown", async () => {
+      controller._setupInertPanels();
+      controller._teardownInertPanels();
+      expect(controller._panelObservers.length).toBe(0);
+
+      panel1.setAttribute("aria-hidden", "false");
+      await nextTick();
+      expect(panel1.hasAttribute("inert")).toBe(true);
     });
   });
 

--- a/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
+++ b/decidim-core/app/packs/src/decidim/controllers/accordion/controller.js
@@ -31,6 +31,8 @@ export default class extends Controller {
 
     this.fixPanelRole();
 
+    this._setupInertPanels();
+
     this.expandIfNeeded();
 
     this.boundReconnect = this.reconnect.bind(this);
@@ -51,6 +53,8 @@ export default class extends Controller {
     if (this.boundExpand) {
       this.toggleButton.removeEventListener("click", this.boundExpand);
     }
+
+    this._teardownInertPanels();
 
     this._stopListeningForBreakpointChanges();
   }
@@ -164,6 +168,45 @@ export default class extends Controller {
   }
   expandToggle() {
     this.previouslyExpanded = this.toggleButton.getAttribute("aria-expanded");
+  }
+
+  /**
+   * Syncs the `inert` attribute of partially visible panels (those rendered
+   * inert) with their `aria-hidden` state, moving focus to the panel on expand.
+   *
+   * @returns {void}
+   */
+  _setupInertPanels() {
+    this._panelObservers = [];
+
+    this.element.querySelectorAll("[data-controls]").forEach((trigger) => {
+      const panel = document.getElementById(trigger.dataset.controls);
+      if (!panel || (!panel.hasAttribute("inert") && !("inertManaged" in panel.dataset))) {
+        return;
+      }
+
+      panel.dataset.inertManaged = "";
+      panel.toggleAttribute("inert", panel.getAttribute("aria-hidden") === "true");
+
+      const observer = new MutationObserver(() => {
+        if (panel.getAttribute("aria-hidden") === "true") {
+          panel.setAttribute("inert", "");
+        } else {
+          panel.removeAttribute("inert");
+          panel.focus();
+        }
+      });
+      observer.observe(panel, { attributes: true, attributeFilter: ["aria-hidden"] });
+
+      this._panelObservers.push(observer);
+    });
+  }
+
+  _teardownInertPanels() {
+    if (this._panelObservers) {
+      this._panelObservers.forEach((observer) => observer.disconnect());
+      this._panelObservers = [];
+    }
   }
 
   fixPanelRole() {

--- a/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/_content_blocks.scss
@@ -13,18 +13,12 @@
         @apply block max-h-40 overflow-hidden relative first:[&_*]:mt-0 before:content-[''] before:absolute before:inset-0 before:h-full before:w-full before:bg-gradient-to-b before:from-transparent before:to-white after:content-[''] after:absolute after:inset-0 after:h-full after:w-full after:bg-gradient-to-b after:from-transparent after:to-white;
       }
 
-      [aria-expanded="false"] > svg:last-of-type,
-      [aria-expanded="false"] > span:last-of-type,
-      [aria-expanded="true"] > span:first-of-type,
-      [aria-expanded="true"] > svg:first-of-type {
-        @apply hidden;
+      [aria-expanded] > svg {
+        @apply transition-transform;
       }
 
-      [aria-expanded="true"] > svg:last-of-type,
-      [aria-expanded="true"] > span:last-of-type,
-      [aria-expanded="false"] > span:first-of-type,
-      [aria-expanded="false"] > svg:first-of-type {
-        @apply block;
+      [aria-expanded="true"] > svg {
+        @apply rotate-180;
       }
     }
 

--- a/decidim-core/app/views/decidim/application/_radio_accordion.html.erb
+++ b/decidim-core/app/views/decidim/application/_radio_accordion.html.erb
@@ -12,7 +12,7 @@
   </label>
 
   <div data-controller="accordion" class="radio-accordion-section content-block__description editor-content">
-    <div id="panel-title--<%= panel_id %>" aria-hidden="true">
+    <div id="panel-title--<%= panel_id %>" aria-hidden="true" inert>
       <%= yield %>
     </div>
 
@@ -21,10 +21,6 @@
         <%= show_more_text %>
       </span>
       <%= icon "arrow-down-s-line" %>
-      <span>
-        <%= show_less_text %>
-      </span>
-      <%= icon "arrow-up-s-line" %>
     </button>
   </div>
 </div>

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -2102,7 +2102,6 @@ en:
   layouts:
     decidim:
       announcements:
-        view_less: Show less
         view_more: More information
       data_consent:
         details:

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/select_initiative_type.html.erb
@@ -22,7 +22,6 @@
                    input_radio_name: "initiative[type_id]",
                    input_radio_value: type.id,
                    show_more_text: t("show_more", scope: "decidim.initiatives.create_initiative.select_initiative_type"),
-                   show_less_text: t("show_less", scope: "decidim.initiatives.create_initiative.select_initiative_type"),
                    disabled: !is_allowed
                  } do %>
         <p>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -415,7 +415,6 @@ en:
           new: Create a new initiative
           select: I want to promote this initiative
           select_initiative_type_help_html: "<p>Initiatives are a means by which the participants can intervene so that the organization can undertake actions in defence of the general interest. Which initiative do you want to launch?</p>"
-          show_less: Show less
           show_more: Show more
           subtitle: What initiative do you want to promote?
           verification_required: Verify your account to promote this initiative


### PR DESCRIPTION
#### :tophat: What? Why?
The "More information" button on participatory space descriptions (processes and assemblies landing pages) and the "Show more" button on initiative type cards indicated their expanded state in two ways at once: the accessible name changed (a "Show less" label was swapped in via CSS) and aria-expanded toggled. For screen reader users this duplicates and can contradict the announced state, which was flagged as a WCAG 2.1 4.1.2 (Name, Role, Value) failure in an accessibility audit of decidim.barcelona.

This PR:

- Keeps the button label stable — the state is now conveyed only through aria-expanded, with the chevron icon rotating as the visual cue.
- Moves the inert and focus handling into the accordion controller, replacing the inline scripts in the template. Only panels that start with inert are affected. All other accordions behave exactly as before.
- Applies the same fix to the "Show more" button on the initiative type selection step, which had the same problem.

#### :pushpin: Related Issues

#### Testing
**Participatory process or assembly description:**

1. As an admin, give a process (or assembly) a description longer than 300 characters.
2. Visit its landing page and find the "About this process" section.
3. Check the "More information" button: the label stays the same when you toggle it, only aria-expanded and the chevron change.
4. With the description collapsed, Tab through the section: links inside the truncated text are skipped. Expand it: focus moves to the description and its links are now reachable.
5. Toggle with Enter and Space too — both should work.
6. With a description shorter than 300 characters: no button is shown and there is no error in the browser console.

**Initiative type selection:**

1. Make sure the organization has at least two initiative types, then start creating an initiative.
2. Check the "Show more" button on each type card behaves the same way as above.

### :camera: Screenshots
After the fix, button still says "More information", chevron pointing up:
<img width="1330" height="901" alt="image" src="https://github.com/user-attachments/assets/9bb2cb3f-d977-45e0-b540-ad28ead6966b" />

Same for initiatives types:
<img width="1342" height="738" alt="image" src="https://github.com/user-attachments/assets/fda30407-7322-46ab-969f-cfb45f6190f1" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accordion accessibility by preventing hidden content from receiving focus.
  * Accordion panels now synchronize visibility and accessibility states as they expand and collapse.
  * Expanded panels receive focus to support keyboard navigation.

* **Style**
  * Accordion icons now animate and rotate when panels expand.
  * Simplified controls to consistently display “show more” guidance.

* **Tests**
  * Added comprehensive coverage for accordion accessibility and panel state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->