### PR TITLE
Fix survey questions partially lost on space import

### DIFF
--- a/decidim-surveys/app/serializers/decidim/surveys/data_importer.rb
+++ b/decidim-surveys/app/serializers/decidim/surveys/data_importer.rb
@@ -10,7 +10,8 @@ module Decidim
 
       # Public: Creates a new Decidim::Surveys::Survey and Decidim::Forms::Questionnaire associated to the given +component+
       #         for each serialized survey object.
-      # It imports the whole tree of Survey->Questionnaire->questions->response_options.
+      # It imports the whole tree of Survey->Questionnaire->questions with their
+      # response_options, matrix_rows and display_conditions.
       #
       # serialized        - The Hash of attributes for the Questionnaire and its relations.
       # user              - The +user+ that is performing this action
@@ -53,13 +54,55 @@ module Decidim
       end
 
       def import_questions(questionnaire, serialized_questions)
+        questions_by_original_id = {}
+        response_options_by_original_id = {}
+        pending_display_conditions = []
+
         serialized_questions.each do |serialized_question|
-          serialized_response_options = serialized_question.delete(:response_options)
-          question = questionnaire.questions.create!(serialized_question.except(:id, :created_at, :updated_at))
+          serialized_response_options = serialized_question.delete(:response_options) || []
+          serialized_matrix_rows = serialized_question.delete(:matrix_rows) || []
+          pending_serialized_conditions = serialized_question.delete(:display_conditions) || []
+
+          question = questionnaire.questions.create!(question_attributes(serialized_question))
+          questions_by_original_id[serialized_question[:id]] = question
+          pending_display_conditions << [question, pending_serialized_conditions]
+
           serialized_response_options.each do |serialized_response_option|
-            question.response_options.create!(serialized_response_option.except(:id, :created_at, :updated_at))
+            response_option = question.response_options.create!(serialized_response_option.except(:id, :created_at, :updated_at))
+            response_options_by_original_id[serialized_response_option[:id]] = response_option
+          end
+
+          serialized_matrix_rows.each do |serialized_matrix_row|
+            question.matrix_rows.create!(serialized_matrix_row.except(:id, :created_at, :updated_at))
           end
         end
+
+        pending_display_conditions.each do |question, serialized_conditions|
+          serialized_conditions.each do |serialized_condition|
+            import_display_condition(question, serialized_condition, questions_by_original_id, response_options_by_original_id)
+          end
+        end
+      end
+
+      def import_display_condition(question, serialized_condition, questions_by_original_id, response_options_by_original_id)
+        question.display_conditions.create!(
+          serialized_condition.except(
+            :id, :created_at, :updated_at,
+            :decidim_question_id, :decidim_condition_question_id, :decidim_response_option_id
+          ).merge(
+            condition_question: questions_by_original_id.fetch(serialized_condition[:decidim_condition_question_id]),
+            response_option: serialized_condition[:decidim_response_option_id] &&
+              response_options_by_original_id.fetch(serialized_condition[:decidim_response_option_id])
+          )
+        )
+      end
+
+      def question_attributes(serialized_question)
+        serialized_question.except(
+          :id, :created_at, :updated_at,
+          :response_options_count, :matrix_rows_count,
+          :display_conditions_count, :display_conditions_for_other_questions_count
+        )
       end
     end
   end

--- a/decidim-surveys/app/serializers/decidim/surveys/data_serializer.rb
+++ b/decidim-surveys/app/serializers/decidim/surveys/data_serializer.rb
@@ -3,7 +3,8 @@
 module Decidim
   module Surveys
     # This class serializes the specific data in each Survey.
-    # This is `Questionnaire->questions->response_options` but not `responses`
+    # This is `Questionnaire->questions` with their `response_options`,
+    # `matrix_rows` and `display_conditions`, but not `responses`
     # and `response_choices`.
     class DataSerializer < Decidim::Exporters::Serializer
       # Returns: Array of Decidim::Forms::Questionnaire as a json hash,
@@ -22,7 +23,9 @@ module Decidim
       def serialize_survey(survey)
         questionnaire = survey.questionnaire
         questionnaire_json = questionnaire.attributes.as_json
-        questionnaire_json[:questions] = serialize_questions(questionnaire.questions.order(:position))
+        questionnaire_json[:questions] = serialize_questions(
+          questionnaire.questions.includes(:response_options, :matrix_rows, :display_conditions).order(:position)
+        )
         json = survey.attributes.as_json
         json[:questionnaire] = questionnaire_json
         json
@@ -32,6 +35,8 @@ module Decidim
         questions.collect do |question|
           json = question.attributes.as_json
           json[:response_options] = serialize_response_options(question.response_options)
+          json[:matrix_rows] = serialize_matrix_rows(question.matrix_rows)
+          json[:display_conditions] = serialize_display_conditions(question.display_conditions)
           json
         end
       end
@@ -39,6 +44,18 @@ module Decidim
       def serialize_response_options(response_options)
         response_options.collect do |option|
           option.attributes.as_json
+        end
+      end
+
+      def serialize_matrix_rows(matrix_rows)
+        matrix_rows.collect do |matrix_row|
+          matrix_row.attributes.as_json
+        end
+      end
+
+      def serialize_display_conditions(display_conditions)
+        display_conditions.collect do |display_condition|
+          display_condition.attributes.as_json
         end
       end
     end

--- a/decidim-surveys/spec/serializers/decidim/surveys/data_importer_spec.rb
+++ b/decidim-surveys/spec/serializers/decidim/surveys/data_importer_spec.rb
@@ -13,15 +13,31 @@ module Decidim::Surveys
       let!(:original_questionnaire) { create(:questionnaire, :with_questions) }
       let!(:survey) { create(:survey, questionnaire: original_questionnaire) }
       let(:component) { survey.component }
+      let!(:matrix_question) do
+        create(:questionnaire_question, :with_response_options,
+               question_type: "matrix_single",
+               position: 3,
+               questionnaire: original_questionnaire)
+      end
+      let!(:matrix_rows) do
+        [0, 1].map { |position| create(:question_matrix_row, question: matrix_question, position:) }
+      end
+      let(:condition_question) { original_questionnaire.questions.order(:position).third }
+      let!(:display_condition) do
+        create(:display_condition, :equal,
+               question: matrix_question,
+               condition_question:,
+               response_option: condition_question.response_options.first)
+      end
 
       let(:as_json) do
         questionnaire_attrs = original_questionnaire.attributes
         questions = []
         original_questionnaire.questions.order(:position).each do |q|
-          question_attrs = q.attributes
-          response_options = q.response_options.map(&:attributes)
-          question_attrs[:response_options] = response_options
-          question_attrs = question_attrs.reject { |key, _value| key.ends_with?("_count") }
+          question_attrs = q.reload.attributes
+          question_attrs[:response_options] = q.response_options.map(&:attributes)
+          question_attrs[:matrix_rows] = q.matrix_rows.map(&:attributes)
+          question_attrs[:display_conditions] = q.display_conditions.map(&:attributes)
           questions << question_attrs
         end
         questionnaire_attrs[:questions] = questions
@@ -29,6 +45,23 @@ module Decidim::Surveys
           id: rand(99_999),
           questionnaire: questionnaire_attrs
         }]
+      end
+
+      context "when the serialized data comes from an export without matrix rows and display conditions" do
+        let(:as_json) do
+          super().each do |serialized_survey|
+            serialized_survey[:questionnaire][:questions].each do |serialized_question|
+              serialized_question.delete(:matrix_rows)
+              serialized_question.delete(:display_conditions)
+            end
+          end
+        end
+
+        it "imports the survey questions" do
+          questions = subject.first.questionnaire.questions
+          expect(questions.size).to eq(4)
+          expect(questions.flat_map(&:response_options).size).to eq(6)
+        end
       end
 
       describe "#import" do
@@ -55,7 +88,7 @@ module Decidim::Surveys
       private
 
       def imported_questions_should_eq_serialized(imported_questions)
-        original_questions = original_questionnaire.questions
+        original_questions = original_questionnaire.questions.reload
         expect(imported_questions.size).to eq(original_questions.size)
 
         imported_questions.zip(original_questions).each do |imported, original|
@@ -66,7 +99,11 @@ module Decidim::Surveys
           expect(imported.description).to eq(original.description)
           expect(imported.max_choices).to eq(original.max_choices)
           imported_question_options_should_eq_serialized(imported.response_options, original.response_options)
+          imported_question_matrix_rows_should_eq_serialized(imported.matrix_rows, original.matrix_rows)
+          imported_question_counters_should_be_consistent(imported)
         end
+
+        imported_display_conditions_should_eq_serialized(imported_questions)
       end
 
       def imported_question_options_should_eq_serialized(imported_response_options, original_response_options)
@@ -75,6 +112,39 @@ module Decidim::Surveys
           expect(imported.body).to eq(original.body)
           expect(imported.free_text).to eq(original.free_text)
         end
+      end
+
+      def imported_question_matrix_rows_should_eq_serialized(imported_matrix_rows, original_matrix_rows)
+        expect(imported_matrix_rows.size).to eq(original_matrix_rows.size)
+        imported_matrix_rows.zip(original_matrix_rows).each do |imported, original|
+          expect(imported.body).to eq(original.body)
+          expect(imported.position).to eq(original.position)
+        end
+      end
+
+      # The display condition of the imported question must point to the
+      # imported copies of the condition question and response option, not to
+      # the original records.
+      def imported_display_conditions_should_eq_serialized(imported_questions)
+        imported_matrix_question = imported_questions.detect { |question| question.question_type == "matrix_single" }
+        imported_condition_question = imported_questions.detect { |question| question.position == condition_question.position }
+
+        expect(imported_matrix_question.display_conditions.size).to eq(1)
+        imported_condition = imported_matrix_question.display_conditions.first
+        expect(imported_condition.condition_type).to eq(display_condition.condition_type)
+        expect(imported_condition.mandatory).to eq(display_condition.mandatory)
+        expect(imported_condition.condition_question).to eq(imported_condition_question)
+        expect(imported_condition.condition_question).not_to eq(condition_question)
+        expect(imported_condition.response_option).to eq(imported_condition_question.response_options.first)
+        expect(imported_condition.response_option).not_to eq(display_condition.response_option)
+      end
+
+      def imported_question_counters_should_be_consistent(imported_question)
+        imported_question.reload
+        expect(imported_question.response_options_count).to eq(imported_question.response_options.count)
+        expect(imported_question.matrix_rows_count).to eq(imported_question.matrix_rows.count)
+        expect(imported_question.display_conditions_count).to eq(imported_question.display_conditions.count)
+        expect(imported_question.display_conditions_for_other_questions_count).to eq(imported_question.display_conditions_for_other_questions.count)
       end
     end
   end

--- a/decidim-surveys/spec/serializers/decidim/surveys/data_serializer_spec.rb
+++ b/decidim-surveys/spec/serializers/decidim/surveys/data_serializer_spec.rb
@@ -11,6 +11,22 @@ module Decidim::Surveys
 
       let!(:questionnaire) { build(:questionnaire, :with_questions) }
       let!(:survey) { create(:survey, questionnaire:) }
+      let!(:matrix_question) do
+        create(:questionnaire_question, :with_response_options,
+               question_type: "matrix_single",
+               position: 3,
+               questionnaire:)
+      end
+      let!(:matrix_rows) do
+        [0, 1].map { |position| create(:question_matrix_row, question: matrix_question, position:) }
+      end
+      let(:condition_question) { questionnaire.questions.order(:position).third }
+      let!(:display_condition) do
+        create(:display_condition, :equal,
+               question: matrix_question,
+               condition_question:,
+               response_option: condition_question.response_options.first)
+      end
 
       let(:serialized_surveys) { subject.serialize }
 
@@ -31,8 +47,8 @@ module Decidim::Surveys
       end
 
       def questions_should_be_as_expected(questions, serializeds)
-        expect(serializeds.size).to eq(3)
-        num_expected_responses_list = [0, 0, 3]
+        expect(serializeds.size).to eq(4)
+        num_expected_responses_list = [0, 0, 3, 3]
         serializeds.zip(questions, num_expected_responses_list) do |serialized, question, num_expected_responses|
           expect(serialized[:id]).to eq(question.id)
           expect(serialized[:decidim_questionnaire_id]).to eq(question.decidim_questionnaire_id)
@@ -44,6 +60,8 @@ module Decidim::Surveys
           expect(serialized[:max_choices]).to eq(question.max_choices)
 
           options_should_be_as_expected(question.response_options.order(:id), serialized[:response_options], num_expected_responses)
+          matrix_rows_should_be_as_expected(question.matrix_rows, serialized[:matrix_rows])
+          display_conditions_should_be_as_expected(question.display_conditions, serialized[:display_conditions])
         end
       end
 
@@ -54,6 +72,29 @@ module Decidim::Surveys
           expect(serialized[:decidim_question_id]).to eq(option.decidim_question_id)
           expect(serialized[:body]).to eq(option.body)
           expect(serialized[:free_text]).to eq(option.free_text)
+        end
+      end
+
+      def matrix_rows_should_be_as_expected(matrix_rows, serializeds)
+        expect(serializeds.size).to eq(matrix_rows.size)
+        serializeds.zip(matrix_rows) do |serialized, matrix_row|
+          expect(serialized[:id]).to eq(matrix_row.id)
+          expect(serialized[:decidim_question_id]).to eq(matrix_row.decidim_question_id)
+          expect(serialized[:body]).to eq(matrix_row.body)
+          expect(serialized[:position]).to eq(matrix_row.position)
+        end
+      end
+
+      def display_conditions_should_be_as_expected(display_conditions, serializeds)
+        expect(serializeds.size).to eq(display_conditions.size)
+        serializeds.zip(display_conditions) do |serialized, display_condition|
+          expect(serialized[:id]).to eq(display_condition.id)
+          expect(serialized[:decidim_question_id]).to eq(display_condition.decidim_question_id)
+          expect(serialized[:decidim_condition_question_id]).to eq(display_condition.decidim_condition_question_id)
+          expect(serialized[:decidim_response_option_id]).to eq(display_condition.decidim_response_option_id)
+          expect(serialized[:condition_type]).to eq(display_condition.condition_type)
+          expect(serialized[:condition_value]).to eq(display_condition.condition_value)
+          expect(serialized[:mandatory]).to eq(display_condition.mandatory)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

solves #17567 

#### :pushpin: Related Issues
- Fixes #17567 

#### Testing

1. Log in as admin.
2. Export the seeded participatory process.
3. Go to `/admin/participatory_processes/imports/new`. Upload the exported JSON and check "Import components".
4. Open the questions of the imported survey in the admin panel. Check that:
   - matrix questions still have their rows
   - display conditions still exist
   - display conditions point to the imported questions and response options,
     not to the original ones

### :camera: Screenshots

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Survey exports now include matrix question rows and display conditions.
  - Survey imports now restore matrix rows, response options, and display conditions, preserving their relationships.
  - Imported questions and response options remain correctly linked to their original references.

- **Bug Fixes**
  - Improved compatibility with older exports that do not contain response options, matrix rows, or display conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->