### PR TITLE
Fix flaky specs at `manage_landing_page_examples.rb`

### DIFF
--- a/decidim-participatory_processes/spec/shared/manage_landing_page_examples.rb
+++ b/decidim-participatory_processes/spec/shared/manage_landing_page_examples.rb
@@ -34,6 +34,7 @@ shared_examples "manage landing page examples" do
             find("a", text: "Hero image and CTA", exact_text: true).click
           end
         end
+        expect(page).to have_callout("Content block successfully created.")
       end.to change(active_content_blocks, :count).by(1)
     end
 
@@ -47,6 +48,7 @@ shared_examples "manage landing page examples" do
             find("a", text: "Hero image and CTA", exact_text: true).click
           end
         end
+        expect(page).to have_callout("Content block successfully created.")
 
         first("ul.js-list-available li").drag_to(find("ul.js-list-actives"))
         sleep(2)
@@ -72,6 +74,7 @@ shared_examples "manage landing page examples" do
 
     it "updates the settings of the content block" do
       visit edit_content_block_path(resource, content_block)
+      expect(page).to have_css("form.edit_content_block")
 
       fill_in(
         :content_block_settings_button_text_en,
@@ -79,6 +82,8 @@ shared_examples "manage landing page examples" do
       )
 
       click_on "Update"
+      expect(page).to have_no_css("form.edit_content_block")
+
       visit edit_content_block_path(resource, content_block)
       expect(page).to have_css("input[value='Custom button text!']")
 


### PR DESCRIPTION
#### :tophat: What? Why?
Noticed these flaky specs at example run:
https://github.com/decidim/decidim/actions/runs/34457533096/job/102807318222

Relevant test output:
```
Failures:

  1) Admin manages participatory process landing page behaves like manage landing page examples when editing a non-persisted content block creates the content block to the db before editing it
     Failure/Error:
       expect do
         within ".edit_content_blocks" do
           click_on(text: "Add content block")
           within "#add-content-block-dropdown" do
             find("a", text: "Hero image and CTA", exact_text: true).click
           end
         end
       end.to change(active_content_blocks, :count).by(1)

       expected `Decidim::ContentBlock::ActiveRecord_Relation#count` to have changed by 1, but was changed by 0


     Shared Example Group: "manage landing page examples" called from ./spec/system/admin/admin_manages_participatory_process_landing_page_spec.rb:15
     # ./spec/shared/manage_landing_page_examples.rb:37:in 'block (3 levels) in <top (required)>'

Failed examples:

rspec ./spec/system/admin/admin_manages_participatory_process_landing_page_spec.rb[1:1:2:1] # Admin manages participatory process landing page behaves like manage landing page examples when editing a non-persisted content block creates the content block to the db before editing it
```

#### Testing
```bash
cd decidim-participatory_processes
for i in {1..20}; do bundle exec rspec ./spec/system/admin/admin_manages_participatory_process_landing_page_spec.rb || break; done
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of content block creation by confirming a success message is displayed.
  * Updated persisted settings checks to verify the edit form appears initially and closes after changes are saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->