### PR TITLE
Add sidekiq configuration copy to decidim:upgrade task

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,18 @@ This change is based on the GDPR regulation:
 
 You can read more about this change on PR [#11036](https://github.com/decidim/decidim/pull/11036).
 
+### 2.3. Sidekiq configuration overwrite
+
+As we are doing changes in the default sidekiq.yml configuration and we want to do them automatically, this file will be overwritten during the upgrade process (on the `bin/rails decidim:ugprade` command).
+
+If you have queues or any configuration particular to your environment that you do not want to get overwriten, you can do so by calling another configuration file on the sidekiq daemon call. For instance:
+
+```bash
+sidekiq -C config/sidekiq.yml -C config/sidekiq.local.yml
+```
+
+You can read more about this change on PR [#17596](https://github.com/decidim/decidim/pull/17596).
+
 ### 2.2. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,9 +58,9 @@ You can read more about this change on PR [#11036](https://github.com/decidim/de
 
 ### 2.3. Sidekiq configuration overwrite
 
-As we are doing changes in the default sidekiq.yml configuration and we want to do them automatically, this file will be overwritten during the upgrade process (on the `bin/rails decidim:ugprade` command).
+As we are doing changes in the default sidekiq.yml configuration and we want to do them automatically, this file will be overwritten during the upgrade process (on the `bin/rails decidim:upgrade` command).
 
-If you have queues or any configuration particular to your environment that you do not want to get overwriten, you can do so by calling another configuration file on the sidekiq daemon call. For instance:
+If you have queues or any configuration particular to your environment that you do not want to get overwritten, you can do so by calling another configuration file on the sidekiq daemon call. For instance:
 
 ```bash
 sidekiq -C config/sidekiq.yml -C config/sidekiq.local.yml

--- a/decidim-core/lib/tasks/decidim_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_tasks.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "thor"
+
 namespace :decidim do
   desc "Performs upgrade tasks (migrations, node, docs )."
   task upgrade: [
@@ -9,10 +11,28 @@ namespace :decidim do
     :"railties:install:migrations",
     :"decidim:upgrade:migrations",
     :"decidim:upgrade:shakapacker",
+    :"decidim:upgrade:sidekiq",
     :"decidim_api:generate_docs"
   ]
 
   task update: [:upgrade]
+
+  namespace :upgrade do
+    desc "Copy the sidekiq configuration file"
+    task :sidekiq do
+      actions :template, "sidekiq.yml.erb", "config/sidekiq.yml"
+    end
+
+    class SidekiqConfigActions < Thor
+      include Thor::Actions
+
+      source_root File.join(Gem.loaded_specs["decidim-generators"].full_gem_path, "lib", "decidim", "generators", "app_templates")
+    end
+
+    def actions(*)
+      SidekiqConfigActions.new.send(*)
+    end
+  end
 
   desc "Sets up environment so that only decidim migrations are installed."
   task :choose_target_plugins do

--- a/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
@@ -33,6 +33,7 @@ describe "rake decidim:upgrade:sidekiq", type: :task do
         - [exports, 1]
         - [close_meeting_reminder, 1]
         - [spam_analysis, 1]
+        - [active_storage, 1]
     YAML
   end
 end

--- a/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:upgrade:sidekiq", type: :task do
+  around do |example|
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        example.run
+      end
+    end
+  end
+
+  it "copies the sidekiq configuration file" do
+    task.execute
+
+    expect(File).to exist("config/sidekiq.yml")
+    expect(File.read("config/sidekiq.yml")).to eq(<<~YAML)
+      :concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 5) %>
+      :queues:
+        - [mailers, 4]
+        - [vote_reminder, 2]
+        - [reminders, 2]
+        - [default, 2]
+        - [delete_inactive_participants, 2]
+        - [newsletter, 2]
+        - [newsletters_opt_in, 2]
+        - [conference_diplomas, 2]
+        - [events, 2]
+        - [translations, 2]
+        - [user_report, 2]
+        - [block_user, 2]
+        - [exports, 1]
+        - [close_meeting_reminder, 1]
+        - [spam_analysis, 1]
+    YAML
+  end
+end

--- a/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
+++ b/decidim-core/spec/tasks/upgrade/decidim_tasks_sidekiq_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "readline"
 
 describe "rake decidim:upgrade:sidekiq", type: :task do
   around do |example|
@@ -35,5 +36,51 @@ describe "rake decidim:upgrade:sidekiq", type: :task do
         - [spam_analysis, 1]
         - [active_storage, 1]
     YAML
+  end
+
+  context "when a custom config/sidekiq.yml already exists" do
+    let(:custom_content) { "# custom sidekiq configuration\n" }
+    let(:expected_content) do
+      <<~YAML
+        :concurrency: <%= ENV.fetch("SIDEKIQ_CONCURRENCY", 5) %>
+        :queues:
+          - [mailers, 4]
+          - [vote_reminder, 2]
+          - [reminders, 2]
+          - [default, 2]
+          - [delete_inactive_participants, 2]
+          - [newsletter, 2]
+          - [newsletters_opt_in, 2]
+          - [conference_diplomas, 2]
+          - [events, 2]
+          - [translations, 2]
+          - [user_report, 2]
+          - [block_user, 2]
+          - [exports, 1]
+          - [close_meeting_reminder, 1]
+          - [spam_analysis, 1]
+          - [active_storage, 1]
+      YAML
+    end
+
+    before do
+      FileUtils.mkdir_p("config")
+      File.write("config/sidekiq.yml", custom_content)
+    end
+
+    it "preserves the existing file when rejecting the replacement prompt" do
+      allow(Readline).to receive(:readline).and_return("n")
+
+      expect { task.execute }.not_to(change { File.read("config/sidekiq.yml") })
+      expect(File.read("config/sidekiq.yml")).to eq(custom_content)
+    end
+
+    it "replaces the existing file when accepting the replacement prompt" do
+      allow(Readline).to receive(:readline).and_return("Y")
+
+      task.execute
+
+      expect(File.read("config/sidekiq.yml")).to eq(expected_content)
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #17520, I noticed that we need to have a release note for updating this file manually. I was preparing the oneliner for wget, but then I realized that it just would be better to have this file managed with the `decidim:upgrade` task so it is get overwritten automatically. 

For now I'm not forcing the file, so the implementer would have a prompt to accept/view diff/etc of the change. To be honest I'm not 100% sure what is the best option here: 

1. override directly 
2. to ask for confirmation to implementer (as it is now)

Either way I'm also adding a Release Note so it isn't an unexpected thing for the implementer (or at least is documented if they have the question during the upgrade process)

#### :pushpin: Related Issues
 
- Related to #17520 

#### Testing

1. Do changes to `decidim-generators/lib/decidim/generators/app_templates/sidekiq.yml.erb`
2. Run `bin/rails decidim:upgrade`
3. See that you get asked for changing this file  

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an upgrade step to create or overwrite the default Sidekiq configuration.
  * Added configurable concurrency and queue priorities, including the dedicated `active_storage` queue.
  * Configure concurrency with `SIDEKIQ_CONCURRENCY`; the default is 5.
  * Active Storage jobs now require a Sidekiq process consuming the `active_storage` queue.
  * Keep environment-specific settings in a separate configuration file.

* **Tests**
  * Added coverage for configuration generation, replacement prompts, and custom configuration preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->