### PR TITLE
Allow defining development app queue adapter through ENV vars

### DIFF
--- a/decidim-dev/lib/tasks/generators.rake
+++ b/decidim-dev/lib/tasks/generators.rake
@@ -54,7 +54,7 @@ namespace :decidim do
         "--locales",
         "en,ca,es",
         "--dev_ssl",
-        "--queue=sidekiq"
+        "--queue=#{ENV.fetch("QUEUE_ADAPTER", "sidekiq")}"
       )
     end
   end

--- a/decidim-dev/spec/tasks/decidim_generate_external_development_app_spec.rb
+++ b/decidim-dev/spec/tasks/decidim_generate_external_development_app_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "rake decidim:generate_external_development_app", type: :task do
+  context "when executing task" do
+    it "starts the app generator with correct options" do
+      expect(Decidim::Generators::AppGenerator).to receive(:start).with(
+        [
+          "development_app",
+          "--app_name",
+          "decidim_dev_development_app",
+          "--path",
+          "..",
+          "--recreate_db",
+          "--seed_db",
+          "--demo",
+          "--profiling",
+          "--locales",
+          "en,ca,es",
+          "--dev_ssl",
+          "--queue=sidekiq"
+        ]
+      )
+
+      task.execute
+    end
+
+    context "with the queue adapter passed through ENV" do
+      let(:adapter_name) { "" }
+
+      before do
+        allow(ENV).to receive(:fetch).with("QUEUE_ADAPTER", "sidekiq").and_return(adapter_name)
+      end
+
+      it "starts the app generator with correct options" do
+        expect(Decidim::Generators::AppGenerator).to receive(:start).with(
+          [
+            "development_app",
+            "--app_name",
+            "decidim_dev_development_app",
+            "--path",
+            "..",
+            "--recreate_db",
+            "--seed_db",
+            "--demo",
+            "--profiling",
+            "--locales",
+            "en,ca,es",
+            "--dev_ssl",
+            "--queue=#{adapter_name}"
+          ]
+        )
+
+        task.execute
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This allows defining the development app queue adapter through ENV vars.

This supercedes #17283 as an alternative approach to the problem as was discussed in that issue. See further details from that issue.

Opening this as a draft first because the spec currently fails due to another problem with `decidim-dev`. The fix for that is available in another PR (#17638).

#### :pushpin: Related Issues
- Related to #17283

#### Testing
Generate the development app as follows:
```
QUEUE_ADAPTER= bundle exec rake development_app
```

After the generation finishes, see that the sidekiq adapter was not added to the generated application.