### PR TITLE
Fix flaky specs at `admin_manages_static_page_content_blocks_spec.rb`

### DIFF
--- a/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_static_page_content_blocks_spec.rb
@@ -24,6 +24,7 @@ describe "Admin manages static page content blocks" do
           find("a", text: "Summary").click
         end
       end
+      expect(page).to have_callout("Content block successfully created.")
 
       expect(Decidim::ContentBlock.count).to eq 1
     end
@@ -42,6 +43,7 @@ describe "Admin manages static page content blocks" do
               find("a", text: "Section").click
             end
           end
+          expect(page).to have_callout("Content block successfully created.")
         end
       end.to change(Decidim::ContentBlock, :count).by number_of_content_blocks
     end
@@ -91,6 +93,7 @@ describe "Admin manages static page content blocks" do
                           en: "<p>Custom privacy policy summary text!</p>"
 
       click_on "Update"
+      expect(page).to have_css("#static_page_title_en:focus")
       visit decidim.page_path(tos_page)
       expect(page).to have_text("Custom privacy policy summary text!")
 


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/32340235244/job/96337692761

Relevant test output:
```
  1) Admin manages static page content blocks when editing a persisted content block updates the settings of the content block
     Failure/Error: expect(page).to have_text("Custom privacy policy summary text!")
       expected to find text "Custom privacy policy summary text!" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nPredovic, Champlin and Smith\nSee site\nEnglish\nuser3@example.org\n/\nPages\nPages\nTopics\nEdit page\nTitle*\nRequired field\nEnglish\nCatalà\nCastellano\nContent\nEnglish\nCatalà\nCastellano\nNormal\nHeading 2\nHeading 3\nHeading 4\nHeading 5\nHeading 6\nUt facilis et. 36\n\nTopic\nNone\nThere have been noticeable changes.\nIf checked, participants will be notified to accept the new terms of service.\nLast notable change: 20/08/2026 06:47\nOrder position\nUpdate\nPage contents\nAdd content block\nActive content blocks\nSummary\nInactive content blocks"

     # ./spec/system/admin_manages_static_page_content_blocks_spec.rb:95:in 'block (3 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/admin_manages_static_page_content_blocks_spec.rb:86 # Admin manages static page content blocks when editing a persisted content block updates the settings of the content block
```

#### :pushpin: Related Issues
- Related to #17515

#### Testing
```bash
cd decidim-admin
for i in {1..20}; do bundle exec rspec ./spec/system/admin_manages_static_page_content_blocks_spec.rb || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that users see a success notification after creating static page content blocks.
  * Added coverage for success notifications when adding multiple blocks of the same type.
  * Added coverage confirming the static page title field receives focus after updating a content block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->