### PR TITLE
Open Data README counts CSV lines instead of resources

### DIFF
--- a/decidim-core/app/services/decidim/open_data_exporter.rb
+++ b/decidim-core/app/services/decidim/open_data_exporter.rb
@@ -98,8 +98,7 @@ module Decidim
 
             collection.push(filename)
 
-            collection_count = exported.read.split("\n").count - 1
-            get_help_definition(:components, exporter, export_manifest, collection_count) unless collection.empty?
+            get_help_definition(:components, exporter, export_manifest, batch.size) unless collection.empty?
           end
         end
       end

--- a/decidim-proposals/spec/services/decidim/open_data_exporter_spec.rb
+++ b/decidim-proposals/spec/services/decidim/open_data_exporter_spec.rb
@@ -69,4 +69,27 @@ describe Decidim::OpenDataExporter do
 
     it_behaves_like "open data exporter"
   end
+
+  describe "proposals with multi-paragraph bodies" do
+    let(:organization) { create(:organization) }
+    let(:path) { "/tmp/test-open-data-multiline-proposals.zip" }
+    let(:component) do
+      create(:proposal_component, organization:, published_at: Time.current)
+    end
+    # Bodies are exported through `convert_to_plain_text`, which wraps the text and
+    # keeps the paragraph breaks, so a single proposal spans several physical lines
+    # of the generated CSV.
+    let(:body) do
+      { "en" => "<p>#{"lorem ipsum " * 12}</p><p>#{"dolor sit amet " * 12}</p>" }
+    end
+    let!(:proposals) { create_list(:proposal, 2, component:, body:) }
+    let(:readme) do
+      subject.export
+      Zip::File.open(path).glob("README.md").first.get_input_stream.read
+    end
+
+    it "counts resources, not lines of the generated CSV" do
+      expect(readme[/^### proposals \(.*\)$/]).to eq("### proposals (2 resources)")
+    end
+  end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

`Decidim::OpenDataExporter#data_for_resource` counted `exported.read.split("\n").count - 1`
— the physical lines of the generated CSV, not the records in it. CSV keeps newlines inside
quoted fields, and `ProposalSerializer` exports `body` through `convert_to_plain_text`
(Premailer, hard-wrapped at 65 columns, paragraph breaks preserved), so any real proposal
spans several lines. That number is summed into `collection_count` and printed in the
`README.md` shipped inside every organization's Open Data ZIP, so the row counts a city
publishes for its components are inflated.

The two sibling paths in the same class already pass `collection.count` (`data_for_core`,
`data_for_spaces`); only the component path counted lines. This passes `batch.size`, which is
the collection the exporter was built from two lines earlier.

#### :pushpin: Related Issues

The count came in with #13773. No open issue for this.

#### Testing

New example in `decidim-proposals/spec/services/decidim/open_data_exporter_spec.rb`:
two proposals, two paragraphs each. Before the fix the README says
`### proposals (14 resources)`; after, `### proposals (2 resources)`. Reverting only the
service change makes the new example fail with exactly that 14.

Ran the open-data exporter specs in core, proposals, blogs, debates, meetings,
accountability, budgets, pages and surveys — no new failures. Five pre-existing failures in
proposals/blogs/debates/meetings are `Shakapacker::Manifest::MissingEntryError` from my not
having compiled test assets; identical with and without the change. Rubocop clean on both
files.

Why the suite did not catch it: every open-data exporter spec builds its body from
`generate_localized_description`, one `<p>` of roughly 25 characters, which is under
Premailer's wrap — so one record is one physical line and the old expression happened to be
right.

#### :camera: Screenshots

The output is inside a downloaded ZIP rather than on screen, so the README block itself:

```
before:  ### proposals (14 resources)
after:   ### proposals (2 resources)
```
