### PR TITLE
Fix flaky date picker specs

### DIFF
--- a/decidim-core/spec/system/date_picker/date_picker_spec.rb
+++ b/decidim-core/spec/system/date_picker/date_picker_spec.rb
@@ -100,7 +100,7 @@ describe "Datepicker" do
         month = find("select.wc-datepicker__month-select").value
         formatted_month = format("%02d", month)
 
-        find("td > span", text: "20", match: :first).click
+        find("td > span[aria-hidden=true]", text: "20", match: :first).click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click
@@ -149,7 +149,7 @@ describe "Datepicker" do
             it "hides the datepicker calendar" do
               find(".datepicker__calendar-button").click
               yesterday = Date.yesterday.strftime("%-d")
-              find("td > span", text: yesterday, match: :first).click
+              find("td > span[aria-hidden=true]", text: yesterday, match: :first).click
               expect(find_by_id("example_input_date").value).not_to eq("")
               expect(page).to have_css("#example_input_date_datepicker", visible: :hidden)
             end
@@ -170,7 +170,7 @@ describe "Datepicker" do
             find(".datepicker__calendar-button").click
             find("span > input.wc-datepicker__year-select").set("1994")
             find(".wc-datepicker__next-month-button").click
-            find("td > span", text: "20", match: :first).click
+            find("td > span[aria-hidden=true]", text: "20", match: :first).click
             find(".datepicker__calendar-button").click
             element = find("td.wc-datepicker__date--selected")
             expect(element).to have_text("20")
@@ -502,7 +502,7 @@ describe "Datepicker" do
         month = find("select.wc-datepicker__month-select").value
         formatted_month = format("%02d", month)
 
-        find("td > span", text: "20", match: :first).click
+        find("td > span[aria-hidden=true]", text: "20", match: :first).click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click
@@ -758,7 +758,7 @@ describe "Datepicker" do
         month = find("select.wc-datepicker__month-select").value
         formatted_month = format("%02d", month)
 
-        find("td > span", text: "20", match: :first).click
+        find("td > span[aria-hidden=true]", text: "20", match: :first).click
 
         find(".datepicker__clock-button").click
         find(".datepicker__hour-up").click


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/32451994958/job/96697530897

Relevant test output:
```
Failures:

  1) Datepicker when date format dd.mm.yyyy and clock format 24 when choosing date when using picker when opening datepicker when choosing a date hides the datepicker calendar
     Failure/Error: find("td > span", text: yesterday, match: :first).click

     Selenium::WebDriver::Error::ElementClickInterceptedError:
       element click intercepted: Element <span class="visually-hidden sc-wc-datepicker">...</span> is not clickable at point (10, 423). Other element would receive the click: <td aria-disabled="false" class="wc-datepicker__date wc-datepicker__date--overflowing sc-wc-datepicker" data-date="2026-07-26" role="gridcell" tabindex="-1">...</td>
         (Session info: chrome=151.0.7922.108)

     # ./spec/system/date_picker/date_picker_spec.rb:152:in 'block (7 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # Selenium::WebDriver::Error::WebDriverError:
     #   #0 0x55e24cd3b36a <unknown>

Failed examples:

rspec ./spec/system/date_picker/date_picker_spec.rb:149 # Datepicker when date format dd.mm.yyyy and clock format 24 when choosing date when using picker when opening datepicker when choosing a date hides the datepicker calendar
```

Similar possible failures also in the same spec.

Within the date cells, there are two elements:
- The visible date number (marked with `aria-hidden=true`)
- A 1x1 px accessibility label that is apparently not always clickable within the clicked area (`element click intercepted: Element <span class="visually-hidden sc-wc-datepicker">...</span> is not clickable at point (10, 423)`)

<img width="724" height="82" alt="Elements within day cells" src="https://github.com/user-attachments/assets/655e1ddf-2a16-4da4-9be4-d6c64b111578" />

This targets the click to the visible `aria-hidden=true` elements in order to expand the clickable area larger.

#### :pushpin: Related Issues
- Related to #17547

#### Testing
```bash
cd decidim-core
for i in {1..20}; do bundle exec rspec ./spec/system/date_picker/date_picker_spec.rb:149 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date picker interactions by targeting the correct date cells.
  * Increased reliability of date selection in system tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->