### PR TITLE
Fix browsing data in a deleted component raises an error

### DIFF
--- a/decidim-accountability/app/views/decidim/accountability/admin/results/_result-tr.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/_result-tr.html.erb
@@ -24,6 +24,6 @@
     <%= l result.created_at, format: :decidim_short %>
   </td>
   <td class="table-list__actions" data-label="<%= t("actions.title", scope: "decidim.accountability") %>">
-    <%= render partial: "decidim/accountability/admin/results/actions", locals: { result:, view: } %>
+    <%= render partial: "decidim/accountability/admin/results/actions", locals: { result:, view: } unless current_component.deleted? %>
   </td>
 </tr>

--- a/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
+++ b/decidim-accountability/app/views/decidim/accountability/admin/results/index.html.erb
@@ -9,35 +9,36 @@
         <%= t(".title") %>
         <span data-selected-count class="component-counter" title="<%= t(".selected") %>"></span>
       </div>
-
-      <div class="flex items-center gap-x-4">
-        <%= render partial: "decidim/accountability/admin/results/bulk_actions/dropdown" %>
-        <%= export_dropdowns(query) %>
-        <%= import_dropdown do %>
-          <% if allowed_to?(:create, :result) && parent_result.nil? %>
-            <li class="dropdown__item">
-              <%= link_to new_import_component_path, class: "dropdown__button" do %>
-                <%= t("actions.import", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")) %>
-              <% end %>
-            </li>
+      <% unless current_component.deleted? %>
+        <div class="flex items-center gap-x-4">
+          <%= render partial: "decidim/accountability/admin/results/bulk_actions/dropdown" %>
+          <%= export_dropdowns(query) %>
+          <%= import_dropdown do %>
+            <% if allowed_to?(:create, :result) && parent_result.nil? %>
+              <li class="dropdown__item">
+                <%= link_to new_import_component_path, class: "dropdown__button" do %>
+                  <%= t("actions.import", scope: "decidim.accountability", name: t("models.result.name", scope: "decidim.accountability.admin")) %>
+                <% end %>
+              </li>
+            <% end %>
+            <% if allowed_to? :create, :result %>
+              <li class="dropdown__item">
+                <%= link_to import_results_path, class: "dropdown__button" do %>
+                  <%= t("actions.import_csv", scope: "decidim.accountability") %>
+                <% end %>
+              </li>
+            <% end %>
           <% end %>
-          <% if allowed_to? :create, :result %>
-            <li class="dropdown__item">
-              <%= link_to import_results_path, class: "dropdown__button" do %>
-                <%= t("actions.import_csv", scope: "decidim.accountability") %>
-              <% end %>
-            </li>
-          <% end %>
-        <% end %>
-        <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
-        <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
-        <%= render partial: "decidim/admin/components/resource_action" %>
-      </div>
+          <%= render partial: "decidim/accountability/admin/shared/subnav" unless parent_result %>
+          <%= link_to t("actions.new_result", scope: "decidim.accountability"), new_result_path(parent_id: parent_result), class: "button button__sm button__secondary" if allowed_to? :create, :result %>
+          <%= render partial: "decidim/admin/components/resource_action" %>
+        </div>
+      <% end %>
     </h1>
 
-    <%= render partial: "decidim/accountability/admin/results/bulk_actions/taxonomies_form" %>
-    <%= render partial: "decidim/accountability/admin/results/bulk_actions/status_form" %>
-    <%= render partial: "decidim/accountability/admin/results/bulk_actions/dates_form" %>
+    <%= render partial: "decidim/accountability/admin/results/bulk_actions/taxonomies_form" unless current_component.deleted? %>
+    <%= render partial: "decidim/accountability/admin/results/bulk_actions/status_form" unless current_component.deleted? %>
+    <%= render partial: "decidim/accountability/admin/results/bulk_actions/dates_form" unless current_component.deleted? %>
   </div>
 
   <%= admin_filter_selector(:results) %>

--- a/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
@@ -71,4 +71,35 @@ describe "Admin manages accountability" do
     it_behaves_like "manage soft deletable resource", "result"
     it_behaves_like "manage trashed resource", "result"
   end
+
+  describe "when component is trashed" do
+    before do
+      component.destroy!
+      visit current_path
+
+      expect(page).to have_callout("You are currently viewing deleted items. To make any edits or changes, you must first restore them.")
+    end
+
+    it "shows page title" do
+      expect(page).to have_text("Results")
+    end
+
+    it "hides the deleted links page" do
+      expect(page).to have_no_link("View deleted results")
+    end
+
+    it "hides the actions" do
+      expect(page).to have_no_link("Export all")
+      expect(page).to have_no_link("Import")
+      expect(page).to have_no_link("Statuses")
+      expect(page).to have_no_link("Configure")
+      expect(page).to have_no_link("New result")
+    end
+
+    it "displays the result in the trash" do
+      within "table" do
+        expect(page).to have_text(translated(result.title))
+      end
+    end
+  end
 end

--- a/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
+++ b/decidim-accountability/spec/system/admin/admin_manages_accountability_spec.rb
@@ -84,10 +84,6 @@ describe "Admin manages accountability" do
       expect(page).to have_text("Results")
     end
 
-    it "hides the deleted links page" do
-      expect(page).to have_no_link("View deleted results")
-    end
-
     it "hides the actions" do
       expect(page).to have_no_link("Export all")
       expect(page).to have_no_link("Import")


### PR DESCRIPTION
#### :tophat: What? Why?
In this PR i am adding some conditions that would allow us to navigate through deleted components data. 
This is a POC of the implementation needed to fix: #16364

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #16364
- Fixes #?

#### Testing
1. Login as admin, visit the admin panel 
2. Find a space, and delete it 
3. Visit the respective space component's link
4. Click on "View deleted components"
5. Click on accountability 
6. See the error
7. Apply this patch & refresh 
8. See there is no error

### :camera: Screenshots


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled result management actions for deleted accountability components.
  * Hid creation, import, export, navigation, configuration, and bulk-edit controls when viewing deleted components.
  * Preserved visibility of deleted results and the relevant page context for administrators.
* **Tests**
  * Added coverage verifying deleted-component pages display the expected notice and suppress unavailable actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->