### PR TITLE
Fix published survey responses chart counting option combinations

### DIFF
--- a/decidim-surveys/app/helpers/decidim/surveys/publish_responses_helper.rb
+++ b/decidim-surveys/app/helpers/decidim/surveys/publish_responses_helper.rb
@@ -80,7 +80,7 @@ module Decidim
       end
 
       def options_column_chart_wrapper(question)
-        tally = question.responses.map { |response| response.choices.map { |choice| translated_attribute(choice.response_option.body) } }.tally
+        tally = question.responses.flat_map { |response| response.choices.map { |choice| translated_attribute(choice.response_option.body) } }.tally
 
         column_chart(tally, download: true)
       end

--- a/decidim-surveys/spec/helpers/publish_responses_helper_spec.rb
+++ b/decidim-surveys/spec/helpers/publish_responses_helper_spec.rb
@@ -50,6 +50,33 @@ module Decidim
           it "returns the chart code" do
             expect(helper.chart_for_question(question.id)).to have_text("ColumnChart")
           end
+
+          context "and the responses select more than one option" do
+            let(:questionnaire) { question.questionnaire }
+            let!(:option_a) { create(:response_option, question:, body: { "en" => "Option A" }) }
+            let!(:option_b) { create(:response_option, question:, body: { "en" => "Option B" }) }
+            let!(:option_c) { create(:response_option, question:, body: { "en" => "Option C" }) }
+
+            before do
+              # A response selecting the three options at once.
+              response1 = create(:response, questionnaire:, question:)
+              [option_a, option_b, option_c].each do |response_option|
+                create(:response_choice, response: response1, response_option:, matrix_row: nil)
+              end
+
+              # And a response for the first option and another one for the last option.
+              response2 = create(:response, questionnaire:, question:)
+              [option_a, option_c].each do |response_option|
+                create(:response_choice, response: response2, response_option:, matrix_row: nil)
+              end
+            end
+
+            it "counts every selected option, not the combination of options of each response" do
+              expect(helper).to receive(:column_chart).with({ "Option A" => 2, "Option B" => 1, "Option C" => 2 }, download: true)
+
+              helper.chart_for_question(question.id)
+            end
+          end
         end
 
         context "when the question type is sorting" do


### PR DESCRIPTION
#### :tophat: What? Why?

Solves #17491.
Use `flat_map` instead of `map` to collect valid keys in responses.

#### :pushpin: Related Issues
- Fixes https://github.com/decidim/decidim/issues/17491

#### Testing

Add some tests in decidim-surveys/spec/helpers/publish_responses_helper_spec.rb.

See also `To Reproduce` in #17491 .

### :camera: Screenshots

<img width="748" height="388" alt="survey2" src="https://github.com/user-attachments/assets/4d8dd804-d96d-4751-ac28-5a6c5630abb4" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected survey response charts to aggregate counts for each selected option independently.
  * Improved chart accuracy for questions allowing multiple selections.

* **Tests**
  * Added coverage for responses containing different combinations of selected options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->