### PR TITLE
Fix flaky spec at explore_budgets_spec.rb

### DIFF
--- a/decidim-budgets/spec/system/explore_budgets_spec.rb
+++ b/decidim-budgets/spec/system/explore_budgets_spec.rb
@@ -202,8 +202,9 @@ describe "Explore Budgets", :slow do
           expect(item).to have_text("Delete your vote")
           within item do
             accept_confirm { click_on "Delete your vote" }
-            expect(Decidim::Budgets::Order.where(budget:)).to be_blank
           end
+          expect(page).to have_callout("Your vote has been successfully canceled.")
+          expect(Decidim::Budgets::Order.where(budget:)).to be_blank
         end
 
         context "and the voting is disabled" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/32370767539/job/96430561895

Relevant test output:
```
Failures:

  1) Explore Budgets with many budgets budget list item when an item is voted has a link to remove vote
     Failure/Error: expect(Decidim::Budgets::Order.where(budget:)).to be_blank
       expected `#<ActiveRecord::Relation [#<Decidim::Budgets::Order id: 32, checked_out_at: "2026-08-20 13:05:02.4482...m_budgets_budget_id: 339, decidim_user_id: 572, updated_at: "2026-08-20 13:05:02.457583000 +0000">]>.blank?` to be truthy, got false

     # ./spec/system/explore_budgets_spec.rb:205:in 'block (6 levels) in <top (required)>'
     # ./spec/system/explore_budgets_spec.rb:203:in 'block (5 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:173:in 'block (3 levels) in <top (required)>'
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/capybara.rb:172:in 'block (2 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/explore_budgets_spec.rb:199 # Explore Budgets with many budgets budget list item when an item is voted has a link to remove vote

```

#### :pushpin: Related Issues
- Related to #17526

#### Testing
```bash
cd decidim-budgets
for i in {1..20}; do bundle exec rspec ./spec/system/explore_budgets_spec.rb:199 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the budget vote deletion flow so the success confirmation and removal of associated orders are correctly verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->