### PR TITLE
Optimize fetching the conversation between a set of users

### DIFF
--- a/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
+++ b/decidim-core/app/controllers/decidim/messaging/conversations_controller.rb
@@ -25,7 +25,7 @@ module Decidim
 
         if @form.recipient.is_a? Enumerable
           participants = @form.recipient.to_a.prepend(current_user)
-          conversation = conversation_between_multiple(participants)
+          conversation = conversation_between(*participants)
         else
           conversation = conversation_between(current_user, @form.recipient)
         end

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -121,27 +121,12 @@ module Decidim
 
         active_participant = opts[:nickname].present? ? Decidim::UserBaseEntity.find_by(nickname: opts[:nickname]) : current_user
         participants = users.to_a.prepend(active_participant)
-        conversation = conversation_between_multiple(participants)
+        conversation = conversation_between(*participants)
 
         if opts[:nickname].present?
           current_or_new_profile_conversation_path(opts[:nickname], users, conversation)
         else
           current_or_new_user_conversation_path(users, conversation)
-        end
-      end
-
-      #
-      # Finds the conversation between the given participants
-      #
-      # @param participants [Array<Decidim::User>] The participants to find a
-      #   conversation between.
-      #
-      # @return [Decidim::Messaging::Conversation]
-      def conversation_between_multiple(participants)
-        return if participants.to_set.length <= 1
-
-        UserConversations.for(participants.first).find do |conversation|
-          conversation.participants.to_set == participants.to_set
         end
       end
 

--- a/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
+++ b/decidim-core/app/helpers/decidim/messaging/conversation_helper.rb
@@ -110,9 +110,7 @@ module Decidim
       def conversation_between(*participants)
         return if participants.to_set.length <= 1
 
-        UserConversations.for(participants.first).find do |conversation|
-          conversation.participants.to_set == participants.to_set
-        end
+        ConversationBetween.for(participants)
       end
 
       #

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -85,7 +85,7 @@ module Decidim
       #
       # @return [ActiveRecord::Relation]
       def groupped_conversations
-        participants_table = Decidim::Messaging::Participation.arel_table
+        participants_table = Participation.arel_table
         participants_column = participants_table[:decidim_participant_id]
 
         order_clause = Arel::Nodes::InfixOperation.new(
@@ -105,11 +105,15 @@ module Decidim
         )
         cast = Arel::Nodes::NamedFunction.new("CAST", [cast_operation])
 
-        Decidim::Messaging::Conversation
+        Conversation
+          .where(id: candidate_conversations)
           .joins(:participations)
-          .where(decidim_messaging_participations: { decidim_participant_id: users.first.id })
           .group(:id)
           .select(:id, cast.as("participant_ids"))
+      end
+
+      def candidate_conversations
+        Conversation.joins(:participations).where(decidim_messaging_participations: { decidim_participant_id: users.first.id })
       end
     end
   end

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -114,6 +114,13 @@ module Decidim
           .select(:id, cast.as("participant_ids"))
       end
 
+      # Returns a relation for the possible candidate conversations where the
+      # first user is participating. This limits the amount of queried
+      # conversations to only the ones where at least one of the participants
+      # is taking part in, rather than comparing the set of users to all
+      # conversations on the platform.
+      #
+      # @return [ActiveRecord::Relation]
       def candidate_conversations
         Conversation.joins(:participations).where(decidim_messaging_participations: { decidim_participant_id: users.first.id })
       end

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -26,9 +26,10 @@ module Decidim
       # these users. There is always only one conversation between the same set
       # of users.
       #
-      # @return [ActiveRecord::Relation] The query for conversation(s) between
-      #   the set of users or nil if not found. The `find` method will fetch the
-      #   first result as there is only one result.
+      # @return [ActiveRecord::Relation, nil] The query for conversation(s)
+      #   between the set of users or nil if the list of users is empty. The
+      #   `find` method will fetch the first result as there is only one
+      #   result.
       def query
         return if users.blank?
 

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -103,7 +103,7 @@ module Decidim
 
         order_clause = Arel::Nodes::InfixOperation.new(
           "",
-          Arel::Nodes::SqlLiteral.new("ORDER BY"),
+          Arel.sql("ORDER BY"),
           participants_column.asc
         )
         array_agg = Arel::Nodes::NamedFunction.new(

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -69,13 +69,23 @@ module Decidim
         users.map(&:id).uniq.sort
       end
 
-      # Generates the following query for all participants in a conversation:
+      # Generates the following query for all participants in a conversation
+      # where the first user is taking part in (123 in the example represents
+      # the first participant ID):
       #   SELECT
       #       c.id,
       #       CAST(ARRAY_AGG(p.decidim_participant_id ORDER BY p.decidim_participant_id) AS bigint[])
       #     FROM decidim_messaging_conversations c
       #     INNER JOIN decidim_messaging_participations p
       #       ON p.decidim_conversation_id = c.id
+      #     WHERE
+      #       c.id IN (
+      #         SELECT subc.id FROM decidim_messaging_conversations subc
+      #            INNER JOIN decidim_messaging_participations subp
+      #            ON subp.id = subc.id
+      #         WHERE
+      #           subp.id = 123
+      #       )
       #     GROUP BY c.id
       #
       # Returns the following kind of table where we can match the exact

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Messaging
+    # A class used to find a conversation between the given set of users and
+    # only between those users. There is always only a single conversation
+    # between the same set of users.
+    class ConversationBetween < Decidim::Query
+      # Syntactic sugar to initialize the class and return the queried object.
+      #
+      # @param users [Array<Decidim::User>] (see #initialize)
+      # @return [Decidim::Messaging::Conversation, nil] (see #find)
+      def self.for(users)
+        new(users).find
+      end
+
+      # Initializes the query object.
+      #
+      # @param users [Array<Decidim::User>] A list of users for which to find
+      #   the conversation.
+      def initialize(users)
+        @users = users
+      end
+
+      # Returns all conversations where all of the users are part of and only
+      # these users. There is always only one conversation between the same set
+      # of users.
+      #
+      # @return [ActiveRecord::Relation] The query for conversation(s) between
+      #   the set of users or nil if not found. The `find` method will fetch the
+      #   first result as there is only one result.
+      def query
+        join_table = Arel::Table.new("participants")
+        subquery = Arel::Nodes::As.new(groupped_conversations.arel, join_table)
+
+        join_condition = Conversation.arel_table[:id].eq(join_table[:id])
+
+        join_query =
+          Conversation
+          .arel_table
+          .join(subquery, Arel::Nodes::InnerJoin).on(join_condition)
+
+        Conversation
+          .joins(join_query.join_sources)
+          .where("participants.participant_ids = ARRAY[?]::bigint[]", sorted_user_ids)
+      end
+
+      # Finds the first record from the query result, as there is always only
+      # one record returned.
+      #
+      # @return [Decidim::Messaging::Conversation, nil] The conversation between
+      #   the set of users or nil if not found.
+      def find
+        query.first
+      end
+
+      private
+
+      attr_reader :users
+
+      # Sorts the user IDs for the final query as they should be always in
+      # sorted order for the query to work. The `groupped_conversations` method
+      # will return the participant IDs sorted.
+      #
+      # @return [Array<Integer>]
+      def sorted_user_ids
+        users.map(&:id).sort
+      end
+
+      # Generates the following query for all participants in a conversation:
+      #   SELECT
+      #       c.id,
+      #       CAST(ARRAY_AGG(p.decidim_participant_id ORDER BY p.decidim_participant_id) AS bigint[])
+      #     FROM decidim_messaging_conversations c
+      #     INNER JOIN decidim_messaging_participations p
+      #       ON p.decidim_conversation_id = c.id
+      #     GROUP BY c.id
+      #
+      # Returns the following kind of table where we can match the exact
+      # participants in all conversations:
+      #   id | participant_ids
+      #   --------------------
+      #    1 | {1,2}
+      #    2 | {3,4}
+      #
+      # @return [ActiveRecord::Relation]
+      def groupped_conversations
+        participants_table = Decidim::Messaging::Participation.arel_table
+        participants_column = participants_table[:decidim_participant_id]
+
+        order_clause = Arel::Nodes::InfixOperation.new(
+          "",
+          Arel::Nodes::SqlLiteral.new("ORDER BY"),
+          participants_column.asc
+        )
+        array_agg = Arel::Nodes::NamedFunction.new(
+          "ARRAY_AGG",
+          [Arel::Nodes::InfixOperation.new("", participants_column, order_clause)]
+        )
+
+        cast_operation = Arel::Nodes::InfixOperation.new(
+          "AS",
+          array_agg,
+          Arel.sql("bigint[]")
+        )
+        cast = Arel::Nodes::NamedFunction.new("CAST", [cast_operation])
+
+        Decidim::Messaging::Conversation
+          .joins(:participations)
+          .group(:id)
+          .select(:id, cast.as("participant_ids"))
+      end
+    end
+  end
+end

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -30,6 +30,8 @@ module Decidim
       #   the set of users or nil if not found. The `find` method will fetch the
       #   first result as there is only one result.
       def query
+        return if users.blank?
+
         join_table = Arel::Table.new("participants")
         subquery = Arel::Nodes::As.new(groupped_conversations.arel, join_table)
 
@@ -51,7 +53,7 @@ module Decidim
       # @return [Decidim::Messaging::Conversation, nil] The conversation between
       #   the set of users or nil if not found.
       def find
-        query.first
+        query&.first
       end
 
       private

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -107,6 +107,7 @@ module Decidim
 
         Decidim::Messaging::Conversation
           .joins(:participations)
+          .where(decidim_messaging_participations: { decidim_participant_id: users.first.id })
           .group(:id)
           .select(:id, cast.as("participant_ids"))
       end

--- a/decidim-core/app/queries/decidim/messaging/conversation_between.rb
+++ b/decidim-core/app/queries/decidim/messaging/conversation_between.rb
@@ -66,7 +66,7 @@ module Decidim
       #
       # @return [Array<Integer>]
       def sorted_user_ids
-        users.map(&:id).sort
+        users.map(&:id).uniq.sort
       end
 
       # Generates the following query for all participants in a conversation:

--- a/decidim-core/spec/queries/decidim/messaging/conversation_between_spec.rb
+++ b/decidim-core/spec/queries/decidim/messaging/conversation_between_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Messaging::ConversationBetween do
+  subject(:query) { described_class.new(users) }
+
+  let(:organization) { create(:organization) }
+  let!(:user1) { create(:user, :confirmed, organization:) }
+  let!(:user2) { create(:user, :confirmed, organization:) }
+  let!(:user3) { create(:user, :confirmed, organization:) }
+  let!(:user4) { create(:user, :confirmed, organization:) }
+  let!(:conversation_between_u1_u2) { create(:conversation, originator: user1, interlocutors: [user2]) }
+  let!(:conversation_between_u1_u2_u3) { create(:conversation, originator: user1, interlocutors: [user2, user3]) }
+  let!(:conversation_between_u2_u1_u3_u4) { create(:conversation, originator: user2, interlocutors: [user1, user3, user4]) }
+
+  shared_examples "working conversations between query" do
+    context "with user1 and user2" do
+      let(:users) { [user1, user2] }
+
+      it "finds the correct conversations for all combinations" do
+        expect(subject).to eq(conversation_between_u1_u2)
+      end
+    end
+
+    context "with user2 and user1" do
+      let(:users) { [user2, user1] }
+
+      it "finds the correct conversations for all combinations" do
+        expect(subject).to eq(conversation_between_u1_u2)
+      end
+    end
+
+    context "with user1, user2 and user3" do
+      let(:users) { [user1, user2, user3].shuffle }
+
+      it "finds the correct conversations for all combinations" do
+        expect(subject).to eq(conversation_between_u1_u2_u3)
+      end
+    end
+
+    context "with user1, user2, user3 and user4" do
+      let(:users) { [user1, user2, user3, user4].shuffle }
+
+      it "finds the correct conversations for all combinations" do
+        expect(subject).to eq(conversation_between_u2_u1_u3_u4)
+      end
+    end
+  end
+
+  describe "#query" do
+    subject(:result) { query.query }
+
+    it_behaves_like "working conversations between query" do
+      subject { result.first }
+    end
+
+    context "with user1 and user2" do
+      let(:users) { [user1, user2] }
+
+      it "finds the correct amount of conversations" do
+        expect(result.count).to eq(1)
+      end
+    end
+
+    context "with user1, user2 and user3" do
+      let(:users) { [user1, user2, user3].shuffle }
+
+      it "finds the correct amount of conversations" do
+        expect(result.count).to eq(1)
+      end
+    end
+
+    context "with user1, user2, user3 and user4" do
+      let(:users) { [user1, user2, user3, user4].shuffle }
+
+      it "finds the correct amount of conversations" do
+        expect(result.count).to eq(1)
+      end
+    end
+  end
+
+  describe "#find" do
+    subject { query.find }
+
+    it_behaves_like "working conversations between query"
+  end
+end

--- a/decidim-core/spec/queries/decidim/messaging/conversation_between_spec.rb
+++ b/decidim-core/spec/queries/decidim/messaging/conversation_between_spec.rb
@@ -78,11 +78,23 @@ describe Decidim::Messaging::ConversationBetween do
         expect(result.count).to eq(1)
       end
     end
+
+    context "when no users are provided" do
+      let(:users) { [] }
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe "#find" do
     subject { query.find }
 
     it_behaves_like "working conversations between query"
+
+    context "when no users are provided" do
+      let(:users) { [] }
+
+      it { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
I noticed that the `conversation_between` helper is not working optimally, in fact it is very inefficient. This can be a problem especially if there is a large set of conversations for the target user.

What it currently does is:
- Fetches **all conversations** for the first participant in the given set
- For each conversation, fetches **all participants** (N+1)
- Matches the set of participants in each conversation to the provided set of users

This is very inefficient. The same workload can be pushed to the database backend more efficiently.

I noticed this when I was wondering so many queries for the `decidim_users` table when inspecting a moderation report at `/en/admin/moderations/{id}/reports`. In that view, it prints a contact link for the author of the content and therefore uses the `conversation_between` helper to try to figure out whether or not there is an existing conversation.

#### Testing
Test that the conversations between a specific set of users (typically two users in either order) is returning the correct conversations.

Also see the added specs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation lookup to reliably identify the unique conversation shared by exactly the selected participants.
  * Conversation matching now works consistently regardless of participant order.
  * Prevents conversations with additional participants from being incorrectly returned.
  * Handles empty participant selections safely without returning an unrelated conversation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->