### PR TITLE
Fix blog posts ordering by publication time

### DIFF
--- a/decidim-blogs/app/cells/decidim/blogs/content_blocks/highlighted_posts_cell.rb
+++ b/decidim-blogs/app/cells/decidim/blogs/content_blocks/highlighted_posts_cell.rb
@@ -11,7 +11,7 @@ module Decidim
         private
 
         def posts
-          @posts ||= Decidim::Blogs::Post.published.where(component: published_components).created_at_desc
+          @posts ||= Decidim::Blogs::Post.published.where(component: published_components).published_at_desc
         end
 
         def decidim_blogs

--- a/decidim-blogs/app/controllers/decidim/blogs/admin/application_controller.rb
+++ b/decidim-blogs/app/controllers/decidim/blogs/admin/application_controller.rb
@@ -10,7 +10,7 @@ module Decidim
         helper_method :posts, :post
 
         def posts
-          @posts ||= Post.where(component: current_component).page(params[:page]).per(15)
+          @posts ||= Post.where(component: current_component).published_at_desc.page(params[:page]).per(15)
         end
 
         def post

--- a/decidim-blogs/spec/cells/decidim/blogs/content_blocks/highlighted_posts_cell_spec.rb
+++ b/decidim-blogs/spec/cells/decidim/blogs/content_blocks/highlighted_posts_cell_spec.rb
@@ -25,13 +25,26 @@ describe Decidim::Blogs::ContentBlocks::HighlightedPostsCell, type: :cell do
   end
 
   context "with 4 posts" do
-    let!(:posts) { create_list(:post, 3, component:, created_at: 1.day.ago) }
-    let!(:post) { create(:post, title: { en: "Blog post title" }, component:, created_at: 1.year.ago) }
+    let!(:posts) { create_list(:post, 3, component:, published_at: 1.day.ago) }
+    let!(:post) { create(:post, title: { en: "Blog post title" }, component:, published_at: 1.year.ago) }
 
-    it "renders 3 posts" do
+    it "renders the 3 most recently published posts" do
       expect(subject).to have_text("Last published")
       expect(subject).to have_no_text("Blog post title")
       expect(subject).to have_css(".card__grid", count: 3)
+    end
+  end
+
+  context "with posts published in a different order than they were created" do
+    let!(:oldest_created_latest_published) do
+      create(:post, title: { en: "Latest published post" }, component:, created_at: 2.days.ago, published_at: 1.hour.ago)
+    end
+    let!(:latest_created_oldest_published) do
+      create(:post, title: { en: "First published post" }, component:, created_at: 1.hour.ago, published_at: 2.days.ago)
+    end
+
+    it "orders posts by publication time, most recent first" do
+      expect(subject.text.index("Latest published post")).to be < subject.text.index("First published post")
     end
   end
 

--- a/decidim-blogs/spec/controllers/decidim/blogs/admin/posts_controller_spec.rb
+++ b/decidim-blogs/spec/controllers/decidim/blogs/admin/posts_controller_spec.rb
@@ -28,6 +28,23 @@ module Decidim
                         resource_name: :post,
                         resource_path: :posts_path,
                         trash_path: :manage_trash_posts_path
+
+        describe "GET index" do
+          let!(:oldest_created_latest_published) do
+            create(:post, component:, created_at: 2.days.ago, published_at: 1.hour.ago)
+          end
+          let!(:latest_created_oldest_published) do
+            create(:post, component:, created_at: 1.hour.ago, published_at: 2.days.ago)
+          end
+
+          it "lists posts ordered by publication time, most recent first" do
+            get :index
+
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:index)
+            expect(controller.posts.to_a).to eq([oldest_created_latest_published, latest_created_oldest_published])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?
Blog posts have a configurable publication date/time (`published_at`), but the three places that list posts each use a different order:

- **Public component view** (`posts_controller.rb`): orders by `published_at DESC` ✔️
- **Highlighted posts content block** (`highlighted_posts_cell.rb`): orders by `created_at DESC`, even though the block's heading is literally "Last published".
- **Admin posts list** (`admin/application_controller.rb`): applies no `ORDER BY` at all, so the order is unspecified (in practice, database insertion order)

This PR makes the content block and the admin list use the same ordering as the public view.

#### :pushpin: Related Issues


#### Testing
1. In a blogs component, create post A, then post B (B is newer by creation).
2. Edit post A and set its publication date/time to be more recent than B's.
3. Check the admin posts list, the public posts index, and the "Last published" content block on the space homepage: all three should list A before B.

### :camera: Screenshots

Before:

<img width="1440" height="490" alt="highlighted-posts-before" src="https://github.com/user-attachments/assets/90987e06-c537-437e-88d4-727f352418e4" />

After:

<img width="1440" height="490" alt="highlighted-posts-after" src="https://github.com/user-attachments/assets/cbdee240-2ffa-48c8-8a74-6b90b808a325" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Highlighted blog posts are now displayed by publication date, with the most recently published posts first.
  * The admin blog post list now follows publication-date order, ensuring newer published content appears first.

* **Tests**
  * Added coverage to verify consistent publication-date ordering in highlighted posts and the admin post list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->