### PR TITLE
Fix flaky spec at `manage_conference_components_examples.rb`

### DIFF
--- a/decidim-conferences/spec/shared/manage_conference_components_examples.rb
+++ b/decidim-conferences/spec/shared/manage_conference_components_examples.rb
@@ -179,6 +179,8 @@ shared_examples "manage conference components" do
           click_on "Publish"
         end
 
+        expect(page).to have_callout("The component has been successfully published.")
+
         expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
                                                 "decidim.events.components.component_published", {
                                                   resource: component,


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/33890255681/job/101079912575

Relevant test output:
```
Failures:

  1) Admin manages conference components behaves like manage conference components publish and unpublish a component when the component is unpublished notifies its followers
     Failure/Error:
       expect(Decidim::EventPublisherJob).to(have_been_enqueued.with(
                                               "decidim.events.components.component_published", {
                                                 resource: component,
                                                 event_class: "Decidim::ComponentPublishedEvent",
                                                 affected_users: [],
                                                 followers: [follower],
                                                 force_send: false,
                                                 extra: {}
                                               }
                                             ))

       expected to enqueue exactly 1 jobs, with ["decidim.events.components.component_published", {resource: #<Decidim::Component id: 14, created_at: "2026-09-04 15:43:52.354646607 +0000", deleted_at: nil, manifest_name: "dummy", name: {"en" => "<script>alert(\"component_name\");</script> Dolor minima perspiciatis. 1751", "ca" => "<script>alert(\"component_name\");</script> Voluptatem quidem nostrum. 1752", "machine_translations" => {"es" => "<script>alert(\"component_name\");</script> A fugiat voluptas. 1753"}}, participatory_space_id: 48, participatory_space_type: "Decidim::Conference", permissions: nil, published_at: nil, settings: {"global" => {"taxonomy_filters" => [], "comments_enabled" => true, "comments_max_length" => 1000, "resources_permissions_enabled" => true, "dummy_global_attribute1" => false, "dummy_global_attribute2" => false, "readonly_attribute" => true, "enable_pads_creation" => false, "amendments_enabled" => false, "dummy_global_translatable_text" => {"en" => "<script>alert(\"dummy_global_translatable_text\");</script> Asperiores quod ab. 1754", "ca" => "<script>alert(\"dummy_global_translatable_text\");</script> Odit voluptatem quia. 1755", "machine_translations" => {"es" => "<script>alert(\"dummy_global_translatable_text\");</script> Tempore tenetur omnis. 1756"}}, "dummy_global_translatable_text_en" => nil, "dummy_global_translatable_text_ca" => nil, "dummy_global_translatable_text_es" => nil}, "default_step" => {"comments_blocked" => false, "dummy_step_attribute1" => false, "dummy_step_attribute2" => false, "dummy_step_translatable_text" => {"en" => "<script>alert(\"dummy_step_translatable_text\");</script> Quo omnis blanditiis. 1757", "ca" => "<script>alert(\"dummy_step_translatable_text\");</script> Voluptate laboriosam ut. 1758", "machine_translations" => {"es" => "<script>alert(\"dummy_step_translatable_text\");</script> Ea et et. 1759"}}, "dummy_step_translatable_text_en" => nil, "dummy_step_translatable_text_ca" => nil, "dummy_step_translatable_text_es" => nil, "readonly_step_attribute" => true, "amendment_creation_enabled" => true, "amendment_reaction_enabled" => true, "amendment_promotion_enabled" => true, "amendments_visibility" => "all", "likes_enabled" => false, "likes_blocked" => false}}, updated_at: "2026-09-04 15:43:52.354646607 +0000", visible: true, weight: 18>, event_class: "Decidim::ComponentPublishedEvent", affected_users: [], followers: [#<Decidim::User id: 47, about: "<script>alert(\"user_about\");</script>Impedit volup...", accepted_tos_version: "2026-09-04 15:43:52.227526130 +0000", admin: false, admin_terms_accepted_at: nil, api_key: nil, block_id: nil, blocked: false, blocked_at: nil, created_at: "2026-09-04 15:43:53.643812704 +0000", decidim_organization_id: 40, delete_reason: nil, deleted_at: nil, digest_sent_at: nil, direct_message_types: "all", email: "user47@example.org", email_on_assigned_proposals: true, email_on_moderations: true, extended_data: {}, followers_count: 0, following_count: 1, follows_count: 0, locale: "en", managed: false, name: "Stan Prosacco", newsletter_notifications_at: nil, newsletter_token: "", nickname: "5gwif_47", notification_settings: {}, notification_types: "all", notifications_sending_frequency: "real_time", officialized_as: nil, officialized_at: nil, password_updated_at: "2026-09-04 15:43:53.627120257 +0000", personal_url: "http://rath.test/laurene.bernhard", previous_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 15:43:53.699088625 +0000">], force_send: false, extra: {}}], but enqueued 0
       Queued jobs:
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 305, byte_size: 67265, checksum: "s8RnHV46B+yTJ0vDgBGxRA==", content_type: "image/jpeg", created_at: "2026-09-04 15:43:52.209360000 +0000", filename: "avatar.jpg", key: "nzxwvxckj2l3ytap1a80ws0f532w", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 306, byte_size: 11898, checksum: "ViB0NB81iSxRSbG/CYaZNA==", content_type: "image/png", created_at: "2026-09-04 15:43:52.213878000 +0000", filename: "icon.png", key: "qfdrzowjn9pkfkmtrnqe31idokn4", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 307, byte_size: 67265, checksum: "s8RnHV46B+yTJ0vDgBGxRA==", content_type: "image/jpeg", created_at: "2026-09-04 15:43:52.304226000 +0000", filename: "avatar.jpg", key: "929qjmsptt0pz8pkvf28nxqcbw5s", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 308, byte_size: 107047, checksum: "ZP4bDPKM3a0W+5rGHO5pqQ==", content_type: "image/jpeg", created_at: "2026-09-04 15:43:52.330788000 +0000", filename: "city.jpeg", key: "9yyw8w9pu0q62a9ogp7txlw0rclr", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 309, byte_size: 130482, checksum: "OdH03rNv5ECy3Gfur3EHOw==", content_type: "image/jpeg", created_at: "2026-09-04 15:43:52.337041000 +0000", filename: "city2.jpeg", key: "vkb7enfcjed0gdvdcut0tipzopez", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         Decidim::FindAndUpdateDescendantsJob job with [#<Decidim::User id: 46, about: "<script>alert(\"user_about\");</script>Quos velit ve...", accepted_tos_version: "2026-09-04 15:43:52.227526000 +0000", admin: true, admin_terms_accepted_at: "2026-09-04 15:43:52.257797000 +0000", api_key: nil, block_id: nil, blocked: false, blocked_at: nil, created_at: "2026-09-04 15:43:52.267614000 +0000", decidim_organization_id: 40, delete_reason: nil, deleted_at: nil, digest_sent_at: nil, direct_message_types: "all", email: "user46@example.org", email_on_assigned_proposals: true, email_on_moderations: true, extended_data: {}, followers_count: 0, following_count: 0, follows_count: 0, locale: "en", managed: false, name: "Yolando Frami", newsletter_notifications_at: nil, newsletter_token: "", nickname: "kmvq_46", notification_settings: {}, notification_types: "all", notifications_sending_frequency: "real_time", officialized_as: nil, officialized_at: nil, password_updated_at: "2026-09-04 15:43:52.257750000 +0000", personal_url: "http://bailey.example/bryan_johnson", previous_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 15:43:52.379126000 +0000">, 0], on queue default, with no priority specified
         ActionMailer::MailDeliveryJob job with ["Decidim::DecidimDeviseMailer", "confirmation_instructions", "deliver_now", {args: [#<Decidim::User id: 47, about: "<script>alert(\"user_about\");</script>Impedit volup...", accepted_tos_version: "2026-09-04 15:43:52.227526000 +0000", admin: false, admin_terms_accepted_at: nil, api_key: nil, block_id: nil, blocked: false, blocked_at: nil, created_at: "2026-09-04 15:43:53.643812000 +0000", decidim_organization_id: 40, delete_reason: nil, deleted_at: nil, digest_sent_at: nil, direct_message_types: "all", email: "user47@example.org", email_on_assigned_proposals: true, email_on_moderations: true, extended_data: {}, followers_count: 0, following_count: 1, follows_count: 0, locale: "en", managed: false, name: "Stan Prosacco", newsletter_notifications_at: nil, newsletter_token: "", nickname: "5gwif_47", notification_settings: {}, notification_types: "all", notifications_sending_frequency: "real_time", officialized_as: nil, officialized_at: nil, password_updated_at: "2026-09-04 15:43:53.627120000 +0000", personal_url: "http://rath.test/laurene.bernhard", previous_passwords: [], roles: [], session_token: nil, updated_at: "2026-09-04 15:43:53.699088000 +0000">, "_oupsdzWqKtdC--m2e84", {}]}], on queue mailers, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 310, byte_size: 67265, checksum: "s8RnHV46B+yTJ0vDgBGxRA==", content_type: "image/jpeg", created_at: "2026-09-04 15:43:53.695002000 +0000", filename: "avatar.jpg", key: "w8oz9ysyyzzwadnfsasda7b2gnue", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 311, byte_size: 12230, checksum: "7xwLm2RU1IL/BV18mfLiHg==", content_type: "image/png", created_at: "2026-09-04 15:43:53.727967000 +0000", filename: "icon.png", key: "f696dix8yrtfgmj4d34j8mot3ovo", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified
         ActiveStorage::AnalyzeJob job with [#<ActiveStorage::Blob id: 312, byte_size: 2155, checksum: "IRBhQTMw8xOY4eNsLi1awg==", content_type: "image/png", created_at: "2026-09-04 15:43:53.861218000 +0000", filename: "icon.png", key: "4d6scrb7fbd3y6lb0fvq8owsihjw", metadata: {"identified" => true}, service_name: "test">], on queue active_storage, with no priority specified

     Shared Example Group: "manage conference components" called from ./spec/system/admin/admin_manages_conference_components_spec.rb:8
     # ./spec/shared/manage_conference_components_examples.rb:182:in 'block (4 levels) in <top (required)>'

Finished in 6 minutes 25 seconds (files took 18.11 seconds to load)
53 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_conference_components_spec.rb[1:1:3:1:2] # Admin manages conference components behaves like manage conference components publish and unpublish a component when the component is unpublished notifies its followers
```

#### Testing
```bash
cd decidim-conferences
for i in {1..20}; do bundle exec rspec ./spec/system/admin/admin_manages_conference_components_spec.rb[1:1:3:1:2] || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Publishing a conference component now displays a confirmation message indicating that the component was successfully published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->