### PR TITLE
Move the lock-in mechanism for verifications to the DB

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,6 +80,8 @@ The verification code confirmation flow has been enhanced with multiple security
 
 Server-side failed attempt tracking applies to all verification handlers (SMS, postal letter, ID documents, CSV census). Code expiration applies only to SMS verification. HTTP-level rate limiting applies only to SMS and postal letter authorization paths.
 
+We strongly recommend that implementers review any custom authorization handlers for code that may still rely on the old session-based attempt tracking patterns, which have been replaced by the new server-side mechanism.
+
 You can read more about this change on PR [#17639](https://github.com/decidim/decidim/pull/17639).
 
 ### 2.4. [[TITLE OF THE ACTION]]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -78,7 +78,7 @@ The verification code confirmation flow has been enhanced with multiple security
 
 3. **HTTP-level rate limiting**: Rack::Attack now throttles verification confirmation endpoints to 10 requests per minute per IP.
 
-These changes apply to all verification handlers (SMS, postal letter, ID documents, CSV census).
+Server-side failed attempt tracking applies to all verification handlers (SMS, postal letter, ID documents, CSV census). Code expiration applies only to SMS verification. HTTP-level rate limiting applies only to SMS and postal letter authorization paths.
 
 You can read more about this change on PR [#17639](https://github.com/decidim/decidim/pull/17639).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,7 +56,7 @@ This change is based on the GDPR regulation:
 
 You can read more about this change on PR [#11036](https://github.com/decidim/decidim/pull/11036).
 
-### 2.3. Sidekiq configuration overwrite
+### 2.2. Sidekiq configuration overwrite
 
 As we are doing changes in the default sidekiq.yml configuration and we want to do them automatically, this file will be overwritten during the upgrade process (on the `bin/rails decidim:upgrade` command).
 
@@ -68,7 +68,21 @@ sidekiq -C config/sidekiq.yml -C config/sidekiq.local.yml
 
 You can read more about this change on PR [#17596](https://github.com/decidim/decidim/pull/17596).
 
-### 2.2. [[TITLE OF THE ACTION]]
+### 2.3. Verification code security hardening
+
+The verification code confirmation flow has been enhanced with multiple security improvements. Failed attempt tracking has been moved from client-side session to server-side database storage, with three layers of protection:
+
+1. **Server-side failed attempt tracking**: Failed attempts are now tracked in the database with automatic lockout after 5 failed attempts (configurable via `DECIDIM_VERIFICATION_MAX_FAILED_ATTEMPTS`) and automatic unlock after 30 minutes (configurable via `DECIDIM_VERIFICATION_UNLOCK_IN`).
+
+2. **Code expiration**: SMS verification codes now expire after 10 minutes (configurable via `DECIDIM_VERIFICATION_CODE_EXPIRY_MINUTES`), reducing the window of opportunity for unauthorized access.
+
+3. **HTTP-level rate limiting**: Rack::Attack now throttles verification confirmation endpoints to 10 requests per minute per IP.
+
+These changes apply to all verification handlers (SMS, postal letter, ID documents, CSV census).
+
+You can read more about this change on PR [#17639](https://github.com/decidim/decidim/pull/17639).
+
+### 2.4. [[TITLE OF THE ACTION]]
 
 You can read more about this change on PR [#XXXX](https://github.com/decidim/decidim/pull/XXXX).
 

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -99,10 +99,12 @@ module Decidim
     end
 
     def record_failed_attempt!
-      increment!(:failed_attempts) # rubocop:disable Rails/SkipsModelValidations
-      return unless failed_attempts > Decidim.verification_max_failed_attempts
+      with_lock do
+        increment!(:failed_attempts) # rubocop:disable Rails/SkipsModelValidations
+        return unless failed_attempts > Decidim.verification_max_failed_attempts
 
-      update!(locked_at: Time.current)
+        update!(locked_at: Time.current)
+      end
     end
 
     def reset_failed_attempts!

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -101,7 +101,7 @@ module Decidim
     def record_failed_attempt!
       with_lock do
         increment!(:failed_attempts) # rubocop:disable Rails/SkipsModelValidations
-        return unless failed_attempts > Decidim.verification_max_failed_attempts
+        return unless failed_attempts >= Decidim.verification_max_failed_attempts
 
         update!(locked_at: Time.current)
       end

--- a/decidim-core/app/models/decidim/authorization.rb
+++ b/decidim-core/app/models/decidim/authorization.rb
@@ -98,6 +98,28 @@ module Decidim
       user == self.user
     end
 
+    def record_failed_attempt!
+      increment!(:failed_attempts) # rubocop:disable Rails/SkipsModelValidations
+      return unless failed_attempts > Decidim.verification_max_failed_attempts
+
+      update!(locked_at: Time.current)
+    end
+
+    def reset_failed_attempts!
+      update!(failed_attempts: 0, locked_at: nil)
+    end
+
+    def locked_for_confirmation?
+      locked_at.present? && locked_at + Decidim.verification_unlock_in > Time.current
+    end
+
+    def clear_expired_lock!
+      return if locked_at.blank?
+      return if locked_for_confirmation?
+
+      update!(locked_at: nil, failed_attempts: 0)
+    end
+
     private
 
     def active_handler?

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -37,12 +37,12 @@ if Rails.env.production? || Rails.env.test?
 
       # Throttle SMS verification confirmation attempts per IP to 10 reqs/minute
       Rack::Attack.throttle("limit sms verification attempts per ip", limit: 10, period: 60.seconds) do |request|
-        request.ip if request.path.match?(%r{^/[^/]+/sms/authorizations$}) && request.put?
+        request.ip if request.path.match?(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$}) && request.put?
       end
 
       # Throttle postal letter verification confirmation attempts per IP to 10 reqs/minute
       Rack::Attack.throttle("limit postal letter verification attempts per ip", limit: 10, period: 60.seconds) do |request|
-        request.ip if request.path.match?(%r{^/[^/]+/postal_letter/authorizations$}) && request.put?
+        request.ip if request.path.match?(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$}) && request.put?
       end
     end
   end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -37,12 +37,12 @@ if Rails.env.production? || Rails.env.test?
 
       # Throttle SMS verification confirmation attempts per IP to 10 reqs/minute
       Rack::Attack.throttle("limit sms verification attempts per ip", limit: 10, period: 60.seconds) do |request|
-        request.ip if request.path.match?(%r{^/\w+/sms/authorizations$}) && request.put?
+        request.ip if request.path.match?(%r{^/[^/]+/sms/authorizations$}) && request.put?
       end
 
       # Throttle postal letter verification confirmation attempts per IP to 10 reqs/minute
       Rack::Attack.throttle("limit postal letter verification attempts per ip", limit: 10, period: 60.seconds) do |request|
-        request.ip if request.path.match?(%r{^/\w+/postal_letter/authorizations$}) && request.put?
+        request.ip if request.path.match?(%r{^/[^/]+/postal_letter/authorizations$}) && request.put?
       end
     end
   end

--- a/decidim-core/config/initializers/rack_attack.rb
+++ b/decidim-core/config/initializers/rack_attack.rb
@@ -34,6 +34,16 @@ if Rails.env.production? || Rails.env.test?
       Rack::Attack.throttle("limit password recovery attempts per email", limit: 5, period: 60.seconds) do |request|
         request.params["user"]["email"] if request.path == "/users/password" && request.post?
       end
+
+      # Throttle SMS verification confirmation attempts per IP to 10 reqs/minute
+      Rack::Attack.throttle("limit sms verification attempts per ip", limit: 10, period: 60.seconds) do |request|
+        request.ip if request.path.match?(%r{^/\w+/sms/authorizations$}) && request.put?
+      end
+
+      # Throttle postal letter verification confirmation attempts per IP to 10 reqs/minute
+      Rack::Attack.throttle("limit postal letter verification attempts per ip", limit: 10, period: 60.seconds) do |request|
+        request.ip if request.path.match?(%r{^/\w+/postal_letter/authorizations$}) && request.put?
+      end
     end
   end
 end

--- a/decidim-core/db/migrate/20260909000000_add_failed_attempts_and_locked_at_to_decidim_authorizations.rb
+++ b/decidim-core/db/migrate/20260909000000_add_failed_attempts_and_locked_at_to_decidim_authorizations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddFailedAttemptsAndLockedAtToDecidimAuthorizations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :decidim_authorizations, :failed_attempts, :integer, default: 0, null: false
+    add_column :decidim_authorizations, :locked_at, :datetime
+  end
+end

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -482,6 +482,9 @@ module Decidim
   # Time window after which a locked verification is automatically unlocked.
   mattr_accessor :verification_unlock_in, default: Decidim::Env.new("DECIDIM_VERIFICATION_UNLOCK_IN", "30").to_i.minutes
 
+  # Time window (in minutes) after which a verification code expires (SMS only).
+  mattr_accessor :verification_code_expiry_minutes, default: Decidim::Env.new("DECIDIM_VERIFICATION_CODE_EXPIRY_MINUTES", "10").to_i
+
   # Time window were users can access the website even if their email is not confirmed.
   mattr_accessor :unconfirmed_access_for, default: Decidim::Env.new("DECIDIM_UNCONFIRMED_ACCESS_FOR", "0").to_i.days
 

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -476,6 +476,12 @@ module Decidim
   # Time window in which the throttling is applied.
   mattr_accessor :throttling_period, default: Decidim::Env.new("DECIDIM_THROTTLING_PERIOD", "1").to_i.minutes
 
+  # Max failed attempts for verification code confirmation before lockout.
+  mattr_accessor :verification_max_failed_attempts, default: Decidim::Env.new("DECIDIM_VERIFICATION_MAX_FAILED_ATTEMPTS", "5").to_i
+
+  # Time window after which a locked verification is automatically unlocked.
+  mattr_accessor :verification_unlock_in, default: Decidim::Env.new("DECIDIM_VERIFICATION_UNLOCK_IN", "30").to_i.minutes
+
   # Time window were users can access the website even if their email is not confirmed.
   mattr_accessor :unconfirmed_access_for, default: Decidim::Env.new("DECIDIM_UNCONFIRMED_ACCESS_FOR", "0").to_i.days
 

--- a/decidim-core/spec/config/initializers/rack/attack_spec.rb
+++ b/decidim-core/spec/config/initializers/rack/attack_spec.rb
@@ -2,17 +2,17 @@
 
 require "spec_helper"
 
-describe "Rack::Attack configuration" do
+describe Rack::Attack do
   # Since throttles are only registered outside test environment,
   # we test the throttle logic directly by simulating request objects
   let(:request_class) do
-    Struct.new(:path, :ip, :method, :params) do
+    Struct.new(:path, :ip, :request_method, :params) do
       def put?
-        method == :put
+        request_method == :put
       end
 
       def post?
-        method == :post
+        request_method == :post
       end
     end
   end
@@ -20,14 +20,14 @@ describe "Rack::Attack configuration" do
   describe "SMS verification throttle" do
     it "matches PUT requests to SMS authorization path" do
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
       expect(request).to be_put
     end
 
     it "matches SMS authorization path with different locales" do
       %w(en es ca fr de).each do |locale|
         request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
         expect(request).to be_put
       end
     end
@@ -35,9 +35,15 @@ describe "Rack::Attack configuration" do
     it "matches SMS authorization path with hyphenated locales" do
       %w(es-MX pt-BR zh-CN en-US).each do |locale|
         request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
         expect(request).to be_put
       end
+    end
+
+    it "matches SMS authorization path with JSON format" do
+      request = request_class.new("/en/sms/authorizations.json", "1.2.3.4", :put, {})
+      expect(request.path).to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
+      expect(request).to be_put
     end
 
     it "does not match GET requests to SMS authorization path" do
@@ -52,32 +58,32 @@ describe "Rack::Attack configuration" do
 
     it "does not match other verification paths" do
       request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
     end
 
     it "does not match paths with additional segments" do
       request = request_class.new("/en/sms/authorizations/edit", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
     end
 
     it "does not match paths with query parameters in the path segment" do
       # Query params are separate from path, so this should still match
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, { code: "123456" })
-      expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/sms/authorizations(?:\.[^/]+)?$})
     end
   end
 
   describe "postal letter verification throttle" do
     it "matches PUT requests to postal letter authorization path" do
       request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
       expect(request).to be_put
     end
 
     it "matches postal letter authorization path with different locales" do
       %w(en es ca fr de).each do |locale|
         request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
         expect(request).to be_put
       end
     end
@@ -85,9 +91,15 @@ describe "Rack::Attack configuration" do
     it "matches postal letter authorization path with hyphenated locales" do
       %w(es-MX pt-BR zh-CN en-US).each do |locale|
         request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
         expect(request).to be_put
       end
+    end
+
+    it "matches postal letter authorization path with JSON format" do
+      request = request_class.new("/en/postal_letter/authorizations.json", "1.2.3.4", :put, {})
+      expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
+      expect(request).to be_put
     end
 
     it "does not match GET requests to postal letter authorization path" do
@@ -102,12 +114,12 @@ describe "Rack::Attack configuration" do
 
     it "does not match other verification paths" do
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
     end
 
     it "does not match paths with additional segments" do
       request = request_class.new("/en/postal_letter/authorizations/edit", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations(?:\.[^/]+)?$})
     end
   end
 end

--- a/decidim-core/spec/config/initializers/rack_attack_spec.rb
+++ b/decidim-core/spec/config/initializers/rack_attack_spec.rb
@@ -20,14 +20,22 @@ describe "Rack::Attack configuration" do
   describe "SMS verification throttle" do
     it "matches PUT requests to SMS authorization path" do
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
       expect(request).to be_put
     end
 
     it "matches SMS authorization path with different locales" do
       %w[en es ca fr de].each do |locale|
         request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
+        expect(request).to be_put
+      end
+    end
+
+    it "matches SMS authorization path with hyphenated locales" do
+      %w[es-MX pt-BR zh-CN en-US].each do |locale|
+        request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
+        expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
         expect(request).to be_put
       end
     end
@@ -44,32 +52,40 @@ describe "Rack::Attack configuration" do
 
     it "does not match other verification paths" do
       request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/\w+/sms/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations$})
     end
 
     it "does not match paths with additional segments" do
       request = request_class.new("/en/sms/authorizations/edit", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/\w+/sms/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/sms/authorizations$})
     end
 
     it "does not match paths with query parameters in the path segment" do
       # Query params are separate from path, so this should still match
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, { code: "123456" })
-      expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
     end
   end
 
   describe "postal letter verification throttle" do
     it "matches PUT requests to postal letter authorization path" do
       request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).to match(%r{^/\w+/postal_letter/authorizations$})
+      expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
       expect(request).to be_put
     end
 
     it "matches postal letter authorization path with different locales" do
       %w[en es ca fr de].each do |locale|
         request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
-        expect(request.path).to match(%r{^/\w+/postal_letter/authorizations$})
+        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
+        expect(request).to be_put
+      end
+    end
+
+    it "matches postal letter authorization path with hyphenated locales" do
+      %w[es-MX pt-BR zh-CN en-US].each do |locale|
+        request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
+        expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
         expect(request).to be_put
       end
     end
@@ -86,12 +102,12 @@ describe "Rack::Attack configuration" do
 
     it "does not match other verification paths" do
       request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/\w+/postal_letter/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations$})
     end
 
     it "does not match paths with additional segments" do
       request = request_class.new("/en/postal_letter/authorizations/edit", "1.2.3.4", :put, {})
-      expect(request.path).not_to match(%r{^/\w+/postal_letter/authorizations$})
+      expect(request.path).not_to match(%r{^/[^/]+/postal_letter/authorizations$})
     end
   end
 end

--- a/decidim-core/spec/config/initializers/rack_attack_spec.rb
+++ b/decidim-core/spec/config/initializers/rack_attack_spec.rb
@@ -25,7 +25,7 @@ describe "Rack::Attack configuration" do
     end
 
     it "matches SMS authorization path with different locales" do
-      %w[en es ca fr de].each do |locale|
+      %w(en es ca fr de).each do |locale|
         request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
         expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
         expect(request).to be_put
@@ -33,7 +33,7 @@ describe "Rack::Attack configuration" do
     end
 
     it "matches SMS authorization path with hyphenated locales" do
-      %w[es-MX pt-BR zh-CN en-US].each do |locale|
+      %w(es-MX pt-BR zh-CN en-US).each do |locale|
         request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
         expect(request.path).to match(%r{^/[^/]+/sms/authorizations$})
         expect(request).to be_put
@@ -75,7 +75,7 @@ describe "Rack::Attack configuration" do
     end
 
     it "matches postal letter authorization path with different locales" do
-      %w[en es ca fr de].each do |locale|
+      %w(en es ca fr de).each do |locale|
         request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
         expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
         expect(request).to be_put
@@ -83,7 +83,7 @@ describe "Rack::Attack configuration" do
     end
 
     it "matches postal letter authorization path with hyphenated locales" do
-      %w[es-MX pt-BR zh-CN en-US].each do |locale|
+      %w(es-MX pt-BR zh-CN en-US).each do |locale|
         request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
         expect(request.path).to match(%r{^/[^/]+/postal_letter/authorizations$})
         expect(request).to be_put

--- a/decidim-core/spec/config/initializers/rack_attack_spec.rb
+++ b/decidim-core/spec/config/initializers/rack_attack_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Rack::Attack configuration" do
+  # Since throttles are only registered outside test environment,
+  # we test the throttle logic directly by simulating request objects
+  let(:request_class) do
+    Struct.new(:path, :ip, :method, :params) do
+      def put?
+        method == :put
+      end
+
+      def post?
+        method == :post
+      end
+    end
+  end
+
+  describe "SMS verification throttle" do
+    it "matches PUT requests to SMS authorization path" do
+      request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
+      expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+      expect(request).to be_put
+    end
+
+    it "matches SMS authorization path with different locales" do
+      %w[en es ca fr de].each do |locale|
+        request = request_class.new("/#{locale}/sms/authorizations", "1.2.3.4", :put, {})
+        expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+        expect(request).to be_put
+      end
+    end
+
+    it "does not match GET requests to SMS authorization path" do
+      request = request_class.new("/en/sms/authorizations", "1.2.3.4", :get, {})
+      expect(request).not_to be_put
+    end
+
+    it "does not match POST requests to SMS authorization path" do
+      request = request_class.new("/en/sms/authorizations", "1.2.3.4", :post, {})
+      expect(request).not_to be_put
+    end
+
+    it "does not match other verification paths" do
+      request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
+      expect(request.path).not_to match(%r{^/\w+/sms/authorizations$})
+    end
+
+    it "does not match paths with additional segments" do
+      request = request_class.new("/en/sms/authorizations/edit", "1.2.3.4", :put, {})
+      expect(request.path).not_to match(%r{^/\w+/sms/authorizations$})
+    end
+
+    it "does not match paths with query parameters in the path segment" do
+      # Query params are separate from path, so this should still match
+      request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, { code: "123456" })
+      expect(request.path).to match(%r{^/\w+/sms/authorizations$})
+    end
+  end
+
+  describe "postal letter verification throttle" do
+    it "matches PUT requests to postal letter authorization path" do
+      request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :put, {})
+      expect(request.path).to match(%r{^/\w+/postal_letter/authorizations$})
+      expect(request).to be_put
+    end
+
+    it "matches postal letter authorization path with different locales" do
+      %w[en es ca fr de].each do |locale|
+        request = request_class.new("/#{locale}/postal_letter/authorizations", "1.2.3.4", :put, {})
+        expect(request.path).to match(%r{^/\w+/postal_letter/authorizations$})
+        expect(request).to be_put
+      end
+    end
+
+    it "does not match GET requests to postal letter authorization path" do
+      request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :get, {})
+      expect(request).not_to be_put
+    end
+
+    it "does not match POST requests to postal letter authorization path" do
+      request = request_class.new("/en/postal_letter/authorizations", "1.2.3.4", :post, {})
+      expect(request).not_to be_put
+    end
+
+    it "does not match other verification paths" do
+      request = request_class.new("/en/sms/authorizations", "1.2.3.4", :put, {})
+      expect(request.path).not_to match(%r{^/\w+/postal_letter/authorizations$})
+    end
+
+    it "does not match paths with additional segments" do
+      request = request_class.new("/en/postal_letter/authorizations/edit", "1.2.3.4", :put, {})
+      expect(request.path).not_to match(%r{^/\w+/postal_letter/authorizations$})
+    end
+  end
+end

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -178,9 +178,9 @@ module Decidim
         expect { authorization.record_failed_attempt! }.to change(authorization, :failed_attempts).by(1)
       end
 
-      context "when failed_attempts exceeds the maximum" do
+      context "when failed_attempts reaches the maximum" do
         before do
-          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts)
+          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts - 1)
         end
 
         it "sets locked_at" do
@@ -189,9 +189,9 @@ module Decidim
         end
       end
 
-      context "when failed_attempts does not exceed the maximum" do
+      context "when failed_attempts does not reach the maximum" do
         before do
-          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts - 1)
+          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts - 2)
         end
 
         it "does not set locked_at" do

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -199,6 +199,25 @@ module Decidim
           expect(authorization.reload.locked_at).to be_nil
         end
       end
+
+      context "with concurrent calls" do
+        let!(:authorization) { create(:authorization, :pending, failed_attempts: 0) }
+
+        it "atomically increments and locks when threshold is reached" do
+          threads = Decidim.verification_max_failed_attempts.times.map do
+            Thread.new do
+              auth = Decidim::Authorization.find(authorization.id)
+              auth.record_failed_attempt!
+            end
+          end
+
+          threads.each(&:join)
+
+          reloaded = authorization.reload
+          expect(reloaded.failed_attempts).to eq(Decidim.verification_max_failed_attempts)
+          expect(reloaded.locked_at).to be_present
+        end
+      end
     end
 
     describe "#reset_failed_attempts!" do

--- a/decidim-core/spec/models/decidim/authorization_spec.rb
+++ b/decidim-core/spec/models/decidim/authorization_spec.rb
@@ -170,5 +170,117 @@ module Decidim
         expect(Time.current - start).to be < 1
       end
     end
+
+    describe "#record_failed_attempt!" do
+      let!(:authorization) { create(:authorization, :pending) }
+
+      it "increments the failed_attempts counter" do
+        expect { authorization.record_failed_attempt! }.to change(authorization, :failed_attempts).by(1)
+      end
+
+      context "when failed_attempts exceeds the maximum" do
+        before do
+          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts)
+        end
+
+        it "sets locked_at" do
+          authorization.record_failed_attempt!
+          expect(authorization.reload.locked_at).to be_present
+        end
+      end
+
+      context "when failed_attempts does not exceed the maximum" do
+        before do
+          authorization.update!(failed_attempts: Decidim.verification_max_failed_attempts - 1)
+        end
+
+        it "does not set locked_at" do
+          authorization.record_failed_attempt!
+          expect(authorization.reload.locked_at).to be_nil
+        end
+      end
+    end
+
+    describe "#reset_failed_attempts!" do
+      let!(:authorization) { create(:authorization, :pending, failed_attempts: 3, locked_at: Time.current) }
+
+      it "resets failed_attempts to 0" do
+        authorization.reset_failed_attempts!
+        expect(authorization.failed_attempts).to eq(0)
+      end
+
+      it "clears locked_at" do
+        authorization.reset_failed_attempts!
+        expect(authorization.locked_at).to be_nil
+      end
+    end
+
+    describe "#locked_for_confirmation?" do
+      let!(:authorization) { create(:authorization, :pending) }
+
+      context "when locked_at is nil" do
+        it "returns false" do
+          expect(authorization.locked_for_confirmation?).to be false
+        end
+      end
+
+      context "when locked_at is within the unlock window" do
+        before do
+          authorization.update!(locked_at: Time.current)
+        end
+
+        it "returns true" do
+          expect(authorization.locked_for_confirmation?).to be true
+        end
+      end
+
+      context "when locked_at is outside the unlock window" do
+        before do
+          authorization.update!(locked_at: Decidim.verification_unlock_in.ago - 1.minute)
+        end
+
+        it "returns false" do
+          expect(authorization.locked_for_confirmation?).to be false
+        end
+      end
+    end
+
+    describe "#clear_expired_lock!" do
+      let!(:authorization) { create(:authorization, :pending) }
+
+      context "when locked_at is nil" do
+        it "does nothing" do
+          authorization.clear_expired_lock!
+          expect(authorization.locked_at).to be_nil
+        end
+      end
+
+      context "when locked_at is within the unlock window" do
+        before do
+          authorization.update!(locked_at: Time.current, failed_attempts: 5)
+        end
+
+        it "does not clear the lock" do
+          authorization.clear_expired_lock!
+          expect(authorization.reload.locked_at).to be_present
+        end
+      end
+
+      context "when locked_at is outside the unlock window" do
+        before do
+          authorization.update!(locked_at: Decidim.verification_unlock_in.ago - 1.minute, failed_attempts: 5)
+        end
+
+        it "clears the lock" do
+          authorization.clear_expired_lock!
+          expect(authorization.reload.locked_at).to be_nil
+        end
+
+        it "resets failed_attempts" do
+          authorization.clear_expired_lock!
+          expect(authorization.reload.failed_attempts).to eq(0)
+        end
+      end
+    end
   end
 end

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -24,18 +24,21 @@ module Decidim
       def call
         return already_confirmed! if authorization.granted?
 
-        authorization.clear_expired_lock!
+        Decidim::Authorization.transaction do
+          authorization.lock!
+          authorization.clear_expired_lock!
 
-        return locked! if authorization.locked_for_confirmation?
+          return locked! if authorization.locked_for_confirmation?
 
-        return invalid! unless form.valid?
+          return invalid! unless form.valid?
 
-        return expired! if code_expired?
+          return expired! if code_expired?
 
-        if confirmation_successful?
-          valid!
-        else
-          invalid!
+          if confirmation_successful?
+            valid!
+          else
+            invalid!
+          end
         end
       rescue StandardError => e
         invalid!(e.message)

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -4,23 +4,20 @@ module Decidim
   module Verifications
     # A command to confirm a previous partial authorization.
     class ConfirmUserAuthorization < Decidim::Command
-      # Number of failed confirmation attempts before throttling.
-      MAX_FAILED_ATTEMPTS = 2
-
       # Public: Initializes the command.
       #
       # authorization - An Authorization to be confirmed.
       # form - A form object with the verification data to confirm it.
-      def initialize(authorization, form, session)
+      def initialize(authorization, form)
         @authorization = authorization
         @form = form
-        @session = session
       end
 
       # Executes the command. Broadcasts these events:
       #
       # - :ok when everything is valid.
       # - :invalid if the handler was not valid and we could not proceed.
+      # - :locked if too many failed attempts and the authorization is locked.
       #
       # Returns nothing.
       def call
@@ -28,7 +25,9 @@ module Decidim
 
         return invalid! unless form.valid?
 
-        throttle! if too_many_failed_attempts?
+        authorization.clear_expired_lock!
+
+        return locked! if authorization.locked_for_confirmation?
 
         if confirmation_successful?
           valid!
@@ -51,41 +50,25 @@ module Decidim
 
       def valid!
         authorization.grant!
-        reset_failed_attempts!
+        authorization.reset_failed_attempts!
         broadcast(:ok)
       end
 
       def invalid!(message = nil)
-        record_failed_attempt!
+        authorization.record_failed_attempt!
         broadcast(:invalid, message)
       end
 
       def already_confirmed!
-        reset_failed_attempts!
+        authorization.reset_failed_attempts!
         broadcast(:already_confirmed)
       end
 
-      def too_many_failed_attempts?
-        failed_attempts > MAX_FAILED_ATTEMPTS
+      def locked!
+        broadcast(:locked)
       end
 
-      def failed_attempts
-        session[:failed_attempts] ||= 0
-      end
-
-      def reset_failed_attempts!
-        session[:failed_attempts] = 0
-      end
-
-      def record_failed_attempt!
-        session[:failed_attempts] = failed_attempts + 1
-      end
-
-      def throttle!
-        sleep rand * failed_attempts
-      end
-
-      attr_reader :authorization, :form, :session
+      attr_reader :authorization, :form
     end
   end
 end

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -24,11 +24,11 @@ module Decidim
       def call
         return already_confirmed! if authorization.granted?
 
-        return invalid! unless form.valid?
-
         authorization.clear_expired_lock!
 
         return locked! if authorization.locked_for_confirmation?
+
+        return invalid! unless form.valid?
 
         return expired! if code_expired?
 

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -18,6 +18,7 @@ module Decidim
       # - :ok when everything is valid.
       # - :invalid if the handler was not valid and we could not proceed.
       # - :locked if too many failed attempts and the authorization is locked.
+      # - :expired if the verification code has expired.
       #
       # Returns nothing.
       def call
@@ -28,6 +29,8 @@ module Decidim
         authorization.clear_expired_lock!
 
         return locked! if authorization.locked_for_confirmation?
+
+        return expired! if code_expired?
 
         if confirmation_successful?
           valid!
@@ -66,6 +69,20 @@ module Decidim
 
       def locked!
         broadcast(:locked)
+      end
+
+      def code_expired?
+        sent_at = authorization.verification_metadata["code_sent_at"]
+        return false unless sent_at
+
+        sent_at = Time.parse(sent_at.to_s) if sent_at.is_a?(String)
+        sent_at < Decidim.verification_code_expiry_minutes.minutes.ago
+      end
+
+      def expired!
+        authorization.update!(verification_metadata: {})
+        authorization.reset_failed_attempts!
+        broadcast(:expired)
       end
 
       attr_reader :authorization, :form

--- a/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/confirm_user_authorization.rb
@@ -75,7 +75,7 @@ module Decidim
         sent_at = authorization.verification_metadata["code_sent_at"]
         return false unless sent_at
 
-        sent_at = Time.parse(sent_at.to_s) if sent_at.is_a?(String)
+        sent_at = Time.zone.parse(sent_at.to_s) if sent_at.is_a?(String)
         sent_at < Decidim.verification_code_expiry_minutes.minutes.ago
       end
 

--- a/decidim-verifications/app/commands/decidim/verifications/csv_census/confirm_census_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/csv_census/confirm_census_authorization.rb
@@ -7,17 +7,20 @@ module Decidim
         def call
           return broadcast(:invalid) unless form.valid?
 
-          authorization.clear_expired_lock!
+          Decidim::Authorization.transaction do
+            authorization.lock!
+            authorization.clear_expired_lock!
 
-          return broadcast(:locked) if authorization.locked_for_confirmation?
+            return broadcast(:locked) if authorization.locked_for_confirmation?
 
-          if confirmation_successful?
-            authorization.grant!
-            authorization.reset_failed_attempts!
-            broadcast(:ok)
-          else
-            authorization.record_failed_attempt!
-            broadcast(:invalid)
+            if confirmation_successful?
+              authorization.grant!
+              authorization.reset_failed_attempts!
+              broadcast(:ok)
+            else
+              authorization.record_failed_attempt!
+              broadcast(:invalid)
+            end
           end
         end
       end

--- a/decidim-verifications/app/commands/decidim/verifications/csv_census/confirm_census_authorization.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/csv_census/confirm_census_authorization.rb
@@ -7,10 +7,16 @@ module Decidim
         def call
           return broadcast(:invalid) unless form.valid?
 
+          authorization.clear_expired_lock!
+
+          return broadcast(:locked) if authorization.locked_for_confirmation?
+
           if confirmation_successful?
             authorization.grant!
+            authorization.reset_failed_attempts!
             broadcast(:ok)
           else
+            authorization.record_failed_attempt!
             broadcast(:invalid)
           end
         end

--- a/decidim-verifications/app/commands/decidim/verifications/perform_authorization_step.rb
+++ b/decidim-verifications/app/commands/decidim/verifications/perform_authorization_step.rb
@@ -34,7 +34,9 @@ module Decidim
           unique_id: handler.unique_id,
           metadata: handler.metadata,
           verification_metadata: handler.verification_metadata,
-          verification_attachment: handler.verification_attachment
+          verification_attachment: handler.verification_attachment,
+          failed_attempts: 0,
+          locked_at: nil
         }
 
         authorization.save!

--- a/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/csv_census/authorizations_controller.rb
@@ -12,12 +12,15 @@ module Decidim
 
         def new
           @form = CensusForm.from_params(user: current_user)
-          ConfirmCensusAuthorization.call(@authorization, @form, session) do
+          ConfirmCensusAuthorization.call(@authorization, @form) do
             on(:ok) do
               flash[:notice] = t("authorizations.new.success", scope: "decidim.verifications.csv_census")
             end
             on(:invalid) do
               flash[:alert] = t("authorizations.new.error", scope: "decidim.verifications.csv_census")
+            end
+            on(:locked) do
+              flash[:alert] = t("authorizations.new.locked", scope: "decidim.verifications.csv_census")
             end
             redirect_to decidim_verifications.authorizations_path
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/id_documents/admin/confirmations_controller.rb
@@ -28,7 +28,7 @@ module Decidim
 
             @form = InformationForm.from_params(params)
 
-            ConfirmUserAuthorization.call(@pending_authorization, @form, session) do
+            ConfirmUserAuthorization.call(@pending_authorization, @form) do
               on(:ok) do
                 flash[:notice] = t("confirmations.create.success", scope: "decidim.verifications.id_documents.admin")
                 redirect_to pending_authorizations_path
@@ -37,6 +37,11 @@ module Decidim
               on(:invalid) do
                 flash.now[:alert] = t("confirmations.create.error", scope: "decidim.verifications.id_documents.admin")
                 render action: :new, status: :unprocessable_content
+              end
+
+              on(:locked) do
+                flash.now[:alert] = t("confirmations.create.locked", scope: "decidim.verifications.id_documents.admin")
+                render action: :new, status: :too_many_requests
               end
             end
           end

--- a/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/postal_letter/authorizations_controller.rb
@@ -45,7 +45,7 @@ module Decidim
 
           @form = ConfirmationForm.from_params(params)
 
-          ConfirmUserAuthorization.call(@authorization, @form, session) do
+          ConfirmUserAuthorization.call(@authorization, @form) do
             on(:ok) do
               flash[:notice] = t("authorizations.update.success", scope: "decidim.verifications.postal_letter")
               redirect_to decidim_verifications.authorizations_path
@@ -54,6 +54,11 @@ module Decidim
             on(:invalid) do
               flash.now[:alert] = t("authorizations.update.error", scope: "decidim.verifications.postal_letter")
               render :edit, status: :unprocessable_content
+            end
+
+            on(:locked) do
+              flash.now[:alert] = t("authorizations.update.locked", scope: "decidim.verifications.postal_letter")
+              render :edit, status: :too_many_requests
             end
           end
         end

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -43,7 +43,7 @@ module Decidim
 
           @form = ConfirmationForm.from_params(params)
 
-          ConfirmUserAuthorization.call(authorization, @form, session) do
+          ConfirmUserAuthorization.call(authorization, @form) do
             on(:ok) do
               flash[:notice] = t("authorizations.update.success", scope: "decidim.verifications.sms")
 
@@ -53,6 +53,11 @@ module Decidim
             on(:invalid) do
               flash.now[:alert] = t("authorizations.update.error", scope: "decidim.verifications.sms")
               render :edit, status: :unprocessable_content
+            end
+
+            on(:locked) do
+              flash.now[:alert] = t("authorizations.update.locked", scope: "decidim.verifications.sms")
+              render :edit, status: :too_many_requests
             end
           end
         end

--- a/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
+++ b/decidim-verifications/app/controllers/decidim/verifications/sms/authorizations_controller.rb
@@ -59,6 +59,11 @@ module Decidim
               flash.now[:alert] = t("authorizations.update.locked", scope: "decidim.verifications.sms")
               render :edit, status: :too_many_requests
             end
+
+            on(:expired) do
+              flash[:alert] = t("authorizations.update.expired", scope: "decidim.verifications.sms")
+              redirect_to redirect_url || decidim_verifications.authorizations_path
+            end
           end
         end
 

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -228,6 +228,7 @@ en:
         authorizations:
           new:
             error: We could not verify your account or you are not in the organization's census.
+            locked: Too many failed attempts. Please try again later.
             success: Your account has been successfully verified.
       dummy_authorization:
         extra_explanation:
@@ -253,6 +254,7 @@ en:
           confirmations:
             create:
               error: Verification does not match. Please try again or reject the verification so the participant can amend it.
+              locked: Too many failed attempts. Please try again later.
               success: Participant successfully verified.
             new:
               reject: Reject
@@ -329,6 +331,7 @@ en:
             title: Request your verification code
           update:
             error: Your verification code does not match ours. Please double-check the letter we sent to you.
+            locked: Too many failed attempts. Please try again later.
             success: Congratulations. You have been successfully verified.
       sms:
         authorizations:
@@ -348,6 +351,7 @@ en:
             title: Request your verification code
           update:
             error: Your verification code does not match ours. Please double-check the SMS we sent you.
+            locked: Too many failed attempts. Please try again later or request a new code.
             success: Congratulations. You have been successfully verified.
   errors:
     messages:

--- a/decidim-verifications/config/locales/en.yml
+++ b/decidim-verifications/config/locales/en.yml
@@ -351,6 +351,7 @@ en:
             title: Request your verification code
           update:
             error: Your verification code does not match ours. Please double-check the SMS we sent you.
+            expired: The verification code has expired. Please request a new one.
             locked: Too many failed attempts. Please try again later or request a new code.
             success: Congratulations. You have been successfully verified.
   errors:

--- a/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
@@ -91,6 +91,61 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
     end
   end
 
+  context "when the verification code has expired" do
+    let(:secret_code) { "XX42YY" }
+
+    before do
+      authorization.update!(verification_metadata: { secret_code: "XX42YY", code_sent_at: Decidim.verification_code_expiry_minutes.minutes.ago - 1.minute })
+    end
+
+    it "broadcasts expired" do
+      expect { subject.call }.to broadcast(:expired)
+    end
+
+    it "clears the verification metadata" do
+      subject.call
+      expect(authorization.reload.verification_metadata).to eq({})
+    end
+
+    it "resets the failed attempts" do
+      authorization.update!(failed_attempts: 3)
+      subject.call
+      expect(authorization.reload.failed_attempts).to eq(0)
+    end
+  end
+
+  context "when the verification code has not expired" do
+    let(:secret_code) { "XX42YY" }
+
+    before do
+      authorization.update!(verification_metadata: { secret_code: "XX42YY", code_sent_at: Decidim.verification_code_expiry_minutes.minutes.ago + 1.minute })
+    end
+
+    it "broadcasts ok" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+  end
+
+  context "when there is no code_sent_at timestamp" do
+    let(:secret_code) { "XX42YY" }
+
+    it "does not expire the code" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+  end
+
+  context "when there is only a letter_sent_at timestamp" do
+    let(:secret_code) { "XX42YY" }
+
+    before do
+      authorization.update!(verification_metadata: { secret_code: "XX42YY", letter_sent_at: Decidim.verification_code_expiry_minutes.minutes.ago - 1.hour })
+    end
+
+    it "does not expire the code" do
+      expect { subject.call }.to broadcast(:ok)
+    end
+  end
+
   context "when the authorization fails too many times" do
     let(:secret_code) { "wrong" }
 

--- a/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
@@ -3,9 +3,7 @@
 require "spec_helper"
 
 describe Decidim::Verifications::ConfirmUserAuthorization do
-  subject { described_class.new(authorization, form, session) }
-
-  let(:session) { {} }
+  subject { described_class.new(authorization, form) }
 
   let(:authorization) do
     create(
@@ -49,9 +47,9 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
       expect { subject.call }.to broadcast(:invalid)
     end
 
-    it "remembers the failed attempt in the session" do
+    it "records the failed attempt on the authorization" do
       subject.call
-      expect(session[:failed_attempts]).to eq(1)
+      expect(authorization.reload.failed_attempts).to eq(1)
     end
   end
 
@@ -64,19 +62,41 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
       expect { subject.call }.to broadcast(:already_confirmed)
     end
 
-    it "resets the failed attempts in the session" do
+    it "resets the failed attempts on the authorization" do
+      authorization.update!(failed_attempts: 3)
       subject.call
-      expect(session[:failed_attempts]).to eq(0)
+      expect(authorization.reload.failed_attempts).to eq(0)
     end
   end
 
-  context "when the authorization fails too many times in a row" do
+  context "when the authorization is locked" do
     let(:secret_code) { "XX42YY" }
-    let(:session) { { failed_attempts: 3 } }
 
-    it "throttles before proceeding" do
-      expect(subject).to receive(:throttle!) # rubocop:disable RSpec/SubjectStub
-      expect { subject.call }.to broadcast(:ok)
+    before do
+      authorization.update!(locked_at: Time.current, failed_attempts: Decidim.verification_max_failed_attempts + 1)
+    end
+
+    it "broadcasts locked" do
+      expect { subject.call }.to broadcast(:locked)
+    end
+
+    context "when the lock has expired" do
+      before do
+        authorization.update!(locked_at: Decidim.verification_unlock_in.ago - 1.minute)
+      end
+
+      it "clears the expired lock and proceeds" do
+        expect { subject.call }.to broadcast(:ok)
+      end
+    end
+  end
+
+  context "when the authorization fails too many times" do
+    let(:secret_code) { "wrong" }
+
+    it "locks the authorization after exceeding max attempts" do
+      (Decidim.verification_max_failed_attempts + 1).times { subject.call }
+      expect(authorization.reload.locked_at).to be_present
     end
   end
 
@@ -91,9 +111,10 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
       expect { subject.call }.to change(authorizations, :count).by(1)
     end
 
-    it "resets the failed attempts in the session" do
+    it "resets the failed attempts on the authorization" do
+      authorization.update!(failed_attempts: 3)
       subject.call
-      expect(session[:failed_attempts]).to eq(0)
+      expect(authorization.reload.failed_attempts).to eq(0)
     end
 
     context "when there is a problem with the SMS service" do

--- a/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
@@ -80,6 +80,20 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
       expect { subject.call }.to broadcast(:locked)
     end
 
+    context "when the form is invalid" do
+      let(:secret_code) { nil }
+
+      it "broadcasts locked instead of invalid" do
+        expect { subject.call }.to broadcast(:locked)
+      end
+
+      it "does not increment failed_attempts" do
+        initial_attempts = authorization.failed_attempts
+        subject.call
+        expect(authorization.reload.failed_attempts).to eq(initial_attempts)
+      end
+    end
+
     context "when the lock has expired" do
       before do
         authorization.update!(locked_at: Decidim.verification_unlock_in.ago - 1.minute)

--- a/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
+++ b/decidim-verifications/spec/commands/decidim/verifications/confirm_user_authorization_spec.rb
@@ -149,8 +149,8 @@ describe Decidim::Verifications::ConfirmUserAuthorization do
   context "when the authorization fails too many times" do
     let(:secret_code) { "wrong" }
 
-    it "locks the authorization after exceeding max attempts" do
-      (Decidim.verification_max_failed_attempts + 1).times { subject.call }
+    it "locks the authorization after reaching max attempts" do
+      Decidim.verification_max_failed_attempts.times { subject.call }
       expect(authorization.reload.locked_at).to be_present
     end
   end

--- a/decidim-verifications/spec/system/sms/code_verification_spec.rb
+++ b/decidim-verifications/spec/system/sms/code_verification_spec.rb
@@ -34,7 +34,7 @@ describe "sms code verification" do
     let(:prior_verification_metadata) do
       {
         verification_code: "111111",
-        code_sent_at: 1.day.ago
+        code_sent_at: 1.minute.ago
       }
     end
 

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -504,6 +504,16 @@ Mind that this depends on your environment, for instance you could also need to 
 |1
 |No
 
+|DECIDIM_VERIFICATION_MAX_FAILED_ATTEMPTS
+|Maximum number of failed verification code confirmation attempts before the authorization is locked. Applies to all verification handlers (SMS, postal letter, ID documents, CSV census).
+|5
+|No
+
+|DECIDIM_VERIFICATION_UNLOCK_IN
+|Time window (in number of minutes) after which a locked verification is automatically unlocked.
+|30
+|No
+
 |DECIDIM_UNCONFIRMED_ACCESS_FOR
 |Time window (in number of days) were users can access the website even if their email is not confirmed.
 |0

--- a/docs/modules/configure/pages/environment_variables.adoc
+++ b/docs/modules/configure/pages/environment_variables.adoc
@@ -514,6 +514,11 @@ Mind that this depends on your environment, for instance you could also need to 
 |30
 |No
 
+|DECIDIM_VERIFICATION_CODE_EXPIRY_MINUTES
+|Time window (in number of minutes) after which a verification code expires. Applies only to SMS verification.
+|10
+|No
+
 |DECIDIM_UNCONFIRMED_ACCESS_FOR
 |Time window (in number of days) were users can access the website even if their email is not confirmed.
 |0


### PR DESCRIPTION
### :tophat: What? Why?

This PR improves the verifications/authorizations mechanisms by introducing three changes: 

1. Moving the lock-in mechanism from session (that can be resetted by cleaning the cookies) to DB 
2. Adding code expiration logic in SMS
3. Adding throttling with rack-attack 
 
This is the thin line between a feature and a fix. As it is a change involving security mechanisms, I'm leaning into fix so already working installations can benefit from them. 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Verification attempts are now tracked securely across SMS, postal letter, identity document, and census verification.
  - Repeated failed attempts temporarily lock verification, with automatic unlocking after the configured delay.
  - SMS verification codes now expire after a configurable period.
  - Users receive clear messages when verification is locked or an SMS code has expired.
  - SMS and postal-letter verification requests are rate-limited, including formatted requests.

- **Documentation**
  - Added configuration guidance for attempt limits, unlock delays, and SMS code expiry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->