### PR TITLE
Fix admin show participant email after session is expired

### DIFF
--- a/decidim-admin/app/packs/src/decidim/admin/officializations.js
+++ b/decidim-admin/app/packs/src/decidim/admin/officializations.js
@@ -35,7 +35,10 @@ document.addEventListener("turbo:load", () => {
       $("#user_email").html(userEmail);
       $button.hide()
     } else if (response && response.redirectError) {
-      const message = getMessages("unauthorized") || "Unauthorized.";
+      let message = getMessages("unauthorized");
+      if (!(message instanceof String)) {
+        message = "Unauthorized.";
+      }
       $("#user_email").text(message);
     } else {
       console.log(`Error-HTTP: " + ${response.status}`);

--- a/decidim-admin/app/packs/src/decidim/admin/officializations.js
+++ b/decidim-admin/app/packs/src/decidim/admin/officializations.js
@@ -35,10 +35,7 @@ document.addEventListener("turbo:load", () => {
       $("#user_email").html(userEmail);
       $button.hide()
     } else if (response && response.redirectError) {
-      let message = getMessages("unauthorized");
-      if (!(message instanceof String)) {
-        message = "Unauthorized.";
-      }
+      const message = getMessages().unauthorized || "Unauthorized.";
       $("#user_email").text(message);
     } else {
       console.log(`Error-HTTP: " + ${response.status}`);

--- a/decidim-admin/app/packs/src/decidim/admin/officializations.js
+++ b/decidim-admin/app/packs/src/decidim/admin/officializations.js
@@ -1,3 +1,5 @@
+import { getMessages } from "src/decidim/refactor/moved/i18n";
+
 document.addEventListener("turbo:load", () => {
   const $modal = $("#show-email-modal");
 
@@ -20,11 +22,21 @@ document.addEventListener("turbo:load", () => {
 
   /* eslint-disable */
   async function getUserEmail(url) {
-    let response = await fetch(url);
-    if (response.ok) {
+    let response = null;
+    try {
+      response = await fetch(url, { redirect: "error" });
+    } catch (error) {
+      if (error instanceof TypeError && error.message === "Failed to fetch") {
+        response = { redirectError: true };
+      }
+    }
+    if (response && response.ok) {
       let userEmail = await response.text();
       $("#user_email").html(userEmail);
       $button.hide()
+    } else if (response && response.redirectError) {
+      const message = getMessages("unauthorized") || "Unauthorized.";
+      $("#user_email").text(message);
     } else {
       console.log(`Error-HTTP: " + ${response.status}`);
     }

--- a/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
+++ b/decidim-admin/app/views/layouts/decidim/admin/_js_configuration.html.erb
@@ -4,6 +4,7 @@ js_configs = {
   icons_path: Decidim.cors_enabled ? "" : asset_pack_path("media/images/remixicon.symbol.svg"),
   messages: {
     "selfxssWarning": t("decidim.security.selfxss_warning"),
+    unauthorized: t("actions.unauthorized", scope: "decidim.core"),
     editor: t("editor"),
     date: t("date"),
     time: t("time"),

--- a/decidim-admin/spec/system/admin_manages_officializations_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_officializations_spec.rb
@@ -350,5 +350,26 @@ describe "Admin manages officializations" do
         expect(page).to have_text("#{admin.name} retrieved the email of the participant #{user.name}")
       end
     end
+
+    context "when the session has expired" do
+      let(:user) { users.first }
+
+      it "displays the correct message" do
+        within "tr[data-user-id=\"#{user.id}\"]" do
+          find("button[data-controller='dropdown']").click
+          click_on "Show email"
+        end
+
+        travel Decidim.expire_session_after + 1.second do
+          within "#show-email-modal" do
+            click_on "Show"
+
+            within "#user_email" do
+              expect(page).to have_text("You are not authorized to perform this action.")
+            end
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
If an admin user has had the participant view open for a while and tries to click the "show email" button on any participant, the login screen is embedded into the modal. This fixes the issue.

#### Testing
- Start the server normally
- Login as admin
- Go to Participants -> Participants (LOL)
- Stop the server
- Comment out this line and change it to `1.second` instead:
https://github.com/decidim/decidim/blob/1a9586cae71db357a457d62eb3a67f725792dfc3/decidim-core/lib/decidim/core.rb#L488
- Restart the server
- In the screen you left open, click on any participant's "Actions" menu and from there select "Show email"
- Click the "Show" button
- See the correct message (with this PR, without you should see a login screen embedded to the view)

### :camera: Screenshots
**Before**
<img width="899" height="862" alt="Show email screen before the change" src="https://github.com/user-attachments/assets/0b2f8944-9725-4dbf-9e29-7040ff54285f" />

**After**
<img width="899" height="458" alt="Show email screen after the change" src="https://github.com/user-attachments/assets/da43a71a-e8f0-471f-b422-21ab8753c61c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an administrator’s session expires while retrieving a user’s email.
  * Displays a localized authorization error instead of attempting to load unavailable email information.
  * Prevents redirects and handles failed requests gracefully when access is no longer authorized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->