### PR TITLE
Do not skip the no `aria-*` attributes for hidden inputs validation

### DIFF
--- a/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
+++ b/decidim-dev/lib/decidim/dev/test/w3c_rspec_validators_overrides.rb
@@ -19,8 +19,7 @@ module W3CValidators
 
     def ignore_errors
       @ignore_errors ||= [
-        "An “input” element with a “type” attribute whose value is “hidden” must not have an “autocomplete” attribute whose value is “on” or “off”.",
-        "An “input” element with a “type” attribute whose value is “hidden” must not have any “aria-*” attributes."
+        "An “input” element with a “type” attribute whose value is “hidden” must not have an “autocomplete” attribute whose value is “on” or “off”."
       ]
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
I believe skipping the "no aria-* attributes for hidden inputs" validation is unnecessary after the removal of `foundation-sites`.

Actually shouldn't be even required with foundation after foundation/foundation-sites#12496

#### :pushpin: Related Issues
- Related to
  * #16889
  * foundation/foundation-sites#12496

#### Testing
See that there are no errors in the CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * W3C validation now reports hidden inputs with `aria-*` attributes instead of ignoring these messages.
  * Existing handling for hidden-input autocomplete validation messages remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->