### PR TITLE
Fix flaky spec at `admin_manages_initiative_components_spec.rb`

### DIFF
--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_components_spec.rb
@@ -60,6 +60,7 @@ describe "Admin manages initiative components" do
     end
 
     it "has a successful admin log" do
+      expect(page).to have_callout("Component created successfully.")
       visit decidim_admin.root_path
       expect(page).to have_text("created #{translated(attributes[:name])} in #{translated(initiative.title)}")
     end


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed this flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/34142393638/job/101807017873

Relevant test output:
```
Failures:

  1) Admin manages initiative components when adds a component has a successful admin log
     Failure/Error: expect(page).to have_text("created #{translated(attributes[:name])} in #{translated(initiative.title)}")
       expected to find text "created <script>alert(\"component_name\");</script> Consequuntur voluptatem commodi. 1089 in <script>alert(\"initiative_title\");</script> Rerum ratione ipsa. 1070" in "Processes\nAssemblies\nInitiatives\nConferences\nGlobal moderations\nPages\nParticipants\nNewsletters\nSettings\nAdmin activity log\nInsights\nTemplates\nMiller and Sons\nSee site\nEnglish\nuser141@example.org\n/\nInitiatives\n/\n<script>alert(\"initiative_title\");</script> Rerum ratione ipsa. 1070\n/\nComponents\nSee initiative\nComponent created successfully.\n  About this initiative\nCommittee members\nComponents\n<script>alert(\"component_name\");</script> Consequuntur voluptatem commodi. 1089\n10\nAttachments\nModerations\nAccess links\nComponents\nAdd component\nComponent name Component type Visibility Actions\n<script>alert(\"component_name\");</script> Consequuntur voluptatem commodi. 1089\nDummy Component\nUnpublished\nView deleted components"

     # ./spec/system/admin/admin_manages_initiative_components_spec.rb:64:in 'block (3 levels) in <top (required)>'

Finished in 4 minutes 5.3 seconds (files took 18.75 seconds to load)
39 examples, 1 failure

Failed examples:

rspec ./spec/system/admin/admin_manages_initiative_components_spec.rb:62 # Admin manages initiative components when adds a component has a successful admin log

```

#### Testing
```bash
cd decidim-initiatives
for i in {1..20}; do bundle exec rspec ./spec/system/admin/admin_manages_initiative_components_spec.rb:62 || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an admin workflow test to verify that a “Component created successfully.” confirmation appears before checking the activity log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->