### PR TITLE
Fix flaky spec related to background jobs at `manage_impersonations_examples.rb`

### DIFF
--- a/decidim-admin/spec/shared/manage_impersonations_examples.rb
+++ b/decidim-admin/spec/shared/manage_impersonations_examples.rb
@@ -264,9 +264,11 @@ shared_examples "manage impersonations examples" do
         fill_in :managed_user_promotion_email, with: "foo@example.org"
       end
 
-      perform_enqueued_jobs { click_on "Promote" }
+      perform_enqueued_jobs do
+        click_on "Promote"
+        expect(page).to have_callout("The managed participant has been successfully promoted.")
+      end
 
-      expect(page).to have_callout("The managed participant has been successfully promoted.")
       expect(page).to have_text(managed_user.name)
 
       logout :user


### PR DESCRIPTION
#### :tophat: What? Why?
Another flaky one in this spec noticed at this example run:
https://github.com/decidim/decidim/actions/runs/32451109845/job/96679670623

Relevant test output:

```
Failures:

  1) Admin manages impersonations behaves like manage impersonations examples when a managed user already exists can promote users inviting them to the application
     Failure/Error: visit last_email_link

     NoMethodError:
       undefined method '[]' for nil

     Shared Example Group: "manage impersonations examples" called from ./spec/system/admin_manages_impersonations_spec.rb:74
     # /home/runner/work/decidim/decidim/decidim-dev/lib/decidim/dev/test/rspec_support/action_mailer.rb:34:in 'MailerHelpers#last_email_link'
     # ./spec/shared/manage_impersonations_examples.rb:274:in 'block (3 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/admin_manages_impersonations_spec.rb[1:2:5:2] # Admin manages impersonations behaves like manage impersonations examples when a managed user already exists can promote users inviting them to the application
```

#### :pushpin: Related Issues
- Related to #17517

#### Testing
```bash
cd decidim-admin
for i in {1..20}; do bundle exec rspec ./spec/system/admin_manages_impersonations_spec.rb[1:2:5:2] || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impersonation promotion handling in automated workflows by ensuring queued operations complete before success confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->