### PR TITLE
Fix flaky specs at `admin_manages_newsletters_spec.rb`

### DIFF
--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -132,9 +132,9 @@ describe "Admin manages newsletters" do
 
         perform_enqueued_jobs do
           click_on "Send me a test email"
+          expect(page).to have_text("Newsletter has been sent")
         end
 
-        expect(page).to have_text("Newsletter has been sent")
         expect(last_email.subject).to include("A fancy newsletter for")
       end
     end
@@ -147,10 +147,10 @@ describe "Admin manages newsletters" do
           find("button[data-controller='dropdown']").click
           perform_enqueued_jobs do
             click_on "Send me a test email"
+            expect(page).to have_text("Newsletter has been sent")
           end
         end
 
-        expect(page).to have_text("Newsletter has been sent")
         expect(last_email.subject).to include("A fancy newsletter for")
       end
     end

--- a/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
+++ b/decidim-admin/spec/system/admin_manages_newsletters_spec.rb
@@ -143,12 +143,12 @@ describe "Admin manages newsletters" do
       it "sends a test email" do
         visit decidim_admin.newsletters_path
 
-        within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
-          find("button[data-controller='dropdown']").click
-          perform_enqueued_jobs do
+        perform_enqueued_jobs do
+          within("tr[data-newsletter-id=\"#{newsletter.id}\"]") do
+            find("button[data-controller='dropdown']").click
             click_on "Send me a test email"
-            expect(page).to have_text("Newsletter has been sent")
           end
+          expect(page).to have_text("Newsletter has been sent")
         end
 
         expect(last_email.subject).to include("A fancy newsletter for")


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/34107678041/job/101696351542

Relevant test output:
```
Failures:

  1) Admin manages newsletters previews a newsletter when admin clicks on the 'send me a test email' button in the index page sends a test email
     Failure/Error: expect(last_email.subject).to include("A fancy newsletter for")

     NoMethodError:
       undefined method 'subject' for nil


     # ./spec/system/admin_manages_newsletters_spec.rb:154:in 'block (4 levels) in <top (required)>'

Finished in 12 minutes 17 seconds (files took 16.16 seconds to load)
188 examples, 1 failure

Failed examples:

rspec ./spec/system/admin_manages_newsletters_spec.rb:143 # Admin manages newsletters previews a newsletter when admin clicks on the 'send me a test email' button in the index page sends a test email
```

#### Testing
```bash
cd decidim-admin
for i in {1..20}; do bundle exec rspec ./spec/system/admin_manages_newsletters_spec.rb:143 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated newsletter email tests to verify that the successful delivery message appears while test emails are being processed.
  - Improved coverage for the newsletter index workflow, including opening the action menu and selecting the test-email option during background job processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->