### PR TITLE
Fix '"minify" must be a boolean' in assets compilation process

### DIFF
--- a/decidim-core/lib/decidim/shakapacker/webpack/custom.js
+++ b/decidim-core/lib/decidim/shakapacker/webpack/custom.js
@@ -82,6 +82,7 @@ module.exports = {
   optimization: {
     minimizer: [
       new EsbuildPlugin({
+        minify: true,
         target: "es2015",
         css: true
       })


### PR DESCRIPTION
#### :tophat: What? Why?
While working on some PR i have noticed there is a pipeline error, that later seen on @ahukkanen's PR in #17576

This PR fixes the issue. 

```
⚠️ WARNING
Setting 'useContentHash' to 'false' in the production environment (specified by NODE_ENV environment variable) is not allowed!
Content hashes get added to the filenames regardless of setting useContentHash in 'shakapacker.yml' to false.

[webpack-cli] ✖ HookWebpackError: Transform failed with 1 error:
/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:534:29: ERROR: "minify" must be a boolean
    at makeWebpackError (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/webpack/lib/errors/HookWebpackError.js:76:9)
    at /home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/webpack/lib/Compilation.js:3918:13
    at eval (eval at create (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/tapable/lib/HookCodeFactory.js:31:10), <anonymous>:53:1)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
-- inner error --
Error: Transform failed with 1 error:
/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:534:29: ERROR: "minify" must be a boolean
    at failureErrorWithLog (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:1752:15)
    at /home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:1053:20
    at responseCallbacks.<computed> (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:886:9)
    at handleIncomingPacket (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:941:12)
    at Socket.readFromStdout (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:864:7)
    at Socket.emit (node:events:509:28)
    at addChunk (node:internal/streams/readable:563:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
    at Readable.push (node:internal/streams/readable:394:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
caused by plugins in Compilation.hooks.processAssets
Error: Transform failed with 1 error:
/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:534:29: ERROR: "minify" must be a boolean
    at failureErrorWithLog (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:1752:15)
    at /home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:1053:20
    at responseCallbacks.<computed> (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:886:9)
    at handleIncomingPacket (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:941:12)
    at Socket.readFromStdout (/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:864:7)
    at Socket.emit (node:events:509:28)
    at addChunk (node:internal/streams/readable:563:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
    at Readable.push (node:internal/streams/readable:394:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
Error: Transform failed with 1 error:
/home/runner/work/decidim/decidim/spec/decidim_dummy_app/node_modules/esbuild/lib/main.js:534:29: ERROR: "minify" must be a boolean
```

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #?
- Fixes #?

#### Testing
1. Green pipeline

### :camera: Screenshots
<img width="1246" height="801" alt="image" src="https://github.com/user-attachments/assets/9fddee52-f912-48e6-bc97-beedd83b1a66" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enabled JavaScript minification in the production build process, helping reduce asset sizes and improve load times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->