### PR TITLE
Improve asset routing in jobs

### DIFF
--- a/decidim-core/app/jobs/concerns/decidim/job_with_assets.rb
+++ b/decidim-core/app/jobs/concerns/decidim/job_with_assets.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  # This module configures the asset router for the jobs as there is no request
+  # present causing the asset router have to do extra work when resolving the
+  # correct hostname for each asset separately. This can be heavy especially
+  # during export jobs when potentially a large amount of records is exported
+  # and the host resolving would have to be otherwise repeated for each record
+  # individually causing potentially a lot of unnecessary database queries
+  # performed during the job.
+  #
+  # The best way to use this is to have a named argument `organization` defined
+  # for the `#perform` method of the job that has the associated organization.
+  # This module will resolve the organization from the value passed to that
+  # argument position. Alternatively, if one of the arguments passed to the
+  # `#perform` method return the organization through the `#organization` method
+  # or association, that will also work. Otherwise, the default host will be
+  # configured for the assets through `EngineRouter#default_url_options`.
+  module JobWithAssets
+    extend ActiveSupport::Concern
+
+    included do
+      before_perform :configure_activestorage
+    end
+
+    private
+
+    # Configures the ActiveStorage URL options for generating asset URLs.
+    #
+    # @return [void]
+    def configure_activestorage
+      options = EngineRouter.new("main_app", {}).default_url_options
+      options[:host] = organization.host if organization
+      return if options[:host].blank?
+
+      ActiveStorage::Current.url_options = options
+    end
+
+    # Resolves the organization through the arguments passed to the `perform`
+    # method and returns the value if found.
+    #
+    # @return [Decidim::Organization, nil] The resolved organization record or
+    #   nil if it could not be resolved.
+    def organization
+      return @organization if instance_variable_defined?(:@organization)
+
+      @organization = OrganizationArgumentResolver.resolve(method(:perform), arguments)
+    end
+
+    class OrganizationArgumentResolver
+      # Syntatic sugar for creating a new instance and running the `#resolve`
+      # method on it.
+      #
+      # @param source_method (see #initialize)
+      # @param values (see #initialize)
+      # @return (see #resolve)
+      def self.resolve(source_method, values)
+        new(source_method, values).resolve
+      end
+
+      # Initializes the resolver.
+      #
+      # @param source_method [Method] The source method that receives the
+      #   arguments.
+      # @param values [Array] An array of the values passed to the
+      #   source_method's arguments.
+      def initialize(source_method, values)
+        @source_method = source_method
+        @values = values
+      end
+
+      # Tries to resolve the organization from the source method arguments and
+      # their values.
+      #
+      # @return [Decidim::Organization, nil] The resolved organization record or
+      #   nil if not found.
+      def resolve
+        from_named_argument || from_argument_values || from_argument_value_associations
+      end
+
+      private
+
+      attr_reader :source_method, :values
+
+      # Finds the position of the named argument `organization` if such argument
+      # is defined for the source method. If defined, fetches its value and
+      # returns it if it is a `Decidim::Organization`.
+      #
+      # @return [Decidim::Organization, nil] The resolved organization record or
+      #   nil if not found.
+      def from_named_argument
+        org_arg = source_method.parameters.find_index { |p| p[0] == :req && p[1] == :organization }
+        org = values[org_arg] unless org_arg.nil?
+        org if org.is_a?(Decidim::Organization)
+      end
+
+      # Iterates over all arguments and returns the value if the value is a
+      # `Decidim::Organization`.
+      #
+      # @return [Decidim::Organization, nil] The resolved organization record or
+      #   nil if not found.
+      def from_argument_values
+        org = values.find { |arg| arg.is_a?(Decidim::Organization) }
+        org if org.is_a?(Decidim::Organization)
+      end
+
+      # Iterates over all arguments and returns the first value's associated
+      # organization if the value responds to `organization` that returns a
+      # `Decidim::Organization`.
+      #
+      # @return [Decidim::Organization, nil] The resolved organization record or
+      #   nil if not found.
+      def from_argument_value_associations
+        org = values.find { |arg| arg.respond_to?(:organization) }&.organization
+        org if org.is_a?(Decidim::Organization)
+      end
+    end
+  end
+end

--- a/decidim-core/app/jobs/concerns/decidim/job_with_assets.rb
+++ b/decidim-core/app/jobs/concerns/decidim/job_with_assets.rb
@@ -113,8 +113,13 @@ module Decidim
       # @return [Decidim::Organization, nil] The resolved organization record or
       #   nil if not found.
       def from_argument_value_associations
-        org = values.find { |arg| arg.respond_to?(:organization) }&.organization
-        org if org.is_a?(Decidim::Organization)
+        values.each do |arg|
+          next unless arg.respond_to?(:organization)
+
+          return arg.organization if arg.organization.is_a?(Decidim::Organization)
+        end
+
+        nil
       end
     end
   end

--- a/decidim-core/app/jobs/decidim/export_job.rb
+++ b/decidim-core/app/jobs/decidim/export_job.rb
@@ -3,6 +3,7 @@
 module Decidim
   class ExportJob < ApplicationJob
     include Decidim::PrivateDownloadHelper
+    include Decidim::JobWithAssets
 
     queue_as :exports
 

--- a/decidim-core/app/jobs/decidim/open_data_job.rb
+++ b/decidim-core/app/jobs/decidim/open_data_job.rb
@@ -2,6 +2,8 @@
 
 module Decidim
   class OpenDataJob < ApplicationJob
+    include Decidim::JobWithAssets
+
     queue_as :exports
 
     def perform(organization, resource = nil)

--- a/decidim-core/spec/jobs/concerns/decidim/job_with_assets_spec.rb
+++ b/decidim-core/spec/jobs/concerns/decidim/job_with_assets_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::JobWithAssets do
+  let(:organization) { build(:organization) }
+
+  shared_examples "changed current URL options with host" do
+    it "sets the current URL options correctly" do
+      subject
+      expect(state_storage.before).to be_blank
+      expect(state_storage.after).to eq(
+        host: expected_host,
+        port: Capybara.server_port
+      )
+    end
+  end
+
+  shared_examples "unchanged current URL options" do
+    it "does not change the current URL options" do
+      subject
+      expect(state_storage.before).to eq(state_storage.after)
+    end
+  end
+
+  shared_examples "working job with assets" do
+    let(:job_target) { self.class.const_get(:DummyJob) }
+    let(:state_storage) { Struct.new(:before, :after).new }
+    let(:state_tracker) do
+      # Hack needed to track the state before and after when the jobs are run
+      # through the enqueued jobs (`#perform_later`). This is because the
+      # reloader clears `ActiveStorage::Current.url_options` which would cause
+      # it to be empty after the enqueued job has been performed.
+      mod = Module.new do
+        extend ActiveSupport::Concern
+
+        included do
+          before_perform :track_state_before
+          after_perform :track_state_after
+        end
+
+        private
+
+        def track_state_before
+          state_storage.before = ActiveStorage::Current.url_options.dup
+        end
+
+        def track_state_after
+          state_storage.after = ActiveStorage::Current.url_options.dup
+        end
+
+        def state_storage
+          self.class::STORAGE
+        end
+      end
+      mod.tap do |mod|
+        mod.const_set(:STORAGE, state_storage)
+      end
+    end
+
+    around do |example|
+      self.class.const_set(:DummyJob, job_class)
+      example.run
+      self.class.send(:remove_const, :DummyJob)
+    end
+
+    context "with a positional argument named organization" do
+      let(:job_class) do
+        tracker = state_tracker
+        mod = described_class
+        Class.new(Decidim::ApplicationJob) do
+          include tracker
+          include mod
+
+          def perform(first, second, organization, fourth); end
+        end
+      end
+      let(:arguments) { ["first", "second", organization, "fourth"] }
+
+      it_behaves_like "changed current URL options with host" do
+        let(:expected_host) { organization.host }
+      end
+
+      context "when the argument value is not a Decidim::Organization" do
+        let(:arguments) { ["first", "second", nil, "fourth"] }
+
+        it_behaves_like "changed current URL options with host" do
+          let(:expected_host) { "localhost" }
+        end
+
+        context "and default URL options do not define the host" do
+          before { allow(Rails.env).to receive(:local?).and_return(false) }
+
+          it_behaves_like "unchanged current URL options"
+        end
+      end
+    end
+
+    context "with alternatively named argument that is a Decidim::Organization" do
+      let(:job_class) do
+        tracker = state_tracker
+        mod = described_class
+        Class.new(Decidim::ApplicationJob) do
+          include tracker
+          include mod
+
+          def perform(first, org, third, fourth); end
+        end
+      end
+      let(:arguments) { ["first", organization, "third", "fourth"] }
+
+      it_behaves_like "changed current URL options with host" do
+        let(:expected_host) { organization.host }
+      end
+
+      context "when the argument value is not a Decidim::Organization" do
+        let(:arguments) { ["first", "second", nil, "fourth"] }
+
+        it_behaves_like "changed current URL options with host" do
+          let(:expected_host) { "localhost" }
+        end
+
+        context "and default URL options do not define the host" do
+          before { allow(Rails.env).to receive(:local?).and_return(false) }
+
+          it_behaves_like "unchanged current URL options"
+        end
+      end
+    end
+
+    context "with an argument responding to #organization" do
+      let(:job_class) do
+        tracker = state_tracker
+        mod = described_class
+        Class.new(Decidim::ApplicationJob) do
+          include tracker
+          include mod
+
+          def perform(first, second, third, fourth); end
+        end
+      end
+      let(:arguments) { ["first", "second", record, "third"] }
+      let(:record) do
+        if organization.present?
+          build(:user, organization:)
+        else
+          build(:user).tap do |user|
+            user.organization = nil
+          end
+        end
+      end
+
+      it_behaves_like "changed current URL options with host" do
+        let(:expected_host) { organization.host }
+      end
+
+      context "when the organization value is not a Decidim::Organization" do
+        let(:organization) { nil }
+
+        it_behaves_like "changed current URL options with host" do
+          let(:expected_host) { "localhost" }
+        end
+
+        context "and default URL options do not define the host" do
+          before { allow(Rails.env).to receive(:local?).and_return(false) }
+
+          it_behaves_like "unchanged current URL options"
+        end
+      end
+    end
+
+    context "with unresolved organization" do
+      let(:job_class) do
+        tracker = state_tracker
+        mod = described_class
+        Class.new(Decidim::ApplicationJob) do
+          include tracker
+          include mod
+
+          def perform; end
+        end
+      end
+      let(:arguments) { [] }
+
+      it_behaves_like "changed current URL options with host" do
+        let(:expected_host) { "localhost" }
+      end
+
+      context "when default URL options do not define the host" do
+        before { allow(Rails.env).to receive(:local?).and_return(false) }
+
+        it_behaves_like "unchanged current URL options"
+      end
+    end
+  end
+
+  describe "#perform_now" do
+    subject { job_target.perform_now(*arguments) }
+
+    it_behaves_like "working job with assets"
+  end
+
+  describe "#perform_later" do
+    subject { perform_enqueued_jobs(only: job_target) { job_target.perform_later(*arguments) } }
+
+    before do
+      organization&.save!
+
+      if respond_to?(:record)
+        # Insert without validations and callbacks
+        record.class.insert(record.attributes.compact_blank) # rubocop:disable Rails/SkipsModelValidations
+        record.id = record.class.order(:id).last.id
+      end
+    end
+
+    it_behaves_like "working job with assets"
+  end
+end

--- a/decidim-core/spec/jobs/concerns/decidim/job_with_assets_spec.rb
+++ b/decidim-core/spec/jobs/concerns/decidim/job_with_assets_spec.rb
@@ -166,6 +166,15 @@ describe Decidim::JobWithAssets do
 
           it_behaves_like "unchanged current URL options"
         end
+
+        context "and another argument has a valid organization association" do
+          let(:arguments) { ["first", record, "third", valid_record] }
+          let(:valid_record) { build(:user) }
+
+          it_behaves_like "changed current URL options with host" do
+            let(:expected_host) { valid_record.organization.host }
+          end
+        end
       end
     end
 
@@ -211,6 +220,7 @@ describe Decidim::JobWithAssets do
         record.class.insert(record.attributes.compact_blank) # rubocop:disable Rails/SkipsModelValidations
         record.id = record.class.order(:id).last.id
       end
+      valid_record.save! if respond_to?(:valid_record)
     end
 
     it_behaves_like "working job with assets"


### PR DESCRIPTION
#### :tophat: What? Why?
During other work I discovered a performance issue with the asset routing which I am fixing in another PR.

During that fix I also thought that loading the current host through the record organizations during background jobs is not even necessary most of the times. This can be improved by setting `ActiveStorage::Current.url_options` once at the beginning of the job and then using the same options throughout the background jobs.

For example, if you are exporting 1000 records, the organization could be currently fetched 1000 times through the asset router (which also causes other queries during the URL resolving). With this change, the amount of additional queries needed to achieve the same result is 0 or 1 (if the organization is fetched e.g. through a component or a user).

#### :pushpin: Related Issues
- Related to #17599

#### Testing
Run the added specs and also the specs related to the jobs where this concern is applied to.

I also explained further to test the performance impact at the related issue. Note that to see the performance impact, that PR needs to be first merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Export and open data jobs now generate asset links using the relevant organization’s host.
  - Asset URLs produced during background processing include appropriate local server settings when applicable.
  - Jobs without a resolvable organization continue using the existing default URL behavior.
  - Organization details are resolved reliably when multiple job arguments are present.

- **Tests**
  - Added coverage for organization-aware asset URLs across immediate and queued job execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->