### PR TITLE
Pin webpack to v5.109.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -864,7 +864,7 @@ GEM
     selma (0.4.15-arm64-darwin)
     selma (0.4.15-x86_64-linux)
     semantic_range (3.1.1)
-    shakapacker (10.3.1)
+    shakapacker (10.3.2)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/decidim-generators/Gemfile.lock
+++ b/decidim-generators/Gemfile.lock
@@ -852,7 +852,7 @@ GEM
       websocket (~> 1.0)
     selma (0.4.15-x86_64-linux)
     semantic_range (3.1.1)
-    shakapacker (10.3.1)
+    shakapacker (10.3.2)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)

--- a/decidim-generators/lib/decidim/generators/app_templates/package.json
+++ b/decidim-generators/lib/decidim/generators/app_templates/package.json
@@ -11,7 +11,8 @@
     "@decidim/dev": "file:packages/dev",
     "@decidim/eslint-config": "file:packages/eslint-config",
     "@decidim/prettier-config": "file:packages/prettier-config",
-    "@decidim/stylelint-config": "file:packages/stylelint-config"
+    "@decidim/stylelint-config": "file:packages/stylelint-config",
+    "webpack": "~5.109.0"
   },
   "browserslist": [
     "extends @decidim/browserslist-config"

--- a/package-lock.json
+++ b/package-lock.json
@@ -24887,7 +24887,7 @@
         "postcss-preset-env": "^11.2.0",
         "postcss-scss": "^4.0.6",
         "sass-embedded": "^1.63.6",
-        "shakapacker": "^10.3.1",
+        "shakapacker": "10.3.2",
         "source-map-loader": "^5.0.0",
         "style-loader": "^4.0.0",
         "tailwindcss": "^3.4.19",
@@ -25946,9 +25946,9 @@
       }
     },
     "packages/webpacker/node_modules/shakapacker": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-10.3.1.tgz",
-      "integrity": "sha512-yYSbA+JaFisZQL9ImB9IMmPNKUzm0Ycw/wUnwf88f7BeHX9k/M4FIa/4syq/0xx18JqgEL3MIJmsM0RaXQ5zuA==",
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/shakapacker/-/shakapacker-10.3.2.tgz",
+      "integrity": "sha512-W4LV0MFS1c6ayODF/Ra4RM5xS3DljBc9XGLqz04WGSap97U5gJ7FjBTChPmoJ/7VDiTYmL1w+vh+D360e9qK7Q==",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/packages/webpacker/package.json
+++ b/packages/webpacker/package.json
@@ -34,7 +34,7 @@
     "postcss-preset-env": "^11.2.0",
     "postcss-scss": "^4.0.6",
     "sass-embedded": "^1.63.6",
-    "shakapacker": "^10.3.1",
+    "shakapacker": "10.3.2",
     "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "tailwindcss": "^3.4.19",


### PR DESCRIPTION
#### :tophat: What? Why?

This is an alternative approach to https://github.com/decidim/decidim/pull/17578

After applying the `minify`change, I also saw other errors locally related to the versions of `framer-motion`, `motion-dom` and `motion-utils` npm packages (dependencies of `graphiql`). As I don't want to start a rabbit hole of dependencies, I prefer to just downgrade the webpack version and try again once https://github.com/webpack/webpack/issues/21879 is solved and released (in v5.110.3 or whatever version has that fix).

Finally, there are lots of warnings here that I want to tackle in another PR. Currently there's just too much noise here. 

#### :pushpin: Related Issues
 
- Related to #17578 

#### Testing

Pipeline should be green
Building assets locally should work well: 

``` 
rm -rf development_app/public/decidim-packs/
cd development_app
bin/rails assets:precompile
``` 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application development tooling to use Webpack 5.109.0.
  * Standardized the frontend build tooling on a fixed Shakapacker 10.3.2 release for more consistent development and deployment results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->