### PR TITLE
Add validation for commentable types in GraphQL API

### DIFF
--- a/decidim-comments/lib/decidim/comments/mutation_extensions.rb
+++ b/decidim-comments/lib/decidim/comments/mutation_extensions.rb
@@ -30,6 +30,8 @@ module Decidim
       end
 
       def commentable(id:, type:, locale: Decidim.default_locale, toggle_translations: false)
+        raise GraphQL::ExecutionError, "Invalid commentable type" unless valid_commentable_type?(type)
+
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
         type.constantize.find(id)
@@ -39,6 +41,16 @@ module Decidim
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
         Comment.find(id)
+      end
+
+      private
+
+      def valid_commentable_type?(type)
+        klass = type.safe_constantize
+        return false unless klass
+        return false unless klass.is_a?(Class)
+
+        klass.include?(Decidim::Comments::Commentable)
       end
     end
   end

--- a/decidim-comments/lib/decidim/comments/query_extensions.rb
+++ b/decidim-comments/lib/decidim/comments/query_extensions.rb
@@ -21,6 +21,7 @@ module Decidim
 
       def commentable(id:, locale:, toggle_translations:, type:)
         raise GraphQL::ExecutionError, "#{locale} is not a valid locale" unless available_locales.include?(locale)
+        raise GraphQL::ExecutionError, "Invalid commentable type" unless valid_commentable_type?(type)
 
         I18n.locale = locale.presence
         RequestStore.store[:toggle_machine_translations] = toggle_translations
@@ -28,6 +29,14 @@ module Decidim
       end
 
       private
+
+      def valid_commentable_type?(type)
+        klass = type.safe_constantize
+        return false unless klass
+        return false unless klass.is_a?(Class)
+
+        klass.include?(Decidim::Comments::Commentable)
+      end
 
       def available_locales
         if context[:current_organization].present?

--- a/decidim-comments/spec/lib/decidim/comments/query_extensions_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/query_extensions_spec.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::Comments::QueryExtensions do
+  let(:organization) { create(:organization) }
+  let(:current_user) { nil }
+  let(:context) do
+    {
+      current_organization: organization,
+      current_user: current_user,
+      scopes: Doorkeeper::OAuth::Scopes.from_string("api:read"),
+      can_introspect: false
+    }
+  end
+
+  describe "commentable query" do
+    let(:query) do
+      <<~GRAPHQL
+        query Commentable($id: String!, $type: String!, $locale: String!, $toggleTranslations: Boolean!) {
+          commentable(id: $id, type: $type, locale: $locale, toggleTranslations: $toggleTranslations) {
+            id
+            type
+          }
+        }
+      GRAPHQL
+    end
+
+    context "when type does not include Decidim::Comments::Commentable" do
+      it "raises an error for Decidim::System::Admin" do
+        variables = {
+          id: "1",
+          type: "Decidim::System::Admin",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to eq("Invalid commentable type")
+      end
+
+      it "raises an error for Decidim::User" do
+        variables = {
+          id: "1",
+          type: "Decidim::User",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to eq("Invalid commentable type")
+      end
+
+      it "raises an error for Doorkeeper::AccessToken" do
+        variables = {
+          id: "1",
+          type: "Doorkeeper::AccessToken",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to eq("Invalid commentable type")
+      end
+
+      it "raises an error for arbitrary class names" do
+        variables = {
+          id: "1",
+          type: "SomeRandomClass",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to eq("Invalid commentable type")
+      end
+
+      it "raises an error for non-existent class names" do
+        variables = {
+          id: "1",
+          type: "NonExistent::Class::Name",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to eq("Invalid commentable type")
+      end
+    end
+
+    context "when type includes Decidim::Comments::Commentable" do
+      it "accepts Decidim::Proposals::Proposal" do
+        variables = {
+          id: "1",
+          type: "Decidim::Proposals::Proposal",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Meetings::Meeting" do
+        variables = {
+          id: "1",
+          type: "Decidim::Meetings::Meeting",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Debates::Debate" do
+        variables = {
+          id: "1",
+          type: "Decidim::Debates::Debate",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Budgets::Project" do
+        variables = {
+          id: "1",
+          type: "Decidim::Budgets::Project",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Blogs::Post" do
+        variables = {
+          id: "1",
+          type: "Decidim::Blogs::Post",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Accountability::Result" do
+        variables = {
+          id: "1",
+          type: "Decidim::Accountability::Result",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Initiative" do
+        variables = {
+          id: "1",
+          type: "Decidim::Initiative",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+
+      it "accepts Decidim::Comments::Comment" do
+        variables = {
+          id: "1",
+          type: "Decidim::Comments::Comment",
+          locale: "en",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).not_to be_present
+      end
+    end
+
+    context "when locale is invalid" do
+      it "raises an error for invalid locale" do
+        variables = {
+          id: "1",
+          type: "Decidim::Proposals::Proposal",
+          locale: "invalid_locale",
+          toggleTranslations: false
+        }
+
+        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        expect(result["errors"]).to be_present
+        expect(result["errors"].first["message"]).to include("is not a valid locale")
+      end
+    end
+  end
+end

--- a/decidim-comments/spec/lib/decidim/comments/query_extensions_spec.rb
+++ b/decidim-comments/spec/lib/decidim/comments/query_extensions_spec.rb
@@ -8,7 +8,7 @@ describe Decidim::Comments::QueryExtensions do
   let(:context) do
     {
       current_organization: organization,
-      current_user: current_user,
+      current_user:,
       scopes: Doorkeeper::OAuth::Scopes.from_string("api:read"),
       can_introspect: false
     }
@@ -35,7 +35,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to eq("Invalid commentable type")
       end
@@ -48,7 +48,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to eq("Invalid commentable type")
       end
@@ -61,7 +61,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to eq("Invalid commentable type")
       end
@@ -74,7 +74,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to eq("Invalid commentable type")
       end
@@ -87,7 +87,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to eq("Invalid commentable type")
       end
@@ -102,7 +102,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -114,7 +114,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -126,7 +126,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -138,7 +138,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -150,7 +150,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -162,7 +162,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -174,7 +174,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
 
@@ -186,7 +186,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).not_to be_present
       end
     end
@@ -200,7 +200,7 @@ describe Decidim::Comments::QueryExtensions do
           toggleTranslations: false
         }
 
-        result = Decidim::Api::Schema.execute(query, variables: variables, context: context)
+        result = Decidim::Api::Schema.execute(query, variables:, context:)
         expect(result["errors"]).to be_present
         expect(result["errors"].first["message"]).to include("is not a valid locale")
       end


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that the commentable query in the GraphQL API is missing some validations to prevent trying to get some information to types that aren't actually commentable.

This PR adds this validation.  

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GraphQL commentable lookups by validating requested types before attempting to resolve them.
  - Invalid, unknown, or unsupported types now return a clear “Invalid commentable type” error instead of causing unexpected failures.
  - Valid commentable resources continue to resolve normally, including support for locale validation.

- **Tests**
  - Expanded coverage for valid commentable types, invalid types, nonexistent classes, and invalid locales across queries and mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->