### PR TITLE
Allow `npm i` to fail and retry during application generation

### DIFF
--- a/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
@@ -225,8 +225,8 @@ namespace :decidim do
     status = false
     attempts.times do |n|
       if n.positive?
-        # Doubles the wait time on every attempt, starting from 5s.
-        wait = 5 * (2**(n - 1))
+        # Doubles the wait time on every attempt, starting from 30s.
+        wait = 30 * (2**(n - 1))
         puts "Command #{command} failed. Retrying in #{wait}s..."
         sleep wait
       end

--- a/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
@@ -100,7 +100,11 @@ namespace :decidim do
 
   def install_decidim_npm
     decidim_npm_packages.each do |type, packages|
-      system! "npm i --save-#{type} #{packages.join(" ")}"
+      # NPM installation can sometimes fail with 404 error when a new version of
+      # one of the dependencies has just been published but the upload of the
+      # package has not yet been completed. This tries the install command
+      # multiple times to avoid this situation.
+      system! "npm i --save-#{type} #{packages.join(" ")}", attempts: 5
     end
   end
 
@@ -217,8 +221,19 @@ namespace :decidim do
     File.write(file, contents)
   end
 
-  def system!(command)
-    system("cd #{rails_app_path} && #{command}") || abort("\n== Command #{command} failed ==")
+  def system!(command, attempts: 1)
+    status = false
+    attempts.times do |n|
+      if n.positive?
+        # Doubles the wait time on every attempt, starting from 5s.
+        wait = 5 * (2**(n - 1))
+        puts "Command #{command} failed. Retrying in #{wait}s..."
+        sleep wait
+      end
+
+      break if (status = system("cd #{rails_app_path} && #{command}"))
+    end
+    status || abort("\n== Command #{command} failed ==")
   end
 end
 

--- a/decidim-core/spec/tasks/decidim_tasks_shakapacker_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_shakapacker_spec.rb
@@ -3,6 +3,9 @@
 require "spec_helper"
 
 describe "rake decidim:shakapacker:install", type: :task do
+  let(:npm_dependencies) { %w(@decidim/browserslist-config @decidim/core @decidim/webpacker) }
+  let(:npm_dev_dependencies) { %w(@decidim/dev @decidim/eslint-config @decidim/prettier-config @decidim/stylelint-config) }
+
   it "preloads the Rails environment" do
     expect(task.prerequisites).to include "environment"
   end
@@ -14,7 +17,54 @@ describe "rake decidim:shakapacker:install", type: :task do
     task.execute
 
     package_json_content = JSON.parse(File.read(package_json))
-    expect(package_json_content["dependencies"].keys).to contain_exactly("@decidim/browserslist-config", "@decidim/core", "@decidim/webpacker")
-    expect(package_json_content["devDependencies"].keys).to contain_exactly("@decidim/dev", "@decidim/eslint-config", "@decidim/prettier-config", "@decidim/stylelint-config")
+    expect(package_json_content["dependencies"].keys).to match_array(npm_dependencies)
+    expect(package_json_content["devDependencies"].keys).to match_array(npm_dev_dependencies)
+  end
+
+  context "when NPM install fails" do
+    let(:local_npm_dependencies) { npm_dependencies.map { |dep| dep.sub(%r{\A@decidim/}, "./packages/") } }
+    let(:npm_command) { "npm i --save-prod #{local_npm_dependencies.join(" ")}" }
+    let(:main) { TOPLEVEL_BINDING.eval("self") }
+
+    before do
+      # Prevent actual system calls for these specs
+      allow(main).to receive(:system).and_return(true)
+    end
+
+    it "retries the command" do
+      attempts = 0
+      allow(main).to receive(:system).with("cd #{Rails.root} && #{npm_command}") do
+        attempts += 1
+        attempts == 5
+      end
+
+      sleeps = []
+      expect(main).to receive(:sleep).exactly(4).times do |amt|
+        sleeps << amt
+      end
+
+      messages = []
+      expect(main).to receive(:puts).exactly(4).times do |msg|
+        messages << msg
+      end
+
+      expect { task.execute }.not_to raise_error
+
+      expected_sleeps = [5, 10, 20, 40]
+      expect(attempts).to be(5)
+      expect(sleeps).to eq(expected_sleeps)
+      expect(messages).to eq(expected_sleeps.map { |amt| "Command #{npm_command} failed. Retrying in #{amt}s..." })
+    end
+
+    it "fails the command after too many tries" do
+      allow(main).to receive(:sleep)
+
+      expect(main).to receive(:system).with("cd #{Rails.root} && #{npm_command}").exactly(5).times.and_return(false)
+      expect(main).to receive(:abort).with("\n== Command #{npm_command} failed ==") do |msg|
+        raise SystemExit, msg
+      end
+
+      expect { task.execute }.to raise_error(SystemExit)
+    end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
This implements a retry logic for the `npm i` commands run during application generation. The generation can fail with 404 errors when a new version of one of the NPM dependencies has just been published but not yet available through NPM (e.g. the upload has not completed yet).

This allows the command to retry 4 times after the initial attempt with wait times 30s, 60s, 120s and 240s (total of 7.5 minutes).

Today (2026-09-11) noticed that it may take around 5 minutes for the package to be available which is why I adjusted the wait time accordingly. It was initially 5s, 10s, 20s and 40s.

Noticed this failing at this example run:
https://github.com/decidim/decidim/actions/runs/34460707397/job/102817607061

Relevant output of the run:
```
[...]
      create  package.json
using npm@11.16.0 to manage dependencies and scripts in package.json
       apply  /home/runner/work/decidim/decidim/vendor/bundle/ruby/3.4.0/gems/shakapacker-10.3.2/lib/install/binstubs.rb
  Copying binstubs
       exist    bin
      create    bin/diff-bundler-config
      create    bin/shakapacker
      create    bin/shakapacker-config
      create    bin/shakapacker-dev-server
      create    bin/shakapacker-watch
         run  bundle install --quiet
[...]
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.72.2.tgz - Not found
npm error 404
npm error 404  The requested resource '@jsonjoy.com/fs-node-to-fsa@https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.72.2.tgz' could not be found or you do not have permission to access it.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-09-10T09_28_39_561Z-debug-0.log

== Command npm i --save-prod ./packages/browserslist-config ./packages/core ./packages/webpacker failed ==
Error: Process completed with exit code 1.
```

Another failed attempt here:
https://github.com/decidim/decidim/actions/runs/34460430423/job/102816703760

With the following message (same reason):
```
npm error code ETARGET
npm error notarget No matching version found for @jsonjoy.com/fs-node-to-fsa@4.72.2.
npm error notarget In most cases you or one of your dependencies are requesting a package version that doesn't exist.
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-09-10T09_25_31_953Z-debug-0.log

== Command npm i --save-prod ./packages/browserslist-config ./packages/core ./packages/webpacker failed ==
```

#### Testing
First create a dummy NPM executable which simulates the `npm i` failure 2 times each time:
```bash
$ mkdir -p ./tmp/test-path
$ touch ./tmp/test-path/npm && chmod +x ./tmp/test-path/npm
$ cat <<EOT > ./tmp/test-path/npm
#!/usr/bin/env bash

# Adjust with your NPM path
REAL_NPM="/usr/local/bin/npm"

temp_counter="/tmp/temp_npm_counter"
call_idx=\$(cat "\$temp_counter" 2>/dev/null || echo 0)

if [[ "\$1" == "i" && "\$call_idx" -lt 2 ]]; then
  echo "\$((call_idx + 1))" > "\$temp_counter"

  echo "NPM called! Called \$((call_idx + 1)) time(s)."
  exit 1
fi

rm -f "\$temp_counter"

"\$REAL_NPM" "\$@"

EOT
```

After created run the app generator with the adjusted path:
```bash
PATH="$(realpath ./tmp/test-path/):$PATH" bundle exec rake test_app
```

When the generator runs, you should see the following when `npm i` is called:
```
NPM called! Called 1 time(s).
Command npm i --save-prod ./packages/browserslist-config ./packages/core ./packages/webpacker failed. Retrying in 5s...
NPM called! Called 2 time(s).
Command npm i --save-prod ./packages/browserslist-config ./packages/core ./packages/webpacker failed. Retrying in 10s...
(continues normally)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* NPM dependency installation now retries failed attempts up to five times, with progressively longer delays between retries.
* Retry delays begin at 30 seconds and increase between subsequent attempts.
* Installation reports a clear failure and stops when all retry attempts are unsuccessful.
* Existing installation commands continue to run once by default unless retries are explicitly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->