### PR TITLE
Fix flaky system specs related to authentication

### DIFF
--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -457,9 +457,12 @@ describe "Authentication" do
     it "sends an email with the instructions" do
       visit decidim.new_user_confirmation_path
 
-      within ".new_user" do
-        fill_in :confirmation_user_email, with: user.email
-        perform_enqueued_jobs { find("*[type=submit]").click }
+      perform_enqueued_jobs do
+        within ".new_user" do
+          fill_in :confirmation_user_email, with: user.email
+          find("*[type=submit]").click
+        end
+        expect(page).to have_callout("If your email address exists in our database")
       end
 
       expect(emails.count).to eq(2)
@@ -492,8 +495,7 @@ describe "Authentication" do
             fill_in :session_user_password, with: "DfyvHn425mYAy2HL"
           end
 
-          page.driver.browser.manage.delete_all_cookies
-          expect(page.driver.browser.manage.all_cookies).to be_empty
+          expire_browser_session
 
           within "#session_new_user" do
             find("*[type=submit]").click
@@ -563,12 +565,14 @@ describe "Authentication" do
       it "sends a password recovery email" do
         visit decidim.new_user_password_path
 
-        within ".new_user" do
-          fill_in :password_user_email, with: user.email
-          perform_enqueued_jobs { find("*[type=submit]").click }
+        perform_enqueued_jobs do
+          within ".new_user" do
+            fill_in :password_user_email, with: user.email
+            find("*[type=submit]").click
+          end
+          expect(page).to have_callout("If your email address exists in our database")
         end
 
-        expect(page).to have_text("If your email address exists in our database")
         expect(emails.count).to eq(1)
       end
 
@@ -697,10 +701,13 @@ describe "Authentication" do
             click_on("Log in", match: :first)
 
             (maximum_attempts - 1).times do
-              within ".new_user" do
-                fill_in :session_user_email, with: user.email
-                fill_in :session_user_password, with: "not-the-password"
-                perform_enqueued_jobs { find("*[type=submit]").click }
+              perform_enqueued_jobs do
+                within ".new_user" do
+                  fill_in :session_user_email, with: user.email
+                  fill_in :session_user_password, with: "not-the-password"
+                  find("*[type=submit]").click
+                end
+                expect(page).to have_callout("Invalid email address or password")
               end
             end
           end
@@ -728,12 +735,14 @@ describe "Authentication" do
         end
 
         it "resends the unlock instructions" do
-          within ".new_user" do
-            fill_in :unlock_user_email, with: user.email
-            perform_enqueued_jobs { find("*[type=submit]").click }
+          perform_enqueued_jobs do
+            within ".new_user" do
+              fill_in :unlock_user_email, with: user.email
+              find("*[type=submit]").click
+            end
+            expect(page).to have_callout("If your account exists")
           end
 
-          expect(page).to have_text("If your account exists")
           expect(emails.count).to eq(1)
         end
 

--- a/decidim-core/spec/system/authentication_spec.rb
+++ b/decidim-core/spec/system/authentication_spec.rb
@@ -495,13 +495,13 @@ describe "Authentication" do
             fill_in :session_user_password, with: "DfyvHn425mYAy2HL"
           end
 
-          expire_browser_session
+          expire_browser_session do
+            within "#session_new_user" do
+              find("*[type=submit]").click
+            end
 
-          within "#session_new_user" do
-            find("*[type=submit]").click
+            expect(page).to have_text("Unable to verify your request. Please retry.")
           end
-
-          expect(page).to have_text("Unable to verify your request. Please retry.")
         end
       end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -67,23 +67,19 @@ module Decidim
 
     # Waits for any pending requests to finish and clears any active browser
     # background connections after that.
-    def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time)
+    def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
       wait_time = 0
       loop do
-        pending_requests = page.evaluate_script(
+        time_since_last_asset = page.evaluate_script(
           <<~JS
-            (() => {
-              const entries = window.performance.getEntriesByType("resource");
-              return entries.filter((e) => e.responseEnd === 0);
-            })()
+            performance.now() - Math.max(...window.performance.getEntriesByType("resource").map((r) => r.responseEnd), 0)
           JS
         )
-        break if pending_requests.count.zero?
-
+        break if time_since_last_asset > (idle_time * 1000)
         raise StandardError, "Requests still pending." if wait_time >= max_wait_time
 
-        sleep 1
-        wait_time += 1
+        sleep idle_time
+        wait_time += idle_time
       end
       force_browser_offline_state
     end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -45,7 +45,8 @@ module Decidim
       page.driver.browser.execute_cdp(
         "Emulation.setVirtualTimePolicy",
         policy: "advance",
-        maxVirtualTimeTaskStarvationCount: 0
+        maxVirtualTimeTaskStarvationCount: 0,
+        initialVirtualTime: Time.now.to_f
       )
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -77,6 +77,7 @@ module Decidim
     # background connections after that.
     def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
       wait_time = 0
+      max_wait_time = idle_time * 2 if max_wait_time < idle_time * 2
       loop do
         time_since_last_asset = page.evaluate_script(
           <<~JS

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -31,13 +31,21 @@ module Decidim
     def expire_browser_session(wait: Capybara.default_max_wait_time)
       wait_pending_requests(wait)
 
-      travel Decidim.config.expire_session_after + 1.second
+      travel(Decidim.config.expire_session_after + 1.second) do
+        # Set the browser clock to the same time.
+        page.driver.browser.execute_cdp(
+          "Emulation.setVirtualTimePolicy",
+          policy: "advance",
+          initialVirtualTime: (Time.now.to_f * 1000).to_i
+        )
 
-      # Set the browser clock to the same time.
+        yield
+      end
+    ensure
       page.driver.browser.execute_cdp(
         "Emulation.setVirtualTimePolicy",
         policy: "advance",
-        initialVirtualTime: (Time.now.to_f * 1000).to_i
+        maxVirtualTimeTaskStarvationCount: 0
       )
     end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -76,8 +76,8 @@ module Decidim
     # Waits for any pending requests to finish and clears any active browser
     # background connections after that.
     def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
+    def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
       wait_time = 0
-      max_wait_time = idle_time * 2 if max_wait_time < idle_time * 2
       loop do
         time_since_last_asset = page.evaluate_script(
           <<~JS
@@ -85,10 +85,12 @@ module Decidim
           JS
         )
         break if time_since_last_asset > (idle_time * 1000)
-        raise StandardError, "Requests still pending." if wait_time >= max_wait_time
+        remaining_wait_time = max_wait_time - wait_time
+        raise StandardError, "Requests still pending." if remaining_wait_time <= 0
 
-        sleep idle_time
-        wait_time += idle_time
+        sleep_time = [idle_time, remaining_wait_time].min
+        sleep sleep_time
+        wait_time += sleep_time
       end
       force_browser_offline_state
     end

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -32,22 +32,8 @@ module Decidim
       wait_pending_requests(wait)
 
       travel(Decidim.config.expire_session_after + 1.second) do
-        # Set the browser clock to the same time.
-        page.driver.browser.execute_cdp(
-          "Emulation.setVirtualTimePolicy",
-          policy: "advance",
-          initialVirtualTime: Time.now.to_f
-        )
-
         yield
       end
-    ensure
-      page.driver.browser.execute_cdp(
-        "Emulation.setVirtualTimePolicy",
-        policy: "advance",
-        maxVirtualTimeTaskStarvationCount: 0,
-        initialVirtualTime: Time.now.to_f
-      )
     end
 
     # Clear the buffers and background connections by taking the browser to

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -36,7 +36,7 @@ module Decidim
         page.driver.browser.execute_cdp(
           "Emulation.setVirtualTimePolicy",
           policy: "advance",
-          initialVirtualTime: (Time.now.to_f * 1000).to_i
+          initialVirtualTime: Time.now.to_f
         )
 
         yield

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -27,6 +27,66 @@ module Decidim
 
       "http"
     end
+
+    def expire_browser_session(wait: Capybara.default_max_wait_time)
+      wait_pending_requests(wait)
+
+      travel Decidim.config.expire_session_after + 1.second
+
+      # Set the browser clock to the same time.
+      page.driver.browser.execute_cdp(
+        "Emulation.setVirtualTimePolicy",
+        policy: "advance",
+        initialVirtualTime: (Time.now.to_f * 1000).to_i
+      )
+    end
+
+    # Clear the buffers and background connections by taking the browser to
+    # offline state for a tiny moment. If a block is given, any further commands
+    # can be run during the offline state.
+    def force_browser_offline_state
+      page.driver.browser.execute_cdp(
+        "Network.emulateNetworkConditions",
+        offline: true,
+        latency: 0,
+        downloadThroughput: 0,
+        uploadThroughput: 0
+      )
+      sleep 0.05
+
+      yield if block_given?
+    ensure
+      page.driver.browser.execute_cdp(
+        "Network.emulateNetworkConditions",
+        offline: false,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput: -1
+      )
+    end
+
+    # Waits for any pending requests to finish and clears any active browser
+    # background connections after that.
+    def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time)
+      wait_time = 0
+      loop do
+        pending_requests = page.evaluate_script(
+          <<~JS
+            (() => {
+              const entries = window.performance.getEntriesByType("resource");
+              return entries.filter((e) => e.responseEnd === 0);
+            })()
+          JS
+        )
+        break if pending_requests.count.zero?
+
+        raise StandardError, "Requests still pending." if wait_time >= max_wait_time
+
+        sleep 1
+        wait_time += 1
+      end
+      force_browser_offline_state
+    end
   end
 end
 

--- a/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
+++ b/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb
@@ -76,7 +76,6 @@ module Decidim
     # Waits for any pending requests to finish and clears any active browser
     # background connections after that.
     def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
-    def wait_pending_requests(max_wait_time = Capybara.default_max_wait_time, idle_time: 1)
       wait_time = 0
       loop do
         time_since_last_asset = page.evaluate_script(
@@ -85,6 +84,7 @@ module Decidim
           JS
         )
         break if time_since_last_asset > (idle_time * 1000)
+
         remaining_wait_time = max_wait_time - wait_time
         raise StandardError, "Requests still pending." if remaining_wait_time <= 0
 

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -54,13 +54,13 @@ describe "Sessions" do
         fill_in :admin_password, with: "decidim123456789"
       end
 
-      expire_browser_session
+      expire_browser_session do
+        within ".new_admin" do
+          find("*[type=submit]").click
+        end
 
-      within ".new_admin" do
-        find("*[type=submit]").click
+        expect(page).to have_text("Unable to verify your request. Please retry.")
       end
-
-      expect(page).to have_text("Unable to verify your request. Please retry.")
     end
   end
 end

--- a/decidim-system/spec/system/sessions_spec.rb
+++ b/decidim-system/spec/system/sessions_spec.rb
@@ -54,8 +54,7 @@ describe "Sessions" do
         fill_in :admin_password, with: "decidim123456789"
       end
 
-      page.driver.browser.manage.delete_all_cookies
-      expect(page.driver.browser.manage.all_cookies).to be_empty
+      expire_browser_session
 
       within ".new_admin" do
         find("*[type=submit]").click


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/32340235283/job/96337693498

Relevant test output:
```
Failures:

  1) Authentication when a user is already registered with lockable account Resend unlock instructions email resends the unlock instructions
     Failure/Error: expect(emails.count).to eq(1)

       expected: 1
            got: 0

       (compared using ==)

     # ./spec/system/authentication_spec.rb:737:in 'block (5 levels) in <top (required)>'
     # ./spec/system/authentication_spec.rb:659:in 'block (4 levels) in <top (required)>'
     # ./spec/system/authentication_spec.rb:41:in 'block (2 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/authentication_spec.rb:730 # Authentication when a user is already registered with lockable account Resend unlock instructions email resends the unlock instructions
```

At the same time, I also noticed the CSRF related authentication specs were failing locally pretty consistently, so fixed those too.

#### :pushpin: Related Issues
- Related to #17515

#### Testing
Run the affected specs several times:
```bash
cd decidim-core
for i in {1..20}; do bundle exec rspec spec/system/authentication_spec.rb || break; done
cd ../decidim-system
for i in {1..20}; do bundle exec rspec spec/system/sessions_spec.rb -e "when the csrf token is expired" || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired sessions and CSRF errors during authentication.
  * Improved reliability of confirmation emails, password recovery, failed-login locking, and account unlock instructions.

* **Tests**
  * Expanded coverage for authentication messages and session expiration scenarios.
  * Improved browser testing for delayed requests and temporary network interruptions, increasing confidence in authentication flows.
  * Added validation for authentication behavior after sessions expire or connectivity is briefly interrupted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->