### PR TITLE
Show all child assemblies in admin list

### DIFF
--- a/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
+++ b/decidim-assemblies/app/controllers/decidim/assemblies/admin/assemblies_controller.rb
@@ -74,6 +74,12 @@ module Decidim
 
         private
 
+        def filtered_collection
+          return query.result if request.format.js? && ransack_params[:parent_id_eq].present?
+
+          paginate(query.result)
+        end
+
         def collection
           @collection ||= OrganizationAssemblies.new(current_user.organization).query
         end

--- a/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
+++ b/decidim-assemblies/spec/system/admin/admin_manages_assemblies_spec.rb
@@ -201,6 +201,21 @@ describe "Admin manages assemblies" do
         expect(page).to have_no_text(translated(child_assembly.title))
       end
     end
+
+    describe "listing more child assemblies than the results per page" do
+      let!(:other_child_assemblies) { create_list(:assembly, 25, organization:, parent: parent_assembly) }
+
+      it "shows all the children without paginating them" do
+        within "tr", text: translated(parent_assembly.title) do
+          find("a[data-arrow-down]").click
+        end
+
+        expect(page).to have_text(translated(child_assembly.title))
+        other_child_assemblies.each do |child|
+          expect(page).to have_text(translated(child.title))
+        end
+      end
+    end
   end
 
   context "when navigating grandchild assemblies (3rd level)" do


### PR DESCRIPTION
#### :tophat: What? Why?
In the admin assemblies list, expanding a parent assembly with more than 25 children only showed the first 25 — the rest were unreachable, since the children rows are injected via a JS response that renders no pagination controls, yet the collection was paginated with the default limit of 25.

This PR skips pagination when serving the children expansion request (JS format with q[parent_id_eq]), so all child assemblies are listed. The regular HTML index keeps its pagination.

#### :pushpin: Related Issues

#### Testing
1. In the Admin panel, create an assembly and give it more than 25 child assemblies (e.g. 26). You can do it quickly from the console:
```
 parent = Decidim::Assembly.first # or any assembly
 26.times { |i| Decidim::Assembly.create!(organization: parent.organization, parent: parent, slug: "child-#{i}", title: {en: "Child #{i}" }, subtitle: { en: "s" }, short_description: { en: "<p>s</p>" }, description: { en: "<p>d</p>" }) }
```
2. Go to /admin/assemblies and click the expand arrow of the parent assembly.
3. Without this PR, only the first 25 children are shown and the rest are unreachable. With this PR, all 26 children appear.
4.. Check the main assemblies list still paginates normally at 25 per page.

### :camera: Screenshots
Before (no 'Child 26' found):

<img width="1716" height="963" alt="image" src="https://github.com/user-attachments/assets/70188543-459f-402d-aba6-346b629f4cc5" />


After:
<img width="1728" height="937" alt="image" src="https://github.com/user-attachments/assets/3ce3eb80-91d0-40ae-87c4-d8f5c2bfdab4" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanding a parent assembly now displays all child assemblies, including those beyond the first page.
  * Preserved pagination for other assembly listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->