### PR TITLE
Remove azure mirrors in workflows

### DIFF
--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - name: Fix APT mirrors and install dependencies
+      - name: Fix APT mirrors
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then
             sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/ci_generators.yml
+++ b/.github/workflows/ci_generators.yml
@@ -80,6 +80,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Fix APT mirrors and install dependencies
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/*.sources || true
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list || true
       - run: |
           sudo apt-get update && sudo apt-get install libvips libvips-tools
         name: Install libvips

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -64,6 +64,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Fix APT mirrors and install dependencies
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/*.sources || true
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list || true
       - run: |
           sudo apt-get update && sudo apt-get install libvips libvips-tools
         name: Install libvips

--- a/.github/workflows/ci_performance_metrics_monitoring.yml
+++ b/.github/workflows/ci_performance_metrics_monitoring.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - name: Fix APT mirrors and install dependencies
+      - name: Fix APT mirrors
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then
             sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -54,6 +54,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Fix APT mirrors and install dependencies
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/*.sources || true
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list || true
       - run: |
           sudo apt-get update && sudo apt-get install libvips libvips-tools
         name: Install libvips

--- a/.github/workflows/ci_production_check.yml
+++ b/.github/workflows/ci_production_check.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - name: Fix APT mirrors and install dependencies
+      - name: Fix APT mirrors
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then
             sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - name: Fix APT mirrors and install dependencies
+      - name: Fix APT mirrors
         run: |
           if [ -f /etc/apt/apt-mirrors.txt ]; then
             sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt

--- a/.github/workflows/test_app.yml
+++ b/.github/workflows/test_app.yml
@@ -94,6 +94,13 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Fix APT mirrors and install dependencies
+        run: |
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i '/azure.archive.ubuntu.com/d' /etc/apt/apt-mirrors.txt
+          fi
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list.d/*.sources || true
+          sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|http://archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list || true
       - run: |
           sudo apt-get update && sudo apt-get install libvips libvips-tools
         name: Install libvips


### PR DESCRIPTION
#### :tophat: What? Why?
Recently we have noticed that azure mirrors are failing to fetch packages causing timeouts across the whole workflow pipeline. This PR removes azure repos, to enable us to run the pipeline without issues. 

#### Testing
1. Green pipelines 
2. No timeouts

### :camera: Screenshots
<img width="2054" height="915" alt="image" src="https://github.com/user-attachments/assets/3c821048-b5e2-4680-aaf3-76c984264a8a" />

:hearts: Thank you!
