### PR TITLE
Fix display issues of logo in mailer

### DIFF
--- a/decidim-core/app/packs/stylesheets/decidim/legacy/email.scss
+++ b/decidim-core/app/packs/stylesheets/decidim/legacy/email.scss
@@ -1717,7 +1717,6 @@ body.outlook p {
 table.body th.decidim-bar,
 table.body td.decidim-bar {
   padding: 10px 0;
-  background-color: #1a181d;
 }
 
 table.body {
@@ -1732,10 +1731,6 @@ table.body {
 .decidim-logo a {
   display: inline-block;
   height: 30px;
-}
-
-.cityhall-bar {
-  background-color: #2c2930;
 }
 
 .cityhall-logo {

--- a/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
@@ -8,7 +8,7 @@
     <% if organization.logo.attached? %>
       <%= image_tag(
             organization.attached_uploader(:logo).variant_url(:medium, host: organization.host),
-            style: "max-height: 50px",
+            style: "max-height: 50px; display: inherit",
             alt: organization_name(organization)
           ) %>
     <% else %>

--- a/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
+++ b/decidim-core/app/views/layouts/decidim/_mailer_logo.html.erb
@@ -8,7 +8,7 @@
     <% if organization.logo.attached? %>
       <%= image_tag(
             organization.attached_uploader(:logo).variant_url(:medium, host: organization.host),
-            style: "max-height: 50px; display: inherit",
+            style: "max-height: 50px; display: inline-block",
             alt: organization_name(organization)
           ) %>
     <% else %>


### PR DESCRIPTION
#### :tophat: What? Why?
Fixing the image position in mailer template. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #16082

#### Testing
1. In admin area, visit the settings / configuration 
2. Add to the logo, image the below biscuit 
3. Persist / update the settings
4. Head over to http://localhost:3000/rails/mailers 
5. Chose any template 
6. See the logo position ( like the before) 
7. Switch to this branch 
8. See the logo position ( like the after) 

### :camera: Screenshots
Before:
<img width="617" height="416" alt="image" src="https://github.com/user-attachments/assets/30f4406f-813e-4ad7-8fa7-de1c3767ff47" />

After:
<img width="641" height="363" alt="image" src="https://github.com/user-attachments/assets/81083b9a-aacf-4f0e-be68-4b759c3a970e" />


<img width="612" height="612" alt="biscuit" src="https://github.com/user-attachments/assets/6e5b768b-c171-4821-a1fe-364966e77dce" />



:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email logo rendering by ensuring the logo displays correctly while retaining its maximum height constraint.
  * Removed background colors from email header bars for cleaner, more consistent styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->