### PR TITLE
Prevent bug with proposals' unassigned evaluator role activity log

### DIFF
--- a/decidim-proposals/app/presenters/decidim/proposals/admin_log/value_types/evaluator_role_user_presenter.rb
+++ b/decidim-proposals/app/presenters/decidim/proposals/admin_log/value_types/evaluator_role_user_presenter.rb
@@ -8,9 +8,10 @@ module Decidim
           def present
             return unless value
 
-            role = Decidim::Proposals::EvaluationAssignment.find_by(evaluator_role_id: value).evaluator_role
-            user = role.user
-            user.try(:name)
+            assignment = Decidim::Proposals::EvaluationAssignment.find_by(evaluator_role_id: value)
+            return unless assignment
+
+            assignment.evaluator_role&.user&.name
           end
         end
       end

--- a/decidim-proposals/spec/presenters/decidim/proposals/admin_log/value_types/evaluator_role_user_presenter_spec.rb
+++ b/decidim-proposals/spec/presenters/decidim/proposals/admin_log/value_types/evaluator_role_user_presenter_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Proposals::AdminLog::ValueTypes::EvaluatorRoleUserPresenter, type: :helper do
+  subject { described_class.new(value, helper) }
+
+  let(:organization) { create(:organization) }
+  let(:participatory_space) { create(:participatory_process, organization:) }
+  let(:component) { create(:proposal_component, participatory_space:) }
+  let(:proposal) { create(:proposal, component:) }
+
+  describe "#present" do
+    context "when value is nil" do
+      let(:value) { nil }
+
+      it "returns nil" do
+        expect(subject.present).to be_nil
+      end
+    end
+
+    context "when the evaluation assignment exists" do
+      let(:evaluation_assignment) { create(:evaluation_assignment, proposal:) }
+      let(:value) { evaluation_assignment.evaluator_role_id }
+
+      it "returns the evaluator's name" do
+        expect(subject.present).to eq(evaluation_assignment.evaluator.name)
+      end
+    end
+
+    context "when the evaluation assignment has been deleted" do
+      let(:value) { 999_999 }
+
+      it "returns nil" do
+        expect(subject.present).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?

There's a bug on the Activity Log when unassigning an evaluator for a proposal, it is giving an error:

> Information for cause: NoMethodError (undefined method
'evaluator_role' for nil):
>
> evaluator_role_user_presenter.rb:11:in
'Decidim::Proposals::AdminLog::ValueTypes::EvaluatorRoleUserPresenter#present'

This PR fixes this exception

#### Testing

1. As an admin, assign a valuator to a proposal, then unassign them.
2. Open http://localhost:3000/admin/logs
3. (Before the patch) see an exception
4. (After the patch) see that it works

### :camera: Screenshots

#### Before

<img width="1660" height="792" alt="image" src="https://github.com/user-attachments/assets/4a9ed000-02a7-4701-afd2-4d5a6d0e5eb0" />

#### After

<img width="1285" height="414" alt="image" src="https://github.com/user-attachments/assets/1060cb65-5379-456a-b112-c0a827539e69" />

### Stacktrace

``` 
Information for cause: NoMethodError (undefined method 'evaluator_role' for nil):

/workspaces/decidim/decidim-proposals/app/presenters/decidim/proposals/admin_log/value_types/evaluator_role_user_presenter.rb:11:in 'Decidim::Proposals::AdminLog::ValueTypes::EvaluatorRoleUserPresenter#present'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:93:in 'Decidim::Log::DiffPresenter#present_value'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:64:in 'block in Decidim::Log::DiffPresenter#present_previous_value'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/buffers.rb:75:in 'ActionView::OutputBuffer#capture'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/helpers/tag_helper.rb:521:in 'ActionView::Helpers::TagHelper#content_tag'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:62:in 'Decidim::Log::DiffPresenter#present_previous_value'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:48:in 'block (2 levels) in Decidim::Log::DiffPresenter#present_diff'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:46:in 'Array#each'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:46:in 'block in Decidim::Log::DiffPresenter#present_diff'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/buffers.rb:75:in 'ActionView::OutputBuffer#capture'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/helpers/tag_helper.rb:521:in 'ActionView::Helpers::TagHelper#content_tag'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:45:in 'Decidim::Log::DiffPresenter#present_diff'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/diff_presenter.rb:30:in 'Decidim::Log::DiffPresenter#present'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/base_presenter.rb:152:in 'Decidim::Log::BasePresenter#present_diff'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/base_presenter.rb:94:in 'Decidim::Log::BasePresenter#present_dropdown'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/base_presenter.rb:127:in 'block in Decidim::Log::BasePresenter#present_content'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/buffers.rb:75:in 'ActionView::OutputBuffer#capture'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/helpers/tag_helper.rb:521:in 'ActionView::Helpers::TagHelper#content_tag'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/base_presenter.rb:126:in 'Decidim::Log::BasePresenter#present_content'
/workspaces/decidim/decidim-core/app/presenters/decidim/log/base_presenter.rb:161:in 'block in Decidim::Log::BasePresenter#present_action_log'
actionview (8.1.3.1) lib/action_view/helpers/capture_helper.rb:50:in 'block in ActionView::Helpers::CaptureHelper#capture'
actionview (8.1.3.1) lib/action_view/buffers.rb:75:in 'ActionView::OutputBuffer#capture'
```

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved admin activity details when an evaluator assignment is unavailable.
  - Evaluator names now display correctly when the related assignment exists.
  - Missing or deleted assignments no longer cause errors and are shown as unavailable.

- **Tests**
  - Added coverage for missing values, valid evaluator assignments, and deleted assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->