### PR TITLE
Remove `packageManager` field from the root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-test-renderer": "^19.2.8",
     "yaml-jest": "^1.2.0"
   },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "allowScripts": {
     "core-js": true,
     "@parcel/watcher@2.5.6": true,


### PR DESCRIPTION
#### :tophat: What? Why?
In another PR (#17645) the AI review thought that the repository is using Yarn to manage dependencies because it appears in this non-standard field of the root `package.json`.

Removing this to avoid confusion.

#### :pushpin: Related Issues
- Related to #17645

#### Testing
AI should no longer think that Yarn is used to manage the NPM packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the package manager version declaration from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->