### PR TITLE
Fix API root `users` field not working with deleted users

### DIFF
--- a/decidim-api/lib/decidim/api/test/factories.rb
+++ b/decidim-api/lib/decidim/api/test/factories.rb
@@ -16,8 +16,6 @@ FactoryBot.define do
     organization
     locale { organization.default_locale }
     tos_agreement { "1" }
-    confirmation_sent_at { Time.current }
-    accepted_tos_version { organization.tos_version }
     admin { true }
     admin_terms_accepted_at { Time.current }
     notifications_sending_frequency { "none" }

--- a/decidim-core/lib/decidim/api/functions/user_entity_list.rb
+++ b/decidim-core/lib/decidim/api/functions/user_entity_list.rb
@@ -21,6 +21,7 @@ module Decidim
         @query = Decidim::UserBaseEntity
                  .where(organization: ctx[:current_organization])
                  .confirmed
+                 .not_deleted
                  .not_blocked
         add_filter_keys(args[:filter])
         add_order_keys(args[:order].to_h)

--- a/decidim-core/spec/types/query_type_spec.rb
+++ b/decidim-core/spec/types/query_type_spec.rb
@@ -79,5 +79,25 @@ module Decidim::Api
         end
       end
     end
+
+    describe "users" do
+      let!(:confirmed_users) { create_list(:user, 3, :confirmed, organization: current_organization) }
+      let!(:other_org_user) { create(:user, :confirmed) }
+      let!(:api_user) { create(:api_user, organization: current_organization) }
+      let!(:managed_user) { create(:user, :confirmed, :managed, organization: current_organization) }
+      let!(:blocked_user) { create(:user, :confirmed, :blocked, organization: current_organization) }
+      let!(:deleted_user) { create(:user, :confirmed, :deleted, organization: current_organization) }
+      let!(:ephemeral_user) { create(:user, :ephemeral, organization: current_organization) }
+
+      let(:expected_users) { [current_user, managed_user] + confirmed_users }
+
+      context "with no arguments" do
+        let(:query) { "{ users { id name } }" }
+
+        it "returns the visible users" do
+          expect(response["users"]).to match_array(expected_users.map { |u| { "id" => u.id.to_s, "name" => u.name } })
+        end
+      end
+    end
   end
 end

--- a/decidim-core/spec/types/query_type_spec.rb
+++ b/decidim-core/spec/types/query_type_spec.rb
@@ -83,10 +83,13 @@ module Decidim::Api
     describe "users" do
       let!(:confirmed_users) { create_list(:user, 3, :confirmed, organization: current_organization) }
       let!(:other_org_user) { create(:user, :confirmed) }
+      let!(:unconfirmed_user) { create(:user, organization: current_organization) }
       let!(:api_user) { create(:api_user, organization: current_organization) }
       let!(:managed_user) { create(:user, :confirmed, :managed, organization: current_organization) }
+      let!(:unconfirmed_managed_user) { create(:user, :managed, organization: current_organization) }
       let!(:blocked_user) { create(:user, :confirmed, :blocked, organization: current_organization) }
       let!(:deleted_user) { create(:user, :confirmed, :deleted, organization: current_organization) }
+      let!(:unconfirmed_deleted_user) { create(:user, :deleted, organization: current_organization) }
       let!(:ephemeral_user) { create(:user, :ephemeral, organization: current_organization) }
 
       let(:expected_users) { [current_user, managed_user] + confirmed_users }


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed at `try.decidim.org` that the API query `users { id name }` is failing and after further investigation found the reason and this PR fixes the issue.

This PR is made directly against `release/0.32-stable` branch because this issue does not exist at `develop` after #11036. In the related issue I have added the same changes to tests as in this PR to `develop`.

Also there is a difference in v0.32 that the API also returns managed users which no longer happens at `develop`.

#### :pushpin: Related Issues
- Related to #17515

#### Testing
See the added spec and see that CI is green.

Manually you can test this by replicating the same situation as in the added spec (with API user, another org user, managed user, blocked user, deleted user, and ephemeral user) and see the results returned from the API.