### PR TITLE
Fix flaky spec at `proposals_wizards_examples.rb`

### DIFF
--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -217,6 +217,7 @@ shared_examples "proposals wizards" do |options|
 
       it "shows the activity logs" do
         click_on "Publish"
+        expect(page).to have_callout("Proposal successfully published.")
 
         visit decidim.last_activities_path
         expect(page).to have_text("New proposal: #{translated(proposal_draft.title)}")
@@ -272,6 +273,7 @@ shared_examples "proposals wizards" do |options|
       login_as user, scope: :user
       visit_component
       click_on "New proposal"
+      expect(page).to have_css("h1", text: "Create new proposal")
     end
 
     it_behaves_like "with address" if options[:with_address]


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/33843318832/job/100929867712

Relevant test output:
```
Failures:

  1) Proposal behaves like proposals wizards when creating a new proposal behaves like with address when in step_2: Publish shows the activity logs
     Failure/Error: expect(page).to have_text("New proposal: #{translated(proposal_draft.title)}")
       expected to find text "New proposal: More sidewalks and less roads" in "Skip to main content\nGorczany, Ziemann and Reinger\nEnglish\nMenu\nHome\nProcesses\n<script>alert(\"participatory_process_title\");</script> Voluptate vel ipsum. 16893\n<script>alert(\"proposals\");</script> Proposals\nMore sidewalks and less roads\nProposal successfully published.\n  More sidewalks and less roads\nVance Batz\n04/09/2026 19:57\nResource controls\nCities need more people, not more cars\nPlaça Santa Jaume, 1, 08002 Barcelona\n(External link)\nLike\nComment\nShare\n0 comments\nSort by: \n        \n          \nBest rated\n        \n           Recent\n        \n           Older\n        \n           Most discussed\n        \n       Vance Batz\n1000 characters left\n1000 characters left\nPublish comment\nReference: V-PROP-2026-09-343\nWelcome to Gorczany, Ziemann and Reinger participatory platform.\nalert(\"organization_description\"); Consectetur odit nihil. 16881\nDecidim\nProcesses\nMy account\nConfiguration\nMy public profile\nNotifications\nConversations\nResources\nActivity\nMeetings\nOpen Data\nHelp\nTerms of Service\nCookie settings\nGorczany, Ziemann and Reinger at X\n(External link)\nGorczany, Ziemann and Reinger at Facebook\n(External link)\nGorczany, Ziemann and Reinger at Instagram\n(External link)\nGorczany, Ziemann and Reinger at YouTube\n(External link)\nGorczany, Ziemann and Reinger at GitHub\n(External link)\n(External link)\nWebsite made with free software\n(External link)\n.\nCreative Commons License\n(External link)"


     Shared Example Group: "with address" called from ./spec/shared/proposals_wizards_examples.rb:277
     Shared Example Group: "proposals wizards" called from ./spec/system/proposal_wizard_spec.rb:7
     # ./spec/shared/proposals_wizards_examples.rb:222:in 'block (4 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/proposal_wizard_spec.rb[1:2:1:1:2:2] # Proposal behaves like proposals wizards when creating a new proposal behaves like with address when in step_2: Publish shows the activity logs

```

#### Testing
```bash
cd decidim-proposals
for i in {1..20}; do bundle exec rspec ./spec/system/proposal_wizard_spec.rb[1:2:1:1:2:2] || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming a success message appears after publishing a proposal with an address.
  * Added coverage confirming the new proposal page displays the “Create new proposal” heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->