### PR TITLE
Fix member role text being capitalized per word on members page

### DIFF
--- a/decidim-core/app/cells/decidim/member/show.erb
+++ b/decidim-core/app/cells/decidim/member/show.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <div class="mt-3">
-      <span class="text-gray-2 capitalize font-semibold">
+      <span class="text-gray-2 font-semibold">
         <%= role_translated %>
       </span>
     </div>

--- a/decidim-core/spec/cells/decidim/member_cell_spec.rb
+++ b/decidim-core/spec/cells/decidim/member_cell_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::MemberCell, type: :cell do
+  subject { my_cell.call }
+
+  controller Decidim::PagesController
+
+  let(:my_cell) { cell("decidim/member", model) }
+  let(:user) { create(:user, :confirmed) }
+  let(:role) { { "en" => "responsible for community outreach" } }
+  let(:member) { create(:member, user:, role:) }
+  let(:model) { Decidim::ParticipatorySpace::MemberPresenter.new(member) }
+
+  it "renders the member's name, nickname and role" do
+    expect(subject).to have_content(user.name)
+    expect(subject).to have_content(user.nickname)
+    expect(subject).to have_content("responsible for community outreach")
+  end
+
+  it "does not apply a text transform to the role text" do
+    expect(subject).to have_no_css(".capitalize")
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
On the participatory space members page (/processes/:slug/members, /assemblies/:slug/members), the member's role is rendered with the Tailwind `capitalize` class, which uppercases the first letter of every word.
The role attribute is an admin-entered, translatable free-text field, so this transform misrenders the stored content — e.g. a role saved as "membre de la comissió de seguiment" is displayed as "Membre De La Comissió De Seguiment", which is incorrect orthography in languages like Catalan or Spanish.

#### :pushpin: Related Issues

#### Testing
1. In a participatory process (or assembly), add a member with a multi-word role, e.g. "responsible for community outreach (Admin → process → Members), and publish it. Make sure the space has the members page enabled (has_members) so /processes/:slug/members is accessible.
2. Visit the public members page of that space.
3. Before this change, the role was displayed as "Responsible For Community Outreach"; with this change, it is displayed exactly as entered: "responsible for community outreach".

### :camera: Screenshots
**Before:**
<img width="1008" height="560" alt="image" src="https://github.com/user-attachments/assets/797a14dd-2067-4dc8-ae71-f68277068fde" />

**After:**
<img width="941" height="524" alt="image" src="https://github.com/user-attachments/assets/bffdd736-5b05-4a2d-bc2f-a4e72f1a5a4b" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role labels in member displays now preserve their original capitalization instead of being automatically capitalized.

* **Tests**
  * Added coverage confirming that member names, nicknames, and localized roles render correctly without capitalization styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->