### PR TITLE
Fix NoMethodError in open data export and moderatedUsers query

### DIFF
--- a/decidim-core/app/serializers/decidim/exporters/open_data_blocked_user_serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/open_data_blocked_user_serializer.rb
@@ -16,10 +16,19 @@ module Decidim
           about: resource.user.about,
           reasons: resource.reports.map(&:reason),
           details: resource.reports.map(&:details),
-          block_reasons: resource.blocking.justification,
-          blocking_user: resource.blocking.blocking_user.presenter.name
+          block_reasons: blocking&.justification,
+          blocking_user: blocking_user&.presenter&.name
         }
       end
+
+      private
+
+      # The collection filters on `decidim_users.blocked_at`, but this
+      # association is resolved through `decidim_users.block_id`. The two can
+      # disagree, in which case there is no block to read the details from.
+      def blocking = resource.blocking
+
+      def blocking_user = blocking&.blocking_user
     end
   end
 end

--- a/decidim-core/app/serializers/decidim/exporters/open_data_moderation_serializer.rb
+++ b/decidim-core/app/serializers/decidim/exporters/open_data_moderation_serializer.rb
@@ -14,7 +14,7 @@ module Decidim
           id: resource.id,
           hidden_at: resource.hidden_at,
           report_count: resource.report_count,
-          reported_url: resource.reportable.reported_content_url,
+          reported_url:,
           reportable_type: resource.decidim_reportable_type,
           reportable_id: resource.decidim_reportable_id,
           reported_content: resource.reported_content,
@@ -24,6 +24,30 @@ module Decidim
             details: resource.reports.map(&:details)
           }
         }
+      end
+
+      private
+
+      # `Decidim::Moderation#reportable` is polymorphic, so the database cannot
+      # enforce the reference, and the moderation row outlives the resource it
+      # points at. Both of the cases below leave the moderation in the export
+      # collection with no URL to build.
+      def reported_url
+        reportable = resource.reportable
+
+        # The resource is gone. Reportables such as proposals and meetings are
+        # soft-deletable while `belongs_to :reportable` does not use
+        # `with_deleted`, so moving one to the trash is enough for this.
+        return if reportable.nil?
+
+        # The component is gone but the resource is not: trashing a component
+        # does not trash its contents. `ResourceLocatorPresenter#route_proxy`
+        # falls back to the resource itself when `component` is nil, and
+        # `EngineRouter.main_proxy` then calls `mounted_engine` on it, which
+        # only components and participatory spaces respond to.
+        return if reportable.is_a?(Decidim::HasComponent) && reportable.component.nil?
+
+        reportable.reported_content_url
       end
     end
   end

--- a/decidim-core/lib/decidim/api/types/user_moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_moderation_type.rb
@@ -21,7 +21,7 @@ module Decidim
       end
 
       def block_reasons
-        object.blocking.justification
+        object.blocking&.justification
       end
 
       def blocked_at
@@ -29,7 +29,7 @@ module Decidim
       end
 
       def blocking_user
-        object.blocking.blocking_user
+        object.blocking&.blocking_user
       end
     end
   end

--- a/decidim-core/spec/serializers/decidim/exporters/open_data_blocked_user_serializer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/exporters/open_data_blocked_user_serializer_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Exporters
+  describe OpenDataBlockedUserSerializer do
+    subject { described_class.new(resource) }
+
+    let(:organization) { create(:organization) }
+    let(:serialized) { subject.serialize }
+
+    describe "#serialize" do
+      context "when the user has an associated block" do
+        let!(:user_block) { create(:user_block, organization:) }
+        let(:resource) { create(:user_moderation, user: user_block.user) }
+
+        it "includes the block reasons" do
+          expect(serialized).to include(block_reasons: user_block.justification)
+        end
+
+        it "includes the blocking user" do
+          expect(serialized).to include(blocking_user: user_block.blocking_user.presenter.name)
+        end
+      end
+
+      # The collection filters on `decidim_users.blocked_at`, but `blocking` is
+      # resolved through `decidim_users.block_id`. Users blocked before #11235
+      # have the former set and the latter still NULL, so the association
+      # returns nil and the whole open data export used to abort here.
+      context "when the user is blocked but has no associated block" do
+        let(:user) { create(:user, :blocked, :confirmed, organization:) }
+        let(:resource) { create(:user_moderation, user:) }
+
+        before { user.update!(block_id: nil, blocked_at: Time.current) }
+
+        it "does not raise" do
+          expect { serialized }.not_to raise_error
+        end
+
+        it "serializes the block reasons as nil" do
+          expect(serialized).to include(block_reasons: nil)
+        end
+
+        it "serializes the blocking user as nil" do
+          expect(serialized).to include(blocking_user: nil)
+        end
+
+        it "still serializes the rest of the record" do
+          expect(serialized).to include(user_id: user.id, about: user.about)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/serializers/decidim/exporters/open_data_moderation_serializer_spec.rb
+++ b/decidim-core/spec/serializers/decidim/exporters/open_data_moderation_serializer_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::Exporters
+  describe OpenDataModerationSerializer do
+    subject { described_class.new(resource) }
+
+    let(:resource) { create(:moderation, :hidden, reportable:) }
+    let(:reportable) { create(:dummy_resource) }
+    let(:serialized) { subject.serialize }
+
+    describe "#serialize" do
+      context "when the reportable can be resolved" do
+        it "includes the reported url" do
+          expect(serialized).to include(reported_url: reportable.reported_content_url)
+        end
+
+        it "includes the moderation data" do
+          expect(serialized).to include(
+            id: resource.id,
+            report_count: resource.report_count,
+            reportable_type: resource.decidim_reportable_type,
+            reportable_id: resource.decidim_reportable_id
+          )
+        end
+      end
+
+      # `belongs_to :reportable` is polymorphic, so the reference cannot be
+      # enforced by the database. Reportables such as proposals and meetings are
+      # also soft-deletable without `with_deleted` here, so moving one to the
+      # trash is enough to reach this state.
+      context "when the reportable no longer exists" do
+        before do
+          reportable.destroy!
+          resource.reload
+        end
+
+        it "does not raise" do
+          expect { serialized }.not_to raise_error
+        end
+
+        it "serializes the reported url as nil" do
+          expect(serialized).to include(reported_url: nil)
+        end
+
+        it "still serializes the rest of the record" do
+          expect(serialized).to include(
+            id: resource.id,
+            reportable_type: resource.decidim_reportable_type,
+            reportable_id: resource.decidim_reportable_id
+          )
+        end
+      end
+
+      # Trashing a component does not trash its contents, so the resource
+      # survives with an unresolvable component. `ResourceLocatorPresenter`
+      # would then hand the resource itself to `EngineRouter.main_proxy`, which
+      # calls `mounted_engine` on it.
+      context "when the component of the reportable was deleted" do
+        before do
+          reportable.component.destroy
+          resource.reload
+        end
+
+        it "does not raise" do
+          expect { serialized }.not_to raise_error
+        end
+
+        it "serializes the reported url as nil" do
+          expect(serialized).to include(reported_url: nil)
+        end
+      end
+    end
+  end
+end

--- a/decidim-core/spec/types/user_moderation_type_spec.rb
+++ b/decidim-core/spec/types/user_moderation_type_spec.rb
@@ -74,6 +74,30 @@ module Decidim
           expect(response).to eq("userId" => moderation.user.id.to_s)
         end
       end
+
+      # The collection filters on `decidim_users.blocked_at`, but `blocking` is
+      # resolved through `decidim_users.block_id`. Users blocked before #11235
+      # have the former set and the latter still NULL, so the association
+      # returns nil. Both fields are already declared `null: true`.
+      context "when the user is blocked but has no associated block" do
+        before { user.update!(block_id: nil, blocked_at: Time.current) }
+
+        describe "block_reasons" do
+          let(:query) { "{ blockReasons }" }
+
+          it "returns nil instead of raising" do
+            expect(response).to eq("blockReasons" => nil)
+          end
+        end
+
+        describe "blocking_user" do
+          let(:query) { "{ blockingUser { id } }" }
+
+          it "returns nil instead of raising" do
+            expect(response).to eq("blockingUser" => nil)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

Three places call methods on associations that the collections feeding them do not guarantee to be resolvable, so a single inconsistent record raises `NoMethodError` and aborts the whole open data export.

**Blocked users** — `OpenDataBlockedUserSerializer` and `UserModerationType`

The collections filter on `decidim_users.blocked_at`, but `blocking` is resolved through a different column, `decidim_users.block_id`:

```ruby
# decidim-core/app/models/decidim/user_base_entity.rb
has_one :blocking, class_name: "Decidim::UserBlock", foreign_key: :id, primary_key: :block_id, dependent: :destroy
```

Users blocked before v0.26.8 / v0.27.4 have the former set and the latter still `NULL`. Until #11235 the block command did `form.user.blocking = @current_blocking`, and because `has_one :blocking` inverts the usual key roles, that assignment never wrote `block_id`. The upgrade task shipped with that fix only backfills the missing `UserModeration` rows, so those users survive every later upgrade in the same state.

Both GraphQL fields are already declared `null: true`, so `nil` is an expected value there — only the resolvers did not allow for it.

**Moderations** — `OpenDataModerationSerializer`

`Decidim::Moderation#reportable` is polymorphic, so the reference cannot be enforced by the database, and two situations leave it unusable:

1. **The resource is gone.** Proposals and meetings are soft-deletable while `belongs_to :reportable` does not use `with_deleted`, so moving one to the trash is enough for the association to return `nil`. This is the case we hit in production.
2. **The component is gone but the resource is not.** Trashing a component does not trash its contents. `ResourceLocatorPresenter#route_proxy` then falls back to the resource itself and `EngineRouter.main_proxy` calls `mounted_engine` on it, which only components and participatory spaces respond to.

The second case does not apply to comments, whose `reported_content_url` already returns early when `root_commentable` is missing, so the guard is scoped with `is_a?(Decidim::HasComponent)` to avoid changing their behaviour.

**Impact**

`moderated_users` and `moderations` are the first two core manifests processed in `OpenDataExporter#data_for_all_resources`, so either failure aborts the export before any file is written — no proposals, no meetings, no users. And since `OpenDataController#download` enqueues `OpenDataJob` whenever no file is attached, every click on a download link enqueues another job that fails the same way.

This follows the same approach as the earlier fixes in #13592 (`ProposalSerializer`, `MeetingSerializer`, `DebateSerializer`) and #16121 (`CommentSerializer`).

#### :pushpin: Related Issues

- Related to #17574

#### Testing

Specs are added for both serializers and extended for the GraphQL type, covering the healthy record, the missing block, the missing reportable and the deleted component.

```
cd decidim-core
bundle exec rspec \
  spec/serializers/decidim/exporters/open_data_blocked_user_serializer_spec.rb \
  spec/serializers/decidim/exporters/open_data_moderation_serializer_spec.rb \
  spec/types/user_moderation_type_spec.rb
```

```
24 examples, 0 failures
```

Reverting the three guards makes 11 of those 24 examples fail, so the specs do exercise the behaviour rather than just the happy path.

To reproduce the bug manually, block a user and then clear `block_id` (`user.update!(block_id: nil)`), or report a proposal and move it to the trash, then request the open data export.

### :camera: Screenshots

n/a — background job and API only.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved moderation data exports for users marked as blocked without an associated block record.
  * Prevented errors when moderation reports reference deleted content or unavailable components.
  * Ensured missing block reasons, blocking users, and reported URLs are returned as empty values instead of causing failures.

* **Tests**
  * Added coverage for missing block records and unavailable moderation reportables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->