### PR TITLE
Add "Hide from the menu" action to activity log

### DIFF
--- a/decidim-core/app/presenters/decidim/admin_log/component_presenter.rb
+++ b/decidim-core/app/presenters/decidim/admin_log/component_presenter.rb
@@ -29,7 +29,7 @@ module Decidim
 
       def action_string
         case action
-        when "export_component", "soft_delete", "restore"
+        when "export_component", "soft_delete", "restore", "menu_hidden"
           "decidim.admin_log.component.#{action}"
         when "create", "delete", "publish", "unpublish", "update_permissions", "update_filters"
           generate_action_string(action)

--- a/decidim-core/config/locales/en.yml
+++ b/decidim-core/config/locales/en.yml
@@ -252,6 +252,7 @@ en:
         create: "%{user_name} added the %{resource_name} component to the %{space_name} space"
         delete: "%{user_name} removed the %{resource_name} component from the %{space_name} space"
         export_component: "%{user_name} exported the %{resource_name} %{component_name} in %{space_name} as %{format_name}"
+        menu_hidden: "%{user_name} hid the %{resource_name} component from the menu in the %{space_name} space"
         publish: "%{user_name} published the %{resource_name} component in the %{space_name} space"
         restore: "%{user_name} restored the %{resource_name} component in the %{space_name} space"
         soft_delete: "%{user_name} moved to trash the %{resource_name} component in the %{space_name} space"

--- a/decidim-core/spec/presenters/decidim/admin_log/component_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/admin_log/component_presenter_spec.rb
@@ -8,6 +8,11 @@ describe Decidim::AdminLog::ComponentPresenter, type: :helper do
     let(:action) { "unpublish" }
   end
 
+  include_examples "present admin log entry" do
+    let(:admin_log_resource) { create(:component, organization:) }
+    let(:action) { "menu_hidden" }
+  end
+
   include_examples "present admin log entry", versioning: true do
     let(:admin_log_resource) { create(:component, organization:) }
     let(:root_taxonomy) { create(:taxonomy, organization:, name: { en: "A taxonomy" }) }


### PR DESCRIPTION
#### :tophat: What? Why?

While working with #17622 I noticed that the "Hide from menu" on components feature doesn't have any action log associated, so it appears as "some action".

This PR adds it.

#### :pushpin: Related Issues
 
- Related to #17622 

#### Testing

1. Log in as admin
2. Go to a Components table in a participatory process
3. Click in the meatballs / action menu in a component and click on "Hide from menu" 
4. Open http://localhost:3000/admin/logs
5. (Before) see that the last action is "performed some action"
6. (After) see that the last action is "hid the XX component from the menu in the" 

### :camera: Screenshots

<img width="1265" height="558" alt="image" src="https://github.com/user-attachments/assets/1946cb4d-cb11-4caf-b72c-f5f4a1449f93" />

#### Before

<img width="1276" height="395" alt="image" src="https://github.com/user-attachments/assets/693471d4-d25a-49a7-bee5-8ad3bccf25d3" />

#### After

<img width="1308" height="418" alt="image" src="https://github.com/user-attachments/assets/b79cbbb7-f133-4aab-a8e9-932a0936405d" />

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin activity logs now correctly display when a component is hidden from the menu.
  - Added a clear English description for this action in participatory space logs.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->