### PR TITLE
Fix fetch of proposals state when importing to projects

### DIFF
--- a/decidim-proposals/app/packs/src/decidim/proposals/admin/controllers/import_proposals/controller.js
+++ b/decidim-proposals/app/packs/src/decidim/proposals/admin/controllers/import_proposals/controller.js
@@ -62,8 +62,10 @@ export default class ImportProposalsController extends Controller {
       return;
     }
 
-    const url = `${this.statesUrlValue}?origin_id=${componentId}`;
-    fetch(url, {
+    const url = new URL(this.statesUrlValue, window.location.origin);
+    url.searchParams.append("origin_id", componentId);
+    
+    fetch(url.toString(), {
       credentials: "same-origin",
       headers: { Accept: "application/json" }
     }).then((res) => {


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

When importing proposals to projects, the url was encoded with the `locale`, and the js appended the `origin_id` parameter after, making it not work properly.

This is only for decidim <= 0.32 (before the changes of use of locales -> from ?locale=en to /en/).

In case I should point this commit to another branch (release/0.31-stable or other), just tell me, because i understand it's not going to be merged to `develop` because the problem is not there.

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes #17597 

#### Testing
*Describe the best way to test or validate your PR.*
Reproduce the steps of the issue, and make sure that the proposals state appear in every language.

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved state loading during proposal imports by ensuring requests correctly include the selected origin identifier.
  - Prevented malformed state requests when the application is hosted under different URL paths or configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->