### PR TITLE
Remove unnecessary gem override path for Rails overrides

### DIFF
--- a/decidim-core/lib/gem_overrides/rails/tasks/yarn.rake
+++ b/decidim-core/lib/gem_overrides/rails/tasks/yarn.rake
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-# This is overridden because of a bug in Rails 6.0 which forces the yarn:install
-# task to the end of assets:precompile task which fails when bin/yarn has been
-# removed from Decidim applications. This should be fixed with Rails 6.1.
-#
-# See:
-# https://git.io/JEH9s (and the equivalent line in Rails 6.1)
-# https://github.com/rails/rails/commit/87e9ae053d661daa3b8549e1cc9ea5ecd3b8ad62

--- a/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
+++ b/decidim-core/lib/tasks/decidim_shakapacker_tasks.rake
@@ -231,7 +231,3 @@ if (config_path = Decidim::Shakapacker.configuration.configuration_file)
     config_path: Pathname.new(config_path)
   )
 end
-
-# Add gem overrides path to the beginning in order to override rake tasks
-# Needed because of a bug in Rails 6.0 (see the overridden task for details)
-$LOAD_PATH.unshift "#{Gem.loaded_specs["decidim-core"].full_gem_path}/lib/gem_overrides"


### PR DESCRIPTION
#### :tophat: What? Why?
This is no longer needed since Rails 7.

This was the commit that fixed the problem:
https://github.com/rails/rails/commit/87e9ae053d661daa3b8549e1cc9ea5ecd3b8ad62

As you can see, this was released in `v7.0.0.alpha1` and therefore this override is no longer required after that.

#### Testing
1. Re-generate the test app `bundle exec rake test_app`
2. See that yarn is not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved frontend setup and upgrade tasks by cleaning up outdated package manager artifacts.
  - Ensured required frontend configuration files are copied during setup.
  - Removed an outdated Rails task override that could interfere with asset compilation.
- **Chores**
  - Simplified internal task loading for frontend tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->