### PR TITLE
Fix flaky specs at admin_reminds_users_with_pending_orders_spec.rb

### DIFF
--- a/decidim-budgets/spec/system/admin_reminds_users_with_pending_orders_spec.rb
+++ b/decidim-budgets/spec/system/admin_reminds_users_with_pending_orders_spec.rb
@@ -39,8 +39,10 @@ describe "Admin reminds users with pending orders" do
     end
 
     it "sends reminders" do
-      perform_enqueued_jobs { click_on "Send" }
-      expect(page).to have_text("2 users will be reminded")
+      perform_enqueued_jobs do
+        click_on "Send"
+        expect(page).to have_text("2 users will be reminded")
+      end
 
       expect(emails.count).to eq(2)
       emails.each do |email|
@@ -51,11 +53,15 @@ describe "Admin reminds users with pending orders" do
     end
 
     it "does not send reminders twice" do
-      perform_enqueued_jobs { click_on "Send" }
-      expect(page).to have_text("2 users will be reminded")
+      perform_enqueued_jobs do
+        click_on "Send"
+        expect(page).to have_text("2 users will be reminded")
+      end
       click_on "Send voting reminders"
-      perform_enqueued_jobs { click_on "Send" }
-      expect(page).to have_text("0 users will be reminded")
+      perform_enqueued_jobs do
+        click_on "Send"
+        expect(page).to have_text("0 users will be reminded")
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/32365649439/job/96414549150

Relevant test output:
```
Failures:

  1) Admin reminds users with pending orders create vote reminders does not send reminders twice
     Failure/Error: expect(page).to have_text("0 users will be reminded")
       expected to find text "0 users will be reminded" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nWehner-Doyle\nSee site\nEnglish\nuser15@example.org\n/\nProcesses\n/\n<script>alert(\"participatory_process_title\");</script> Soluta et dolore. 780\n/\nComponents\n/\n<script>alert(\"component_name\");</script> Nisi est praesentium. 777\nSee process\n2 users will be reminded.\n  About this process\nLanding page layout\nPhases\nComponents\n<script>alert(\"component_name\");</script> Nisi est praesentium. 777\n1\nAttachments\nProcess admins\nModerations\nAccess links\nBudgets\nExport all\nSend voting reminders\nNew budget\nConfigure\nName Total budget Projects count Actions\n<script>alert(\"budget_title\");</script> Eos doloribus reiciendis. 865\n€ 100,000,000 0\nView deleted budgets\nFinished votes: 0  |  Pending votes: 2  |  Users with finished votes: 0  |  Users with pending votes: 2"

     # ./spec/system/admin_reminds_users_with_pending_orders_spec.rb:58:in 'block (3 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/admin_reminds_users_with_pending_orders_spec.rb:53 # Admin reminds users with pending orders create vote reminders does not send reminders twice
```

#### :pushpin: Related Issues
- Related to #17523

#### Testing
```bash
cd decidim-budgets
for i in {1..20}; do bundle exec rspec ./spec/system/admin_reminds_users_with_pending_orders_spec.rb:53 || break; done
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test execution around reminders for users with pending orders.
  * Existing reminder delivery actions and verification checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->