### PR TITLE
Fix flaky specs at `ephemeral_action_authorization_spec.rb`

### DIFF
--- a/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
@@ -48,7 +48,10 @@ describe "ephemeral action authorization" do
       end
 
       it "creates an ephemeral user session" do
-        expect { click_on "New proposal" }.to change { Decidim::User.ephemeral.count }.by(1)
+        expect do
+          click_on "New proposal"
+          expect(page).to have_callout("Please verify your identity to proceed.")
+        end.to change { Decidim::User.ephemeral.count }.by(1)
 
         expect(page).to have_link("Close", href: decidim.destroy_user_session_path)
       end
@@ -199,11 +202,12 @@ describe "ephemeral action authorization" do
 
       it "redirects to authorization" do
         visit main_component_path(component)
-        expect { click_on "New proposal" }.not_to change(Decidim::User, :count)
-
-        expect(page).to have_no_text("Verify with Example authorization")
-        expect(page).to have_css("#loginModal", visible: :visible)
-        expect(page).to have_text("Please log in")
+        expect do
+          click_on "New proposal"
+          expect(page).to have_no_text("Verify with Example authorization")
+          expect(page).to have_css("#loginModal", visible: :visible)
+          expect(page).to have_text("Please log in")
+        end.not_to change(Decidim::User, :count)
       end
     end
   end
@@ -251,7 +255,10 @@ describe "ephemeral action authorization" do
         end
 
         it "transfers the authorization" do
-          expect { click_on "Send" }.not_to change(Decidim::Authorization, :count)
+          expect do
+            click_on "Send"
+            expect(page).to have_callout("You have been successfully authorized")
+          end.not_to change(Decidim::Authorization, :count)
           expect(Decidim::Authorization.where(user: ephemeral_user)).to be_blank
           expect(authorization.reload.user).to eq(user)
         end
@@ -259,6 +266,7 @@ describe "ephemeral action authorization" do
         it "transfers the authorship of the proposal" do
           expect(proposal.authors).to contain_exactly(ephemeral_user)
           click_on "Send"
+          expect(page).to have_callout("You have been successfully authorized")
           expect(proposal.reload.authors).to contain_exactly(user)
         end
       end

--- a/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
@@ -121,6 +121,8 @@ describe "ephemeral action authorization" do
                 find("#main-bar [data-close]").click
               end
 
+              expect(page).to have_no_css("#main-bar [data-close]")
+
               visit main_component_path(component)
 
               click_on "New proposal"

--- a/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
+++ b/decidim-verifications/spec/system/ephemeral_action_authorization_spec.rb
@@ -78,6 +78,7 @@ describe "ephemeral action authorization" do
 
         before do
           click_on "New proposal"
+          expect(page).to have_css("form#new_authorization_handler")
 
           fill_in :authorization_handler_document_number, with: document_number
           fill_in :authorization_handler_postal_code, with: postal_code
@@ -100,6 +101,7 @@ describe "ephemeral action authorization" do
           before do
             check :authorization_handler_tos_agreement
             click_on "Send"
+            expect(page).to have_no_css("form#new_authorization_handler")
           end
 
           context "when data matches the authorization criteria" do


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/33843318832/job/100929867712

Relevant test output:
```
Failures:

  1) ephemeral action authorization when an ephemeral authorized user exists and a regular user tries to create a new proposal and verifies with the same data than an ephemeral user transfers the authorship of the proposal
     Failure/Error: expect(proposal.reload.authors).to contain_exactly(user)

       expected collection contained:  [#<Decidim::User id: 262, about: "<script>alert(\"user_about\");</script>Autem non ess...", accepted_...us_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 06:32:48.246365432 +0000">]
       actual collection contained:    [#<Decidim::User id: 261, about: "<script>alert(\"user_about\");</script>Deleniti solu...", accepted_...us_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 06:32:48.062002000 +0000">]
       the missing elements were:      [#<Decidim::User id: 262, about: "<script>alert(\"user_about\");</script>Autem non ess...", accepted_...us_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 06:32:48.246365432 +0000">]
       the extra elements were:        [#<Decidim::User id: 261, about: "<script>alert(\"user_about\");</script>Deleniti solu...", accepted_...us_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 06:32:48.062002000 +0000">]


     # ./spec/system/ephemeral_action_authorization_spec.rb:262:in 'block (5 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/ephemeral_action_authorization_spec.rb:259 # ephemeral action authorization when an ephemeral authorized user exists and a regular user tries to create a new proposal and verifies with the same data than an ephemeral user transfers the authorship of the proposal
```

#### Testing
```
cd decidim-verifications
for i in {1..20}; do bundle exec rspec ./spec/system/ephemeral_action_authorization_spec.rb || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded system test coverage for ephemeral authorization transfers.
  - Added verification that successful transfers display a confirmation message.
  - Improved checks for user-count behavior during authorization flows.
  - Strengthened coverage for regular authorization scenarios where counts should remain unchanged.
  - Added validation that the main-bar close button disappears after closing it during session recovery.
  - Added checks that the ephemeral verification form appears when authorization starts and disappears after successful submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->