### PR TITLE
Add soft-delete and trash recovery for Initiatives

### DIFF
--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/needs_initiative.rb
@@ -39,7 +39,7 @@ module Decidim
 
         def detect_initiative
           request.env["current_initiative"] ||
-            Initiative.find_by(
+            Initiative.with_deleted.find_by(
               id: id_from_slug(params[:slug]) || id_from_slug(params[:initiative_slug]) || params[:initiative_id] || params[:id],
               organization: current_organization
             )

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -12,6 +12,7 @@ module Decidim
         include Decidim::Initiatives::TypeSelectorOptions
         include Decidim::Initiatives::Admin::Filterable
         include Decidim::Admin::ParticipatorySpaceAdminBreadcrumb
+        include Decidim::Admin::HasTrashableResources
 
         helper ::Decidim::Admin::ResourcePermissionsHelper
         helper Decidim::Initiatives::InitiativeHelper
@@ -196,6 +197,18 @@ module Decidim
 
         def collection
           @collection ||= ManageableInitiatives.for(current_user)
+        end
+
+        def trashable_deleted_resource_type
+          :initiative
+        end
+
+        def trashable_deleted_resource
+          @trashable_deleted_resource ||= current_initiative
+        end
+
+        def trashable_deleted_collection
+          @trashable_deleted_collection = filtered_collection.only_deleted.deleted_at_desc
         end
 
         def pdf_signature_service

--- a/decidim-initiatives/app/models/decidim/initiative.rb
+++ b/decidim-initiatives/app/models/decidim/initiative.rb
@@ -27,6 +27,7 @@ module Decidim
     include Decidim::FilterableResource
     include Decidim::Reportable
     include Decidim::ShareableWithToken
+    include Decidim::SoftDeletable
 
     translatable_fields :title, :description, :answer
 

--- a/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
+++ b/decidim-initiatives/app/presenters/decidim/initiatives/admin_log/initiative_presenter.rb
@@ -15,9 +15,15 @@ module Decidim
       class InitiativePresenter < Decidim::Log::BasePresenter
         private
 
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.publish")
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.unpublish")
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.update")
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.send_to_technical_validation")
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.soft_delete")
+        # i18n-tasks-use t("decidim.initiatives.admin_log.initiative.restore")
         def action_string
           case action
-          when "publish", "unpublish", "update", "send_to_technical_validation"
+          when "publish", "unpublish", "update", "send_to_technical_validation", "soft_delete", "restore"
             "decidim.initiatives.admin_log.initiative.#{action}"
           else
             super

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_initiative_row.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_initiative_row.html.erb
@@ -1,0 +1,148 @@
+<% if view == :deleted %>
+  <tr>
+    <td class="!text-left" data-label="<%= t("models.initiatives.fields.title", scope: "decidim.admin") %>">
+      <% if allowed_to? :edit, :initiative, initiative: initiative %>
+        <%= link_to translated_attribute(initiative.title),
+                    decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>
+      <% else %>
+        <%= translated_attribute(initiative.title) %>
+      <% end %>
+    </td>
+    <td data-label="<%= t("models.initiatives.fields.state", scope: "decidim.admin") %>"><%= humanize_admin_state initiative.state %></td>
+    <td data-label="<%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %>"><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
+    <td class="table-list__date" data-label="<%= t("models.initiatives.fields.created_at", scope: "decidim.admin") %>"><%= l initiative.created_at, format: :short %></td>
+    <td class="table-list__date" data-label="<%= t("models.initiatives.fields.published_at", scope: "decidim.admin") %>"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
+    <td class="table-list__actions" data-label="<%= t("decidim.initiatives.admin.initiatives.index.actions_title") %>">
+      <button type="button" data-controller="dropdown" data-target="actions-initiative-<%= initiative.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(initiative.title)) %>">
+        <%= icon "more-fill", class: "text-secondary" %>
+      </button>
+
+      <div class="inline-block relative">
+        <ul id="actions-initiative-<%= initiative.id %>" class="dropdown dropdown__action" aria-hidden="true">
+          <% if allowed_to? :restore, :initiative, trashable_deleted_resource: initiative %>
+            <li class="dropdown__item">
+              <%= link_to restore_initiative_path(initiative), class: "dropdown__button", method: :patch do %>
+                <%= icon "refresh-line" %>
+                <%= t("actions.restore", scope: "decidim.admin") %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </td>
+  </tr>
+<% else %>
+  <tr>
+    <td class="!text-left" data-label="<%= t("models.initiatives.fields.title", scope: "decidim.admin") %>">
+      <% if allowed_to? :edit, :initiative, initiative: initiative %>
+        <%= link_to translated_attribute(initiative.title),
+                    decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>
+      <% else %>
+        <%= translated_attribute(initiative.title) %>
+      <% end %>
+    </td>
+    <td data-label="<%= t("models.initiatives.fields.state", scope: "decidim.admin") %>"><%= humanize_admin_state initiative.state %></td>
+    <td data-label="<%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %>"><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
+    <td class="table-list__date" data-label="<%= t("models.initiatives.fields.created_at", scope: "decidim.admin") %>"><%= l initiative.created_at, format: :short %></td>
+    <td class="table-list__date" data-label="<%= t("models.initiatives.fields.published_at", scope: "decidim.admin") %>"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
+    <td class="table-list__actions" data-label="<%= t("decidim.initiatives.admin.initiatives.index.actions_title") %>">
+      <button type="button" data-controller="dropdown" data-target="actions-initiative-<%= initiative.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(initiative.title)) %>">
+        <%= icon "more-fill", class: "text-secondary" %>
+      </button>
+
+      <div class="inline-block relative">
+        <ul id="actions-initiative-<%= initiative.id %>" class="dropdown dropdown__action" aria-hidden="true">
+          <% if allowed_to? :edit, :initiative, initiative: initiative %>
+            <li class="dropdown__item">
+              <%= link_to decidim_admin_initiatives.edit_initiative_path(initiative.to_param), class: "dropdown__button" do %>
+                <%= icon "pencil-line" %>
+                <%= t("actions.edit", scope: "decidim.admin") %>
+              <% end %>
+            </li>
+          <% end %>
+
+          <hr>
+
+          <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
+            <li class="dropdown__item">
+              <%= link_to edit_initiative_answer_path(initiative.slug), class: "dropdown__button" do %>
+                <%= icon "chat-1-line" %>
+                <%= t("actions.answer", scope: "decidim.initiatives") %>
+              <% end %>
+            </li>
+          <% else %>
+            <li class="dropdown__item">
+              <div class="dropdown__button-disabled">
+                <%= with_tooltip(t("actions.cannot_answer", scope: "decidim.admin"), class: :left) do %>
+                  <%= icon "chat-1-line", class: "text-gray" %>
+                  <span><%= t("actions.answer", scope: "decidim.initiatives") %></span>
+                <% end %>
+              </div>
+            </li>
+          <% end %>
+
+          <% if allowed_to? :print, :initiative, initiative: initiative %>
+            <li class="dropdown__item">
+              <%= link_to decidim_initiatives.print_initiative_path(initiative), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+                <%= icon "printer-line" %>
+                <%= t("decidim.initiatives.admin.initiatives.index.print") %>
+              <% end %>
+            </li>
+          <% end %>
+
+          <hr>
+
+          <% if allowed_to? :preview, :initiative, initiative: initiative %>
+            <li class="dropdown__item">
+              <%= link_to decidim_initiatives.initiative_path(initiative.to_param), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
+                <%= icon "eye-line" %>
+                <%= t("decidim.initiatives.admin.initiatives.index.preview") %>
+              <% end %>
+            </li>
+          <% end %>
+
+          <% if allowed_to? :read, :share_token, current_participatory_space: initiative %>
+            <li class="dropdown__item">
+              <%= link_to decidim_admin_initiatives.initiative_share_tokens_path(initiative), class: "dropdown__button" do %>
+                <%= icon "share-line" %>
+                <%= t("actions.share_tokens", scope: "decidim.admin") %>
+              <% end %>
+            </li>
+
+            <hr>
+          <% end %>
+
+          <% if (link = free_resource_permissions_link(initiative)) %>
+            <li class="dropdown__item">
+              <%= link %>
+            </li>
+          <% end %>
+
+          <% if allowed_to? :soft_delete, :initiative, trashable_deleted_resource: initiative %>
+            <hr>
+
+            <% if initiative.published? %>
+              <li class="dropdown__item">
+                <div class="dropdown__button-disabled">
+                  <%= with_tooltip t("tooltips.deleted_initiatives_info", scope: "decidim.admin"), class: :left do %>
+                    <%= icon "delete-bin-line", class: "text-gray" %>
+                    <span>
+                      <%= t("actions.soft_delete", scope: "decidim.admin") %>
+                    </span>
+                  <% end %>
+                </div>
+              </li>
+            <% else %>
+              <li class="dropdown__item">
+                <%= link_to soft_delete_initiative_path(initiative), class: "dropdown__button", method: :patch, data: { confirm: t("actions.confirm_delete_initiative", scope: "decidim.admin") } do %>
+                  <%= icon "delete-bin-line" %>
+                  <%= t("actions.soft_delete", scope: "decidim.admin") %>
+                <% end %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </td>
+  </tr>
+<% end %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/index.html.erb
@@ -31,101 +31,25 @@
         </tr>
         </thead>
         <tbody>
-        <% @initiatives.each do |initiative| %>
-          <tr>
-            <td class="!text-left" data-label="<%= t("models.initiatives.fields.title", scope: "decidim.admin") %>">
-              <% if allowed_to? :edit, :initiative, initiative: initiative %>
-                <%= link_to translated_attribute(initiative.title),
-                            decidim_admin_initiatives.edit_initiative_path(initiative.to_param) %>
-              <% else %>
-                <%= translated_attribute(initiative.title) %>
-              <% end %>
-            </td>
-            <td data-label="<%= t("models.initiatives.fields.state", scope: "decidim.admin") %>"><%= humanize_admin_state initiative.state %></td>
-            <td data-label="<%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %>"><%= initiative.supports_count %>/<%= initiative.scoped_type.supports_required %></td>
-            <td class="table-list__date" data-label="<%= t("models.initiatives.fields.created_at", scope: "decidim.admin") %>"><%= l initiative.created_at, format: :short %></td>
-            <td class="table-list__date" data-label="<%= t("models.initiatives.fields.published_at", scope: "decidim.admin") %>"><%= initiative.published_at? ? l(initiative.published_at, format: :short) : "" %></td>
-            <td class="table-list__actions" data-label="<%= t(".actions_title") %>">
-              <button type="button" data-controller="dropdown" data-target="actions-initiative-<%= initiative.id %>" aria-label="<%= t("decidim.admin.actions.actions_label", resource: translated_attribute(initiative.title)) %>">
-                <%= icon "more-fill", class: "text-secondary" %>
-              </button>
-
-              <div class="inline-block relative">
-                <ul id="actions-initiative-<%= initiative.id %>" class="dropdown dropdown__action" aria-hidden="true">
-                  <% if allowed_to? :edit, :initiative, initiative: initiative %>
-                    <li class="dropdown__item">
-                      <%= link_to decidim_admin_initiatives.edit_initiative_path(initiative.to_param), class: "dropdown__button" do %>
-                        <%= icon "pencil-line" %>
-                        <%= t("actions.edit", scope: "decidim.admin") %>
-                      <% end %>
-                    </li>
-                  <% end %>
-
-                  <hr>
-
-                  <% if allowed_to?(:answer, :initiative, initiative: initiative) %>
-                    <li class="dropdown__item">
-                      <%= link_to edit_initiative_answer_path(initiative.slug), class: "dropdown__button" do %>
-                        <%= icon "chat-1-line" %>
-                        <%= t("actions.answer", scope: "decidim.initiatives") %>
-                      <% end %>
-                    </li>
-                  <% else %>
-                    <li class="dropdown__item">
-                      <div class="dropdown__button-disabled">
-                        <%= with_tooltip(t("actions.cannot_answer", scope: "decidim.admin"), class: :left) do %>
-                          <%= icon "chat-1-line", class: "text-gray" %>
-                          <span><%= t("actions.answer", scope: "decidim.initiatives") %></span>
-                        <% end %>
-                      </div>
-                    </li>
-                  <% end %>
-
-                  <% if allowed_to? :print, :initiative, initiative: initiative %>
-                    <li class="dropdown__item">
-                      <%= link_to decidim_initiatives.print_initiative_path(initiative), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
-                        <%= icon "printer-line" %>
-                        <%= t(".print") %>
-                      <% end %>
-                    </li>
-                  <% end %>
-
-                  <hr>
-
-                  <% if allowed_to? :preview, :initiative, initiative: initiative %>
-                    <li class="dropdown__item">
-                      <%= link_to decidim_initiatives.initiative_path(initiative.to_param), class: "dropdown__button", target: "_blank", data: { "external-link": false } do %>
-                        <%= icon "eye-line" %>
-                        <%= t(".preview") %>
-                      <% end %>
-                    </li>
-                  <% end %>
-
-                  <% if allowed_to? :read, :share_token, current_participatory_space: initiative %>
-                    <li class="dropdown__item">
-                      <%= link_to decidim_admin_initiatives.initiative_share_tokens_path(initiative), class: "dropdown__button" do %>
-                        <%= icon "share-line" %>
-                        <%= t("actions.share_tokens", scope: "decidim.admin") %>
-                      <% end %>
-                    </li>
-
-                    <hr>
-                  <% end %>
-
-                  <% if (link = free_resource_permissions_link(initiative)) %>
-                    <li class="dropdown__item">
-                      <%= link %>
-                    </li>
-                  <% end %>
-                </ul>
-              </div>
-
-            </td>
-          </tr>
-        <% end %>
+          <%= render partial: "decidim/initiatives/admin/initiatives/initiative_row",
+                     collection: @initiatives,
+                     as: :initiative,
+                     locals: { view: :index } %>
         </tbody>
       </table>
+    </div>
+
+    <% if allowed_to? :manage_trash, :initiative %>
+      <div class="mt-4">
+        <%= link_to manage_trash_initiatives_path, class: "flex items-center text-secondary" do %>
+          <%= icon "delete-bin-2-line", class: "mr-2 fill-current text-secondary", role: "img" %>
+          <%= t("actions.view_deleted_initiatives", scope: "decidim.admin") %>
+          <span class="ml-2">
+            <%= icon_with_tooltip("information-line", t("tooltips.deleted_initiatives_info", scope: "decidim.admin")) %>
+          </span>
+        <% end %>
+      </div>
     <% end %>
-  </div>
+  <% end %>
 </div>
 <%= decidim_paginate @initiatives %>

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/manage_trash.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/manage_trash.html.erb
@@ -1,0 +1,30 @@
+<% add_decidim_page_title(t(".title")) %>
+
+<div class="item_show__header">
+  <h1 class="item_show__header-title">
+    <%= t(".title") %>
+  </h1>
+</div>
+<div class="card" id="initiatives">
+  <%= admin_filter_selector(:initiatives) %>
+</div>
+<div class="table-stacked">
+  <table class="table-list">
+    <thead>
+      <tr>
+        <th class="!text-left"><%= t("models.initiatives.fields.title", scope: "decidim.admin") %></th>
+        <th><%= t("models.initiatives.fields.state", scope: "decidim.admin") %></th>
+        <th><%= t("models.initiatives.fields.supports_count", scope: "decidim.admin") %></th>
+        <th><%= t("models.initiatives.fields.created_at", scope: "decidim.admin") %></th>
+        <th><%= t("models.initiatives.fields.published_at", scope: "decidim.admin") %></th>
+        <th><%= t("decidim.initiatives.admin.initiatives.index.actions_title") %></th>
+      </tr>
+    </thead>
+    <tbody>
+      <%= render partial: "decidim/initiatives/admin/initiatives/initiative_row",
+                 collection: trashable_deleted_collection,
+                 as: :initiative,
+                 locals: { view: :deleted } %>
+    </tbody>
+  </table>
+</div>

--- a/decidim-initiatives/config/locales/en.yml
+++ b/decidim-initiatives/config/locales/en.yml
@@ -78,8 +78,10 @@ en:
     admin:
       actions:
         cannot_answer: Cannot answer this initiative
+        confirm_delete_initiative: Are you sure you want to delete this initiative? If you change your mind, you can restore it later.
         new_initiative_type: New initiative type
         new_initiative_type_scope: New initiative type scope
+        view_deleted_initiatives: View deleted initiatives
       filters:
         initiatives:
           decidim_area_id_eq:
@@ -154,6 +156,8 @@ en:
       taxonomy_filters:
         space_filter_for:
           initiatives: All initiatives
+      tooltips:
+        deleted_initiatives_info: An initiative can only be deleted if status is "Unpublished".
     download_your_data:
       show:
         initiatives: Initiatives export
@@ -276,6 +280,8 @@ en:
             edit: Edit
             new: New
             photos: Photos
+          manage_trash:
+            title: Deleted initiatives
           publish:
             success: The initiative has been successfully published.
           reject:
@@ -337,7 +343,9 @@ en:
       admin_log:
         initiative:
           publish: "%{user_name} published the %{resource_name} initiative"
+          restore: "%{user_name} restored the %{resource_name} initiative"
           send_to_technical_validation: "%{user_name} sent the %{resource_name} initiative to technical validation"
+          soft_delete: "%{user_name} moved to trash the %{resource_name} initiative"
           unpublish: "%{user_name} discarded the %{resource_name} initiative"
           update: "%{user_name} updated the %{resource_name} initiative"
         initiatives_settings:

--- a/decidim-initiatives/db/migrate/20260909120000_add_deleted_at_to_decidim_initiatives.rb
+++ b/decidim-initiatives/db/migrate/20260909120000_add_deleted_at_to_decidim_initiatives.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToDecidimInitiatives < ActiveRecord::Migration[7.2]
+  def change
+    add_column :decidim_initiatives, :deleted_at, :datetime
+    add_index :decidim_initiatives, :deleted_at
+  end
+end

--- a/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/admin_engine.rb
@@ -35,9 +35,12 @@ module Decidim
               get :export_pdf_signatures
               post :accept
               delete :reject
+              patch :soft_delete
+              patch :restore
             end
 
             collection do
+              get :manage_trash, to: "initiatives#manage_trash"
               post :export
             end
 

--- a/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
+++ b/decidim-initiatives/lib/decidim/initiatives/test/factories.rb
@@ -123,6 +123,7 @@ FactoryBot.define do
     author { create(:user, :confirmed, organization:, skip_injection:) }
     state { "open" }
     published_at { Time.current.utc }
+    deleted_at { nil }
     signature_type { "online" }
     signature_start_date { Date.current - 1.day }
     signature_end_date { Date.current + 120.days }
@@ -242,6 +243,10 @@ FactoryBot.define do
           )
         end
       end
+    end
+
+    trait :trashed do
+      deleted_at { Time.current }
     end
   end
 

--- a/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
+++ b/decidim-initiatives/spec/controllers/decidim/initiatives/admin/initiatives_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "decidim/core/test/shared_examples/softdeleteable_components_examples"
 
 describe Decidim::Initiatives::Admin::InitiativesController do
   routes { Decidim::Initiatives::AdminEngine.routes }
@@ -16,6 +17,17 @@ describe Decidim::Initiatives::Admin::InitiativesController do
     initiative.author.update(admin_terms_accepted_at: Time.current)
     initiative.committee_members.approved.first.user.update(admin_terms_accepted_at: Time.current)
     created_initiative.author.update(admin_terms_accepted_at: Time.current)
+  end
+
+  context "when soft deletable" do
+    before do
+      sign_in admin_user, scope: :user
+    end
+
+    it_behaves_like "a soft-deletable space",
+                    space_name: :initiative,
+                    space_path: :initiatives_path,
+                    trash_path: :manage_trash_initiatives_path
   end
 
   context "when index" do

--- a/decidim-initiatives/spec/system/admin/admin_manages_initiative_soft_delete_spec.rb
+++ b/decidim-initiatives/spec/system/admin/admin_manages_initiative_soft_delete_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Admin manages initiative soft delete" do
+  let!(:user) { create(:user, :admin, :confirmed, organization:) }
+  let(:organization) { create(:organization) }
+  let(:admin_resource_path) { decidim_admin_initiatives.initiatives_path }
+  let(:trash_path) { decidim_admin_initiatives.manage_trash_initiatives_path }
+  let(:title) { { en: "My space" } }
+  let!(:resource) { create(:initiative, title:, organization:) }
+
+  it_behaves_like "manage soft deletable component or space", "initiative"
+  it_behaves_like "manage trashed resource", "initiative"
+end


### PR DESCRIPTION
#### :tophat: What? Why?
Adds soft-delete (trash bin) and restore for Initiatives in the admin panel, following the same pattern already used for Assemblies / Participatory Processes (#13297).

Admins can move **unpublished** initiatives to trash and recover them later. Published initiatives show a disabled delete action with a tooltip, matching other spaces.

#### :pushpin: Related Issues
- Fixes #6542

#### Testing
1. As an organization admin, go to Admin → Initiatives.
2. Unpublish (or use a draft/created) initiative → Actions → **Move to trash**.
3. Confirm it disappears from the list and appears under **View deleted initiatives**.
4. From the trash, **Restore** the initiative and confirm it returns to the list.
5. Confirm a published initiative cannot be moved to trash (disabled action + tooltip).

Specs added:
- `spec/system/admin/admin_manages_initiative_soft_delete_spec.rb`
- soft-deletable space shared examples in `initiatives_controller_spec.rb`

### :camera: Screenshots
N/A (behavior mirrors existing Assemblies trash UI)

:hearts: Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a trash-management workflow for initiatives in the admin interface.
  - Administrators can soft-delete unpublished initiatives, view deleted initiatives, and restore them.
  - Added confirmation prompts, status indicators, filters, and action controls for initiative management.
  - Added admin log entries for deletion and restoration actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->