### PR TITLE
Fix special characters being double-escaped by decidim_html_escape

### DIFF
--- a/decidim-accountability/spec/system/explore_results_spec.rb
+++ b/decidim-accountability/spec/system/explore_results_spec.rb
@@ -163,6 +163,28 @@ describe "Explore results", :versioning do
           end
         end
       end
+
+      context "when filtering by a taxonomy with special characters in its name" do
+        let(:taxonomy) do
+          create(:taxonomy, :with_parent, skip_injection: true, organization:, name: { en: "Accessibility, inclusion & equal d'opportunities" })
+        end
+        let(:path) do
+          decidim_participatory_process_accountability.results_path(
+            participatory_process_slug: participatory_process.slug,
+            component_id: component.id,
+            locale: I18n.locale,
+            filter: { taxonomies_part_of_contains: taxonomy.id }
+          )
+        end
+
+        it "shows the taxonomy name escaped only once" do
+          within("main h2") do
+            expect(page).to have_text("Accessibility, inclusion & equal d'opportunities")
+            expect(page).to have_no_text("&#39;")
+            expect(page).to have_no_text("&amp;")
+          end
+        end
+      end
     end
 
     describe "show" do

--- a/decidim-core/app/helpers/decidim/sanitize_helper.rb
+++ b/decidim-core/app/helpers/decidim/sanitize_helper.rb
@@ -55,8 +55,18 @@ module Decidim
       )
     end
 
+    # Public: Escapes the HTML special characters of a user-inputted string.
+    #
+    # The result is marked as HTML-safe, so that when the views output it with
+    # `<%= %>` (or pass it to a tag helper) Rails does not escape it a second
+    # time. Otherwise, a text such as `it's` would end up as `it&amp;#39;s` in
+    # the HTML and the browser would display the `&#39;` entity literally.
+    #
+    # text - A String (or an object responding to `to_str`).
+    #
+    # Returns an HTML-safe String.
     def decidim_html_escape(text)
-      ERB::Util.unwrapped_html_escape(text.to_str)
+      ERB::Util.html_escape(text.to_str)
     end
 
     def decidim_url_escape(text)

--- a/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
+++ b/decidim-core/spec/helpers/decidim/sanitize_helper_spec.rb
@@ -45,6 +45,43 @@ module Decidim
         end
       end
 
+      context "when html_escape is invoked" do
+        let(:user_input) { "Accessibilitat, inclusió i igualtat d'oportunitats <script>alert(\"XSS\")</script>" }
+
+        it "escapes the HTML special characters" do
+          expect(helper.decidim_html_escape(user_input)).to eq(
+            "Accessibilitat, inclusió i igualtat d&#39;oportunitats &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;"
+          )
+        end
+
+        it "returns an HTML-safe string so it is not escaped again when rendered" do
+          escaped = helper.decidim_html_escape(user_input)
+
+          expect(escaped).to be_html_safe
+          expect(helper.content_tag(:span, escaped)).to eq(
+            "<span>Accessibilitat, inclusió i igualtat d&#39;oportunitats &lt;script&gt;alert(&quot;XSS&quot;)&lt;/script&gt;</span>"
+          )
+        end
+
+        it "escapes the content even when the input is marked as HTML-safe" do
+          escaped = helper.decidim_html_escape("<b>d'oportunitats</b>".html_safe)
+
+          expect(escaped).to eq("&lt;b&gt;d&#39;oportunitats&lt;/b&gt;")
+          expect(escaped).to be_html_safe
+        end
+      end
+
+      context "when escape_translated is invoked" do
+        let(:user_input) { { "ca" => "Igualtat d'oportunitats", "en" => "Equal opportunities" } }
+
+        it "escapes the translated value and returns an HTML-safe string" do
+          I18n.with_locale(:ca) do
+            expect(helper.decidim_escape_translated(user_input)).to eq("Igualtat d&#39;oportunitats")
+            expect(helper.decidim_escape_translated(user_input)).to be_html_safe
+          end
+        end
+      end
+
       context "when url_escape is invoked" do
         it "escapes javascript: in the URL" do
           expect(helper.decidim_url_escape("javascript:alert('hello')")).to eq("alert(&#39;hello&#39;)")


### PR DESCRIPTION
#### :tophat: What? Why?
Titles and names containing characters such as `'` or `&` are displayed with their HTML entities visible (`d&#39;oportunitats`, `Children &amp; parents`) in many public and admin views.

The cause is `Decidim::SanitizeHelper#decidim_html_escape`. It escapes the text with `ERB::Util.unwrapped_html_escape`, which returns a plain `String` without the `html_safe` flag.
When a view outputs it with `<%= %>` (or a tag helper), Rails escapes it a second time: `d'oportunitats` → `d&#39;oportunitats`.

This PR makes `decidim_html_escape` use `ERB::Util.html_escape`, so the (already escaped) result is marked as `html_safe` and is escaped exactly once. The content of the returned string does not change, only the flag, so there is no security impact.

#### :pushpin: Related Issues

#### Testing
1. As an admin, create a taxonomy whose name contains an apostrophe and an ampersand, e.g. `Children's & parents' rights`.
2. Create a taxonomy filter for its root taxonomy, enable it in an Accountability component and assign the taxonomy to a result.
3. Visit the results index filtered by that taxonomy:
  `/processes/<slug>/f/<component_id>/results?filter[taxonomies_part_of_contains]=<taxonomy_id>`.
4. Before this PR the heading reads `Children&#39;s &amp; parents&#39; rights`. After this PR it reads `Children's & parents' rights`.

### :camera: Screenshots
*Please add screenshots of the changes you are proposing*


:hearts: Thank you!
Before:
<img width="1548" height="773" alt="image" src="https://github.com/user-attachments/assets/c2387d6d-1c09-4b84-a0c0-3ea1e5997c74" />

After:
<img width="1527" height="774" alt="image" src="https://github.com/user-attachments/assets/11ab6ded-1971-4da2-b9a5-91abdf5d4706" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed display of taxonomy names containing special characters, including apostrophes and ampersands.
  - Prevented HTML entities from appearing as literal text or being escaped twice in headings and other rendered content.
  - Improved escaping behavior for translated and pre-escaped text, ensuring content displays correctly and safely.

- **Tests**
  - Added coverage for special-character taxonomy names, HTML-safe output, translated content, and prevention of double escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->