### PR TITLE
Fix `decidim-dev` module loading its rake tasks multiple times

### DIFF
--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+# Keep this after the RAILS_ENV definition because some of the dev
+# engines/railties call the "path" method which would set RAILS_ENV to
+# "development".
+# ENV["RAILS_ENV"] ||= "test"
+
 require "decidim/dev/railtie"
 
 require "decidim/dev/admin"

--- a/decidim-dev/lib/decidim/dev.rb
+++ b/decidim-dev/lib/decidim/dev.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-# Keep this after the RAILS_ENV definition because some of the dev
-# engines/railties call the "path" method which would set RAILS_ENV to
-# "development".
-# ENV["RAILS_ENV"] ||= "test"
-
 require "decidim/dev/railtie"
 
 require "decidim/dev/admin"

--- a/decidim-dev/lib/decidim/dev/admin_engine.rb
+++ b/decidim-dev/lib/decidim/dev/admin_engine.rb
@@ -5,6 +5,9 @@ module Decidim
     class AdminEngine < Rails::Engine
       engine_name "dummy_admin"
 
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
       routes do
         resources :dummy_resources do
           resources :nested_dummy_resources

--- a/decidim-dev/lib/decidim/dev/auth_engine.rb
+++ b/decidim-dev/lib/decidim/dev/auth_engine.rb
@@ -9,6 +9,9 @@ module Decidim
       isolate_namespace Decidim::Dev
       engine_name "decidim_dev_auth"
 
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
       routes do
         devise_scope :user do
           match(

--- a/decidim-dev/lib/decidim/dev/engine.rb
+++ b/decidim-dev/lib/decidim/dev/engine.rb
@@ -9,6 +9,9 @@ module Decidim
       isolate_namespace Decidim::Dev
       engine_name "decidim_dev"
 
+      paths["db/migrate"] = nil
+      paths["lib/tasks"] = nil
+
       routes do
         root to: proc { [200, {}, ["DUMMY ENGINE"]] }
 

--- a/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
+++ b/decidim-dev/lib/decidim/dev/test/base_spec_helper.rb
@@ -14,6 +14,10 @@ ENV["DECIDIM_TIMESTAMP_SERVICE"] ||= "Decidim::Initiatives::DummyTimestamp"
 ENV["DECIDIM_PDF_SIGNATURE_SERVICE"] ||= "Decidim::PdfSignatureExample"
 ENV["DECIDIM_MACHINE_TRANSLATION_SERVICE"] ||= "Decidim::Dev::DummyTranslator"
 
+# The env has to be manually set because "decidim/dev" already loads
+# engines/railties which call the "paths" class method that initiates Rails.env.
+Rails.env = ENV.fetch("RAILS_ENV", "test")
+
 engine_spec_dir = File.join(Dir.pwd, "spec")
 
 if ENV["SIMPLECOV"]


### PR DESCRIPTION
#### :tophat: What? Why?
While I wrote the spec for #17635, I noticed that the `decidim-dev` module's engines and railtie all load the rake tasks causing them to be loaded several time.

This can be seen when the task is executed in specs, see the testing instructions to replicate the problem.

You can see the failure at this example run:
https://github.com/decidim/decidim/actions/runs/34364582105/job/102509893955

#### :pushpin: Related Issues
- Related to #17635

#### Testing
- Apply the changes from PR #17635
- Run the added spec:
```
cd decidim-dev
bundle exec rspec ./spec/tasks/decidim_generate_external_development_app_spec.rb
```
- See the following failure output
```
     Failure/Error:
       expect(Decidim::Generators::AppGenerator).to receive(:start).with(
         ...

           expected: 1 time with arguments: ...
           received: 4 times with arguments: ...
```
- Apply the changes from this PR
- See that the spec passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Development and test engines no longer expose database migration or task paths by default.
  - Test runs now consistently use the environment specified by `RAILS_ENV`, defaulting to the test environment when it is not provided. This improves reliability and prevents unintended environment-related setup issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->