### PR TITLE
Hide empty Proposal Origin filter options

### DIFF
--- a/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
+++ b/decidim-proposals/app/helpers/decidim/proposals/application_helper.rb
@@ -149,14 +149,24 @@ module Decidim
       def filter_origin_values
         scope = "decidim.proposals.application_helper.filter_origin_values"
         origin_values = []
-        origin_values << TreePoint.new("official", t("official", scope:)) if component_settings.official_proposals_enabled
-        origin_values << TreePoint.new("participants", t("participants", scope:))
-        origin_values << TreePoint.new("meeting", t("meetings", scope:))
+        origin_values << TreePoint.new("official", t("official", scope:)) if component_settings.official_proposals_enabled && proposals_with_origin?(:official)
+        origin_values << TreePoint.new("participants", t("participants", scope:)) if proposals_with_origin?(:participants)
+        origin_values << TreePoint.new("meeting", t("meetings", scope:)) if proposals_with_origin?(:meeting)
+
+        return if origin_values.empty?
 
         TreeNode.new(
           TreePoint.new("", t("all", scope:)),
           origin_values
         )
+      end
+
+      def proposals_with_origin?(origin)
+        filterable_proposals.public_send("with_#{origin}_origin").exists?
+      end
+
+      def filterable_proposals
+        @filterable_proposals ||= Decidim::Proposals::Proposal.where(component: current_component).published.not_hidden.not_withdrawn
       end
 
       def filter_proposals_state_values

--- a/decidim-proposals/spec/helpers/application_helper_spec.rb
+++ b/decidim-proposals/spec/helpers/application_helper_spec.rb
@@ -185,6 +185,71 @@ module Decidim
           expect(translated_values).to contain_exactly("All", "Proposals", "Amendments")
         end
       end
+
+      describe "#filter_origin_values" do
+        subject { helper.filter_origin_values }
+
+        let(:organization) { create(:organization) }
+        let(:component) { create(:proposal_component, organization:) }
+        let(:origin_values) { subject.node.map(&:value) }
+
+        before do
+          allow(helper).to receive(:current_component).and_return(component)
+          allow(helper).to receive(:component_settings) { component.settings }
+        end
+
+        context "when there are no proposals" do
+          it { is_expected.to be_nil }
+        end
+
+        context "when there are only official proposals" do
+          before { create(:proposal, :official, component:) }
+
+          it "includes only the official origin" do
+            expect(origin_values).to eq(%w(official))
+          end
+        end
+
+        context "when there are only participant proposals" do
+          before { create(:proposal, component:) }
+
+          it "includes only the participants origin" do
+            expect(origin_values).to eq(%w(participants))
+          end
+        end
+
+        context "when there are only meeting proposals" do
+          before { create(:proposal, :official_meeting, component:) }
+
+          it "includes only the meeting origin" do
+            expect(origin_values).to eq(%w(meeting))
+          end
+        end
+
+        context "when there are proposals from all origins" do
+          before do
+            create(:proposal, :official, component:)
+            create(:proposal, component:)
+            create(:proposal, :official_meeting, component:)
+          end
+
+          it "includes all origins" do
+            expect(origin_values).to contain_exactly("official", "participants", "meeting")
+          end
+        end
+
+        context "when official proposals are disabled" do
+          before do
+            component.update!(settings: { official_proposals_enabled: false })
+            create(:proposal, :official, component:)
+            create(:proposal, component:)
+          end
+
+          it "does not include the official origin" do
+            expect(origin_values).to eq(%w(participants))
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-proposals/spec/system/filter_proposals_spec.rb
+++ b/decidim-proposals/spec/system/filter_proposals_spec.rb
@@ -60,6 +60,7 @@ describe "Filter Proposals", :slow do
       end
 
       it "can be filtered by origin" do
+        create(:proposal, :official, component:)
         visit_component
 
         within "form.new_filter" do
@@ -96,6 +97,63 @@ describe "Filter Proposals", :slow do
           expect(page).to have_css("[id^='proposals__proposal']", count: 2)
         end
       end
+
+      context "when there are no proposals" do
+        it "does not show the origin filter" do
+          visit_component
+
+          within "form.new_filter" do
+            expect(page).to have_no_text(/Origin/i)
+          end
+        end
+      end
+
+      context "when there are no official proposals" do
+        it "does not show the official origin option" do
+          create(:proposal, component:)
+          visit_component
+
+          within "#dropdown-menu-filters div.filter-container", text: "Origin" do
+            expect(page).to have_no_text(/Official/i)
+            expect(page).to have_text(/Participants/i)
+          end
+        end
+      end
+
+      context "when there are no participant proposals" do
+        it "does not show the participants origin option" do
+          create(:proposal, :official, component:)
+          visit_component
+
+          within "#dropdown-menu-filters div.filter-container", text: "Origin" do
+            expect(page).to have_text(/Official/i)
+            expect(page).to have_no_text(/Participants/i)
+          end
+        end
+      end
+
+      context "when there are no meeting proposals" do
+        it "does not show the meetings origin option" do
+          create(:proposal, :official, component:)
+          create(:proposal, component:)
+          visit_component
+
+          within "#dropdown-menu-filters div.filter-container", text: "Origin" do
+            expect(page).to have_no_text(/Meetings/i)
+          end
+        end
+      end
+
+      context "when there are meeting proposals" do
+        it "shows the meetings origin option" do
+          create(:proposal, :official_meeting, component:)
+          visit_component
+
+          within "#dropdown-menu-filters div.filter-container", text: "Origin" do
+            expect(page).to have_text(/Meetings/i)
+          end
+        end
+      end
     end
 
     context "when official_proposals setting is not enabled" do
@@ -104,6 +162,7 @@ describe "Filter Proposals", :slow do
       end
 
       it "cannot be filtered by origin" do
+        create(:proposal, component:)
         visit_component
 
         within "form.new_filter" do
@@ -114,6 +173,7 @@ describe "Filter Proposals", :slow do
   end
 
   it "collapses the accordions on click" do
+    create(:proposal, :official, component:)
     visit_component
 
     within ".layout-2col__aside" do


### PR DESCRIPTION
#### :tophat: What? Why?
The Proposals sidebar always showed every Origin option (Official / Participants / Meetings), even when the component had no proposals of that origin — or no proposals at all.

This change builds the Origin filter from published, visible, non-withdrawn proposals in the current component and only includes origins that have matching content. If none remain, the Origins section is omitted (existing `filter_sections` already rejects blank collections).

Note: the old “Groups” / “Citizen” labels from the issue map to today’s **Participants** origin (`UserBaseEntity`); there is no separate Groups origin in current Decidim.

#### :pushpin: Related Issues
- Fixes #6023

#### Testing
1. Enable official proposals on a Proposals component.
2. With no proposals, confirm the Origin filter is absent.
3. Create only participant proposals → Origin shows Participants, not Official or Meetings.
4. Add official / meeting-authored proposals → those options appear.
5. Filter by origin as before and confirm counts are correct.

Helper and system specs cover the empty / per-origin cases.

### :camera: Screenshots
N/A (filter option visibility)

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The proposal origin filter now displays only options with matching proposals.
  * The Official option remains hidden when official proposals are disabled.
  * The origin filter is omitted when no proposals are available.
* **Tests**
  * Added coverage for origin filter visibility across official, participant, meeting, and mixed proposal sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->