### PR TITLE
Patch dependabot configuration for Gemfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
+      time: "03:00"
       timezone: "Europe/Madrid"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     ignore:
       - dependency-name: "rails"
         update-types: [ "version-update:semver-minor", "version-update:semver-major" ]


### PR DESCRIPTION
#### :tophat: What? Why?
Since we have initially installed and configured the dependabot, I have spend consistently a few hours a day during the working hours to consume the backlog of pending Gemfile updates. 
This PR move to 5 the number of concurrent PRs that can be opened, and also is moving the timeframe from 6:00 to 3:00 to make sure the backlog is consumed. 

Also, this fixes another issue that previously happened. If small gem update is generating an error, and we do not have the time to tackle, the entire dependency flow will be blocked. Having the new limit, will allow us to continue merging leaner PR, while we allocate time to fix blocking upgrades.

Context: 
- This morning i woke up to 6 different updates 
- On August 14th there were 3 pending upgrades 
- On August 10th i already merged (#17440, #17437)
- On august 8th (#17431 )
- On august 7 there were 2  (#17430, 17429)
- On august 6th
- On august 5 there were 2 
- On august 4 there were at lest 3 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16132
- Fixes #?

#### Testing
*Describe the best way to test or validate your PR.*

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*
![Description](URL)

:hearts: Thank you!
