### PR TITLE
Allow only admins to access moderations on GraphQL API

### DIFF
--- a/decidim-api/lib/decidim/api/query_type.rb
+++ b/decidim-api/lib/decidim/api/query_type.rb
@@ -92,10 +92,14 @@ module Decidim
       end
 
       def moderated_users
+        return [] unless Decidim::Core::UserModerationType.authorized?(nil, context)
+
         Decidim::UserModeration.joins(:user).where(decidim_users: { decidim_organization_id: organization&.id }).where.not(decidim_users: { blocked_at: nil })
       end
 
       def moderations
+        return [] unless Decidim::Core::ModerationType.authorized?(nil, context)
+
         Decidim::Moderation.where(participatory_space: organization.participatory_spaces).includes(:reports).hidden
       end
     end

--- a/decidim-api/spec/lib/decidim/api/query_type_spec.rb
+++ b/decidim-api/spec/lib/decidim/api/query_type_spec.rb
@@ -79,6 +79,7 @@ module Decidim
         let(:moderation) { create(:user_moderation, user:) }
         let!(:user_block) { create(:user_block, user:, blocking_user: reporter) }
         let!(:user_report) { create(:user_report, user: reporter, reason: "spam", details: "Lorem ipsum", moderation:) }
+        let!(:current_user) { create(:user, :confirmed, :admin, organization: current_organization) }
 
         let(:query) do
           %({
@@ -129,6 +130,22 @@ module Decidim
             "userId" => user.id.to_s
           )
         end
+
+        context "when user is not an admin" do
+          let!(:current_user) { create(:user, :confirmed, organization: current_organization) }
+
+          it "returns an empty array" do
+            expect(response["moderatedUsers"]).to eq([])
+          end
+        end
+
+        context "when user is not authenticated" do
+          let!(:current_user) { nil }
+
+          it "returns an empty array" do
+            expect(response["moderatedUsers"]).to eq([])
+          end
+        end
       end
 
       describe "moderations" do
@@ -137,6 +154,7 @@ module Decidim
         let(:commentable) { create(:dummy_resource, :published, component:) }
         let(:moderation) { create(:moderation, reportable: commentable, hidden_at: 2.days.ago, report_count: 1, reported_content: "This is the content") }
         let!(:report) { create(:report, moderation:, details: "This is a report", locale: "en") }
+        let!(:current_user) { create(:user, :confirmed, :admin, organization: current_organization) }
 
         let(:query) do
           %({
@@ -182,6 +200,22 @@ module Decidim
             ],
             "updatedAt" => moderation.updated_at.to_time.iso8601
           )
+        end
+
+        context "when user is not an admin" do
+          let!(:current_user) { create(:user, :confirmed, organization: current_organization) }
+
+          it "returns an empty array" do
+            expect(response["moderations"]).to eq([])
+          end
+        end
+
+        context "when user is not authenticated" do
+          let!(:current_user) { nil }
+
+          it "returns an empty array" do
+            expect(response["moderations"]).to eq([])
+          end
         end
       end
 

--- a/decidim-core/lib/decidim/api/types/moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/moderation_type.rb
@@ -20,6 +20,12 @@ module Decidim
 
         object.reportable.reported_content_url
       end
+
+      def self.authorized?(object, context)
+        return false unless context[:current_user]
+
+        super && allowed_to?(:read, :admin_dashboard, object, context)
+      end
     end
   end
 end

--- a/decidim-core/lib/decidim/api/types/user_moderation_type.rb
+++ b/decidim-core/lib/decidim/api/types/user_moderation_type.rb
@@ -31,6 +31,12 @@ module Decidim
       def blocking_user
         object.blocking.blocking_user
       end
+
+      def self.authorized?(object, context)
+        return false unless context[:current_user]
+
+        super && allowed_to?(:read, :admin_dashboard, object, context)
+      end
     end
   end
 end

--- a/decidim-core/spec/types/moderation_type_spec.rb
+++ b/decidim-core/spec/types/moderation_type_spec.rb
@@ -8,6 +8,7 @@ module Decidim
     describe ModerationType do
       include_context "with a graphql class type"
 
+      let!(:current_user) { create(:user, :confirmed, :admin, organization: current_organization) }
       let(:model) { create(:moderation, :hidden, report_count: 1, reported_content: "This is the content") }
       let!(:report) { create(:report, moderation: model) }
 
@@ -18,6 +19,22 @@ module Decidim
 
         it "returns the id field" do
           expect(response).to eq("id" => model.id.to_s)
+        end
+
+        context "when user is not an admin" do
+          let!(:current_user) { create(:user, :confirmed, organization: current_organization) }
+
+          it "raises an unauthorized error" do
+            expect { response }.to raise_error(Decidim::Api::Errors::UnauthorizedObjectError)
+          end
+        end
+
+        context "when user is not authenticated" do
+          let!(:current_user) { nil }
+
+          it "raises an unauthorized error" do
+            expect { response }.to raise_error(Decidim::Api::Errors::UnauthorizedObjectError)
+          end
         end
       end
 

--- a/decidim-core/spec/types/user_moderation_type_spec.rb
+++ b/decidim-core/spec/types/user_moderation_type_spec.rb
@@ -8,6 +8,7 @@ module Decidim
     describe UserModerationType do
       include_context "with a graphql class type"
 
+      let!(:current_user) { create(:user, :confirmed, :admin, organization: current_organization) }
       let(:current_organization) { create(:organization) }
       let(:user) { create(:user, :confirmed, :blocked, organization: current_organization) }
       let(:reporter) { create(:user, :confirmed, organization: current_organization) }
@@ -24,6 +25,22 @@ module Decidim
 
         it "returns the about field" do
           expect(response).to eq("about" => user.about)
+        end
+
+        context "when user is not an admin" do
+          let!(:current_user) { create(:user, :confirmed, organization: current_organization) }
+
+          it "raises an unauthorized error" do
+            expect { response }.to raise_error(Decidim::Api::Errors::UnauthorizedObjectError)
+          end
+        end
+
+        context "when user is not authenticated" do
+          let!(:current_user) { nil }
+
+          it "raises an unauthorized error" do
+            expect { response }.to raise_error(Decidim::Api::Errors::UnauthorizedObjectError)
+          end
         end
       end
 


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that anyone can access reporter and moderator information for Moderations on the GraphQL API. 

It should be accessed only for admins for the moment. In the future we would want to have a moderation log similar to what Lemmy does (see https://lemmy.world/modlog), but for now it is just better to not show these on the API.   

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted moderation data and user moderation data to authenticated users with admin dashboard read permissions.
  - Unauthorized or unauthenticated requests now receive empty results or an authorization error instead of moderation details.

- **Tests**
  - Added coverage for authorized admin access and rejected non-admin or unauthenticated access across moderation queries and fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->