### PR TITLE
Fix flaky spec at `mobile_header_spec.rb`

### DIFF
--- a/decidim-core/spec/system/mobile_header_spec.rb
+++ b/decidim-core/spec/system/mobile_header_spec.rb
@@ -27,6 +27,7 @@ describe "Mobile header" do
       switch_to_host(organization.host)
       visit decidim.root_path
       click_on(id: "dc-dialog-accept")
+      expect(page).to have_no_css("#dc-dialog-accept")
     end
 
     it "has a header" do

--- a/decidim-core/spec/system/mobile_header_spec.rb
+++ b/decidim-core/spec/system/mobile_header_spec.rb
@@ -27,7 +27,6 @@ describe "Mobile header" do
       switch_to_host(organization.host)
       visit decidim.root_path
       click_on(id: "dc-dialog-accept")
-      expect(page).to have_no_css("#dc-dialog-accept")
     end
 
     it "has a header" do
@@ -59,7 +58,7 @@ describe "Mobile header" do
 
     context "when user is logged in" do
       before do
-        switch_to_host(organization.host)
+        wait_pending_requests
         login_as user, scope: :user
         visit decidim.root_path
       end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky spec at example run:
https://github.com/decidim/decidim/actions/runs/33789304080/job/100761716000

Relevant test output:
```
Failures:

  1) Mobile header when user visit a mobile browser when user is logged in displays an avatar on the header
     Failure/Error: expect(page).to have_css(".main-bar__avatar")
       expected to find css ".main-bar__avatar" but there were no matches

     # ./spec/system/mobile_header_spec.rb:67:in 'block (4 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/mobile_header_spec.rb:66 # Mobile header when user visit a mobile browser when user is logged in displays an avatar on the header
```

#### :pushpin: Related Issues
- Related to #17600

#### Testing
```
cd decidim-core
for i in {1..40}; do bundle exec rspec ./spec/system/mobile_header_spec.rb:66 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the logged-in mobile header test by waiting for pending requests before continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->