### PR TITLE
Fix automatic ID generation for comments component

### DIFF
--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.js
@@ -136,7 +136,7 @@ export default class CommentsComponent {
    * @returns {String} - Returns a unique identifier
    */
   _getUID() {
-    return `comments-${new Date().setUTCMilliseconds()}-${Math.floor(Math.random() * 10000000)}`;
+    return `comments-${new Date().getUTCMilliseconds()}-${Math.floor(Math.random() * 10000000)}`;
   }
 
   /**

--- a/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
+++ b/decidim-comments/app/packs/src/decidim/comments/comments.component.test.js
@@ -400,6 +400,12 @@ describe("CommentsComponent", () => {
     expect(CommentsComponent).toBeDefined();
   });
 
+  it("generates an ID if not defined", () => {
+    const dummyElement = document.createElement("div");
+    const component = new CommentsComponent($(dummyElement), {});
+    expect(component.id).toMatch(/^comments-\d{1,3}-\d+$/);
+  });
+
   it("initializes unmounted", () => {
     expect(subject.mounted).toBeFalsy();
   });


### PR DESCRIPTION
#### :tophat: What? Why?
Just a small issue I noticed with the comments component (while investigating something else): if the root element does not have an ID, the autogenerated ID would be generated in incorrect format (`comments-NaN-1234`).

Should not affect actual use cases since the root element is expected to have an ID associated with it.

#### Testing
Run the added jest test or wait for CI to be green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic comment component ID generation when no element ID is configured.
  - Prevented potential issues caused by date mutation during ID creation.

- **Tests**
  - Added coverage verifying that automatically generated comment IDs follow the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->