### PR TITLE
Fix deleted user profile accessible

### DIFF
--- a/decidim-core/app/controllers/decidim/profiles_controller.rb
+++ b/decidim-core/app/controllers/decidim/profiles_controller.rb
@@ -15,6 +15,7 @@ module Decidim
     before_action :ensure_profile_holder
     before_action :ensure_profile_holder_is_a_user, only: :following
     before_action :ensure_user_not_blocked
+    before_action :ensure_user_not_deleted
 
     def show
       redirect_to profile_activity_path(nickname: params[:nickname].downcase)
@@ -45,6 +46,13 @@ module Decidim
     end
 
     private
+
+    # Deleted users should not normally have a nickname, so in normal situation
+    # this should not be possible, but in some edge cases there may be accounts
+    # left behind with the username field still available.
+    def ensure_user_not_deleted
+      raise ActionController::RoutingError, "Deleted User" if profile_holder&.deleted?
+    end
 
     def ensure_user_not_blocked
       raise ActionController::RoutingError, "Blocked User" if profile_holder&.blocked? && !current_user&.admin?

--- a/decidim-core/app/controllers/decidim/user_activities_controller.rb
+++ b/decidim-core/app/controllers/decidim/user_activities_controller.rb
@@ -14,6 +14,7 @@ module Decidim
     def index
       raise ActionController::RoutingError, "Missing user: #{params[:nickname]}" unless user
       raise ActionController::RoutingError, "Blocked User" if user.blocked? && !current_user&.admin?
+      raise ActionController::RoutingError, "Deleted User" if user.deleted?
     end
 
     private

--- a/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/profiles_controller_spec.rb
@@ -37,6 +37,14 @@ module Decidim
           expect { get :show, params: { locale: I18n.locale, nickname: "Nick" } }.to raise_error(ActionController::RoutingError)
         end
       end
+
+      context "with a deleted user" do
+        let!(:user) { create(:user, :confirmed, :deleted, nickname: "nick", organization:) }
+
+        it "does not return the page" do
+          expect { get :show, params: { locale: I18n.locale, nickname: "Nick" } }.to raise_error(ActionController::RoutingError)
+        end
+      end
     end
   end
 end

--- a/decidim-core/spec/controllers/decidim/user_activities_controller_spec.rb
+++ b/decidim-core/spec/controllers/decidim/user_activities_controller_spec.rb
@@ -28,6 +28,26 @@ module Decidim
           expect(response).to render_template(:index)
         end
       end
+
+      context "with blocked user" do
+        let!(:user) { create(:user, :confirmed, :blocked, nickname: "nick", organization:) }
+
+        it "raises an ActionController::RoutingError" do
+          expect do
+            get :index, params: { locale: I18n.locale, nickname: "nick" }
+          end.to raise_error(ActionController::RoutingError, "Blocked User")
+        end
+      end
+
+      context "with deleted user" do
+        let!(:user) { create(:user, :confirmed, :deleted, nickname: "nick", organization:) }
+
+        it "raises an ActionController::RoutingError" do
+          expect do
+            get :index, params: { locale: I18n.locale, nickname: "nick" }
+          end.to raise_error(ActionController::RoutingError, "Deleted User")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
I noticed at `try.decidim.org` that this user's profile is accessible:
https://try.decidim.org/en/profiles/visitant_btinlkq3/activity

Although, I believe the user has been deleted already. Sending the following query to the API shows an error:
```
user (nickname: "visitant_btinlkq3") { id name }
```

It seemed to be at least with user IDs 47 and 49 in case the nicknames change in some DB reset cycle.

Normally deleted user profiles should not have a nickname associated to them, so it should not be possible normally (I believe):
https://github.com/decidim/decidim/blob/f511ee2b4be51380befde341c21e805626046695/decidim-core/app/commands/decidim/destroy_account.rb#L46

I am suspecting this user comes from some automated seeds where the `DestroyAccount` command is not called and instead the user is only marked as "deleted" when the profile is still accessible. I am unsure where this comes from, this account is a deleted ephemeral user.

This adds a safeguard for not displaying the deleted user profile even if the nickname is still there.

This PR is made directly against `release/0.32-stable` branch because this issue does not exist at `develop` after #11036.

#### :pushpin: Related Issues
- Related to #17516

#### Testing
- Create and account and delete it
- Manually through the console, assign a nickname to the user
- Try to access the profile using that nickname