### PR TITLE
Improve sanitization in Action Logs

### DIFF
--- a/decidim-core/app/presenters/decidim/log/base_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/base_presenter.rb
@@ -111,9 +111,18 @@ module Decidim
       # Returns an HTML-safe String.
       def present_explanation
         h.content_tag(:div, class: "logs__log__explanation") do
+          escaped_params = i18n_params.transform_values do |value|
+            if value.is_a?(String) && !value.html_safe?
+              ERB::Util.html_escape(value)
+            else
+              value
+            end
+          end
+
           I18n.t(
             action_string,
-            **i18n_params
+            escape: false,
+            **escaped_params
           ).html_safe
         end
       end

--- a/decidim-core/app/presenters/decidim/log/user_presenter.rb
+++ b/decidim-core/app/presenters/decidim/log/user_presenter.rb
@@ -67,9 +67,9 @@ module Decidim
 
       # Private: Presents the nickname of the user performing the action.
       #
-      # Returns an HTML-safe String.
+      # Returns a String.
       def present_user_nickname
-        extra["nickname"].html_safe
+        extra["nickname"]
       end
 
       # Private: Calculates the path for the user. Returns the path of the

--- a/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
+++ b/decidim-core/spec/presenters/decidim/log/base_presenter_spec.rb
@@ -124,5 +124,68 @@ describe Decidim::Log::BasePresenter, type: :helper do
 
       subject
     end
+
+    context "when preventing XSS attacks" do
+      it "escapes malicious plain text values in i18n_params" do
+        malicious_presenter = Class.new(described_class) do
+          def action_string
+            "decidim.log.base_presenter.create"
+          end
+
+          def i18n_params
+            { user_name: "<script>alert('XSS')</script>", resource_name: "Resource", space_name: "Space" }
+          end
+        end.new(action_log, helper)
+
+        result = malicious_presenter.present
+        expect(result).not_to include("<script>")
+        expect(result).to include("&lt;script&gt;")
+      end
+
+      it "preserves HTML-safe values like user links" do
+        result = presenter.present
+        expect(result).to include("<a")
+        expect(result).to include(user.name)
+      end
+
+      it "escapes malicious values from extra data when used in i18n_params" do
+        malicious_action_log = create(
+          :action_log,
+          user:,
+          action: :create,
+          resource:,
+          extra_data: { "proposal_title" => { "en" => "<img src=x onerror=alert('XSS')>" } }
+        )
+        malicious_presenter = Class.new(described_class) do
+          def action_string
+            "decidim.log.base_presenter.create_with_space"
+          end
+
+          def i18n_params
+            { user_name: "User", resource_name: "Resource", space_name: h.translated_attribute(action_log.extra["proposal_title"]) }
+          end
+        end.new(malicious_action_log, helper)
+
+        result = malicious_presenter.present
+        expect(result).not_to include("<img")
+        expect(result).to include("&lt;img")
+      end
+
+      it "does not double-escape already escaped values" do
+        escaped_presenter = Class.new(described_class) do
+          def action_string
+            "decidim.log.base_presenter.create"
+          end
+
+          def i18n_params
+            { user_name: h.decidim_html_escape("<b>Bold</b>").html_safe, resource_name: "Resource", space_name: "Space" }
+          end
+        end.new(action_log, helper)
+
+        result = escaped_presenter.present
+        expect(result).to include("&lt;b&gt;Bold&lt;/b&gt;")
+        expect(result).not_to include("&amp;lt;b&amp;gt;")
+      end
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that some strings could be malformed in the action logs. This PR fixes this by escaping the strings before calling `html_safe` method

#### :pushpin: Related Issues
 
- Related to #17622 

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against cross-site scripting by safely escaping user-provided values displayed in activity and event descriptions.
  * Preserved trusted links and formatting while preventing malicious content from being rendered as HTML.
  * Prevented already-escaped content from being escaped again, avoiding display issues such as double-encoded characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->