### PR TITLE
Fix hour picker display in Blog Posts

### DIFF
--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/datepicker_functions.js
@@ -6,11 +6,16 @@ export const adjustPickerPosition = (input, datePickerContainer, selector) => {
   if (getComputedStyle(parent).position === "static") {
     parent.style.position = "relative";
   }
+  const stickyFooterItem = document.querySelector(".item__edit-sticky");
 
-  const rect = input.getBoundingClientRect();
+  const availableBottom = stickyFooterItem
+    ? stickyFooterItem.getBoundingClientRect().top
+    : window.innerHeight;
+
   const calendarHeight = datePickerContainer.offsetHeight;
+  const rect = input.getBoundingClientRect();
+  const spaceBelow = availableBottom - rect.bottom;
   const spaceAbove = rect.top;
-  const spaceBelow = window.innerHeight - rect.bottom;
   const openBelow = spaceBelow >= calendarHeight || spaceBelow >= spaceAbove;
 
   if (openBelow) {

--- a/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/test/datepicker_functions_adjust_picker_position.test.js
+++ b/decidim-core/app/packs/src/decidim/controllers/date_picker/datepicker/test/datepicker_functions_adjust_picker_position.test.js
@@ -231,4 +231,37 @@ describe("adjustTimePickerPosition", () => {
 
     expect(timePicker.style.right).toBe("0px");
   });
+
+  it("opens above when sticky action area reduces the available space below", () => {
+    jest.spyOn(input, "getBoundingClientRect").mockReturnValue({
+      top: 300,
+      bottom: 340
+    });
+
+    Reflect.defineProperty(window, "innerHeight", {
+      writable: true,
+      configurable: true,
+      value: 600
+    });
+
+    const stickyContainer = document.createElement("div");
+    stickyContainer.className = "item__edit-sticky";
+
+    jest.spyOn(stickyContainer, "getBoundingClientRect").mockReturnValue({
+      top: 500
+    });
+
+    document.body.appendChild(stickyContainer);
+
+    adjustPickerPosition(
+      input,
+      timePicker,
+      ".datepicker__time-column"
+    );
+
+    expect(timePicker.style.top).toBe("");
+    expect(timePicker.style.bottom).toBe("30px");
+
+    document.body.removeChild(stickyContainer);
+  });
 });


### PR DESCRIPTION
#### :tophat: What? Why?
Update the available space calculation to account for the padding of the bottom area introduced in #11759 when determining whether the picker should open above or below the input. This prevents pickers from being positioned in an area partially obscured by the bottom element `<div class="item__edit-sticky">`
#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/17269

#### Testing
1. Access the Admin Dashboard.
2. Go to Participatory Space > Component > Blog > New post.
3. Create a post and Fill in Title, Body, Publish Day, and Time.
4. Observe the hour picker display.

### :camera: Screenshots
<img width="1090" height="533" alt="image" src="https://github.com/user-attachments/assets/88a0cdbd-095e-4c2e-80b9-d357650b6653" />


:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time picker positioning when a sticky action area is present.
  * Pickers now better determine whether to open above or below the input based on the available screen space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->