### PR TITLE
Remove unnecessary `npm uninstall` during `decidim:shakapacker:install`

### DIFF
--- a/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
@@ -24,29 +24,6 @@ namespace :decidim do
       # Install JS dependencies
       install_decidim_npm
 
-      # Remove the Shakapacker dependencies as they come through Decidim dependencies.
-      # This ensures we can control their versions from Decidim dependencies to avoid version conflicts.
-      shakapacker_packages = %w(
-        @babel/core
-        @babel/plugin-transform-runtime
-        @babel/preset-env
-        @babel/runtime
-        babel-loader
-        compression-webpack-plugin
-        shakapacker
-        terser-webpack-plugin
-        webpack
-        webpack-assets-manifest
-        webpack-cli
-        webpack-dev-server
-        webpack-merge
-        @rails/actioncable
-        @rails/activestorage
-        @rails/ujs
-        turbolinks
-      )
-      system! "npm uninstall #{shakapacker_packages.join(" ")}"
-
       # Add the Browserslist configuration to the project
       add_decidim_browserslist_configuration
     end


### PR DESCRIPTION
#### :tophat: What? Why?
The `npm uninstall ...` command during the application generation is unnecessary as these packages are never added to the local dependencies. They would be installed if `rake shakapacker:install` was run bit it is not run as this task is customized.

Therefore this uninstall command is unnecessary and can be removed. You can validate this with the testing instructions.

#### :pushpin: Related Issues
- Related to #17645

#### Testing
1. If you do not have an existing test app, create it first **without** applying this PR (`bundle exec rake test_app`)
  * You can also use the `development_app` if that is available.
2. Copy the original `package.json` from the app as a reference `cp spec/decidim_dummy_app/package.json orig-package.json`
3. Apply the changes from this PR
4. Re-generate the test app with `bundle exec rake test_app`
5. Diff the original `package.json` with the newly generated one to see no difference `diff <(jq --sort-keys . orig-package.json) <(jq --sort-keys . spec/decidim_dummy_app/package.json)`

Note that there is already an existing spec that covers the contents of the generated `package.json` file:
https://github.com/decidim/decidim/blob/91e2971fbe1d673976c6de122faa7e86f89b5526/decidim-core/spec/tasks/decidim_tasks_shakapacker_spec.rb#L17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - JavaScript setup now preserves installed packages and tooling instead of removing them during installation.
  - This prevents package versions from being unexpectedly deleted or replaced when running the Shakapacker installation task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->