### PR TITLE
Use enqueue_after_transaction_commit in ActiveJob

### DIFF
--- a/decidim-core/app/jobs/decidim/application_job.rb
+++ b/decidim-core/app/jobs/decidim/application_job.rb
@@ -2,6 +2,7 @@
 
 module Decidim
   class ApplicationJob < ActiveJob::Base
+    self.enqueue_after_transaction_commit = :always
     # Automatically retry jobs that encountered a deadlock
     retry_on ActiveRecord::Deadlocked
 


### PR DESCRIPTION
#### :tophat: What? Why?
Recently i had an issue in my installation, where i have lost a few automatically translated content because the system tried to fetch resources that were not in the database. It translated without any issues after retrying. 
So the issue that i had i have fixed it by making sure the jobs are being enqueued after the database transaction has been performed. 

#### :pushpin: Related Issues
*Link your PR to an issue*
- Related to #6179

#### Testing
1. Green pipeline

### :camera: Screenshots
N/A
:hearts: Thank you!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Background jobs are now queued only after the related database transaction commits.
  * Rolled-back transactions no longer leave their jobs queued, helping prevent processing against unavailable or incomplete data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->