### PR TITLE
Change Steps for Phases across the platform

### DIFF
--- a/decidim-participatory_processes/config/locales/en.yml
+++ b/decidim-participatory_processes/config/locales/en.yml
@@ -13,14 +13,14 @@ en:
         duplicate_categories: Duplicate categories
         duplicate_components: Duplicate components
         duplicate_landing_page_blocks: Duplicate landing page blocks
-        duplicate_steps: Duplicate steps
+        duplicate_steps: Duplicate phases
         end_date: End date
         has_members: This space has members
         hero_image: Home image
         import_attachments: Import attachments
         import_categories: Import categories
         import_components: Import components
-        import_steps: Import steps
+        import_steps: Import phases
         local_area: Organization area
         meta_scope: Scope metadata
         participatory_process_group_id: Processes group


### PR DESCRIPTION
#### :tophat: What? Why?
Changes the terminology of "Steps" for "Phases" in the platform where Phases are used as a reference.

This PR should also pass the acceptance criteria detailed here in the issue: 
<img width="1637" height="362" alt="image" src="https://github.com/user-attachments/assets/542b01bf-0db9-48bb-860c-a8d3d82a31e1" />

#### :pushpin: Related Issues
- Fixes #16369 

#### Testing

1. Login as an admin and go to the admin area
2. Head to Processes
3. Create one or click the drop down options and click duplicate
4. In the form see Phases being used as an option ("Duplicate phases")
5. Go back to Processes index
6. Under Manage (top right of the page) click import
7. See the option "Import phases" correctly being used

### :camera: Screenshots
PROCESSES *Admin Duplicate phases*
<img width="1851" height="796" alt="image" src="https://github.com/user-attachments/assets/353b8c2a-77e9-4f34-9c83-42f5ac06984a" />

PROCESSES *Admin processes import*
<img width="620" height="1210" alt="image" src="https://github.com/user-attachments/assets/2450db45-015e-4a90-842c-b95621c6314a" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated English labels to refer to participatory process steps as “phases” when duplicating or importing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->