### PR TITLE
Check that the previous space is actually a space in Meetings

### DIFF
--- a/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
+++ b/decidim-meetings/app/controllers/decidim/meetings/meetings_controller.rb
@@ -205,11 +205,20 @@ module Decidim
         return unless params[:previous_space]
 
         previous_space_class, previous_space_id = params.expect(:previous_space).split("#")
+        return unless valid_participatory_space_class?(previous_space_class)
 
         @previous_space = previous_space_class.constantize.find_by(id: previous_space_id)
         @previous_space
       rescue NameError, LoadError
         nil
+      end
+
+      def valid_participatory_space_class?(class_name)
+        return false if class_name.blank?
+
+        Decidim.participatory_space_manifests.any? do |manifest|
+          manifest.model_class_name == class_name
+        end
       end
 
       def conference_context?

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -124,6 +124,49 @@ describe Decidim::Meetings::MeetingsController do
       end
     end
 
+    context "with previous_space parameter" do
+      let(:other_process) { create(:participatory_process, organization:) }
+
+      it "accepts valid participatory space class names" do
+        get :show, params: { id: meeting.id, previous_space: "Decidim::ParticipatoryProcess##{other_process.id}" }
+
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+      end
+
+      it "rejects non-participatory space class names" do
+        get :show, params: { id: meeting.id, previous_space: "Decidim::User#1" }
+
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+        expect(flash[:notice]).to be_blank
+      end
+
+      it "rejects arbitrary class names" do
+        get :show, params: { id: meeting.id, previous_space: "Decidim::System::Admin#1" }
+
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+        expect(flash[:notice]).to be_blank
+      end
+
+      it "rejects non-existent class names" do
+        get :show, params: { id: meeting.id, previous_space: "NonExistent::Class#1" }
+
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+        expect(flash[:notice]).to be_blank
+      end
+
+      it "rejects blank class names" do
+        get :show, params: { id: meeting.id, previous_space: "#1" }
+
+        expect(subject).to render_template(:show)
+        expect(flash[:alert]).to be_blank
+        expect(flash[:notice]).to be_blank
+      end
+    end
+
     context "with signed in user" do
       before { sign_in user }
 

--- a/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
+++ b/decidim-meetings/spec/controllers/decidim/meetings/meetings_controller_spec.rb
@@ -132,6 +132,15 @@ describe Decidim::Meetings::MeetingsController do
 
         expect(subject).to render_template(:show)
         expect(flash[:alert]).to be_blank
+        expect(flash[:notice]).to eq(
+          I18n.t(
+            "meetings.show.redirect_notice",
+            scope: "decidim.meetings",
+            previous_space_url: request.referer,
+            previous_space_name: decidim_escape_translated(other_process.title),
+            current_space_name: decidim_escape_translated(participatory_process.title)
+          )
+        )
       end
 
       it "rejects non-participatory space class names" do


### PR DESCRIPTION
#### :tophat: What? Why?

Related to #17628, I found another usage of using the constantize method with user submitted params. This case is in the `previous_space` GET param in meetings. 

This PR fixes it.  

#### :pushpin: Related Issues
 
- Related to #13169 
- Related to #17628 

#### Testing

1. Log in as admin
2. Edit a meeting in the admin panel 
3. Add some "Linked spaces"
4. Click in update
5. Go to the meeting list in the space that you've linked to
6. Click in the meeting that you added 
7. See the URL. Play with it.

#### 📷 Screenshots

<img width="1036" height="717" alt="image" src="https://github.com/user-attachments/assets/20e02bf3-3002-4306-a594-6445abcb0d4a" />
<img width="1075" height="547" alt="image" src="https://github.com/user-attachments/assets/2561e284-ad17-405c-a4fe-96181b78fb41" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid or blank `previous_space` values.
  * Meetings pages now continue rendering normally when the parameter references an unsupported or nonexistent class.
* **Tests**
  * Added coverage for valid, invalid, nonexistent, and blank `previous_space` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->