### PR TITLE
Add app_name option to `decidim --help`

### DIFF
--- a/decidim-generators/exe/decidim
+++ b/decidim-generators/exe/decidim
@@ -31,6 +31,7 @@ Options:
   [name]                   creates an application based on Decidim
 
 App generation extra options (ignored if the --component flag is on):
+  --app_name [name]        The name of the app (defaults to nil, which will be inferred from the folder name)
   --storage [provider]     Setup the Gemfile with the appropriate gem to handle a storage provider. Supported options are: local (default), s3, gcs
   --queue [provider]       Setup the Gemfile with the appropriate gem to handle a job queue backend. Only 'sidekiq' is supported as option for now.
   --force_ssl [true|false] Enables or disables mandatory redirection to HTTPS (defaults to enabled)


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

The `decidim --help` command, does not show all the options that the binary has. This PR adds the missing `--app_name` that's used by the generators when creating the `test_app` and `development_app`.

This might need some changes to the `[name]` parameter, since in fact it's the destination folder and if not `--app_name` then the name is inferred from the folder.

#### Testing
*Describe the best way to test or validate your PR.*
- Execute `decidim --help` see the options shown, and check that `--app_name` is not there.
- Execute `./decidim-generators/exe/decidim --help` and see the `--app_name` option from this PR

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the application generator’s CLI help text to document the `--app_name` option.
  - Clarified that the application name can be specified explicitly or inferred from the folder name by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->