### PR TITLE
Fix validation on background image in participatory spaces

### DIFF
--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -33,9 +33,51 @@ module Decidim
 
     def file_validators
       org = organization
+      target_class = resource_class.constantize
+
+      if target_class == Decidim::ContentBlockAttachment && target_class.validators_on(property.to_sym).none?
+        validate_content_block_image
+      else
+        validate_passthru(target_class, org)
+      end
+    end
+
+    # Content block image uploads (e.g. hero background_image) go through
+    # ContentBlockAttachment which requires a content_block association to
+    # resolve the uploader. The dummy record created by PassthruValidator has
+    # no content_block, so attached_uploader returns nil and validators bail
+    # out silently. Instead, validate the blob directly against the
+    # RecordImageUploader allowlist used by all content block image uploaders.
+    def validate_content_block_image
+      uploader = Decidim::RecordImageUploader.new(nil, :file)
+      allowed_types = uploader.content_type_allowlist
+      allowed_extensions = uploader.extension_allowlist
+
+      content_type = blob.content_type.to_s
+      extension = blob.filename.to_s.split(".").last&.downcase
+
+      unless allowed_types.include?(content_type)
+        message = format(
+          "The file type %{content_type} is not valid. Allowed types: %{allowed}",
+          content_type:, allowed: allowed_types.join(", ")
+        )
+        errors.add(property.to_sym, message)
+      end
+
+      return if extension.blank?
+      return if allowed_extensions.include?(extension)
+
+      message = format(
+        "The file extension .%{ext} is not valid. Allowed extensions: %{allowed}",
+        ext: extension, allowed: allowed_extensions.join(", ")
+      )
+      errors.add(property.to_sym, message)
+    end
+
+    def validate_passthru(target_class, org)
       PassthruValidator.new(
         attributes: [property],
-        to: resource_class.constantize,
+        to: target_class,
         with: lambda { |record|
           validate_with.tap do |hash|
             hash.merge!(organization: record.try(:organization) || org) if !hash[:organization] && record.respond_to?(:organization=)

--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -40,7 +40,6 @@ module Decidim
         org = organization
         PassthruValidator.new(
           attributes: [property],
-
           to: resource_class.constantize,
           with: lambda { |record|
             validate_with.tap do |hash|

--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -50,26 +50,19 @@ module Decidim
     # RecordImageUploader allowlist used by all content block image uploaders.
     def validate_content_block_image
       uploader = Decidim::RecordImageUploader.new(nil, :file)
-      allowed_types = uploader.content_type_allowlist
-      allowed_extensions = uploader.extension_allowlist
 
-      content_type = blob.content_type.to_s
+      check_allowlist(blob.content_type.to_s, uploader.content_type_allowlist, "type")
+
       extension = blob.filename.to_s.split(".").last&.downcase
+      check_allowlist(extension, uploader.extension_allowlist, "extension") if extension.present?
+    end
 
-      unless allowed_types.include?(content_type)
-        message = format(
-          "The file type %{content_type} is not valid. Allowed types: %{allowed}",
-          content_type:, allowed: allowed_types.join(", ")
-        )
-        errors.add(property.to_sym, message)
-      end
-
-      return if extension.blank?
-      return if allowed_extensions.include?(extension)
+    def check_allowlist(value, allowlist, kind)
+      return if allowlist.include?(value)
 
       message = format(
-        "The file extension .%{ext} is not valid. Allowed extensions: %{allowed}",
-        ext: extension, allowed: allowed_extensions.join(", ")
+        "The file %{kind} %{value} is not valid. Allowed %{kind}s: %{allowed}",
+        kind:, value:, allowed: allowlist.join(", ")
       )
       errors.add(property.to_sym, message)
     end

--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -32,45 +32,24 @@ module Decidim
     private
 
     def file_validators
-      org = organization
       target_class = resource_class.constantize
 
       if target_class == Decidim::ContentBlockAttachment && target_class.validators_on(property.to_sym).none?
-        validate_content_block_image
+        extension = blob.filename.to_s.split(".").last&.downcase
+        allowed = Decidim::RecordImageUploader.new(nil, :file).extension_allowlist
+        errors.add(property.to_sym, I18n.t("errors.messages.allowed_file_content_types", types: allowed.join(", "))) if extension.present? && allowed.exclude?(extension)
       else
-        validate_passthru(target_class, org)
+        org = organization
+        PassthruValidator.new(
+          attributes: [property],
+          to: target_class,
+          with: lambda { |record|
+            validate_with.tap do |hash|
+              hash.merge!(organization: record.try(:organization) || org) if !hash[:organization] && record.respond_to?(:organization=)
+            end
+          }
+        ).validate_each(self, property.to_sym, blob)
       end
-    end
-
-    # Content block image uploads (e.g. hero background_image) go through
-    # ContentBlockAttachment which requires a content_block association to
-    # resolve the uploader. The dummy record created by PassthruValidator has
-    # no content_block, so attached_uploader returns nil and validators bail
-    # out silently. Instead, validate the blob directly against the
-    # RecordImageUploader allowlist used by all content block image uploaders.
-    def validate_content_block_image
-      uploader = Decidim::RecordImageUploader.new(nil, :file)
-
-      extension = blob.filename.to_s.split(".").last&.downcase
-      check_allowlist(extension, uploader.extension_allowlist) if extension.present?
-    end
-
-    def check_allowlist(value, allowlist)
-      return if allowlist.include?(value)
-
-      errors.add(property.to_sym, I18n.t("errors.messages.allowed_file_content_types", types: allowlist.join(", ")))
-    end
-
-    def validate_passthru(target_class, org)
-      PassthruValidator.new(
-        attributes: [property],
-        to: target_class,
-        with: lambda { |record|
-          validate_with.tap do |hash|
-            hash.merge!(organization: record.try(:organization) || org) if !hash[:organization] && record.respond_to?(:organization=)
-          end
-        }
-      ).validate_each(self, property.to_sym, blob)
     end
 
     def validate_with

--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -51,20 +51,14 @@ module Decidim
     def validate_content_block_image
       uploader = Decidim::RecordImageUploader.new(nil, :file)
 
-      check_allowlist(blob.content_type.to_s, uploader.content_type_allowlist, "type")
-
       extension = blob.filename.to_s.split(".").last&.downcase
-      check_allowlist(extension, uploader.extension_allowlist, "extension") if extension.present?
+      check_allowlist(extension, uploader.extension_allowlist) if extension.present?
     end
 
-    def check_allowlist(value, allowlist, kind)
+    def check_allowlist(value, allowlist)
       return if allowlist.include?(value)
 
-      message = format(
-        "The file %{kind} %{value} is not valid. Allowed %{kind}s: %{allowed}",
-        kind:, value:, allowed: allowlist.join(", ")
-      )
-      errors.add(property.to_sym, message)
+      errors.add(property.to_sym, I18n.t("errors.messages.allowed_file_content_types", types: allowlist.join(", ")))
     end
 
     def validate_passthru(target_class, org)

--- a/decidim-core/app/forms/decidim/upload_validation_form.rb
+++ b/decidim-core/app/forms/decidim/upload_validation_form.rb
@@ -32,9 +32,7 @@ module Decidim
     private
 
     def file_validators
-      target_class = resource_class.constantize
-
-      if target_class == Decidim::ContentBlockAttachment && target_class.validators_on(property.to_sym).none?
+      if resource_class.constantize == Decidim::ContentBlockAttachment && resource_class.constantize.validators_on(property.to_sym).none?
         extension = blob.filename.to_s.split(".").last&.downcase
         allowed = Decidim::RecordImageUploader.new(nil, :file).extension_allowlist
         errors.add(property.to_sym, I18n.t("errors.messages.allowed_file_content_types", types: allowed.join(", "))) if extension.present? && allowed.exclude?(extension)
@@ -42,7 +40,8 @@ module Decidim
         org = organization
         PassthruValidator.new(
           attributes: [property],
-          to: target_class,
+
+          to: resource_class.constantize,
           with: lambda { |record|
             validate_with.tap do |hash|
               hash.merge!(organization: record.try(:organization) || org) if !hash[:organization] && record.respond_to?(:organization=)

--- a/decidim-core/spec/forms/upload_validation_form_spec.rb
+++ b/decidim-core/spec/forms/upload_validation_form_spec.rb
@@ -61,5 +61,41 @@ module Decidim
         expect(subject.invalid?).to be(true)
       end
     end
+
+    context "when resource class is ContentBlockAttachment" do
+      let(:resource_class) { "Decidim::ContentBlockAttachment" }
+      let(:property) { "background_image" }
+      let(:form_class) { nil }
+
+      context "with a valid image file" do
+        it "accepts a jpeg image" do
+          expect(subject).to be_valid
+        end
+
+        it "accepts a png image" do
+          form = described_class.from_params(params.merge(blob: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/png"), filename: "photo.png")))
+          expect(form).to be_valid
+        end
+
+        it "accepts a webp image" do
+          form = described_class.from_params(params.merge(blob: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/webp"), filename: "photo.webp")))
+          expect(form).to be_valid
+        end
+      end
+
+      context "with a non-image file" do
+        it "rejects a pdf file" do
+          form = described_class.from_params(params.merge(blob: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), filename: "plan.pdf")))
+          expect(form.invalid?).to be(true)
+          expect(form.errors.full_messages.first).to include("jpeg, jpg, png, webp")
+        end
+
+        it "rejects a docx file" do
+          form = described_class.from_params(params.merge(blob: upload_test_file(Decidim::Dev.test_file("city.jpeg", "image/jpeg"), filename: "document.docx")))
+          expect(form.invalid?).to be(true)
+          expect(form.errors.full_messages.first).to include("jpeg, jpg, png, webp")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
The allowlist within the content_block image uploader silently bypasses PDF's and other doc formats within the Hero Image and CTA content block Background image section.

This PR applies a fix to the `UploadValidationForm` which detect a content block image upload and validates against the `RecordImageUploader`. 

#### :pushpin: Related Issues
- Fixes #13703 

#### Testing
1. Login
2. Head to a space Processes/Assemblies
3. Click Landing page layout
4. Click the edit button on "Hero image and CTA" content block
5. Click "Add file" to "Background image" 
6. Add a PDF 
7. See its accepted 
8. Checkout into my branch and refresh the page
9. Repeat steps 5 and 6
10. See the validation error 

Bonus: Add a image in the correct format to check the validation still works

### :camera: Screenshots
BEFORE (validation pass with PDF format file)
<img width="2096" height="1357" alt="image" src="https://github.com/user-attachments/assets/70a6841b-46df-4cd8-b0a4-6909edb64170" />

AFTER (error in validation with a PDF format file)
<img width="2096" height="1357" alt="image" src="https://github.com/user-attachments/assets/3de38b66-774a-4e0b-bfeb-2d7b144a15f4" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for content block background-image uploads.
  - JPEG, PNG, and WebP images are now accepted when appropriate.
  - Unsupported document formats, including PDF and DOCX files, are rejected with a clear message listing the supported image formats.
  - Other upload validations continue to respect their configured rules and organization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->