### PR TITLE
Fix race condition with elections' votes

### DIFF
--- a/decidim-elections/app/commands/decidim/elections/cast_votes.rb
+++ b/decidim-elections/app/commands/decidim/elections/cast_votes.rb
@@ -40,12 +40,14 @@ module Decidim
         voted_questions.each do |question, responses|
           raise StandardError, "No responses for question #{question.id}" if responses.blank?
 
-          question.votes.where(voter_uid:).destroy_all
-          responses.each do |response_option|
-            question.votes.create!(
-              voter_uid:,
-              response_option:
-            )
+          question.with_lock do
+            question.votes.where(voter_uid:).destroy_all
+            responses.each do |response_option|
+              question.votes.create!(
+                voter_uid:,
+                response_option:
+              )
+            end
           end
         end
       end

--- a/decidim-elections/spec/commands/decidim/elections/cast_votes_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/cast_votes_spec.rb
@@ -168,6 +168,34 @@ module Decidim
           expect { subject.call }.to broadcast(:invalid)
         end
       end
+
+      context "when concurrent requests are made for the same question" do
+        let(:election) { create(:election, :ongoing, :per_question, :with_questions) }
+        let(:question) { election.questions.first }
+        let(:response_option_a) { question.response_options.first }
+        let(:response_option_b) { question.response_options.second }
+
+        before do
+          question.update!(question_type: "single_option", max_choices: 1)
+        end
+
+        it "does not allow exceeding max_votable_options" do
+          threads = 2.times.map do |i|
+            response_id = i.zero? ? response_option_a.id : response_option_b.id
+            thread_data = { question.id.to_s => [response_id.to_s] }
+
+            Thread.new do
+              ActiveRecord::Base.connection_pool.with_connection do
+                described_class.call(election, thread_data, voter_uid)
+              end
+            end
+          end
+
+          threads.each(&:join)
+
+          expect(question.votes.where(voter_uid:).count).to be <= question.max_votable_options
+        end
+      end
     end
   end
 end

--- a/decidim-elections/spec/commands/decidim/elections/cast_votes_spec.rb
+++ b/decidim-elections/spec/commands/decidim/elections/cast_votes_spec.rb
@@ -179,21 +179,33 @@ module Decidim
           question.update!(question_type: "single_option", max_choices: 1)
         end
 
+        # Race condition tests are inherently non-deterministic. This test uses
+        # a barrier to maximize thread overlap, but may not reliably fail without
+        # the fix in all test environments. The with_lock fix ensures correctness
+        # in production regardless of test reliability.
         it "does not allow exceeding max_votable_options" do
+          barrier = Queue.new
+          ready_count = Mutex.new
+          ready = 0
+
           threads = 2.times.map do |i|
             response_id = i.zero? ? response_option_a.id : response_option_b.id
             thread_data = { question.id.to_s => [response_id.to_s] }
 
             Thread.new do
               ActiveRecord::Base.connection_pool.with_connection do
+                ready_count.synchronize { ready += 1 }
+                barrier.pop
                 described_class.call(election, thread_data, voter_uid)
               end
             end
           end
 
+          sleep(0.05) until ready == 2
+          2.times { barrier.push(nil) }
           threads.each(&:join)
 
-          expect(question.votes.where(voter_uid:).count).to be <= question.max_votable_options
+          expect(question.votes.where(voter_uid:).count).to eq(1)
         end
       end
     end


### PR DESCRIPTION
#### :tophat: What? Why?

It was detected that multiple requests in parallel could do a race condition in elections' votes. 

This PR fixes it. 

Note for reviewer: I'd want to have a better spec for catching regressions on this one (something that fails by running against `develop` without the patch), but I couldn't find a way to make it fail. 

:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent vote handling so replacing a vote for the same question is processed consistently.
  - Prevented duplicate responses from persisting when votes are submitted simultaneously.
  - Ensured voters remain within the configured maximum number of choices.

- **Tests**
  - Added regression coverage confirming that concurrent submissions leave exactly one vote for the voter’s question.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->